### PR TITLE
Increase support for umzug migration step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -435,6 +435,7 @@ jobs:
       - run:
           name: 'Deploy - Web API - Run Migrations'
           command: docker run -e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" -e "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" -e "DYNAMODB_ENDPOINT=dynamodb.us-east-1.amazonaws.com" --rm efcms /bin/sh -c "npm run build:assets && ./web-api/run-umzug.sh ${ENV}"
+          no_output_timeout: 30m
       - run:
           name: 'Deploy - Web API - Smoke Tests - us-east-1'
           command: |

--- a/web-api/migrations/00013-is-file-attached.js
+++ b/web-api/migrations/00013-is-file-attached.js
@@ -5,7 +5,7 @@ const { Document } = require('../../shared/src/business/entities/Document');
 
 const mutateRecord = async item => {
   if (isDocumentRecord(item)) {
-    console.log(`step 13: (${item.docktNumber}) isFileAttached: ${item.documentId} ${item.isFileAttached}`)
+    console.log(`step 13: (${item.docktNumber} ${item.documentId}) isFileAttached: ${item.isFileAttached ? 'yes' : 'no'}`)
     if (item.isFileAttached === undefined) {
       item.isFileAttached = true;
     }

--- a/web-api/migrations/00013-is-file-attached.js
+++ b/web-api/migrations/00013-is-file-attached.js
@@ -5,6 +5,7 @@ const { Document } = require('../../shared/src/business/entities/Document');
 
 const mutateRecord = async item => {
   if (isDocumentRecord(item)) {
+    console.log(`step 13: (${item.docktNumber}) isFileAttached: ${item.documentId} ${item.isFileAttached}`)
     if (item.isFileAttached === undefined) {
       item.isFileAttached = true;
     }

--- a/web-api/migrations/00013-is-file-attached.js
+++ b/web-api/migrations/00013-is-file-attached.js
@@ -5,7 +5,7 @@ const { Document } = require('../../shared/src/business/entities/Document');
 
 const mutateRecord = async item => {
   if (isDocumentRecord(item)) {
-    console.log(`step 13: (${item.docktNumber} ${item.documentId}) isFileAttached: ${item.isFileAttached ? 'yes' : 'no'}`)
+    console.log(`step 13: (${item.docketNumber} ${item.documentId}) isFileAttached: ${typeof item.isFileAttached === 'undefined' ? 'undefined ': 'defined'}`)
     if (item.isFileAttached === undefined) {
       item.isFileAttached = true;
     }

--- a/web-api/umzug.js
+++ b/web-api/umzug.js
@@ -83,6 +83,7 @@ async function run() {
       pattern: /^\d+[\w-]+\.js$/,
     },
     storage,
+    logging: true,
   });
 
   try {

--- a/web-api/umzug.js
+++ b/web-api/umzug.js
@@ -83,7 +83,6 @@ async function run() {
       pattern: /^\d+[\w-]+\.js$/,
     },
     storage,
-    logging: true,
   });
 
   try {


### PR DESCRIPTION
In order to get the migration environment updated to the latest codebase, we're doing the following:
* [increasing the default 10m to 30m](https://support.circleci.com/hc/en-us/articles/360007188574-Build-has-hit-timeout-limit) for CircleCI to perform the migration step.
* log to the console each document that step 13 (where it is currently timing out) processes

I didn't attempt to include the `logging` attribute for the Umzug instantiation mention in [its documentation](https://github.com/sequelize/umzug/tree/v2.x#umzug-instance) as I'm not certain it would be needed based on our `console.log(...)` addition, and it wasn't clear whether that's a boolean or a function. Something to consider.