### PR TITLE
Specify need for AWS account ID in CircleCI

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -39,6 +39,7 @@
 5. Go to the settings of the project in CircleCI via clicking on the project / job, and clicking the gear icon
 6. Click "Environment Variables"
 7. Add the following:
+     - `AWS_ACCOUNT_ID` (the AWS account ID, without hyphens, e.g. `345678901234`)
      - `AWS_ACCESS_KEY_ID` (the access key for the AWS CircleCI user created in the Prerequisites)
      - `AWS_SECRET_ACCESS_KEY` (the secret access key for the AWS CircleCI user created in the Prerequisites)
      - `EFCMS_DOMAIN` (the domain indented for use by the court, e.g., `ef-cms.example.gov`)


### PR DESCRIPTION
The move to using AWS ECR requires retrieving the Docker container from there, and the URL includes the AWS account ID. So we must store that in CircleCI, and this documents that.