### PR TITLE
Add a "merge to master" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/merge-to-master.md
+++ b/.github/ISSUE_TEMPLATE/merge-to-master.md
@@ -1,0 +1,23 @@
+---
+name: Merge to Master
+about: A proposal to merge from staging to master
+title: Merge to Master
+labels: ''
+assignees: ''
+
+---
+
+- [ ] There are standardized release notes
+- [ ] All dependencies are pinned
+- [ ] No dependencies are deprecated
+- [ ] Major events are logged
+- [ ] Output from vulnerability scan with OWASP ZAP is included
+- [ ] Dependency analysis (with e.g. Code Climate, Snyk, NPM Audit) reveals no non-trivial vulnerabilities that would be deployed to production, and has the output included
+- [ ] Code security analysis (with e.g. Code Climate, Bandit, or Sonarcloud) reveals no non-trivial vulnerabilities, and has the output included
+- [ ] All volatile data storage is on redundant infrastructure
+- [ ] Periodic snapshots of all volatile data storage are configured
+- [ ] There is monitoring, alerting a specific person, for both downtime and error/performance problems
+- [ ] There is a system/network diagram
+- [ ] There is a README badge for dependency analysis
+- [ ] There is a README badge for static code analysis
+- [ ] A “beta” label is prominently featured on every page

--- a/docs/merge-to-master.md
+++ b/docs/merge-to-master.md
@@ -1,0 +1,14 @@
+# Moving Code from Staging to Master
+
+## What this is
+This is the process that’s used to review code in `staging` and determine whether it’s appropriate to move to `master`. This is a more stringent review process than is applied at the end of a sprint, and is intended to be the beginning of the pipeline to move code into production. (When an ATO process is in place, that will serve as the remainder of the pipeline, and will add some more stringent requirements.)
+
+## How to file a PR
+To use this process, open a [new issue](https://github.com/ustaxcourt/ef-cms/issues/new/) and use the `Merge to Master` template. That contains a checklist of every task that needs to be completed in order to move code to `master`. Then open the pull request (of the code you want to merge in from `staging`) and link it to that issue. It’s fine to create the issue at the start of your work, and use it as the base for your work until such time as it’s ready for review, at which point the issue should be assigned to the Court’s designated person.
+
+## How to review a PR
+Step through every item in the checklist and ensure that everything has been done. Regard it as a conversation — if there’s anything that you’re unclear on or have questions about, reply to the issue. If you need to discuss it with the requester out of band (e.g., via phone), that’s fine, but it’s important to record those basic facts in the issue. That is, if you found a problem, and it’s resolved in conversation, ensure that the basis for that resolution is written down for the record.
+
+If all conditions have been met, but you have reservations about merging the PR — i.e., it’s technically compliant, but there is an obvious problem, you _do not need to merge it._ The checklist is a guideline. You can change it at any time, including while a review is in progress.
+
+When you are satisfied that all conditions have been met, merge the pull request to `master`.


### PR DESCRIPTION
This adds a new template for GitHub issues, one that’s intended for proposing to move code from `staging` into `master`. It's a checklist of everything that needs to be provided in order to approve that pull request.

This would be better as a pull-request template, but GitHub doesn't support multiple pull-request templates like they do for issue templates, so we’ll start like this. Presumably GitHub will add that feature before we use this functionality many times.