### PR TITLE
Blue green fixes

### DIFF
--- a/docs/BLUE_GREEN_MIGRATION.md
+++ b/docs/BLUE_GREEN_MIGRATION.md
@@ -1,25 +1,56 @@
-#  Blue-Green Deploy and Migration Steps
-1) If this is the first time running a blue/green deployment on the environment:
-  a. Run `npm run deploy:environment-specific <ENV>` and `npm run deploy:account-specific` if it has not already been run for the account 
-  b. Delete the environment's lambda S3 bucket and 4 UI S3 buckets (`app.<ENV>.<ZONE_NAME>`, `<ENV>.<ZONE_NAME>`, `app-failover.<ENV>.<ZONE_NAME>`, and `failover.<ENV>.<ZONE_NAME>`)
-  c. Attempt to run a deploy on circle. The deploy will fail on the deploy web-api terraform step. In order to resolve the error, run `./setup-s3-deploy-files.sh <ENV>`.
-2) If migration is necessary:
-	a. Run the following command to set the environment's migrate flag to true:
+# Blue-Green Deploy and Migration Steps
+
+## First Time Deployment
+
+If this is the first time running a blue/green deployment on the environment:
+
+1. Ensure you have `COGNITO_SUFFIX` environment variables properly set
+2. Run `npm run deploy:account-specific` if it has not already been run for the account.
+3. Ensure you have `ZONE_NAME` and `EFCMS_DOMAIN` environment variables properly set
+4. Run `npm run deploy:environment-specific <ENV>`
+5. Delete the environment's lambda S3 bucket and 4 UI S3 buckets:
+   * `<ENV>.<ZONE_NAME>.<ENV>.us-east-1.lambdas`
+   * `app.<ENV>.<ZONE_NAME>`,
+   * `<ENV>.<ZONE_NAME>`,
+   * `app-failover.<ENV>.<ZONE_NAME>`,
+   * `failover.<ENV>.<ZONE_NAME>`, and
+6. Attempt to run a deploy on circle. The deploy will fail on the deploy web-api terraform step. In order to resolve the error, run `./setup-s3-deploy-files.sh <ENV>`.
+7. Run the following command to set the environment's migrate flag to true:
 	```aws dynamodb put-item --region us-east-1 --table-name "efcms-deploy-${ENV}" --item '{"pk":{"S":"migrate"},"sk":{"S":"migrate"},"current":{"S":"true"}}'```
-	b. If `destination-table-version` and `source-table-version` do not exist in the deploy table, create destination-table-version record using this command:
+8. Run the following command to set the environment's initial version (`${VERSION}` being the current version of the migrations, which you can tell in [this terraform file](web-api/terraform/template/main.tf)):
+	```aws dynamodb put-item --region us-east-1 --table-name "efcms-deploy-${ENV}" --item '{"pk":{"S":"destination-table-version"},"sk":{"S":"destination-table-version"},"current":{"S":"${VERSION}"}}'```
+
+## If a Migration is necessary
+
+If it's time to run a migration, perform the following steps:
+
+1. Run the following command to set the environment's migrate flag to true:
+	```aws dynamodb put-item --region us-east-1 --table-name "efcms-deploy-${ENV}" --item '{"pk":{"S":"migrate"},"sk":{"S":"migrate"},"current":{"S":"true"}}'```
+2. If `destination-table-version` and `source-table-version` do not exist in the deploy table, create destination-table-version record using this command:
 	```aws dynamodb put-item --region us-east-1 --table-name "efcms-deploy-${ENV}" --item '{"pk":{"S":"destination-table-version"},"sk":{"S":"destination-table-version"},"current":{"S":"1"}}'```
-	c. If `destination-table-version` and `source-table-version` do exist in the deploy table, increment destination-table-version by 1.
-3) If a new dynamo table and elasticsearch domain is necessary, duplicate the modules found in `web-api/terraform/template/main.tf`. Be sure to update the version number at the end of the module names, `table_name`, and `domain_name`. Do not delete the old modules. Add the modules to `depends_on` in `main-east.tf` and `main-west.tf`
-4) Run a deploy in circle.
-5) Verify the new application works at: 
+3. If `destination-table-version` and `source-table-version` do exist in the deploy table, increment destination-table-version by 1.
+
+## If a Migration is not necessary
+
+Still figuring this out and testing
+
+## If a new DynamoDB table and Elasticsearch domain is necessary
+
+If a new dynamo table and elasticsearch domain is necessary, duplicate the modules found in `web-api/terraform/template/main.tf`. Be sure to update the version number at the end of the module names, `table_name`, and `domain_name`. Do not delete the old modules. Add the modules to `depends_on` in `main-east.tf` and `main-west.tf`
+
+1. Run a deploy in circle.
+2. Verify the new application works at: 
 	- https://<DEPLOYED_COLOR>-<ENV>.<ZONE_NAME>
 	- https://app-<DEPLOYED_COLOR>.<ENV>.<ZONE_NAME>
-6) Destroy the migration infrastructure to turn off the live streams
+3. Destroy the migration infrastructure to turn off the live streams
 	`DESTINATION_TABLE=b SOURCE_TABLE=a STREAM_ARN=abc npm run destroy:migration -- <DEPLOYED_ENV>`
 
 ## Errors You May Encounter
+
 ### AWS-related
+
 #### Route53 Error
+
 ```
 Error: [ERR]: Error building changeset: InvalidChangeBatch: [Tried to create resource record set [name='_243f260ea635a6dffe0db2c6cc1c1158.*************************.', type='CNAME'] but it already exists]
 ```
