### PR TITLE
Fix builds by adding newly-required dependencies.

### DIFF
--- a/web-api/runtimes/clamav/Dockerfile
+++ b/web-api/runtimes/clamav/Dockerfile
@@ -40,6 +40,15 @@ RUN rpm2cpio bzip2-libs*.rpm | cpio -vimd
 RUN yumdownloader -x \*i686 --archlist=x86_64 xz-libs
 RUN rpm2cpio xz-libs*.rpm | cpio -vimd
 
+RUN yumdownloader -x \*i686 --archlist=x86_64 libprelude
+RUN rpm2cpio libprelude*.rpm | cpio -vimd
+
+RUN yumdownloader -x \*i686 --archlist=x86_64 gnutls
+RUN rpm2cpio gnutls*.rpm | cpio -vimd
+
+RUN yumdownloader -x \*i686 --archlist=x86_64 nettle
+RUN rpm2cpio nettle*.rpm | cpio -vimd
+
 RUN mkdir -p bin
 RUN mkdir -p lib
 RUN mkdir -p var/lib/clamav


### PR DESCRIPTION
Cherry-picking from https://github.com/flexion/ef-cms/pull/5357 to fix the build issue — there were no strong preferences after speaking with Eric/Kelsey/Julia on how this is done. 

The dependency changed due to `yum` installing different package versions. Adding this to our list to look at when we review how to lock down deploy dependencies.

- [Related Slack thread](https://ustaxcourt.slack.com/archives/CD4PNKEPK/p1591032606006600), for the future.