### PR TITLE
Add libgbm-dev to CI image.

### DIFF
--- a/Dockerfile-CI
+++ b/Dockerfile-CI
@@ -17,7 +17,7 @@ RUN mkdir /home/app/sonar_home && \
   mv sonar-scanner-4.0.0.1744-linux/* /home/app/sonar_home
 
 RUN apt-get install -y gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-  libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
+  libfontconfig1 libgbm-dev libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
   libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
   libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
   ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget \


### PR DESCRIPTION
[The production build failed](https://app.circleci.com/pipelines/github/ustaxcourt/ef-cms/330/workflows/b64cc2a2-032f-4a74-a795-c0839da9ae96) with the image, due to Puppeteer 3 requiring an additional dependency. https://github.com/puppeteer/puppeteer/issues/5661

This indicates a lower-level problem as well — we don’t have a established pattern or automated routine for managing updates to our image used in CI. The development AWS account’s image was last updated in Feb. 

@mmarcotte was kind enough to add to the Site Ops documentation being developed in #244. 

/cc @ericsorenson, might be worth rebuilding your image in ECR as well. 