### PR TITLE
Enable logging for Elasticsearch in Terraform Config

### DIFF
--- a/web-api/terraform/template/elasticsearch.tf
+++ b/web-api/terraform/template/elasticsearch.tf
@@ -15,4 +15,10 @@ resource "aws_elasticsearch_domain" "efcms-search" {
   snapshot_options {
     automated_snapshot_start_hour = 23
   }
+
+  log_publishing_options = {
+    enabled                  = "true"
+    cloudwatch_log_group_arn = "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/aes/debug_${var.environment}"
+    log_type                 = "ES_APPLICATION_LOGS"
+  }
 }

--- a/web-api/terraform/template/elasticsearch.tf
+++ b/web-api/terraform/template/elasticsearch.tf
@@ -1,3 +1,31 @@
+resource "aws_cloudwatch_log_group" "elasticsearch_application_logs" {
+  name = "/aws/aes/debug_${var.environment}"
+}
+
+resource "aws_cloudwatch_log_resource_policy" "allow_elasticsearch_to_write_logs" {
+  policy_name = "allow_elasticsearch_to_write_logs"
+
+  policy_document = <<CONFIG
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "es.amazonaws.com"
+      },
+      "Action": [
+        "logs:PutLogEvents",
+        "logs:PutLogEventsBatch",
+        "logs:CreateLogStream"
+      ],
+      "Resource": "arn:aws:logs:*"
+    }
+  ]
+}
+CONFIG
+}
+
 resource "aws_elasticsearch_domain" "efcms-search" {
   domain_name           = "efcms-search-${var.environment}"
   elasticsearch_version = "7.4"
@@ -16,9 +44,8 @@ resource "aws_elasticsearch_domain" "efcms-search" {
     automated_snapshot_start_hour = 23
   }
 
-  log_publishing_options = {
-    enabled                  = "true"
-    cloudwatch_log_group_arn = "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/aes/debug_${var.environment}"
+  log_publishing_options {
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.elasticsearch_application_logs.arn
     log_type                 = "ES_APPLICATION_LOGS"
   }
 }


### PR DESCRIPTION
In order to handle issues should they arise in Elasticsearch (eg, migration building the indexes that power the UI), this branch should turn on logging based on the [Terraform Docs for the aws_elasticsearch_domain resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain#log_publishing_options). 

Need someone to look over the ARN because it may be attempting to be too prescriptive with the log group:
```
/aws/aes/debug_${var.environment}
``` 