### PR TITLE
Add the visual style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ This is a React-based Javascript application. It’s housed in a [monorepo](http
 
 ## Documentation
 
-- There is a style guide available at http://localhost:1234/style-guide.
+- There is an HTML style guide available at http://localhost:1234/style-guide.
+- There is a visual style guide in [style-guide.pdf](docs/style-guide.pdf).
 - The Javascript is marked up with [JSDoc](https://github.com/jsdoc3/jsdoc) comments, so documentation can be built by running `jsdoc -r .` locally.
 - The API is documented via Swagger, and can be reviewed at http://localhost:3000/v1/swagger.
 - The deployment process is documented in [`SETUP.md`](SETUP.md).


### PR DESCRIPTION
The style guide is stored in Figma, where it is not available publicly. It has a simple function to export the style guide as a PDF, which I did, and then added the style guide to the repository. I also added a link to it from the README. Flexion intends to update this with each sprint.