### PR TITLE
Ensure that blue/green migration process is automated on Court environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -923,9 +923,9 @@ workflows:
             branches:
               only:
                 - irs
+                - migration
                 - staging
                 - test
-                - migration
                 - master
                 - experimental1
                 - experimental2
@@ -937,7 +937,10 @@ workflows:
           filters:
             branches:
               only:
+                - irs
+                - migration
                 - staging
+                - test
                 - experimental1
                 - experimental2
                 - experimental3
@@ -947,7 +950,10 @@ workflows:
           filters:
             branches:
               only:
+                - irs
+                - migration
                 - staging
+                - test
                 - experimental1
                 - experimental2
                 - experimental3
@@ -958,9 +964,9 @@ workflows:
             branches:
               only:
                 - irs
+                - migration
                 - staging
                 - test
-                - migration
                 - master
                 - experimental1
                 - experimental2


### PR DESCRIPTION
This PR ensures that the `migrate`, `smoketests`, and the `switch-colors` steps are performed by CircleCI for the following Court environments:

* Staging (already working)
* IRS
* Test
* Migration

This will speed up the process of moving fixes through the Court's environments and reduce the chance for errors performing these steps manually.

The process is manual for production; however, it can still be improved upon. That is [tracked here](https://github.com/ustaxcourt/ef-cms/issues/481).