### PR TITLE
Update CircleCI-related aspects of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 #### staging
 
-[![CircleCI](https://circleci.com/gh/usataxcourt/ef-cms/tree/staging.svg?style=svg)](https://circleci.com/gh/usataxcourt/ef-cms/tree/staging) 
+[![CircleCI](https://circleci.com/gh/ustaxcourt/ef-cms/tree/staging.svg?style=svg)](https://circleci.com/gh/usataxcourt/ef-cms/tree/staging) 
 
 API | Front-End | Shared Code
 --- | --------- | -----------

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 #### staging
 
-[![CircleCI](https://circleci.com/gh/ustaxcourt/ef-cms/tree/staging.svg?style=svg)](https://circleci.com/gh/usataxcourt/ef-cms/tree/staging) 
+[![CircleCI](https://circleci.com/gh/usataxcourt/ef-cms/tree/staging.svg?style=svg)](https://circleci.com/gh/usataxcourt/ef-cms/tree/staging) 
 
 API | Front-End | Shared Code
 --- | --------- | -----------
@@ -190,11 +190,12 @@ Follow these steps for creating the end of sprint PRs for the court.
 
 ## Prerequisites
 - [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/).
-- In [AWS Identity and Access Management](https://console.aws.amazon.com/iam/), create a `CircleCI` user:
-     - Run the `generate-policy.sh YOUR_ACCOUNT_ID_AS_ARG_1` to generated the policy.json.
-     - Create a IAM policy called CircleCIPolicy with that generated policy.json
-     - Create the CircleCI user and attach the policy
-     - keep track of the access key and secret access key; it is needed for the CircleCI setup.
+- Create a `CircleCI` user in [AWS Identity and Access Management](https://console.aws.amazon.com/iam/):
+     - Determine your organization’s AWS ID, a 12-digit number. While logged into the AWS Console, you can find this in the account menu in the top right, where it may appear with hyphens, e.g. `3503-6506-1526`.
+     - In your local copy of the repository, generate an IAM policy with `./generate-policy.sh [YOUR_ACCOUNT_ID]`, e.g. `generate-policy.sh 350365061526`.
+     - Create a IAM policy called `CircleCIPolicy`, populating it with the contents of the generated `policy.json`.
+     - Create the `CircleCI` user and attach the policy.
+     - Keep track of the access key and secret access key — it is needed for the CircleCI setup.
 - [Create a Route53 Hosted Zone](https://console.aws.amazon.com/route53/home) This will be used for setting up the domains for the UI and API.  Put the desired domain name (e.g. `ef-cms.example.gov.`) and make sure it is a `Public Hosted Zone`.  This is the value you will set for `EFCMS_DOMAIN` in CircleCI.  Make sure the domain name ends with a period.
 - [Create a SonarCloud account](https://sonarcloud.io/). SonarCloud will be used to tests each build.
 - [Create a new SonarCloud organization](https://sonarcloud.io/create-organization).
@@ -204,23 +205,23 @@ Follow these steps for creating the end of sprint PRs for the court.
   - [Create a project and project key](https://sonarcloud.io/projects/create?manual=true) for the SHARED code. (This will be referred to as `SHARED_SONAR_TOKEN` when setting up Jenkins.)
 
 ## Circle CI Setup
-1. Setup a Circle CI account
-2. Click Add Projects
+1. Set up a [CircleCI](https://circleci.com/) account
+2. Click "Add Projects"
 3. Click "Set Up Project" next to the court's repo
 4. Click "Start Building" with defaults
-5. Go to the settings of the project in Circle via clicking on the project / job, and clicking the gear cog
+5. Go to the settings of the project in CircleCI via clicking on the project / job, and clicking the gear icon
 6. Click "Environment Variables"
 7. Add the following: 
-     - AWS_ACCESS_KEY_ID (the access key for the AWS CircleCI user created in the Prerequisites)
-     - AWS_SECRET_ACCESS_KEY (the secret access key for the AWS CircleCI user created in the Prerequisites)
-     - EFCMS_DOMAIN (the domain indented for use by the court, e.g., `ef-cms.example.gov`)
-     - SONAR_ORG (your sonar organization’s name)
-     - SHARED_SONAR_KEY (the sonar key for the SHARED project)
-     - SHARED_SONAR_TOKEN (the token for the sonar SHARED project)
-     - API_SONAR_KEY (the sonar key for the API project)
-     - API_SONAR_TOKEN (the token for the sonar API project)
-     - UI_SONAR_KEY (the sonar key for the UI project)
-     - UI_SONAR_TOKEN (the token for the sonar UI project)
-     - COGNITO_SUFFIX (a suffix of your choice for the cognito url)
-     - USTC_ADMIN_PASS (a unique password of your choice used by the cognito admin user)
-8. You're good to go.  Builds should start running and deploying if everything is setup correctly.
+     - `AWS_ACCESS_KEY_ID` (the access key for the AWS CircleCI user created in the Prerequisites)
+     - `AWS_SECRET_ACCESS_KEY` (the secret access key for the AWS CircleCI user created in the Prerequisites)
+     - `EFCMS_DOMAIN` (the domain indented for use by the court, e.g., `ef-cms.example.gov`)
+     - `SONAR_ORG` (your sonar organization’s name)
+     - `SHARED_SONAR_KEY` (the sonar key for the SHARED project)
+     - `SHARED_SONAR_TOKEN` (the token for the sonar SHARED project)
+     - `API_SONAR_KEY` (the sonar key for the API project)
+     - `API_SONAR_TOKEN` (the token for the sonar API project)
+     - `UI_SONAR_KEY` (the sonar key for the UI project)
+     - `UI_SONAR_TOKEN` (the token for the sonar UI project)
+     - `COGNITO_SUFFIX` (a suffix of your choice for the cognito url)
+     - `USTC_ADMIN_PASS` (a unique password of your choice used by the cognito admin user)
+8. Run a build.


### PR DESCRIPTION
There are two changes here:

1. Fix the URL for the CircleCI badge that shows the build status — it has a typo in it.
2. There were a few parts of the instructions that I found confusing when I was following them, so I've modified them to make them more explicit.