### PR TITLE
Documentation updates around deployment process

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -31,6 +31,7 @@
   - On AWS, setup a role & policy for accessing the Dynamsoft ZIP file that is hosted on a private S3 bucket
      - The role name must match `dynamsoft_s3_download_role`, and it must be for `EC2`
      - The policy must have `s3:GetObject` access to your bucket
+- Deploy Docker images to Amazon ECR with `./docker-to-ecr.sh`. This will build an image per the `Dockerfile-CI` config, tag it as `latest`, and push it to the repo in ECR.
 
 ## CircleCI Setup
 1. Set up a [CircleCI](https://circleci.com/) account

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -10,8 +10,6 @@
           - Make the intended domain name available on your local system, e.g. `export EFCMS_DOMAIN="ef-cms.example.gov"`
           - Create the policies on your local system: `cd iam/terraform/account-specific/main && ../bin/deploy-app.sh`
                - Make a note of the `cloudwatch_role_arn` that is output, to use shortly for the CircleCI setup.
-          - `cd ../../environment-specific/main && ../bin/deploy-app.sh stg`
-               - Make a note of the ARNs that are output, to use shortly for the CircleCI setup.
      - In IAM, attach the `circle_ci_policy` to your `CircleCI` user.
      - Note the AWS-generated access key and secret access key — it will needed shortly for the CircleCI setup.
 - [Create a Route53 Hosted Zone](https://console.aws.amazon.com/route53/home) This will be used for setting up the domains for the UI and API.  Create the desired domain name (e.g. `ef-cms.example.gov.`) and make sure it is a `Public Hosted Zone`. This is the value you will set for `EFCMS_DOMAIN` in CircleCI.  Make sure the domain name ends with a period.
@@ -20,6 +18,7 @@
      - `cd iam/terraform/environment-specific/main && ../bin/deploy-app.sh stg`
      - `cd iam/terraform/environment-specific/main && ../bin/deploy-app.sh test`
      - `cd iam/terraform/environment-specific/main && ../bin/deploy-app.sh prod`
+          - Make a note of the ARNs that are output, to use shortly for the CircleCI setup.
 - [Create a SonarCloud account](https://sonarcloud.io/). SonarCloud will be used to tests each build.
 - [Create a new SonarCloud organization](https://sonarcloud.io/create-organization).
   - There are three sub-projects to the EF-CMS — the front-end (the UI), the back-end (the API), and shared code. Each is handled separately by CircleCI and SonarCloud.

--- a/docs/branch-management.md
+++ b/docs/branch-management.md
@@ -1,5 +1,36 @@
 # Moving Code between Environments
 
+## Deploying Work into Staging
+
+After the end-of-sprint pull request from the vendor has been received, [evaluated](https://github.com/ustaxcourt/ef-cms/blob/staging/docs/CODE_REVIEW.md), and judged acceptable, it must be accepted into `staging` and deployed.
+
+To accept the PR, the reviewer should use GitHub's review functionality to approve it, and then assign the PR to the Court product owner. It’s helpful to also comment on the PR, tagging the product owner, explaining in a sentence or so that you have reviewed the work, found it acceptable, and recommend accepting it into `staging`.
+
+When the pull request is accepted, AWS IAM policies must be updated. The following steps will generate the policies and publish them to IAM:
+
+```
+cd iam/terraform/account-specific/main && ../bin/deploy-app.sh
+cd ../../environment-specific/main && ../bin/deploy-app.sh stg
+```
+
+Because the deploy will happen as soon as the pull request is accepted, it is possible that the deploy will fail in the time between when the PR is accepted and when these policies are updated, if the work done in that sprint requires new permissions within IAM to deploy. If this happens, simply re-run the deploy once the permissions are updated.
+
+If any other problems are encountered in the process of deploying to `staging`, check [the troubleshooting document](https://github.com/ustaxcourt/ef-cms/blob/doc-updates/docs/TROUBLESHOOTING.md) for guidance.
+
+## Deploying to the Test Environment
+
+The Court maintains [an environment for UX testing](https://ui-test.ef-cms.ustaxcourt.gov/), which is built from [the `test` branch](https://github.com/ustaxcourt/ef-cms/tree/test).
+
+Updates flow to the `test` branch from `staging`. That update is performed every two weeks, after the conclusion of each sprint, _after_ changes have been successfully deployed into the staging environment.
+
+To start this process, create a new branch from `staging` named for the sprint (e.g., `sprint-53`), and then [open a new pull request](https://github.com/ustaxcourt/ef-cms/compare) to `test`.
+
+If any special steps proved necessary when deploying into the staging environment that were not documented in the vendor’s pull request, those steps must be documented in the pull request. If there are no special steps, it is fine for the pull request to simply report that it is deploying the results of e.g. sprint 53 and link to the associated pull request to `staging`.
+
+No additional review is performed before moving work into the test environment, such as is performed when moving work into production.
+
+Pull requests to `test` must only be merged by the product owner or their designee. This is to allow them to time the deploy so as to avoid updating the test environment while it’s actually being used for UX testing.
+
 ## Deploying to the “Production” Environment
 
 The Court maintains [a faux-production environment](https://ui-test.ef-cms.ustaxcourt.gov/) (the system is not yet in production), which is built from [the `master` branch](https://github.com/ustaxcourt/ef-cms/tree/master).
@@ -17,18 +48,3 @@ Step through every item in the checklist and ensure that everything has been don
 If all conditions have been met, but you have reservations about merging the PR — i.e., it’s technically compliant, but there is an obvious problem, you _do not need to merge it._ The checklist is a guideline. You can change it at any time, including while a review is in progress.
 
 When you are satisfied that all conditions have been met, merge the pull request to `master`.
-
-
-## Deploying to the Test Environment
-
-The Court maintains [an environment for UX testing](https://ui-test.ef-cms.ustaxcourt.gov/), which is built from [the `test` branch](https://github.com/ustaxcourt/ef-cms/tree/test).
-
-Updates flow to the `test` branch from `staging`. That update is performed every two weeks, after the conclusion of each sprint, _after_ changes have been successfully deployed into the staging environment.
-
-To start this process, create a new branch from `staging` named for the sprint (e.g., `sprint-53`), and then [open a new pull request](https://github.com/ustaxcourt/ef-cms/compare) to `test`.
-
-If any special steps proved necessary when deploying into the staging environment that were not documented in the vendor’s pull request, those steps must be documented in the pull request. If there are no special steps, it is fine for the pull request to simply report that it is deploying the results of e.g. sprint 53 and link to the associated pull request to `staging`.
-
-No additional review is performed before moving work into the test environment, such as is performed when moving work into production.
-
-Pull requests to `test` must only be merged by the product owner or their designee. This is to allow them to time the deploy so as to avoid updating the test environment while it’s actually being used for UX testing.


### PR DESCRIPTION
This updates several aspects of the documentation around the deployment process:

- Adds a step missing from the deploy process
- Documents what happens after reviewing a vendor PR, to get it deployed
- Removes a redundant step from the setup process