### PR TITLE
Use SES to send email on behalf of Cognito; Tidy noreply@ emails

### DIFF
--- a/docs/architecture/email.md
+++ b/docs/architecture/email.md
@@ -44,3 +44,56 @@ Notes:
 2. EF-CMS uses Amazon SES Easy DKIM, [which uses a 1024-bit key](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-authentication-dkim-easy.html).
 3. Amazon SES does not support DNSSEC on its Easy DKIM signing domains.
 4. Encrypting emails with S/MIME would reduce the effectiveness of email notifications, as some recipients would not be able to decrypt the emails. No sensitive information is sent in email notifications.
+
+### Verifying SES Email
+
+At present this is a manual process as a human needs to click on the link in the email in order to verify ownership. We verify ownership so that we can use that verified email's ARN in [our Cognito configuration](../../web-api/terraform/template/cognito.tf). This lets us send more email than Cognito's very low quotas allow. 
+
+Here are the steps required to verify a new email:
+
+1. Need to create an s3 bucket (e.g. `mail-verification.example.com`)
+2. Need to grant SES permission to write to it. Replace `BUCKET-NAME` and `AWSACCCOUNTID` in the following policy, and apply it to the newly created bucket:
+
+    ```json
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AllowSESPuts",
+                "Effect": "Allow",
+                "Principal": {
+                    "Service": "ses.amazonaws.com"
+                },
+                "Action": "s3:PutObject",
+                "Resource": "arn:aws:s3:::BUCKET-NAME/*",
+                "Condition": {
+                    "StringEquals": {
+                        "aws:Referer": "AWSACCOUNTID"
+                    }
+                }
+            }
+        ]
+    }
+    ```
+
+3. In SES, create a rule set: (e.g., `confirm_email_helper`)
+4. Need to create a Rule in that has the following attributes: (Replace `BUCKET-NAME`)
+
+   ```json
+   {
+      "Name": "Confirm Email Rule",
+      "Enabled": true,
+      "Actions": [
+        {
+          "S3Action": {
+            "BucketName": "BUCKET-NAME"
+          }
+        }
+      ]
+    }
+    ```
+
+5. Need to make the Rule Set active
+6. Use SES to send a verification email to that account.
+7. Check the S3 bucket. It should have an item in there with a link to confirm the Email Address. Follow the link, and the email address should be verified.
+8. When complete, delete the S3 Bucket, SES Rule, and SES Rule Set. Future deploys should rely on the verified email.

