### PR TITLE
Increase elasticsearch resources for mig & test

### DIFF
--- a/get-es-instance-count.sh
+++ b/get-es-instance-count.sh
@@ -31,7 +31,7 @@ elif [[ $BRANCH == 'master' ]] ; then
 elif [[ $BRANCH == 'dawson' ]] ; then
   echo "1"
 elif [[ $BRANCH == 'prod' ]] ; then
-  echo "2"
+  echo "3"
 else
   exit 1;
 fi

--- a/get-es-instance-count.sh
+++ b/get-es-instance-count.sh
@@ -23,9 +23,9 @@ elif [[ $BRANCH == 'irs' ]] ; then
 elif [[ $BRANCH == 'staging' ]] ; then
   echo "1"
 elif [[ $BRANCH == 'test' ]] ; then
-  echo "1"
+  echo "3"
 elif [[ $BRANCH == 'migration' ]] ; then
-  echo "1"
+  echo "3"
 elif [[ $BRANCH == 'master' ]] ; then
   echo "2"
 elif [[ $BRANCH == 'dawson' ]] ; then


### PR DESCRIPTION
In order to have better elasticsearch functionality in the environments where we are housing a significant amount of data, this change increases the number of nodes from 1 to 3 for the `test` and `migration` environment. and from 2 to 3 for the `prod` environment ahead of testing next week.