### PR TITLE
change order of token validation to match order of use

### DIFF
--- a/web-api/terraform/template/lambdas/cognito-authorizer.js
+++ b/web-api/terraform/template/lambdas/cognito-authorizer.js
@@ -56,11 +56,11 @@ exports.handler = (event, context, cb) => {
   console.log('Auth function invoked');
 
   let requestToken = null;
-  if (event.authorizationToken) {
-    requestToken = event.authorizationToken.substring(7);
-  } else if (event.queryStringParameters.token) {
+  if (event.queryStringParameters.token) {
     requestToken = event.queryStringParameters.token;
-  }
+  } else if (event.authorizationToken) {
+    requestToken = event.authorizationToken.substring(7);
+  }  
 
   if (requestToken) {
     const { header, payload } = jwk.decode(requestToken, { complete: true });


### PR DESCRIPTION
This changes the order of token validation to match order of use to ensure the used token is the one that is validated.