### PR TITLE
Start off code reviews with a blank slate

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -87,6 +87,7 @@ We wouldn’t want anyone being mean to us because of an oversight, mistake, or 
 
 We use this list when performing a code review to ensure that all tasks have been completed.
 
+- [ ] begin by deleting any existing copy of the Git repository and cloning a fresh copy, and running `docker system prune` to remove any cached artifacts from any prior code review
 - [ ] review the pull request itself, to get oriented
 	- [ ] read the description of the pull request, which should summarize the changes made
 	- [ ] read through every task on the Scrum board that's encompassed by this pull request


### PR DESCRIPTION
Every couple of sprints, there's a problem that has resulted from cached Docker assets. And every couple of sprints, I get 15 minutes into the code review before I realize that I haven't updated my local copy. This step will prevent these problems.