### PR TITLE
Revert behavior change for unknown docket numbers.

### DIFF
--- a/shared/src/persistence/dynamo/cases/getCaseByDocketNumber.js
+++ b/shared/src/persistence/dynamo/cases/getCaseByDocketNumber.js
@@ -24,7 +24,7 @@ exports.getCaseByDocketNumber = async ({
     applicationContext,
   });
 
-  if (!caseItems) {
+  if (caseItems.length === 0) {
     return null;
   }
 

--- a/shared/src/persistence/dynamo/cases/getCaseByDocketNumber.test.js
+++ b/shared/src/persistence/dynamo/cases/getCaseByDocketNumber.test.js
@@ -145,23 +145,16 @@ describe('getCaseByDocketNumber', () => {
     });
   });
 
-  it('should return default object if nothing is returned from the client query request', async () => {
+  it('should return null if nothing is returned from the client query request', async () => {
     applicationContext.getDocumentClient().query.mockReturnValue({
       promise: async () => Promise.resolve({ Items: [] }),
     });
 
     const result = await getCaseByDocketNumber({
       applicationContext,
-      docketNumber: '123-20',
+      docketNumber: '999-19',
     });
 
-    expect(result).toEqual({
-      archivedCorrespondences: [],
-      archivedDocketEntries: [],
-      correspondence: [],
-      docketEntries: [],
-      irsPractitioners: [],
-      privatePractitioners: [],
-    });
+    expect(result).toEqual(null);
   });
 });


### PR DESCRIPTION
Introduced in a2285afde8c1dccb9fdf0dede17260bc1fb90a7f, this commit reverts the change in behavior to return a default object instead of null when a docket number is not found.

By doing so, we restore the 404 behavior on the get case API endpoint — that is, unknown docket numbers return a 404 Not Found instead of 400 Bad Request (due to the default object failing case validation checks). 

This change causes test failures I’m currently looking into — it appears some tests are incompletely mocked:

- Test mocks `getCaseByDocketNumber` to return a non-existent case.
- During the course of executing the test subject, the subject calls a non-mocked `getCaseByDocketNumber`.
- This non-mocked method returns null, because the mocked case does not exist. 
- The test fails due to null references. 

