### PR TITLE
Add `dynamodb:UpdateGlobalTable` for CircleCI

### DIFF
--- a/iam/terraform/account-specific/main/circle-ci.tf
+++ b/iam/terraform/account-specific/main/circle-ci.tf
@@ -166,7 +166,8 @@ resource "aws_iam_policy" "circle_ci_policy" {
         "dynamodb:DescribeStream",
         "dynamodb:GetRecords",
         "dynamodb:GetShardIterator",
-        "dynamodb:ListStreams"
+        "dynamodb:ListStreams",
+        "dynamodb:UpdateGlobalTable"
       ],
       "Resource": [
         "arn:aws:dynamodb::${data.aws_caller_identity.current.account_id}:global-table/efcms-*",


### PR DESCRIPTION
In order to clear the migration environment's DynamoDB table more efficiently, we opted to use `Delete Table` via the Console, which took 1 minute rather than 175 minutes deleting Documents 25 x 25. 

However, on the next deploy in order to use Terraform to recreate the deleted table we ran into the following error:

```
ProcessGlobalTables: Error: AccessDeniedException: User: arn:aws:iam::************:user/CircleCI is not authorized to perform: dynamodb:UpdateGlobalTable on resource: arn:aws:dynamodb:us-west-1:************:table/efcms-mig
```

So we are having to add the `dynamodb:UpdateGlobalTable` permission to the policy for the CircleCI user in order to restore the environment. 