### PR TITLE
#484: Add a new PR template, plus code review checklist updates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pr-to-ustc.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr-to-ustc.md
@@ -1,0 +1,10 @@
+# Description
+
+## Checklist
+
+- [ ] List all stories/issues that track the included changes
+- [ ] If any changes aren't connected to a story, document and briefly explain the change
+- [ ] All changes included are QA tested and closed in the originating repo
+- [ ] Tests are written for new/updated code, or it's been documented why the code isn't tested
+- [ ] At least one internal reviewer signed off on any commits contained in the PR
+- [ ] Impact analysis is done for the changes in each story - any significant changes which would impact users of the application/API or  infrastructure/ops  is highlighted and documented

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -87,17 +87,18 @@ We wouldn’t want anyone being mean to us because of an oversight, mistake, or 
 
 We use this list when performing a code review to ensure that all tasks have been completed.
 
-- [ ] If desired, run `docker system prune` to remove any unused docker images from previous code review.
-- [ ] Fetch the pull request for the sprint (e.g., `git fetch origin pull/{PR #}/head:sprint-{Sprint #}`), and then switch to that branch (e.g. `git checkout sprint-{Sprint #}`)
 - [ ] review the pull request itself, to get oriented
 	- [ ] read the description of the pull request, which should summarize the changes made
 	- [ ] read through every task on the Scrum board that's encompassed by this pull request
 	- [ ] read the description of the commits that comprise the pull request
-- [ ] stand up the site locally, with `./docker-run.sh`
+- [ ] If changes were made in the UI (if not, skip):
+  - [ ] If desired, run `docker system prune` to remove any unused docker images from previous code review.
+  - [ ] Fetch the pull request for the sprint (e.g., `git fetch origin pull/{PR #}/head:sprint-{Sprint #}`), and then switch to that branch (e.g. `git checkout sprint-{Sprint #}`)
+  - [ ] stand up the site locally, with `./docker-run.sh`
 	- [ ] test all functionality in all major browsers, emphasizing the functionality that this pull request addresses
-		- [ ] for internal Court functionality, perform the most thorough testing in Chrome, though also test in Edge and Firefox
-		- [ ] for public-facing functionality, test in browsers consistent with [public browser use data](https://analytics.usa.gov/)
-		- [ ] test in Mobile Safari and Mobile Chrome (or an emulator like Chrome DevTools), with the caveat that not all internal Court functionality will be necessary on these platforms
+	- [ ] for internal Court functionality, perform the most thorough testing in Chrome, though also test in Edge and Firefox
+	- [ ] for public-facing functionality, test in browsers consistent with [public browser use data](https://analytics.usa.gov/)
+	- [ ] test in Mobile Safari and Mobile Chrome (or an emulator like Chrome DevTools), with the caveat that not all internal Court functionality will be necessary on these platforms
 	- [ ] use an automated audit tool for code quality and practices (recommended: [Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools/), aka [Lighthouse](https://chrome.google.com/webstore/detail/lighthouse/blipmdconlkpinefehnmjammfjpmpbjk))
 		- [ ] look at efficiency of page loads, asset sizes, HTTP connection management, etc.
 	- [ ] review for accessibility
@@ -116,5 +117,5 @@ We use this list when performing a code review to ensure that all tasks have bee
 	- [ ] user-visible changes (including API users like the IRS) are documented in CHANGELOG.md (which is linked from US Tax Court website).
 - [ ] provide comments on the pull request on GitHub, as necessary
 	- [ ] for comments that are specific to a particular line of code, comment on those specific lines
-	- [ ] for comments that are more general, attach the comment to a random line in `README.md` (as opposed to commenting on the pull request itself), to be able to use GitHub's ability to thread discussions on those comments
+
 - [ ] for each feature-level bug (i.e., it’s working as designed, but designed wrong), open a new issue and put it in the backlog


### PR DESCRIPTION
This PR addresses #484. Some of the existing code review checklist may not be needed for every PR, so it was updated to reflect that. 

Along with the checklist update, a new pull request template was added - it contains a checklist for the PR submitter to run through to ensure the baseline standards for the PR are met.