### PR TITLE
Add script to switch superuser email by branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -492,6 +492,7 @@ jobs:
             echo "export ENV=$(./get-env.sh $CIRCLE_BRANCH)" >> $BASH_ENV
             echo "export EFCMS_DOMAIN=$(./get-efcms-domain.sh $CIRCLE_BRANCH)" >> $BASH_ENV
             echo "export ZONE_NAME=$(./get-zone-name.sh $CIRCLE_BRANCH)" >> $BASH_ENV
+            echo "export IRS_SUPERUSER_EMAIL=$(./get-irs-superuser-email.sh $CIRCLE_BRANCH)" >> $BASH_ENV
       - run:
           name: Build Docker Image
           command: |

--- a/get-irs-superuser-email.sh
+++ b/get-irs-superuser-email.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Returns the IRS superuser email associated with each branch
+
+# Usage
+#   ./get-irs-superuser-email.sh develop
+
+# Arguments
+#   - $1 - the branch to check
+
+[ -z "$1" ] && echo "The branch name to check must be provided as the \$1 argument." && exit 1
+
+BRANCH=$1
+
+if  [[ $BRANCH == 'develop' ]] ; then
+  echo "${IRS_SUPERUSER_EMAIL_DEV}"
+elif [[ $BRANCH == 'experimental1' ]] ; then
+  echo "${IRS_SUPERUSER_EMAIL_EXP1}"
+elif [[ $BRANCH == 'experimental2' ]] ; then
+  echo "${IRS_SUPERUSER_EMAIL_EXP2}"
+elif [[ $BRANCH == 'irs' ]] ; then
+  echo "${IRS_SUPERUSER_EMAIL_IRS}"
+elif [[ $BRANCH == 'test' ]] ; then
+  echo "${IRS_SUPERUSER_EMAIL_TEST}"
+elif [[ $BRANCH == 'migration' ]] ; then
+  echo "${IRS_SUPERUSER_EMAIL_MIG}"
+elif [[ $BRANCH == 'staging' ]] ; then
+  echo "${IRS_SUPERUSER_EMAIL_STG}"
+elif [[ $BRANCH == 'master' ]] ; then
+  echo "${IRS_SUPERUSER_EMAIL_PROD}"
+elif [[ $BRANCH == 'prod' ]] ; then
+  echo "${IRS_SUPERUSER_EMAIL_PROD}"
+else
+  exit 1;
+fi


### PR DESCRIPTION
This enables us to configure which environments the IRS receives notifications from.

Strategy to fix #359 —

- [ ] Switch other environments to use a different environment variable to configure the IRS email address
- [ ] Add CircleCI configuration for `IRS_SUPERUSER_EMAIL`, which will now only be used by the IRS environment.
- [ ] Run a re-build on CircleCI for the `irs` branch. 

This will enable us to add this configuration without making code changes in the IRS environment. 

## Alternatively…

We’ve set the expectation that we’ll be upgrading their environment in the near-future. We could continue this approach, but instead of re-deploying the current commit to that environment, we could also merge the latest code changes to the IRS environment. 