### PR TITLE
pointing the third party acm module to a specific 0.1.2 version

### DIFF
--- a/document-service/terraform/template/acm.tf
+++ b/document-service/terraform/template/acm.tf
@@ -1,5 +1,5 @@
 module "documents-api-certificate" {
-  source = "github.com/traveloka/terraform-aws-acm-certificate"
+  source = "github.com/traveloka/terraform-aws-acm-certificate?ref=v0.1.2"
 
   domain_name            = "documents-${var.environment}.${var.dns_domain}"
   hosted_zone_name       = "${var.dns_domain}."
@@ -12,7 +12,7 @@ module "documents-api-certificate" {
 }
 
 module "documents-api-certificate-us-west-1" {
-  source = "github.com/traveloka/terraform-aws-acm-certificate"
+  source = "github.com/traveloka/terraform-aws-acm-certificate?ref=v0.1.2"
 
   domain_name            = "documents-${var.environment}.${var.dns_domain}"
   hosted_zone_name       = "${var.dns_domain}."

--- a/management/modules/management/jenkins.tf
+++ b/management/modules/management/jenkins.tf
@@ -170,7 +170,7 @@ resource "aws_elb" "jenkins_elb" {
 }
 
 module "jenkins-certificate" {
-  source = "github.com/traveloka/terraform-aws-acm-certificate"
+  source = "github.com/traveloka/terraform-aws-acm-certificate?ref=v0.1.2"
 
   domain_name            = "jenkins-${var.environment}-${var.deployment}.${var.dns_domain}"
   hosted_zone_name       = "${data.aws_route53_zone.aws_route53_zone.name}"

--- a/web-client/terraform/common/frontend.tf
+++ b/web-client/terraform/common/frontend.tf
@@ -31,7 +31,7 @@ data "aws_iam_policy_document" "allow_public" {
 }
 
 module "ui-certificate" {
-  source = "github.com/traveloka/terraform-aws-acm-certificate"
+  source = "github.com/traveloka/terraform-aws-acm-certificate?ref=v0.1.2"
 
   domain_name            = "ui-${var.environment}.${var.dns_domain}"
   hosted_zone_name       = "${var.dns_domain}."
@@ -42,7 +42,6 @@ module "ui-certificate" {
   description            = "Certificate for ui-${var.environment}.${var.dns_domain}"
   product_domain         = "EFCMS"
 }
-
 
 resource "aws_cloudfront_distribution" "distribution" {
   origin {
@@ -60,10 +59,10 @@ resource "aws_cloudfront_distribution" "distribution" {
   custom_error_response = [
     {
       error_caching_min_ttl = 0
-      error_code = 404
-      response_code = 200
-      response_page_path = "/index.html"
-    }
+      error_code            = 404
+      response_code         = 200
+      response_page_path    = "/index.html"
+    },
   ]
 
   enabled             = true
@@ -81,6 +80,7 @@ resource "aws_cloudfront_distribution" "distribution" {
 
     forwarded_values {
       query_string = false
+
       cookies {
         forward = "none"
       }


### PR DESCRIPTION
This module was previously pointing at the "master" branch of a third party module... this PR locks it down to version 0.1.2