### PR TITLE
Increase the volume size for Kibana

### DIFF
--- a/iam/terraform/account-specific/main/elasticsearch.tf
+++ b/iam/terraform/account-specific/main/elasticsearch.tf
@@ -25,7 +25,7 @@ resource "aws_elasticsearch_domain" "efcms-logs" {
 
   ebs_options{
     ebs_enabled = true
-    volume_size = 10
+    volume_size = 30
   }
 
   snapshot_options {


### PR DESCRIPTION
To assist with #317 -- we need increased resources to index all of the items that we are attempting to index in Elasticsearch to monitor in Kibana. This increases the ebs from 10GB to 30GB. With 3 nodes, that should be enough (for now).