### PR TITLE
Specify temporary_password_validity_days.

### DIFF
--- a/web-api/terraform/template/cognito.tf
+++ b/web-api/terraform/template/cognito.tf
@@ -63,11 +63,12 @@ resource "aws_cognito_user_pool" "pool" {
   }
 
   password_policy {
-    minimum_length    = 8
-    require_lowercase = true
-    require_uppercase = true
-    require_numbers   = true
-    require_symbols   = true
+    minimum_length                   = 8
+    require_lowercase                = true
+    require_uppercase                = true
+    require_numbers                  = true
+    require_symbols                  = true
+    temporary_password_validity_days = 7
   }
 }
 
@@ -168,11 +169,12 @@ resource "aws_cognito_user_pool" "irs_pool" {
   }
 
   password_policy {
-    minimum_length    = 8
-    require_lowercase = true
-    require_uppercase = true
-    require_numbers   = true
-    require_symbols   = true
+    minimum_length                   = 8
+    require_lowercase                = true
+    require_uppercase                = true
+    require_numbers                  = true
+    require_symbols                  = true
+    temporary_password_validity_days = 7
   }
 }
 


### PR DESCRIPTION
Closes #370.

The [default is 7 days](https://docs.amazonaws.cn/en_us/cognito/latest/developerguide/how-to-create-user-accounts.html) — and as we see, terraform continually resets this property to null, and cognito resets it back to 7. 

This PR ends the fight. 😄 Confirmed via `terraform plan` that this does not cause user pools to be deleted and recreated.