### PR TITLE
Update docker-to-ecr.sh.

### DIFF
--- a/docker-to-ecr.sh
+++ b/docker-to-ecr.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # get aws account id if it does not exist in env var
 AWS_ACCOUNT_ID=${AWS_ACCOUNT_ID:-$(aws sts get-caller-identity --query "Account")}
 AWS_ACCOUNT_ID="${AWS_ACCOUNT_ID%\"}"
@@ -9,12 +11,12 @@ IMAGE_TAG=$(git rev-parse --short HEAD)
 MANIFEST=$(aws ecr batch-get-image --repository-name ef-cms-us-east-1 --image-ids imageTag=latest --region us-east-1 --query 'images[].imageManifest' --output text)
 
 if [[ -n $MANIFEST ]]; then
-  aws ecr batch-delete-image --repository-name ef-cms-us-east-1 --image-ids imageTag="latest"
-  aws ecr put-image --repository-name ef-cms-us-east-1 --image-tag "SNAPSHOT-$IMAGE_TAG" --image-manifest "$MANIFEST"
+  aws ecr batch-delete-image --repository-name ef-cms-us-east-1 --image-ids imageTag="latest" --region us-east-1
+  aws ecr put-image --repository-name ef-cms-us-east-1 --image-tag "SNAPSHOT-$IMAGE_TAG" --image-manifest "$MANIFEST" --region us-east-1
 fi
 
 # shellcheck disable=SC2091
-$(aws ecr get-login --no-include-email --region us-east-1)
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com
 
 docker build --no-cache -t "ef-cms-us-east-1:latest" -f Dockerfile-CI .
 docker tag "ef-cms-us-east-1:latest" "$AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:latest"


### PR DESCRIPTION
A few issues when running to create the new production account build:

- Two commands are missing their region definition and as such failed.
- The bash script continues executing on failed commands. Using `set -e` terminates on failed commands instead.
- aws ecr get-login is deprecated and removed from AWS CLI 2, [in favor of](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ecr/get-login-password.html) `get-login-password` and piping to docker login.

Notes:

- The `AWS` username is [just how you do it](https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html), not configured or environment-dependent.