### PR TITLE
Log tweaks: Include environment information in log messages, use syslog logging levels.

### DIFF
--- a/shared/src/utilities/createLogger.js
+++ b/shared/src/utilities/createLogger.js
@@ -3,6 +3,7 @@ const json = require('logform/json');
 const printf = require('logform/printf');
 const timestamp = require('logform/timestamp');
 const {
+  config,
   createLogger: createWinstonLogger,
   format,
   transports,
@@ -39,5 +40,6 @@ exports.createLogger = defaultMeta =>
         : nonProductionFormatters),
     ),
     level: process.env.LOG_LEVEL || 'debug',
+    levels: config.syslog.levels,
     transports: [new transports.Console()],
   });

--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -1236,7 +1236,13 @@ module.exports = (appContextUser, requestId) => {
     return user;
   };
 
-  const logger = createLogger({ requestId });
+  const logger = createLogger({
+    environment: {
+      color: environment.currentColor,
+      stage: environment.stage,
+    },
+    requestId,
+  });
 
   return {
     barNumberGenerator,


### PR DESCRIPTION
As a followup to our audit logging discussions on Friday:

- Include the environment in log messages. This will help filter messages in Kibana to only the environment we’re interested in (stg, dev, mig, irs, etc). 
  - I also included the environment’s color configuration in the logs as well. That seems like it will be very helpful for metrics (ensuring requests switch colors when an environment switches colors, especially considering DNS propagation may be required).
- Use syslog logging levels. This [configures Winston to use syslog](https://github.com/winstonjs/winston#logging-levels) levels as specified in RFC5424: 

  ```javascript
  { 
    emerg: 0, 
    alert: 1, 
    crit: 2, 
    error: 3, 
    warning: 4, 
    notice: 5, 
    info: 6, 
    debug: 7
  }
  ```

  As per discussion, we’d like to continue to configure `LOG_LEVEL` to `info`, but would like to introduce using `notice` for logging messages which are required for auditing purposes.