### PR TITLE
Switch to using USTC's fork of a project

### DIFF
--- a/efcms-service/package-lock.json
+++ b/efcms-service/package-lock.json
@@ -6092,9 +6092,9 @@
       }
     },
     "fs-minipass": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
       "dev": true,
       "requires": {
         "minipass": "^2.2.1"
@@ -13585,8 +13585,8 @@
       }
     },
     "serverless-dynamodb-local": {
-      "version": "github:sutt0n/serverless-dynamodb-local#203f438a1794cd66cf9cf53f4a71901a889d1aba",
-      "from": "github:sutt0n/serverless-dynamodb-local#new-master",
+      "version": "github:ustaxcourt/serverless-dynamodb-local#203f438a1794cd66cf9cf53f4a71901a889d1aba",
+      "from": "github:ustaxcourt/serverless-dynamodb-local#new-master",
       "dev": true,
       "requires": {
         "aws-sdk": "^2.7.0",

--- a/efcms-service/package.json
+++ b/efcms-service/package.json
@@ -33,7 +33,7 @@
     "proxyquire": "^2.1.0",
     "serverless": "^1.42.3",
     "serverless-domain-manager": "2.6.13",
-    "serverless-dynamodb-local": "github:sutt0n/serverless-dynamodb-local#new-master",
+    "serverless-dynamodb-local": "github:ustaxcourt/serverless-dynamodb-local#new-master",
     "serverless-offline": "^4.10.0",
     "serverless-plugin-aws-alerts": "^1.2.4",
     "serverless-plugin-bind-deployment-id": "github:ustaxcourt/serverless-plugin-bind-deployment-id#update_lodash",


### PR DESCRIPTION
For reasons of dealing with an upstream security problem (with the tar npm module), an employee of the vendor needed to fork a project to patch it. Here we have forked _his_ fork, so that the Court is controlling its own copy of the code. This is likely to be a transient situation, until such time as the fix to this tar module flows downstream to us.

The relevant change here is a single line in `package.json`, where we've gone from including @sutt0n's package to including it from the U.S. Tax Court's GitHub organization. The `package-lock.json` change is just a lower-order realization of that modification.