### PR TITLE
Update LogsToElasticSearch_info.

### DIFF
--- a/aws/lambdas/LogsToElasticSearch_info/index-template.md
+++ b/aws/lambdas/LogsToElasticSearch_info/index-template.md
@@ -1,0 +1,52 @@
+# Elasticsearch Index Template
+
+When parsing log entries into an index, Elasticsearch will attempt to create a new index with dynamic field mappings if it does not already exist (the normal behavior). We can control how Elasticsearch performs that operation with an Index Template.
+
+Because log entries may contain data which is of an unknown shape and size, it is desirable to [limit the dynamic field mappings](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html#mapping-limit-settings) that occur. Say more!
+
+- Defining too many fields in an index can cause memory errors that are difficult to recover from.
+- There are limits in place in Elasticsearch to prevent this from happening.
+  - By default, an index will reject new entries if it would cause the field mapping to increase beyond 1,000 fields.
+  - By default, Elasticsearch will prevent returning entries from queries with more than 1,000 fields.
+
+## Current Index Template
+
+Terraform 0.13 introduces a new kind of module which may enable us to manage Elasticsearch and Kibana resources through Terraform. Until then, we’re manually updating this Index Template through Kibana’s Dev Tools (the wrench icon).
+
+To view the current templates defined:
+
+```
+GET _template
+```
+
+To create or update the `cwl` mapping template, which matches the indexes created by `LogsToElasticSearch_info`:
+
+```
+PUT _template/cwl
+{
+  "index_patterns": ["cwl-*"],
+  "mappings": {
+    "properties": {
+      "metadata": { "type": "object", "dynamic": false },
+      "environment": {
+        "properties": {
+          "color": { "type": "keyword" },
+          "stage": { "type": "keyword" }
+        }
+      },
+      "level": { "type": "keyword" },
+      "logGroup": { "type": "text" },
+      "logStream": { "type": "text" },
+      "message": { "type": "text" },
+      "requestId": {
+        "properties": {
+          "apiGateway": { "type": "keyword" },
+          "applicationLoadBalancer": { "type": "keyword" },
+          "lambda": { "type": "keyword" }
+        }
+      },
+      "timestamp": { "type": "date" }
+    }
+  }
+}
+```

--- a/aws/lambdas/LogsToElasticSearch_info/index.js
+++ b/aws/lambdas/LogsToElasticSearch_info/index.js
@@ -10,34 +10,28 @@ const gunzip = promisify(zlib.gunzip);
 const logFailedResponses = true;
 
 exports.handler = async (input, context) => {
-  // decode input from base64
-  let zippedInput = new Buffer.from(input.awslogs.data, 'base64');
+  let payload;
 
-  // decompress the input
-  let buffer;
   try {
-    buffer = await gunzip(zippedInput);
+    payload = await decompressAndParse(input.awslogs.data);
   } catch (error) {
     context.fail(error);
     return;
   }
 
-  // parse the input from JSON
-  const awslogsData = JSON.parse(buffer.toString('utf8'));
-
-  // transform the input to Elasticsearch documents
-  const elasticsearchBulkData = transform(awslogsData);
-
-  // skip control messages
-  if (!elasticsearchBulkData) {
+  if (payload.messageType === 'CONTROL_MESSAGE') {
     console.log('Received a control message');
     context.succeed('Control message handled successfully');
     return;
   }
 
+  const inserts = payload.logEvents
+    .map(convertLogEventToElasticSearchInsert.bind(null, payload))
+    .join('\n');
+
   // post documents to the Amazon Elasticsearch Service
-  const { error, failedItems, statusCode, success } = post(
-    elasticsearchBulkData,
+  const { error, failedItems, statusCode, success } = await post(
+    inserts + '\n',
   );
 
   console.log(`Response: ${JSON.stringify({ statusCode })}`);
@@ -51,50 +45,41 @@ exports.handler = async (input, context) => {
   }
 };
 
-/**
- * Transform the log input to Elasticsearch documents
- *
- * @returns {string} JSON-encoded string of messages
- */
-function transform(payload) {
-  if (payload.messageType === 'CONTROL_MESSAGE') {
-    return null;
-  }
+const decompressAndParse = async data => {
+  const zippedInput = new Buffer.from(data, 'base64');
+  const buffer = await gunzip(zippedInput);
+  return JSON.parse(buffer.toString('utf8'));
+};
 
-  let bulkRequestBody = '';
+const convertLogEventToElasticSearchInsert = (payload, logEvent) => {
+  const timestamp = new Date(1 * logEvent.timestamp);
 
-  payload.logEvents.forEach(function (logEvent) {
-    let timestamp = new Date(1 * logEvent.timestamp);
+  // index name format: cwl-YYYY.MM.DD
+  const indexName = [
+    `cwl-${timestamp.getUTCFullYear()}`, // year
+    ('0' + (timestamp.getUTCMonth() + 1)).slice(-2), // month
+    ('0' + timestamp.getUTCDate()).slice(-2), // day
+  ].join('.');
 
-    // index name format: cwl-YYYY.MM.DD
-    let indexName = [
-      'cwl-' + timestamp.getUTCFullYear(), // year
-      ('0' + (timestamp.getUTCMonth() + 1)).slice(-2), // month
-      ('0' + timestamp.getUTCDate()).slice(-2), // day
-    ].join('.');
+  let source = {};
+  source['logdata'] = extractData(logEvent.message, logEvent.extractedFields);
+  source['@id'] = logEvent.id;
+  source['@timestamp'] = new Date(1 * logEvent.timestamp).toISOString();
+  source['@message'] = logEvent.message;
+  source['@owner'] = payload.owner;
+  source['@log_group'] = payload.logGroup;
+  source['@log_stream'] = payload.logStream;
 
-    let source = {};
-    source['logdata'] = extractData(logEvent.message, logEvent.extractedFields);
-    source['@id'] = logEvent.id;
-    source['@timestamp'] = new Date(1 * logEvent.timestamp).toISOString();
-    source['@message'] = logEvent.message;
-    source['@owner'] = payload.owner;
-    source['@log_group'] = payload.logGroup;
-    source['@log_stream'] = payload.logStream;
+  // Dangling underscores required by Elasticsearch’s bulk insert format
+  /* eslint-disable no-underscore-dangle */
+  let action = { index: {} };
+  action.index._index = indexName;
+  action.index._type = 'ef-cms-info';
+  action.index._id = logEvent.id;
+  /* eslint-enable no-underscore-dangle */
 
-    // Dangling underscores required by Elasticsearch’s bulk insert format
-    /* eslint-disable no-underscore-dangle */
-    let action = { index: {} };
-    action.index._index = indexName;
-    action.index._type = 'ef-cms-info';
-    action.index._id = logEvent.id;
-    /* eslint-enable no-underscore-dangle */
-
-    bulkRequestBody +=
-      [JSON.stringify(action), JSON.stringify(source)].join('\n') + '\n';
-  });
-  return bulkRequestBody;
-}
+  return [JSON.stringify(action), JSON.stringify(source)].join('\n');
+};
 
 /**
  * Extract log data from an individual log message
@@ -170,47 +155,56 @@ function isNumeric(n) {
 
 /**
  * Sends a POST request to Elasticsearch.
+ *
+ * @returns {Promise<Object>} information about the response
  */
-function post(body) {
-  const requestParams = buildRequest(process.env.es_endpoint, body);
+async function post(body) {
+  return new Promise(resolve => {
+    const requestParams = buildRequest(process.env.es_endpoint, body);
 
-  const request = https.request(requestParams, response => {
-    let responseBody = '';
-    response.on('data', chunk => (responseBody += chunk));
+    const request = https.request(requestParams, response => {
+      let responseBody = '';
+      response.on('data', chunk => (responseBody += chunk));
 
-    response.on('end', () => {
-      let info = JSON.parse(responseBody);
-      let failedItems;
-      let success;
-      let error;
+      response.on('end', () => {
+        let info = JSON.parse(responseBody);
+        let failedItems;
+        let success;
+        let error;
 
-      if (response.statusCode >= 200 && response.statusCode < 299) {
-        failedItems = info.items.filter(function (x) {
-          return x.index.status >= 300;
-        });
+        if (response.statusCode >= 200 && response.statusCode < 299) {
+          failedItems = info.items.filter(function (x) {
+            return x.index.status >= 300;
+          });
 
-        success = {
-          attemptedItems: info.items.length,
-          failedItems: failedItems.length,
-          successfulItems: info.items.length - failedItems.length,
-        };
-      }
+          success = {
+            attemptedItems: info.items.length,
+            failedItems: failedItems.length,
+            successfulItems: info.items.length - failedItems.length,
+          };
+        }
 
-      if (response.statusCode !== 200 || info.errors === true) {
-        // prevents logging of failed entries, but allows logging
-        // of other errors such as access restrictions
-        delete info.items;
-        error = {
-          responseBody: info,
+        if (response.statusCode !== 200 || info.errors === true) {
+          // prevents logging of failed entries, but allows logging
+          // of other errors such as access restrictions
+          delete info.items;
+          error = {
+            responseBody: info,
+            statusCode: response.statusCode,
+          };
+        }
+
+        resolve({
+          error,
+          failedItems,
           statusCode: response.statusCode,
-        };
-      }
-
-      return { error, failedItems, statusCode: response.statusCode, success };
+          success,
+        });
+      });
     });
-  });
 
-  request.end(requestParams.body);
+    request.end(requestParams.body);
+  });
 }
 
 /**

--- a/aws/lambdas/LogsToElasticSearch_info/index.js
+++ b/aws/lambdas/LogsToElasticSearch_info/index.js
@@ -1,269 +1,334 @@
-/* eslint-disable */
-
-/*
-/* This Lambda is taken from the magically-generated lambda that is created
-/* in AWS Console when setting up a log subscription to our Elasticsearch Kibana domain.
-/* We need to host this lambda in order to manage it via Terraform.
-*/
-
-// v1.1.2
-var https = require('https');
-var zlib = require('zlib');
-var crypto = require('crypto');
+const crypto = require('crypto');
+const https = require('https');
+const zlib = require('zlib');
 
 // Set this to true if you want to debug why data isn't making it to
 // your Elasticsearch cluster. This will enable logging of failed items
 // to CloudWatch Logs.
-var logFailedResponses = true;
+const logFailedResponses = true;
 
-exports.handler = function(input, context) {
-    // decode input from base64
-    var zippedInput = new Buffer.from(input.awslogs.data, 'base64');
+exports.handler = function (input, context) {
+  // decode input from base64
+  let zippedInput = new Buffer.from(input.awslogs.data, 'base64');
 
-    // decompress the input
-    zlib.gunzip(zippedInput, function(error, buffer) {
-        if (error) { context.fail(error); return; }
+  // decompress the input
+  zlib.gunzip(zippedInput, function (error, buffer) {
+    if (error) {
+      context.fail(error);
+      return;
+    }
 
-        // parse the input from JSON
-        var awslogsData = JSON.parse(buffer.toString('utf8'));
+    // parse the input from JSON
+    const awslogsData = JSON.parse(buffer.toString('utf8'));
 
-        // transform the input to Elasticsearch documents
-        var elasticsearchBulkData = transform(awslogsData);
+    // transform the input to Elasticsearch documents
+    const elasticsearchBulkData = transform(awslogsData);
 
-        // skip control messages
-        if (!elasticsearchBulkData) {
-            console.log('Received a control message');
-            context.succeed('Control message handled successfully');
-            return;
-        }
+    // skip control messages
+    if (!elasticsearchBulkData) {
+      console.log('Received a control message');
+      context.succeed('Control message handled successfully');
+      return;
+    }
 
-        // post documents to the Amazon Elasticsearch Service
-        post(elasticsearchBulkData, function(error, success, statusCode, failedItems) {
-            console.log('Response: ' + JSON.stringify({
-                "statusCode": statusCode
-            }));
+    // post documents to the Amazon Elasticsearch Service
+    post(elasticsearchBulkData, function (
+      error2,
+      success,
+      statusCode,
+      failedItems,
+    ) {
+      console.log(
+        'Response: ' +
+          JSON.stringify({
+            statusCode: statusCode,
+          }),
+      );
 
-            if (error) {
-                logFailure(error, failedItems);
-                context.fail(JSON.stringify(error));
-            } else {
-                console.log('Success: ' + JSON.stringify(success));
-                context.succeed('Success');
-            }
-        });
+      if (error2) {
+        logFailure(error2, failedItems);
+        context.fail(JSON.stringify(error2));
+      } else {
+        console.log('Success: ' + JSON.stringify(success));
+        context.succeed('Success');
+      }
     });
+  });
 };
 
+/**
+ * Transform the log input to Elasticsearch documents
+ *
+ * @returns {string} JSON-encoded string of messages
+ */
 function transform(payload) {
-    if (payload.messageType === 'CONTROL_MESSAGE') {
-        return null;
-    }
+  if (payload.messageType === 'CONTROL_MESSAGE') {
+    return null;
+  }
 
-    var bulkRequestBody = '';
+  let bulkRequestBody = '';
 
-    payload.logEvents.forEach(function(logEvent) {
-        var timestamp = new Date(1 * logEvent.timestamp);
+  payload.logEvents.forEach(function (logEvent) {
+    let timestamp = new Date(1 * logEvent.timestamp);
 
-        // index name format: cwl-YYYY.MM.DD
-        var indexName = [
-            'cwl-' + timestamp.getUTCFullYear(),              // year
-            ('0' + (timestamp.getUTCMonth() + 1)).slice(-2),  // month
-            ('0' + timestamp.getUTCDate()).slice(-2)          // day
-        ].join('.');
+    // index name format: cwl-YYYY.MM.DD
+    let indexName = [
+      'cwl-' + timestamp.getUTCFullYear(), // year
+      ('0' + (timestamp.getUTCMonth() + 1)).slice(-2), // month
+      ('0' + timestamp.getUTCDate()).slice(-2), // day
+    ].join('.');
 
-        var source = {};
-        source['logdata'] = extractData(logEvent.message, logEvent.extractedFields);
-        source['@id'] = logEvent.id;
-        source['@timestamp'] = new Date(1 * logEvent.timestamp).toISOString();
-        source['@message'] = logEvent.message;
-        source['@owner'] = payload.owner;
-        source['@log_group'] = payload.logGroup;
-        source['@log_stream'] = payload.logStream;
+    let source = {};
+    source['logdata'] = extractData(logEvent.message, logEvent.extractedFields);
+    source['@id'] = logEvent.id;
+    source['@timestamp'] = new Date(1 * logEvent.timestamp).toISOString();
+    source['@message'] = logEvent.message;
+    source['@owner'] = payload.owner;
+    source['@log_group'] = payload.logGroup;
+    source['@log_stream'] = payload.logStream;
 
-        var action = { "index": {} };
-        action.index._index = indexName;
-        action.index._type = 'ef-cms-info';
-        action.index._id = logEvent.id;
+    // Dangling underscores required by Elasticsearch’s bulk insert format
+    /* eslint-disable no-underscore-dangle */
+    let action = { index: {} };
+    action.index._index = indexName;
+    action.index._type = 'ef-cms-info';
+    action.index._id = logEvent.id;
+    /* eslint-enable no-underscore-dangle */
 
-        bulkRequestBody += [
-            JSON.stringify(action),
-            JSON.stringify(source),
-        ].join('\n') + '\n';
-    });
-    return bulkRequestBody;
+    bulkRequestBody +=
+      [JSON.stringify(action), JSON.stringify(source)].join('\n') + '\n';
+  });
+  return bulkRequestBody;
 }
 
+/**
+ * Extract log data from an individual log message
+ *
+ * @returns {Object} the log message extracted to a data object
+ */
 function extractData(message, extractedFields) {
-    if (extractedFields) {
-        var data = {};
+  if (extractedFields) {
+    let data = {};
 
-        for (var key in extractedFields) {
-            if (extractedFields.hasOwnProperty(key) && extractedFields[key]) {
-                var value = extractedFields[key];
+    for (let key in extractedFields) {
+      if (extractedFields.hasOwnProperty(key) && extractedFields[key]) {
+        let value = extractedFields[key];
 
-                if (isNumeric(value)) {
-                    data[key] = 1 * value;
-                    continue;
-                }
-
-                jsonSubString = extractJson(value);
-                if (jsonSubString !== null) {
-                    data['$' + key] = JSON.parse(jsonSubString);
-                }
-
-                data[key] = value;
-            }
+        if (isNumeric(value)) {
+          data[key] = 1 * value;
+          continue;
         }
-        return data;
-    }
 
-    jsonSubString = extractJson(message);
-    if (jsonSubString !== null) {
-        return JSON.parse(jsonSubString);
-    }
+        const jsonSubString = extractJson(value);
+        if (jsonSubString !== null) {
+          data['$' + key] = JSON.parse(jsonSubString);
+        }
 
-    return {};
+        data[key] = value;
+      }
+    }
+    return data;
+  }
+
+  const jsonSubString = extractJson(message);
+  if (jsonSubString !== null) {
+    return JSON.parse(jsonSubString);
+  }
+
+  return {};
 }
 
+/**
+ * Return first JSON substring of a message, if it exists.
+ *
+ * @returns {string} JSON-encoded data
+ */
 function extractJson(message) {
-    var jsonStart = message.indexOf('{');
-    if (jsonStart < 0) return null;
-    var jsonSubString = message.substring(jsonStart);
-    return isValidJson(jsonSubString) ? jsonSubString : null;
+  let jsonStart = message.indexOf('{');
+  if (jsonStart < 0) return null;
+  let jsonSubString = message.substring(jsonStart);
+  return isValidJson(jsonSubString) ? jsonSubString : null;
 }
 
+/**
+ * Determines if a passed string is valid JSON
+ *
+ * @returns {boolean} if the string is JSON or not
+ */
 function isValidJson(message) {
-    try {
-        JSON.parse(message);
-    } catch (e) { return false; }
-    return true;
+  try {
+    JSON.parse(message);
+  } catch (e) {
+    return false;
+  }
+  return true;
 }
 
+/**
+ * Determines if a passed string is numeric (float or integer)
+ *
+ * @returns {boolean} if the string is numeric or not
+ */
 function isNumeric(n) {
-    return !isNaN(parseFloat(n)) && isFinite(n);
+  return !isNaN(parseFloat(n)) && isFinite(n);
 }
 
+/**
+ * Sends a POST request to Elasticsearch.
+ */
 function post(body, callback) {
-    var requestParams = buildRequest(process.env.es_endpoint, body);
+  let requestParams = buildRequest(process.env.es_endpoint, body);
 
-    var request = https.request(requestParams, function(response) {
-        var responseBody = '';
-        response.on('data', function(chunk) {
-            responseBody += chunk;
-        });
+  let request = https
+    .request(requestParams, function (response) {
+      let responseBody = '';
+      response.on('data', function (chunk) {
+        responseBody += chunk;
+      });
 
-        response.on('end', function() {
-            var info = JSON.parse(responseBody);
-            var failedItems;
-            var success;
-            var error;
+      response.on('end', function () {
+        let info = JSON.parse(responseBody);
+        let failedItems;
+        let success;
+        let error;
 
-            if (response.statusCode >= 200 && response.statusCode < 299) {
-                failedItems = info.items.filter(function(x) {
-                    return x.index.status >= 300;
-                });
+        if (response.statusCode >= 200 && response.statusCode < 299) {
+          failedItems = info.items.filter(function (x) {
+            return x.index.status >= 300;
+          });
 
-                success = {
-                    "attemptedItems": info.items.length,
-                    "successfulItems": info.items.length - failedItems.length,
-                    "failedItems": failedItems.length
-                };
-            }
+          success = {
+            attemptedItems: info.items.length,
+            failedItems: failedItems.length,
+            successfulItems: info.items.length - failedItems.length,
+          };
+        }
 
-            if (response.statusCode !== 200 || info.errors === true) {
-                // prevents logging of failed entries, but allows logging
-                // of other errors such as access restrictions
-                delete info.items;
-                error = {
-                    statusCode: response.statusCode,
-                    responseBody: info
-                };
-            }
+        if (response.statusCode !== 200 || info.errors === true) {
+          // prevents logging of failed entries, but allows logging
+          // of other errors such as access restrictions
+          delete info.items;
+          error = {
+            responseBody: info,
+            statusCode: response.statusCode,
+          };
+        }
 
-            callback(error, success, response.statusCode, failedItems);
-        });
-    }).on('error', function(e) {
-        callback(e);
+        callback(error, success, response.statusCode, failedItems);
+      });
+    })
+    .on('error', function (e) {
+      callback(e);
     });
-    request.end(requestParams.body);
+  request.end(requestParams.body);
 }
 
+/**
+ * Builds request parameters for a bulk upload to Elasticsearch.
+ *
+ * @returns {Object} The request parameters.
+ */
 function buildRequest(endpoint, body) {
-    var endpointParts = endpoint.match(/^([^\.]+)\.?([^\.]*)\.?([^\.]*)\.amazonaws\.com$/);
-    var region = endpointParts[2];
-    var service = endpointParts[3];
-    var datetime = (new Date()).toISOString().replace(/[:\-]|\.\d{3}/g, '');
-    var date = datetime.substr(0, 8);
-    var kDate = hmac('AWS4' + process.env.AWS_SECRET_ACCESS_KEY, date);
-    var kRegion = hmac(kDate, region);
-    var kService = hmac(kRegion, service);
-    var kSigning = hmac(kService, 'aws4_request');
+  let endpointParts = endpoint.match(
+    /^([^.]+)\.?([^.]*)\.?([^.]*)\.amazonaws\.com$/,
+  );
+  let region = endpointParts[2];
+  let service = endpointParts[3];
+  let datetime = new Date().toISOString().replace(/[:-]|\.\d{3}/g, '');
+  let date = datetime.substr(0, 8);
+  let kDate = hmac('AWS4' + process.env.AWS_SECRET_ACCESS_KEY, date);
+  let kRegion = hmac(kDate, region);
+  let kService = hmac(kRegion, service);
+  let kSigning = hmac(kService, 'aws4_request');
 
-    var request = {
-        host: endpoint,
-        method: 'POST',
-        path: '/_bulk',
-        body: body,
-        headers: {
-            'Content-Type': 'application/json',
-            'Host': endpoint,
-            'Content-Length': Buffer.byteLength(body),
-            'X-Amz-Security-Token': process.env.AWS_SESSION_TOKEN,
-            'X-Amz-Date': datetime
-        }
-    };
+  let request = {
+    body: body,
+    headers: {
+      'Content-Length': Buffer.byteLength(body),
+      'Content-Type': 'application/json',
+      Host: endpoint,
+      'X-Amz-Date': datetime,
+      'X-Amz-Security-Token': process.env.AWS_SESSION_TOKEN,
+    },
+    host: endpoint,
+    method: 'POST',
+    path: '/_bulk',
+  };
 
-    var canonicalHeaders = Object.keys(request.headers)
-        .sort(function(a, b) { return a.toLowerCase() < b.toLowerCase() ? -1 : 1; })
-        .map(function(k) { return k.toLowerCase() + ':' + request.headers[k]; })
-        .join('\n');
+  let canonicalHeaders = Object.keys(request.headers)
+    .sort(function (a, b) {
+      return a.toLowerCase() < b.toLowerCase() ? -1 : 1;
+    })
+    .map(function (k) {
+      return k.toLowerCase() + ':' + request.headers[k];
+    })
+    .join('\n');
 
-    var signedHeaders = Object.keys(request.headers)
-        .map(function(k) { return k.toLowerCase(); })
-        .sort()
-        .join(';');
+  let signedHeaders = Object.keys(request.headers)
+    .map(function (k) {
+      return k.toLowerCase();
+    })
+    .sort()
+    .join(';');
 
-    var canonicalString = [
-        request.method,
-        request.path, '',
-        canonicalHeaders, '',
-        signedHeaders,
-        hash(request.body, 'hex'),
-    ].join('\n');
+  let canonicalString = [
+    request.method,
+    request.path,
+    '',
+    canonicalHeaders,
+    '',
+    signedHeaders,
+    hash(request.body, 'hex'),
+  ].join('\n');
 
-    var credentialString = [ date, region, service, 'aws4_request' ].join('/');
+  let credentialString = [date, region, service, 'aws4_request'].join('/');
 
-    var stringToSign = [
-        'AWS4-HMAC-SHA256',
-        datetime,
-        credentialString,
-        hash(canonicalString, 'hex')
-    ] .join('\n');
+  let stringToSign = [
+    'AWS4-HMAC-SHA256',
+    datetime,
+    credentialString,
+    hash(canonicalString, 'hex'),
+  ].join('\n');
 
-    request.headers.Authorization = [
-        'AWS4-HMAC-SHA256 Credential=' + process.env.AWS_ACCESS_KEY_ID + '/' + credentialString,
-        'SignedHeaders=' + signedHeaders,
-        'Signature=' + hmac(kSigning, stringToSign, 'hex')
-    ].join(', ');
+  request.headers.Authorization = [
+    'AWS4-HMAC-SHA256 Credential=' +
+      process.env.AWS_ACCESS_KEY_ID +
+      '/' +
+      credentialString,
+    'SignedHeaders=' + signedHeaders,
+    'Signature=' + hmac(kSigning, stringToSign, 'hex'),
+  ].join(', ');
 
-    return request;
+  return request;
 }
 
+/**
+ * Creates a SHA256 HMAC digest of a string.
+ *
+ * @returns {string} The calculated digest
+ */
 function hmac(key, str, encoding) {
-    return crypto.createHmac('sha256', key).update(str, 'utf8').digest(encoding);
+  return crypto.createHmac('sha256', key).update(str, 'utf8').digest(encoding);
 }
 
+/**
+ * Creates a SHA256 hash of a string.
+ *
+ * @returns {string} The calculated hash
+ */
 function hash(str, encoding) {
-    return crypto.createHash('sha256').update(str, 'utf8').digest(encoding);
+  return crypto.createHash('sha256').update(str, 'utf8').digest(encoding);
 }
 
+/**
+ * Logs failed responses to the console.
+ */
 function logFailure(error, failedItems) {
-    if (logFailedResponses) {
-        console.log('Error: ' + JSON.stringify(error, null, 2));
+  if (logFailedResponses) {
+    console.log('Error: ' + JSON.stringify(error, null, 2));
 
-        if (failedItems && failedItems.length > 0) {
-            console.log("Failed Items: " +
-                JSON.stringify(failedItems, null, 2));
-        }
+    if (failedItems && failedItems.length > 0) {
+      console.log('Failed Items: ' + JSON.stringify(failedItems, null, 2));
     }
+  }
 }


### PR DESCRIPTION
Note for review: this may be easiest to step through commit-by-commit, as the refactoring commits introduced what appears to be a large changeset. It’s more understandable if you look one change at a time. 😄 

This PR: 

- ♻️ Refactors the `LogsToElasticSearch_info` function:
  - To follow `eslint` JavaScript standards defined elsewhere in the project.
  - To use `async` and `await` instead of callbacks, bringing it up-to-date with the rest of the code base.
  - To abstract the decompression and parsing logic further for greater readability.
- 🤫 Only sends JSON logs to Kibana. Any log entry which fails JSON parsing is ignored, which includes log entries created by AWS with metadata about lambda invocations (desired). 
- 🧹 Introduces an Index Template to our Elasticsearch cluster which will store all log data passed, but indexes only the known log keys. This allows our cluster to accept all log entries without having memory issues or rejecting entries, even those which may have more than 1,000 keys. 

Caveats:

- 🤔 The Index Template needs to be applied to the Elasticsearch cluster after it is created manually. There is [a promising Terraform Elasticsearch provider](https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs) which may allow us to manage this through Terraform — however, it requires Terraform 0.13. I suggest we backlog a ticket to convert this (and any other) Elasticsearch logging resource to Terraform at a later date.

Status:

- This change has already been applied to the Court’s non-production AWS account manually — so you can see the result of this change in the Court’s Kibana interface.