### PR TITLE
Blue green fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -720,6 +720,8 @@ jobs:
             echo "export MIGRATE_FLAG=$(./get-migrate-flag.sh $ENV)" >> $BASH_ENV
             echo "export DESTINATION_TABLE=$(./get-destination-table.sh $ENV)" >> $BASH_ENV
             echo "export SOURCE_TABLE=$(./get-source-table.sh $ENV)" >> $BASH_ENV
+            echo "export ZONE_NAME=$(./get-zone-name.sh $CIRCLE_BRANCH)" >> $BASH_ENV
+            echo "export EFCMS_DOMAIN=$(./get-efcms-domain.sh $CIRCLE_BRANCH)" >> $BASH_ENV
       - run:
           name: Build Docker Image
           command: |

--- a/docs/BLUE_GREEN_MIGRATION.md
+++ b/docs/BLUE_GREEN_MIGRATION.md
@@ -19,7 +19,7 @@ If this is the first time running a blue/green deployment on the environment:
 	```aws dynamodb put-item --region us-east-1 --table-name "efcms-deploy-${ENV}" --item '{"pk":{"S":"migrate"},"sk":{"S":"migrate"},"current":{"S":"true"}}'```
 8. Run the following command to set the environment's initial version (`${VERSION}` being the current version of the migrations, which you can tell in [this terraform file](web-api/terraform/template/main.tf)):
 	```aws dynamodb put-item --region us-east-1 --table-name "efcms-deploy-${ENV}" --item '{"pk":{"S":"destination-table-version"},"sk":{"S":"destination-table-version"},"current":{"S":"${VERSION}"}}'```
-9. Run the following command to set the environment's migrate flag to **tfalse** (for next time):
+9. Run the following command to set the environment's migrate flag to **false** (for next time):
 	```aws dynamodb put-item --region us-east-1 --table-name "efcms-deploy-${ENV}" --item '{"pk":{"S":"migrate"},"sk":{"S":"migrate"},"current":{"S":"false"}}'```
 
 ## If a Migration is necessary

--- a/docs/BLUE_GREEN_MIGRATION.md
+++ b/docs/BLUE_GREEN_MIGRATION.md
@@ -15,16 +15,18 @@ If this is the first time running a blue/green deployment on the environment:
    * `app-failover.<ENV>.<ZONE_NAME>`,
    * `failover.<ENV>.<ZONE_NAME>`, and
 6. Attempt to run a deploy on circle. The deploy will fail on the deploy web-api terraform step. In order to resolve the error, run `./setup-s3-deploy-files.sh <ENV>`.
-7. Run the following command to set the environment's migrate flag to true:
+7. Run the following command to set the environment's migrate flag to **true**:
 	```aws dynamodb put-item --region us-east-1 --table-name "efcms-deploy-${ENV}" --item '{"pk":{"S":"migrate"},"sk":{"S":"migrate"},"current":{"S":"true"}}'```
 8. Run the following command to set the environment's initial version (`${VERSION}` being the current version of the migrations, which you can tell in [this terraform file](web-api/terraform/template/main.tf)):
 	```aws dynamodb put-item --region us-east-1 --table-name "efcms-deploy-${ENV}" --item '{"pk":{"S":"destination-table-version"},"sk":{"S":"destination-table-version"},"current":{"S":"${VERSION}"}}'```
+9. Run the following command to set the environment's migrate flag to **tfalse** (for next time):
+	```aws dynamodb put-item --region us-east-1 --table-name "efcms-deploy-${ENV}" --item '{"pk":{"S":"migrate"},"sk":{"S":"migrate"},"current":{"S":"false"}}'```
 
 ## If a Migration is necessary
 
 If it's time to run a migration, perform the following steps:
 
-1. Run the following command to set the environment's migrate flag to true:
+1. Run the following command to set the environment's migrate flag to **true**:
 	```aws dynamodb put-item --region us-east-1 --table-name "efcms-deploy-${ENV}" --item '{"pk":{"S":"migrate"},"sk":{"S":"migrate"},"current":{"S":"true"}}'```
 2. If `destination-table-version` and `source-table-version` do not exist in the deploy table, create destination-table-version record using this command:
 	```aws dynamodb put-item --region us-east-1 --table-name "efcms-deploy-${ENV}" --item '{"pk":{"S":"destination-table-version"},"sk":{"S":"destination-table-version"},"current":{"S":"1"}}'```
@@ -33,6 +35,9 @@ If it's time to run a migration, perform the following steps:
 ## If a Migration is not necessary
 
 Still figuring this out and testing
+
+1. Run the following command to set the environment's migrate flag to **false**:
+	```aws dynamodb put-item --region us-east-1 --table-name "efcms-deploy-${ENV}" --item '{"pk":{"S":"migrate"},"sk":{"S":"migrate"},"current":{"S":"false"}}'```
 
 ## If a new DynamoDB table and Elasticsearch domain is necessary
 


### PR DESCRIPTION
In order to get the migration step to function properly, `ZONE_NAME` and `EFCMS_DOMAIN` need to be setup. Adding these to the Circle config to setup the environment variables so they are available for the docker container that performs the work.