### PR TITLE
Document OWASP ZAP review process

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -104,6 +104,7 @@ We use this list when performing a code review to ensure that all tasks have bee
 		- [ ] use VoiceOver or Narrator to navigate the site with audio only, with the display turned off
 		- [ ] manually test anything that pa11y cannot test automatically (e.g., contrast of text over images)
 - [ ] review static code analysis results
+- [ ] run OWASP ZAP (`./docker-zap.sh`), review output, ensure that there are no errors that are not known to be false positives or have not been previously declared to be acceptable
 - [ ] critically read all new code, in the context of existing code, [looking for problems](#what-we-look-for), e.g.:
 	- [ ] make sure names of methods and variables are sensible
 	- [ ] make sure code does not contain secrets

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -104,7 +104,7 @@ We use this list when performing a code review to ensure that all tasks have bee
 		- [ ] use VoiceOver or Narrator to navigate the site with audio only, with the display turned off
 		- [ ] manually test anything that pa11y cannot test automatically (e.g., contrast of text over images)
 - [ ] review static code analysis results
-- [ ] run OWASP ZAP (`./docker-zap.sh`), review output, ensure that there are no errors that are not known to be false positives or have not been previously declared to be acceptable
+- [ ] examine OWASP ZAP output in `docs/`, ensure that any errors are known to be false positives or have been previously declared to be acceptable
 - [ ] critically read all new code, in the context of existing code, [looking for problems](#what-we-look-for), e.g.:
 	- [ ] make sure names of methods and variables are sensible
 	- [ ] make sure code does not contain secrets


### PR DESCRIPTION
Sprint 7 incorporates Docker-based OWASP ZAP testing. Flexion is running it on their end to ensure that there are no errors. This could be gated as a part of the CD pipeline, but that would only work if there were _no_ errors and, in fact, there are several errors that we consider acceptable. We may modify this process down the line (e.g., configure OWASP ZAP to ignore those errors), but for now, the process is for them to run OWASP ZAP before filing an end-of-sprint PR and direct the output to `docs/`, which we then review to confirm that there are no errors that we have not previously said are acceptable (in the code review process, on a PR).