--- a/web-api/terraform/template/cognito-trigger.tf
+++ b/web-api/terraform/template/cognito-trigger.tf
@@ -32,7 +32,7 @@ resource "aws_lambda_function" "cognito_post_confirmation_lambda" {
       MASTER_REGION                  = "us-east-1"
       STAGE                          = var.environment
       NODE_ENV                       = "production"
-      EMAIL_SOURCE                   = "noreply@mail.${var.dns_domain}"
+      EMAIL_SOURCE                   = "noreply@${var.dns_domain}"
       EMAIL_DOCUMENT_SERVED_TEMPLATE = "document_served_${var.environment}"
       EMAIL_SERVED_PETITION_TEMPLATE = "petition_served_${var.environment}"
       EFCMS_DOMAIN                   = var.dns_domain

--- a/web-api/terraform/template/cognito.tf
+++ b/web-api/terraform/template/cognito.tf
@@ -27,7 +27,7 @@ resource "aws_cognito_user_pool" "pool" {
   }
 
   email_configuration { # Use SES to send email
-    source_arn = aws_ses_email_identity.ses_sender
+    source_arn = aws_ses_email_identity.ses_sender.arn
     email_sending_account = "DEVELOPER"
     reply_to_email_address = "noreply@${var.dns_domain}"
     from_email_address = "U.S. Tax Court <noreply@${var.dns_domain}>" 

--- a/web-api/terraform/template/cognito.tf
+++ b/web-api/terraform/template/cognito.tf
@@ -26,6 +26,12 @@ resource "aws_cognito_user_pool" "pool" {
     }
   }
 
+  # Use SES to send email
+  source_arn = aws_ses_email_identity.ses_sender
+  email_sending_account = "DEVELOPER"
+  reply_to_email_address = "noreply@${var.dns_domain}"
+  from_email_address = "U.S. Tax Court <noreply@${var.dns_domain}>" 
+  
   schema {
     attribute_data_type = "String"
     name                = "email"

--- a/web-api/terraform/template/cognito.tf
+++ b/web-api/terraform/template/cognito.tf
@@ -26,11 +26,12 @@ resource "aws_cognito_user_pool" "pool" {
     }
   }
 
-  # Use SES to send email
-  source_arn = aws_ses_email_identity.ses_sender
-  email_sending_account = "DEVELOPER"
-  reply_to_email_address = "noreply@${var.dns_domain}"
-  from_email_address = "U.S. Tax Court <noreply@${var.dns_domain}>" 
+  email_config { # Use SES to send email
+    source_arn = aws_ses_email_identity.ses_sender
+    email_sending_account = "DEVELOPER"
+    reply_to_email_address = "noreply@${var.dns_domain}"
+    from_email_address = "U.S. Tax Court <noreply@${var.dns_domain}>" 
+  }
   
   schema {
     attribute_data_type = "String"

--- a/web-api/terraform/template/cognito.tf
+++ b/web-api/terraform/template/cognito.tf
@@ -26,7 +26,7 @@ resource "aws_cognito_user_pool" "pool" {
     }
   }
 
-  email_config { # Use SES to send email
+  email_configuration { # Use SES to send email
     source_arn = aws_ses_email_identity.ses_sender
     email_sending_account = "DEVELOPER"
     reply_to_email_address = "noreply@${var.dns_domain}"

--- a/web-api/terraform/template/locals.tf
+++ b/web-api/terraform/template/locals.tf
@@ -10,7 +10,7 @@ data "null_data_source" "locals" {
     USER_POOL_ID                   = aws_cognito_user_pool.pool.id
     USER_POOL_IRS_ID               = aws_cognito_user_pool.irs_pool.id
     NODE_ENV                       = "production"
-    EMAIL_SOURCE                   = "noreply@mail.${var.dns_domain}"
+    EMAIL_SOURCE                   = "noreply@${var.dns_domain}"
     EMAIL_DOCUMENT_SERVED_TEMPLATE = "document_served_${var.environment}"
     EMAIL_SERVED_PETITION_TEMPLATE = "petition_served_${var.environment}"
     EFCMS_DOMAIN                   = var.dns_domain

--- a/web-api/terraform/template/ses.tf
+++ b/web-api/terraform/template/ses.tf
@@ -14,13 +14,16 @@ resource "aws_route53_record" "ses_verification_record" {
 
 resource "aws_ses_domain_identity_verification" "example_verification" {
   domain = aws_ses_domain_identity.main.id
-
   depends_on = [aws_route53_record.ses_verification_record]
 }
 
 resource "aws_ses_domain_mail_from" "main" {
   domain           = aws_ses_domain_identity.main.domain
   mail_from_domain = "from.${aws_ses_domain_identity.main.domain}"
+}
+
+resource "aws_ses_email_identity" "ses_sender" {
+  email = "noreply@${var.dns_domain}"
 }
 
 #


### PR DESCRIPTION
To complete ustaxcourt/ef-cms#6666, in conjunction with ustaxcourt/ef-cms#6674 and https://github.com/flexion/ef-cms/issues/6824, this PR aims to establish SES as the sender of email and inform Cognito of this change. It includes documentation in docs/architecture/email.md for manually verifying an email in order to permit Cognito to use the ARN of the Verified Email address. It also cleans up the noreply@ email to use the `EFCMS_DOMAIN` (removing the errant `mail.` prefix.)

This also fixes ustaxcourt/ef-cms#6668.