### PR TITLE
Fix typo in CircleCI badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 #### staging
 
-[![CircleCI](https://circleci.com/gh/usataxcourt/ef-cms/tree/staging.svg?style=svg)](https://circleci.com/gh/usataxcourt/ef-cms/tree/staging) 
+[![CircleCI](https://circleci.com/gh/usataxcourt/ef-cms/tree/staging.svg?style=svg)](https://circleci.com/gh/ustaxcourt/ef-cms/tree/staging) 
 
 API | Front-End | Shared Code
 --- | --------- | -----------

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 #### staging
 
-[![CircleCI](https://circleci.com/gh/usataxcourt/ef-cms/tree/staging.svg?style=svg)](https://circleci.com/gh/ustaxcourt/ef-cms/tree/staging) 
+[![CircleCI](https://circleci.com/gh/ustaxcourt/ef-cms/tree/staging.svg?style=svg)](https://circleci.com/gh/ustaxcourt/ef-cms/tree/staging) 
 
 API | Front-End | Shared Code
 --- | --------- | -----------


### PR DESCRIPTION
I thought I'd fixed this in #63, but I missed a character. So here's a PR to delete exactly one character.