### PR TITLE
remove color check from irs user script

### DIFF
--- a/web-api/setup-irs-user.sh
+++ b/web-api/setup-irs-user.sh
@@ -20,8 +20,6 @@
 ENV=$1
 REGION="us-east-1"
 
-CURRENT_COLOR=$(aws dynamodb get-item --region us-east-1 --table-name "efcms-deploy-${ENV}" --key '{"pk":{"S":"deployed-stack"},"sk":{"S":"deployed-stack"}}' | jq -r ".Item.current.S")
-
 restApiId=$(aws apigateway get-rest-apis --region="${REGION}" --query "items[?name=='gateway_api_${ENV}'].id" --output text)
 
 USER_POOL_ID=$(aws cognito-idp list-user-pools --query "UserPools[?Name == 'efcms-${ENV}'].Id | [0]" --max-results 30 --region "${REGION}")


### PR DESCRIPTION
In order to reset the IRS Super User account information, we needed to adjust the script that creates that account. Simply needed to remove some old code that was checking for the release color. 