### PR TITLE
Add missing IAM policy

### DIFF
--- a/policy.json.tpl
+++ b/policy.json.tpl
@@ -30,6 +30,7 @@
       "Effect": "Allow",
       "Action": [
         "cognito-idp:UpdateUserPoolClient",
+        "cognito-idp:UpdateUserPool",
         "cognito-idp:CreateUserPool",
         "cognito-idp:AdminRespondToAuthChallenge",
         "cognito-idp:AdminConfirmSignUp",


### PR DESCRIPTION
Without giving Cognito the `UpdateUserPool` permission, deployment fails.