### PR TITLE
Work can now be found in staging and master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Electronic Filing / Case Management System
 
-An as-yet-unnamed project by the [U.S. Tax Court](https://ustaxcourt.gov/), creating an open-source EF-CMS, which began in October 2018. **All work can be seen [in the staging branch](https://github.com/ustaxcourt/ef-cms/tree/staging).** For background, see [the RFQ to procure agile software development services](https://github.com/ustaxcourt/case-management-rfq).
+An as-yet-unnamed project by the [U.S. Tax Court](https://ustaxcourt.gov/), creating an open-source EF-CMS, which began in October 2018. Work is not yet in production, so `master` does not deploy. For background, see [the RFQ to procure agile software development services](https://github.com/ustaxcourt/case-management-rfq).
 
 #### develop
 


### PR DESCRIPTION
Previously, it was necessary to specify that that `staging` holds all work, and `master` would show no activity. Now that we've merged work from `staging` to `master`, and intend to do so routinely, that's no longer the case. But now the absence of any badges for `master` is weird (there's no build status, etc.), so I've replaced the old disclaimer with a new disclaimer.