### PR TITLE
Remove no-minify flag from npx parcel command

### DIFF
--- a/web-api/terraform/bin/deploy-app.sh
+++ b/web-api/terraform/bin/deploy-app.sh
@@ -25,7 +25,7 @@ npm run build:assets
 
 # build the cognito authorizer, api, and api-public with parcel
 pushd ../template/lambdas
-npx parcel build websockets.js cron.js streams.js log-forwarder.js cognito-authorizer.js cognito-triggers.js api-public.js api.js --target node --bundle-node-modules --no-minify
+npx parcel build websockets.js cron.js streams.js log-forwarder.js cognito-authorizer.js cognito-triggers.js api-public.js api.js --target node --bundle-node-modules
 popd
 
 # exit on any failure


### PR DESCRIPTION
Our deployment is currently failing due to reaching a size limit on a lambda function: https://app.circleci.com/pipelines/github/ustaxcourt/ef-cms/299/workflows/342dc4ea-5c58-4805-a164-5af9ec99cc1d/jobs/3139

Flexion ran into this issue too and resolved to remove the `--no-minify` flag to move past the issue - there may be work in the future to switch to deploying via S3 instead of direct upload. @ericsorenson 