### PR TITLE
Build the new production environment using CircleCI contexts on the prod branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -479,6 +479,21 @@ jobs:
       - store_artifacts:
           path: /home/app/cypress-smoketests/videos/
 
+
+build-and-deploy-defaults: &build-and-deploy-defaults
+  filters:
+    branches:
+      ignore:
+        - develop # run hourly below
+        - prod    # run with context workflow below
+
+build-and-deploy-with-context-defaults: &build-and-deploy-with-context-defaults
+  context: efcms-<< pipeline.git.branch >>
+  filters:
+    branches:
+      only:
+        - prod
+
 workflows:
   version: 2
   hourly:
@@ -512,41 +527,21 @@ workflows:
   build-and-deploy:
     jobs:
       - build-shared:
-          filters:
-            branches:
-              ignore:
-                - develop
+          <<: *build-and-deploy-defaults
       - build-api:
-          filters:
-            branches:
-              ignore:
-                - develop
+          <<: *build-and-deploy-defaults
       - build-client-unit:
-          filters:
-            branches:
-              ignore:
-                - develop
+          <<: *build-and-deploy-defaults
       - build-client-integration:
-          filters:
-            branches:
-              ignore:
-                - develop
+          <<: *build-and-deploy-defaults
       - e2e-pa11y:
-          filters:
-            branches:
-              ignore:
-                - develop
+          <<: *build-and-deploy-defaults
       - e2e-cypress:
-          filters:
-            branches:
-              ignore:
-                - develop
+          <<: *build-and-deploy-defaults
       - e2e-cypress-public:
-          filters:
-            branches:
-              ignore:
-                - develop
+          <<: *build-and-deploy-defaults
       - build-client-coverage:
+          <<: *build-and-deploy-defaults
           requires:
             - build-shared
             - build-api
@@ -555,10 +550,6 @@ workflows:
             - e2e-pa11y
             - e2e-cypress
             - e2e-cypress-public
-          filters:
-            branches:
-              ignore:
-                - develop
       - deploy:
           requires:
             - build-client-coverage
@@ -570,6 +561,36 @@ workflows:
                 - test
                 - migration
                 - master
-                - prod
                 - experimental1
                 - experimental2
+
+  build-and-deploy-with-context:
+    jobs:
+      - build-shared:
+          <<: *build-and-deploy-with-context-defaults
+      - build-api:
+          <<: *build-and-deploy-with-context-defaults
+      - build-client-unit:
+          <<: *build-and-deploy-with-context-defaults
+      - build-client-integration:
+          <<: *build-and-deploy-with-context-defaults
+      - e2e-pa11y:
+          <<: *build-and-deploy-with-context-defaults
+      - e2e-cypress:
+          <<: *build-and-deploy-with-context-defaults
+      - e2e-cypress-public:
+          <<: *build-and-deploy-with-context-defaults
+      - build-client-coverage:
+          <<: *build-and-deploy-with-context-defaults
+          requires:
+            - build-shared
+            - build-api
+            - build-client-unit
+            - build-client-integration
+            - e2e-pa11y
+            - e2e-cypress
+            - e2e-cypress-public
+      - deploy:
+          <<: *build-and-deploy-with-context-defaults
+          requires:
+            - build-client-coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -570,5 +570,6 @@ workflows:
                 - test
                 - migration
                 - master
