### PR TITLE
Ensure floater can view a case

### DIFF
--- a/shared/src/business/entities/User.test.js
+++ b/shared/src/business/entities/User.test.js
@@ -68,6 +68,16 @@ describe('User entity', () => {
     expect(user.entityName).toEqual('User');
   });
 
+  it('Creates a valid floater user', () => {
+    const user = new User({
+      name: 'Saul Goodman',
+      role: ROLES.floater,
+      userId: '3ab77c88-1dd0-4adb-a03c-c466ad72d417',
+    });
+    expect(user.isValid()).toBeTruthy();
+    expect(user.entityName).toEqual('User');
+  });
+
   it('Creates a valid privatePractitioner user', () => {
     const user = new User({
       barNumber: 'SG101',
@@ -133,6 +143,9 @@ describe('User entity', () => {
     });
     it('should return true when the user role is trialclerk', () => {
       expect(User.isInternalUser(ROLES.trialClerk)).toEqual(true);
+    });
+    it('should return true when the user role is floater', () => {
+      expect(User.isInternalUser(ROLES.floater)).toEqual(true);
     });
   });
 });

--- a/web-client/integration-tests/docketRecordJourney.test.js
+++ b/web-client/integration-tests/docketRecordJourney.test.js
@@ -228,7 +228,7 @@ describe('Docket Clerk Verifies Docket Record Display', () => {
     });
   });
 
-  loginAs(test, 'floater@example.com');
+  loginAs(test, 'testFloater@example.com');
   it('allows access to the floater user to view the case detail', async () => {
     await test.runSequence('gotoCaseDetailSequence', {
       docketNumber: test.docketNumber,

--- a/web-client/integration-tests/docketRecordJourney.test.js
+++ b/web-client/integration-tests/docketRecordJourney.test.js
@@ -228,6 +228,13 @@ describe('Docket Clerk Verifies Docket Record Display', () => {
     });
   });
 
+  loginAs(test, 'floater@example.com');
+  it('allows access to the floater user to view the case detail', async () => {
+    await test.runSequence('gotoCaseDetailSequence', {
+      docketNumber: test.docketNumber,
+    });
+  });
+
   loginAs(test, 'docketclerk@example.com');
   it('updates the fee payment status on case detail and verifies minute entry on the docket record', async () => {
     await test.runSequence('gotoCaseDetailSequence', {

--- a/web-client/src/presenter/sequences/gotoCaseDetailSequence.js
+++ b/web-client/src/presenter/sequences/gotoCaseDetailSequence.js
@@ -71,6 +71,7 @@ export const gotoCaseDetailSequence = [
         USER_ROLES.admissionsClerk,
         USER_ROLES.clerkOfCourt,
         USER_ROLES.docketClerk,
+        USER_ROLES.floater,
         USER_ROLES.petitionsClerk,
         USER_ROLES.trialClerk,
       ],


### PR DESCRIPTION
@JessicaMarine observed that the user logged in with the `floater` was unable to view a case. This sets up the path for that user and adds it to the case journey integration test.