### PR TITLE
Add CircleCI config to new environment instructions

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -85,6 +85,7 @@ A prerequisite for a successful build within CircleCI is [access to CircleCI’s
 10. Run the `deploy-app.sh` command that you just added to `SETUP.md`.
 11. Mention your `$ENVIRONMENT`, if necessary, in `web-api/deploy-sandbox.sh` within the `run_development` function
 12. For all files matching `web-api/serverless-*yml`, include your `$ENVIRONMENT` within the list of `custom.alerts.stages` if you want your `$ENVIRONMENT` to be included in those which are monitored & emails delivered upon alarm.
-13. Update CircleCI to have all the new environment variables needed:
+13. Modify `.circleci/config.yml` to add `$ENVIRONMENT` to every step under `build-and-deploy` where you want it to be built and deployed.
+14. Update CircleCI to have all the new environment variables needed:
      - DYNAMSOFT_PRODUCT_KEYS_`$ENVIRONMENT`
      - POST_CONFIRMATION_ROLE_ARN_`$ENVIRONMENT`


### PR DESCRIPTION
This step was missing, and it meant that new environments are _tested,_ but not built.