+                - prod
                 - experimental1
                 - experimental2

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ The [U.S. Tax Court](https://ustaxcourt.gov/) currently uses a non-web-based leg
 
 #### develop
 
-| develop | master | staging | test |
+| develop | prod | staging | test |
 | ------- | ------ | ------- | ---- |
-| [![CircleCI](https://circleci.com/gh/flexion/ef-cms/tree/develop.svg?style=svg)](https://circleci.com/gh/flexion/ef-cms/tree/develop) | [![CircleCI](https://circleci.com/gh/ustaxcourt/ef-cms/tree/master.svg?style=svg)](https://circleci.com/gh/ustaxcourt/ef-cms/tree/master) | [![CircleCI](https://circleci.com/gh/ustaxcourt/ef-cms/tree/staging.svg?style=svg)](https://circleci.com/gh/ustaxcourt/ef-cms/tree/staging) | [![CircleCI](https://circleci.com/gh/ustaxcourt/ef-cms/tree/test.svg?style=svg)](https://circleci.com/gh/ustaxcourt/ef-cms/tree/test) |
+| [![CircleCI](https://circleci.com/gh/flexion/ef-cms/tree/develop.svg?style=svg)](https://circleci.com/gh/flexion/ef-cms/tree/develop) | [![CircleCI](https://circleci.com/gh/ustaxcourt/ef-cms/tree/prod.svg?style=svg)](https://circleci.com/gh/ustaxcourt/ef-cms/tree/prod) | [![CircleCI](https://circleci.com/gh/ustaxcourt/ef-cms/tree/staging.svg?style=svg)](https://circleci.com/gh/ustaxcourt/ef-cms/tree/staging) | [![CircleCI](https://circleci.com/gh/ustaxcourt/ef-cms/tree/test.svg?style=svg)](https://circleci.com/gh/ustaxcourt/ef-cms/tree/test) |
 
 API | Front-End | Shared Code
 --- | --------- | -----------

--- a/docs/environments/setup.md
+++ b/docs/environments/setup.md
@@ -98,7 +98,7 @@ A prerequisite for a successful build within CircleCI is [access to CircleCI’s
 
 EF-CMS currently has both the concept of a deployment at a domain as well as a named environment (stg, mig, prod, test). This section refers to the latter.
 
-1. Choose a name for the branch which will be used for deployments (henceforth `$BRANCH`). Examples are 'master', 'develop', 'staging'.
+1. Choose a name for the branch which will be used for deployments (henceforth `$BRANCH`). Examples are 'prod', 'develop', 'staging'.
 2. Choose a name for this environment (henceforth `$ENVIRONMENT`). Examples are 'prod', 'dev', 'stg'.
 3. Add CircleCI badge link to the README.md according to `$BRANCH`
 4. Edit `get-es-instance-count.sh`, adding a new `elif` statement for your `$BRANCH` which returns the appropriate number of ElasticSearch instances.

--- a/get-env.sh
+++ b/get-env.sh
@@ -28,6 +28,8 @@ elif [[ $BRANCH == 'staging' ]] ; then
   echo 'stg'
 elif [[ $BRANCH == 'master' ]] ; then
   echo 'prod'
+elif [[ $BRANCH == 'prod' ]] ; then
+  echo 'prod'
 else
   exit 1;
 fi

--- a/get-es-instance-count.sh
+++ b/get-es-instance-count.sh
@@ -28,6 +28,8 @@ elif [[ $BRANCH == 'migration' ]] ; then
   echo "1"
 elif [[ $BRANCH == 'master' ]] ; then
   echo "2"
+elif [[ $BRANCH == 'prod' ]] ; then
+  echo "2"
 else
   exit 1;
 fi

--- a/get-honeybadger-keys.sh
+++ b/get-honeybadger-keys.sh
@@ -18,6 +18,8 @@ elif [[ $BRANCH == 'experimental1' ]] ; then
   echo ""
 elif [[ $BRANCH == 'master' ]] ; then
   echo ""
+elif [[ $BRANCH == 'prod' ]] ; then
+  echo ""
 elif [[ $BRANCH == 'staging' ]] ; then
   echo "${CIRCLE_HONEYBADGER_API_KEY_STG}"
 elif [[ $BRANCH == 'test' ]] ; then

--- a/get-keys.sh
+++ b/get-keys.sh
@@ -23,6 +23,8 @@ elif [[ $BRANCH == 'irs' ]] ; then
   echo "${DYNAMSOFT_PRODUCT_KEYS_IRS}"
 elif [[ $BRANCH == 'master' ]] ; then
   echo "${DYNAMSOFT_PRODUCT_KEYS_PROD}"
+elif [[ $BRANCH == 'prod' ]] ; then
+  echo "${DYNAMSOFT_PRODUCT_KEYS_PROD}"
 elif [[ $BRANCH == 'staging' ]] ; then
   echo "${DYNAMSOFT_PRODUCT_KEYS_STG}"
 elif [[ $BRANCH == 'test' ]] ; then

--- a/web-client/src/views/Accessibility/AccessibilityStatement.jsx
+++ b/web-client/src/views/Accessibility/AccessibilityStatement.jsx
@@ -214,8 +214,8 @@ export const AccessibilityStatement = () => (
       </p>
       <ul className="usa-list technical-information related-evidence-other">
         <li>
-          <a href="https://github.com/ustaxcourt/ef-cms/tree/master/docs">
-            https://github.com/ustaxcourt/ef-cms/tree/master/docs
+          <a href="https://github.com/ustaxcourt/ef-cms/tree/prod/docs">
+            https://github.com/ustaxcourt/ef-cms/tree/prod/docs
           </a>
         </li>
       </ul>


### PR DESCRIPTION
This PR implements swapping of AWS accounts, credentials, and EFCMS_DOMAIN configuration for the `prod` branch, and updates references from `master` to `prod` as the production branch name.

- As [discussed on Slack](https://ustaxcourt.slack.com/archives/CD4PNKEPK/p1595514239479100?thread_ts=1595428226.463000&cid=CD4PNKEPK), this approach seems to be the best way forward for now. 
- I have already created the [efcms-prod](https://app.circleci.com/settings/organization/github/ustaxcourt/contexts/c4babc4f-767b-44cb-b161-0a01525c1080) CircleCI Context, which is referenced by this commit and [will override the environment variables](https://circleci.com/docs/2.0/contexts/#environment-variable-usage) in the project configuration.
- This PR doesn’t remove configuration for the `master` branch, as Flexion is still using that name for now. 
- My kingdom for ~a horse~ workflow-level branch filtering and context setting.

----

The logic in the workflow config is a little hard to follow (yaml isn’t the best at representing logic) — a quick summary: 

- The `develop` branch will run the `hourly` workflow, hourly. 
- The `prod` branch will run the `build-and-deploy-with-context` workflow on each commit, and uses the CircleCI context named `efcms-prod` 
- All branches except for `develop` and `prod` will run the `build-and-deploy` workflow on each commit.

(The `develop` branch is used by Flexion, we do not use that branch name). 
