### PR TITLE
Add alarms for UIs being unavailable.

### DIFF
--- a/iam/terraform/account-specific/main/circle-ci.tf
+++ b/iam/terraform/account-specific/main/circle-ci.tf
@@ -26,7 +26,12 @@ resource "aws_iam_policy" "circle_ci_policy" {
         "route53:ListHostedZones",
         "route53:ChangeResourceRecordSets",
         "route53:ListTagsForResource",
-        "route53:ListHostedZonesByName"
+        "route53:ListHostedZonesByName",
+        "route53:CreateHealthCheck",
+        "route53:DeleteHealthCheck",
+        "route53:GetHealthCheck",
+        "route53:ListHealthChecks",
+        "route53:UpdateHealthCheck"
       ],
       "Resource": "*"
     },

--- a/iam/terraform/account-specific/main/system-health-alarms.tf
+++ b/iam/terraform/account-specific/main/system-health-alarms.tf
@@ -1,0 +1,4 @@
+// Target for system health notifications; subscriptions are manually managed.
+resource "aws_sns_topic" "system_health_alarms" {
+  name = "system_health_alarms"
+}

--- a/web-client/terraform/main/main.tf
+++ b/web-client/terraform/main/main.tf
@@ -152,7 +152,7 @@ resource "aws_cloudwatch_metric_alarm" "public_ui_health_check" {
   statistic           = "Minimum"
   threshold           = "1"
   evaluation_periods  = "2"
-  period              = "30"
+  period              = "60"
 
   dimensions = {
     HealthCheckId = aws_route53_health_check.public_ui_health_check.id
@@ -180,7 +180,7 @@ resource "aws_cloudwatch_metric_alarm" "ui_health_check" {
   statistic           = "Minimum"
   threshold           = "1"
   evaluation_periods  = "2"
-  period              = "30"
+  period              = "60"
 
   dimensions = {
     HealthCheckId = aws_route53_health_check.ui_health_check.id

--- a/web-client/terraform/main/main.tf
+++ b/web-client/terraform/main/main.tf
@@ -138,3 +138,64 @@ resource "aws_route53_record" "statuspage" {
     var.statuspage_dns_record
   ]
 }
+
+data "aws_sns_topic" "system_health_alarms" {
+  // account-level resource
+  name = "system_health_alarms"
+}
+
+resource "aws_cloudwatch_metric_alarm" "public_ui_health_check" {
+  alarm_name          = "Public UI is accessible over HTTPS"
+  namespace           = "AWS/Route53"
+  metric_name         = "HealthCheckStatus"
+  comparison_operator = "LessThanThreshold"
+  statistic           = "Minimum"
+  threshold           = "1"
+  evaluation_periods  = "2"
+  period              = "30"
+
+  dimensions = {
+    HealthCheckId = aws_route53_health_check.public_ui_health_check.id
+  }
+
+  alarm_actions = [data.aws_sns_topic.system_health_alarms.arn]
+  insufficient_data_actions = [data.aws_sns_topic.system_health_alarms.arn]
+  ok_actions = [data.aws_sns_topic.system_health_alarms.arn]
+}
+
+resource "aws_route53_health_check" "public_ui_health_check" {
+  fqdn              = var.dns_domain
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "/"
+  failure_threshold = "2"
+  request_interval  = "30"
+}
+
+resource "aws_cloudwatch_metric_alarm" "ui_health_check" {
+  alarm_name          = "Authenticated UI is accessible over HTTPS"
+  namespace           = "AWS/Route53"
+  metric_name         = "HealthCheckStatus"
+  comparison_operator = "LessThanThreshold"
+  statistic           = "Minimum"
+  threshold           = "1"
+  evaluation_periods  = "2"
+  period              = "30"
+
+  dimensions = {
+    HealthCheckId = aws_route53_health_check.ui_health_check.id
+  }
+
+  alarm_actions = [data.aws_sns_topic.system_health_alarms.arn]
+  insufficient_data_actions = [data.aws_sns_topic.system_health_alarms.arn]
+  ok_actions = [data.aws_sns_topic.system_health_alarms.arn]
+}
+
+resource "aws_route53_health_check" "ui_health_check" {
+  fqdn              = "app.${var.dns_domain}"
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "/"
+  failure_threshold = "2"
+  request_interval  = "30"
+}

--- a/web-client/terraform/main/main.tf
+++ b/web-client/terraform/main/main.tf
@@ -145,7 +145,7 @@ data "aws_sns_topic" "system_health_alarms" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "public_ui_health_check" {
-  alarm_name          = "Public UI is accessible over HTTPS"
+  alarm_name          = "${var.dns_domain} is accessible over HTTPS"
   namespace           = "AWS/Route53"
   metric_name         = "HealthCheckStatus"
   comparison_operator = "LessThanThreshold"
@@ -173,7 +173,7 @@ resource "aws_route53_health_check" "public_ui_health_check" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ui_health_check" {
-  alarm_name          = "Authenticated UI is accessible over HTTPS"
+  alarm_name          = "app.${var.dns_domain} is accessible over HTTPS"
   namespace           = "AWS/Route53"
   metric_name         = "HealthCheckStatus"
   comparison_operator = "LessThanThreshold"


### PR DESCRIPTION
To achieve part of #250, this will notify SNS when the public UI or authenticated UI are unavailable. Subscriptions for alertees can be manually managed through the AWS console. 

- [Ran the account-specific step](https://ustaxcourt.slack.com/archives/C015SEE9CUU/p1603749691147000?thread_ts=1603749166.145600&cid=C015SEE9CUU) in the `staging` AWS account already to test. 
- Kicked off a deploy to `develop` to test in that environment, but I think the `develop` environment hasn’t been fixed since blue/green deployments were introduced. I’ll take a look in the morning, but here’s the diff for review in the meantime! 