### PR TITLE
Determine EFCMS_DOMAIN from `prod` branch

### DIFF
--- a/get-efcms-domain.sh
+++ b/get-efcms-domain.sh
@@ -28,8 +28,8 @@ elif [[ $BRANCH == 'staging' ]] ; then
   echo "${EFCMS_DOMAIN_STG}"
 elif [[ $BRANCH == 'master' ]] ; then
   echo "${EFCMS_DOMAIN_PROD}"
-elif [[ $BRANCH == 'dawson' ]] ; then
-  echo "${EFCMS_DOMAIN_DAWSON}"
+elif [[ $BRANCH == 'prod' ]] ; then
+  echo "${EFCMS_DOMAIN_PROD}"
 else
   exit 1;
 fi


### PR DESCRIPTION
In order to deploy to production using the `prod` branch, we need to inform the environment of the environment variable for the `EFCMS_DOMAIN_PROD`. We inadvertently left in `EFCMS_DOMAIN_DAWSON` and accompanying `dawson` branch from #333 . This PR fixes that and should correctly build the environment variables for a production deploy