### PR TITLE
Simplify account-specific deploy steps with Terraform.

### DIFF
--- a/docs/environments/setup.md
+++ b/docs/environments/setup.md
@@ -34,11 +34,8 @@ This document covers the initial setup needed to get EF-CMS continuous integrati
     (cd iam/terraform/account-specific/main && ../bin/deploy-app.sh)
     ```
 
-- Create a `CircleCI` user in [AWS Identity and Access Management](https://console.aws.amazon.com/iam/) which will be used by CircleCI to deploy code.
-  - In IAM, attach the `circle_ci_policy` created by Terraform to your `CircleCI` user.
+- Add an Access Key to the `CircleCI` user in [AWS Identity and Access Management](https://console.aws.amazon.com/iam/) which will be used by CircleCI to deploy code.
   - Note the AWS-generated access key and secret access key — it will needed shortly for the CircleCI setup.
-
-- Create a [Route53 Hosted Zone](https://console.aws.amazon.com/route53/home) which matches the configured `EFCMS_DOMAIN` decided above, making sure it is a `Public Hosted Zone` so it’s accessible over the internet. Make sure the domain name ends with a period.
 
 - From the `iam/terraform/environment-specific/main` directory, use Terraform to create the Lambda roles & policies needed to run the backend:
   ```bash
@@ -48,14 +45,9 @@ This document covers the initial setup needed to get EF-CMS continuous integrati
   ../bin/deploy-app.sh test
   ../bin/deploy-app.sh prod
   ```
-  - Make a note of the ARNs that are output, to use shortly for the CircleCI setup.
 
 - Configure the Dynamsoft TWAIN library, which is used to enable scanning from EF-CMS:
-
-  - Create a private S3 bucket and put the Dynamsoft Dynamic Web TWAIN ZIP file inside that bucket.
-  - Setup a role & policy for accessing the Dynamsoft ZIP file that is hosted on a private S3 bucket:
-    - The role name must match `dynamsoft_s3_download_role`, and it must be for `EC2`.
-    - The policy must have `s3:GetObject` access to your bucket.
+  - Upload the library `.tar.gz` to a folder called Dynamsoft in the S3 bucket named `${EFCMS_DOMAIN}-software`. Note its ARN for CircleCI setup later.
   - Deploy Docker images to Amazon ECR with `./docker-to-ecr.sh`. This will build an image per the `Dockerfile-CI` config, tag it as `latest`, and push it to the repo in ECR.
 
 ## 4. Configure CircleCI to test and release code to this environment.

--- a/iam/terraform/account-specific/bin/deploy-app.sh
+++ b/iam/terraform/account-specific/bin/deploy-app.sh
@@ -22,4 +22,4 @@ fi
 set -eo pipefail
 
 terraform init -backend=true -backend-config=bucket="${BUCKET}" -backend-config=key="${KEY}" -backend-config=dynamodb_table="${LOCK_TABLE}" -backend-config=region="${REGION}"
-TF_VAR_my_s3_state_bucket="${BUCKET}" TF_VAR_my_s3_state_key="${KEY}" terraform apply -auto-approve
+TF_VAR_my_s3_state_bucket="${BUCKET}" TF_VAR_my_s3_state_key="${KEY}" terraform apply -auto-approve -var "dns_domain=${EFCMS_DOMAIN}"

--- a/iam/terraform/account-specific/main/circle-ci.tf
+++ b/iam/terraform/account-specific/main/circle-ci.tf
@@ -1,5 +1,13 @@
 data "aws_caller_identity" "current" {}
 
+resource "aws_iam_user" "circle_ci" {
+  name = "CircleCI"
+}
+
+resource "aws_iam_user_policy_attachment" "circle_ci_policy_attachment" {
+  user = "${aws_iam_user.circle_ci.name}"
+  policy_arn = "${aws_iam_policy.circle_ci_policy.arn}"
+}
 
 resource "aws_iam_policy" "circle_ci_policy" {
   name = "circle_ci_policy"

--- a/iam/terraform/account-specific/main/dynamsoft.tf
+++ b/iam/terraform/account-specific/main/dynamsoft.tf
@@ -1,0 +1,45 @@
+resource "aws_s3_bucket" "dynamsoft" {
+  bucket = "${var.dns_domain}-software"
+  acl = "private"
+}
+
+resource "aws_s3_bucket_public_access_block" "dynamsoft" {
+  bucket = "${aws_s3_bucket.dynamsoft.id}"
+  block_public_acls = true
+  block_public_policy = true
+  ignore_public_acls = true
+  restrict_public_buckets = true
+}
+
+resource "aws_iam_role" "dynamsoft_s3_download_role" {
+  name = "dynamsoft_s3_download_role"
+  assume_role_policy = "${data.aws_iam_policy_document.allow_ec2_to_assume_dynamsoft_s3_download_role.json}"
+}
+
+data "aws_iam_policy_document" "allow_ec2_to_assume_dynamsoft_s3_download_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "access_dynamsoft_s3_bucket" {
+  name = "AccessSoftwareS3Bucket"
+  policy = "${data.aws_iam_policy_document.allow_read_access_to_dynamsoft_s3_bucket.json}"
+}
+
+data "aws_iam_policy_document" "allow_read_access_to_dynamsoft_s3_bucket" {
+  statement {
+    actions = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.dynamsoft.arn}/*"]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "allow_dynamsoft_role_access_to_dynamsoft_s3_bucket" {
+  role = "${aws_iam_role.dynamsoft_s3_download_role.name}"
+  policy_arn = "${aws_iam_policy.access_dynamsoft_s3_bucket.arn}"
+}

--- a/iam/terraform/account-specific/main/route-53.tf
+++ b/iam/terraform/account-specific/main/route-53.tf
@@ -1,0 +1,3 @@
+resource "aws_route53_zone" "primary" {
+  name = "${var.dns_domain}"
+}

--- a/iam/terraform/account-specific/main/variables.tf
+++ b/iam/terraform/account-specific/main/variables.tf
@@ -1,3 +1,6 @@
 variable "aws_region" {
   default = "us-east-1"
 }
+
+variable "dns_domain" {
+}


### PR DESCRIPTION
This change brings 7 additional resources under Terraform configuration which were previously manually created on the AWS Account-specific level, removing their manual documentation from the [Environment setup documentation](https://github.com/ustaxcourt/ef-cms/blob/f189a24cf04e8d1b1da87d29e9431a0cfa4f0f28/docs/environments/setup.md).

- I wouldn’t have been able to get past "Setup a role & policy for accessing the Dynamsoft ZIP file" without copying over from the existing non-production AWS account — this pull request adds that configuration to Terraform so we configure it the same next time around.

⚠️ When this change is merged, existing resources will need to be manually imported into Terraform’s state file so it doesn’t attempt to create duplicate resources when the account-specific manual deployment step is run:

```bash
export TF_VAR_dns_domain=${EFCMS_DOMAIN}

