### PR TITLE
Add Snyk badge to the merge-to-master template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/merge-to-master.md
+++ b/.github/PULL_REQUEST_TEMPLATE/merge-to-master.md
@@ -1,5 +1,7 @@
 # Release Notes
 
+![Known Vulnerabilities](https://snyk.io/test/github/ustaxcourt/ef-cms/sprint-##/badge.svg) Snyk
+
 ## Summary
 
 Explain here, in a paragraph or two, what has changed since the prior merge to master.


### PR DESCRIPTION
Including a Snyk badge means that it can be determined at a glance whether there are any dependencies that have known security holes.