### PR TITLE
Fix kibana searching

### DIFF
--- a/iam/terraform/account-specific/main/lambda-logs-to-elasticsearch.tf
+++ b/iam/terraform/account-specific/main/lambda-logs-to-elasticsearch.tf
@@ -73,16 +73,11 @@ resource "aws_iam_role" "lambda_logs_role" {
 EOF
 }
 
-resource "aws_iam_role_policy" "lambda_policy" {
+resource "aws_iam_role_policy" "lambda_logs_policy" {
   name = "lambda_policy__account" 
   role = aws_iam_role.lambda_logs_role.id
 
   policy = <<EOF
-
-resource "aws_cloudwatch_log_resource_policy" "allow_elasticsearch_to_write_logs" {
-  policy_name = "allow_logstream_lambda_to_write_logs"
-
-  policy_document = <<CONFIG
 {
   "Version": "2012-10-17",
   "Statement": [

--- a/iam/terraform/account-specific/main/lambda-logs-to-elasticsearch.tf
+++ b/iam/terraform/account-specific/main/lambda-logs-to-elasticsearch.tf
@@ -18,7 +18,6 @@ resource "aws_lambda_function" "logs_to_es" {
   }
 }
 
-
 resource "aws_cloudwatch_log_group" "logs_to_elasticsearch" {
   name              = "/aws/lambda/${aws_lambda_function.logs_to_es.function_name}"
   retention_in_days = 14


### PR DESCRIPTION
The recently introduced `LogsToElasticSearch_info` lambda did not have privileges to write to Cloudwatch. This enables that policy so it can function properly and hopefully begin to populate Kibana.