@@ -27,19 +58,29 @@ Manually delete the Route53 record and rerun the deploy.
 
 
 #### IAM Role already exists
+
 ```
 Error: Error creating IAM Role migration_role_<ENV>: EntityAlreadyExists: Role with name 		migration_role_<ENV> already exists.
 	status code: 409, request id: ***********
 
   on migration.tf line 1, in resource "aws_iam_role" "migration_role":
    1: resource "aws_iam_role" "migration_role" {
-   ```
-Delete the role in the AWS IAM console and rerun `npm run deploy:environment-specific <ENV>`.
+```
 
+AWS IAM console and rerun `npm run deploy:environment-specific <ENV>`.
 
 #### Failing smoke tests
+
 When this is run for the first time on a new environment, the smoke tests may fail for up to an hour after the initial deploy due to the header security lambda redeploying to all edge locations. To resolve, wait an hour and rerun the smoke tests.
 
-
 #### 403 on websockets endpoint
+
 If the websockets endpoint returns a 403 Unauthorized error (can be seen during trial session smoke tests), redeploy the websocket APIs for the environment in the AWS console under API Gateway (both east and west).
+
+#### Certificates
+
+```Error: Error creating API Gateway Domain Name: BadRequestException: The provided certificate does not exist.
+
+  on ../api/api-public.tf line 106, in resource "aws_api_gateway_domain_name" "api_public_custom":
+ 106: resource "aws_api_gateway_domain_name" "api_public_custom" {
+```

--- a/docs/BLUE_GREEN_MIGRATION.md
+++ b/docs/BLUE_GREEN_MIGRATION.md
@@ -67,7 +67,7 @@ Error: Error creating IAM Role migration_role_<ENV>: EntityAlreadyExists: Role w
    1: resource "aws_iam_role" "migration_role" {
 ```
 
-AWS IAM console and rerun `npm run deploy:environment-specific <ENV>`.
+Delete the role in the AWS IAM console and rerun `npm run deploy:environment-specific <ENV>`.
 
 #### Failing smoke tests
 
@@ -76,11 +76,3 @@ When this is run for the first time on a new environment, the smoke tests may fa
 #### 403 on websockets endpoint
 
 If the websockets endpoint returns a 403 Unauthorized error (can be seen during trial session smoke tests), redeploy the websocket APIs for the environment in the AWS console under API Gateway (both east and west).
-
-#### Certificates
-
-```Error: Error creating API Gateway Domain Name: BadRequestException: The provided certificate does not exist.
-
-  on ../api/api-public.tf line 106, in resource "aws_api_gateway_domain_name" "api_public_custom":
- 106: resource "aws_api_gateway_domain_name" "api_public_custom" {
-```

--- a/get-source-table.sh
+++ b/get-source-table.sh
@@ -13,6 +13,6 @@
 ENV=$1
 
 SOURCE_TABLE_VERSION=$(aws dynamodb get-item --region us-east-1 --table-name "efcms-deploy-${ENV}" --key '{"pk":{"S":"source-table-version"},"sk":{"S":"source-table-version"}}' | jq -r ".Item.current.S")
-[ -z "$SOURCE_TABLE_VERSION" ] && echo "efcms-${ENV}"
+[ -z "$SOURCE_TABLE_VERSION" ] && echo "efcms-${ENV}" && exit 
 
 echo "efcms-${ENV}-${SOURCE_TABLE_VERSION}"

--- a/iam/terraform/account-specific/bin/deploy-app.sh
+++ b/iam/terraform/account-specific/bin/deploy-app.sh
@@ -11,7 +11,7 @@ if [ -z "$ES_LOGS_INSTANCE_COUNT" ]; then
 fi
 
 if [ -z "$COGNITO_SUFFIX" ]; then
-  echo "Please export the EFCMS_DOMAIN variable in your shell"
+  echo "Please export the COGNITO_SUFFIX variable in your shell"
   exit 1
 fi
 

--- a/iam/terraform/account-specific/bin/deploy-app.sh
+++ b/iam/terraform/account-specific/bin/deploy-app.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+if [ -z "$ZONE_NAME" ]; then
+  echo "Please export the ZONE_NAME variable in your shell"
+  exit 1
+fi
+
+if [ -z "$ES_LOGS_INSTANCE_COUNT" ]; then
+  echo "Please export the ES_LOGS_INSTANCE_COUNT variable in your shell"
+  exit 1
+fi
+
+if [ -z "$COGNITO_SUFFIX" ]; then
+  echo "Please export the EFCMS_DOMAIN variable in your shell"
+  exit 1
+fi
+
 BUCKET="${ZONE_NAME}.terraform.deploys"
 KEY="permissions-account.tfstate"
 LOCK_TABLE=efcms-terraform-lock

--- a/iam/terraform/environment-specific/bin/deploy-app.sh
+++ b/iam/terraform/environment-specific/bin/deploy-app.sh
@@ -12,6 +12,11 @@ if [ -z "$EFCMS_DOMAIN" ]; then
   exit 1
 fi
 
+if [ -z "$ZONE_NAME" ]; then
+  echo "Please export the ZONE_NAME variable in your shell"
+  exit 1
+fi
+
 # Each $ENV will have its own terraform deploy bucket (i.e. "exp1.ustc-case-mgmt.flexion.us")
 BUCKET="${ZONE_NAME}.terraform.deploys"
 KEY="permissions-${ENVIRONMENT}.tfstate"


### PR DESCRIPTION
Working with Flexion to get blue/green up and running in the Court environments. This PR aims to add some clarifications to the the documentation and ensure environment variables are set before attempting deploys that rely upon them. Mainly, it's fixing an issue where a script tries to ascertain the name of the source table for a migration.