### PR TITLE
Lock AWS provider version in Terraform configs

### DIFF
--- a/iam/terraform/account-specific/main/main.tf
+++ b/iam/terraform/account-specific/main/main.tf
@@ -5,4 +5,8 @@ provider "aws" {
 terraform {
   backend "s3" {
   }
+
+  required_providers {
+    aws = "2.70.0"
+  }
 }

--- a/iam/terraform/environment-specific/main/main.tf
+++ b/iam/terraform/environment-specific/main/main.tf
@@ -5,4 +5,8 @@ provider "aws" {
 terraform {
   backend "s3" {
   }
+  
+  required_providers {
+    aws = "2.70.0"
+  }
 }

--- a/web-api/terraform/main/main.tf
+++ b/web-api/terraform/main/main.tf
@@ -5,6 +5,9 @@ provider "aws" {
 terraform {
   backend "s3" {
   }
+  required_providers {
+    aws = "2.70.0"
+  }
 }
 
 module "ef-cms_apis" {

--- a/web-client/terraform/main/main.tf
+++ b/web-client/terraform/main/main.tf
@@ -5,6 +5,10 @@ provider "aws" {
 terraform {
   backend "s3" {
   }
+
+  required_providers {
+    aws = "2.70.0"
+  }
 }
 
 module "environment" {


### PR DESCRIPTION
In response to the [failing CircleCI deployment](https://app.circleci.com/pipelines/github/ustaxcourt/ef-cms/342/workflows/404c4b33-7186-4d11-8a47-6cae09ef4680/jobs/3579) after merging Sprint 45 to staging, we're adding a version specification to our Terraform configs. Terraform was pulling in the latest aws provider, which is version 3.0.0, released 5 days ago, which broke the current config. Note that within the logs for the Terraform deploy, it mentions a couple of other providers that we may want to lock:

```
The following providers do not have any version constraints in configuration,
so the latest version was installed.

To prevent automatic upgrades to new major versions that may contain breaking
changes, it is recommended to add version = "..." constraints to the
corresponding provider blocks in configuration, with the constraint strings
suggested below.

* provider.archive: version = "~> 1.3"
* provider.aws: version = "~> 3.0"
* provider.null: version = "~> 2.1"
```