### PR TITLE
Disassociate `log_group` from `_type`

### DIFF
--- a/aws/lambdas/LogsToElasticSearch_info/index.js
+++ b/aws/lambdas/LogsToElasticSearch_info/index.js
@@ -81,7 +81,7 @@ function transform(payload) {
 
         var action = { "index": {} };
         action.index._index = indexName;
-        action.index._type = payload.logGroup;
+        action.index._type = 'efcms-logs';
         action.index._id = logEvent.id;
 
         bulkRequestBody += [


### PR DESCRIPTION
@mark-meyer found that `_type` is a field that must be unique in Kibana. The magic lambda from AWS links it with the log_group. So, in order to index multiple log groups, we are setting a static string to `_type`. 

We will have to figure out a way to separate logs by environment later, but for now i think we can search off of `log_group`