terraform import aws_route53_zone.primary [HOSTED_ZONE_ID]
terraform import aws_iam_user.circle_ci [USER_NAME]
terraform import aws_iam_user_policy_attachment.circle_ci_policy_attachment [USER_NAME]/[CI_POLICY_ARN]
terraform import aws_s3_bucket.dynamsoft [DYNAMSOFT_BUCKET_NAME]
terraform import aws_iam_role.dynamsoft_s3_download_role dynamsoft_s3_download_role
terraform import aws_iam_policy.access_dynamsoft_s3_bucket [DYNAMSOFT_POLICY_ARN]
terraform import aws_iam_role_policy_attachment.allow_dynamsoft_role_access_to_dynamsoft_s3_bucket dynamsoft_s3_download_role/[DYNAMSOFT_POLICY_ARN]
```

It’s easiest to retrieve these values using the AWS console, as they were created manually and as such may vary slightly:

- `HOSTED_ZONE_ID`: Retrieve from the Hosted Zone in Route 53.
- `USER_NAME`: Retrieve from the Circle CI user in IAM.
- `CI_POLICY_ARN`: Retrieve from the ARN from the circle_ci_policy in IAM.
- `DYNAMSOFT_BUCKET_NAME`: Retrieve the bucket name from S3 which contains the Dynamsoft archive.
- `DYNAMSOFT_POLICY_ARN`: The policy created which grants access to the Dynamsoft S3 bucket.

<details>
<summary>On first run, it’s recommended to avoid <code>-auto-approve</code> and confirm Terraform’s execution plan will perform the desired steps before approving.</summary><br>

Without `-auto-approve`, `terraform apply` will prompt for your review.

```
Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: 
```

</details>