### PR TITLE
Move even more account information into Terraform

### DIFF
--- a/iam/terraform/account-specific/main/dynamsoft.tf
+++ b/iam/terraform/account-specific/main/dynamsoft.tf
@@ -43,3 +43,8 @@ resource "aws_iam_role_policy_attachment" "allow_dynamsoft_role_access_to_dynams
   role = "${aws_iam_role.dynamsoft_s3_download_role.name}"
   policy_arn = "${aws_iam_policy.access_dynamsoft_s3_bucket.arn}"
 }
+
+resource "aws_iam_instance_profile" "dynamsoft_instance_profile" {
+  name = "dynamsoft_s3_download_role"
+  role = "${aws_iam_role.dynamsoft_s3_download_role.name}"
+}


### PR DESCRIPTION
This change brings one additional resource under Terraform control that was previously manually created on the AWS Account-specific level

⚠️ When this change is merged, existing resources will need to be manually imported into Terraform's state file so it doesn't attempt to create duplicate resources when the account-specific manaul deployment step is run.

To import this resource:

```bash
cd iam/terraform/account-specific/main
export ZONE_NAME=${ZONE_NAME}
export TF_VAR_dns_domain=${EFCMS_DOMAIN}
../bin/deploy-init.sh
terraform import aws_iam_instance_profile.dynamsoft_instance_profile dynamsoft_s3_download_role
```

On first run, it's recommended to not use `-auto-approve` to confirm that Terraform is tracking the resources correctly and will perform the desired steps."