### PR TITLE
Adjust account-specific terraform to manually-applied changes.

### DIFF
--- a/iam/terraform/account-specific/bin/deploy-app.sh
+++ b/iam/terraform/account-specific/bin/deploy-app.sh
@@ -10,6 +10,16 @@ if [ -z "$ES_LOGS_INSTANCE_COUNT" ]; then
   exit 1
 fi
 
+if [ -z "$ES_LOGS_INSTANCE_TYPE" ]; then
+  echo "Please export the ES_LOGS_INSTANCE_TYPE variable in your shell"
+  exit 1
+fi
+
+if [ -z "$ES_LOGS_EBS_VOLUME_SIZE_GB" ]; then
+  echo "Please export the ES_LOGS_EBS_VOLUME_SIZE_GB variable in your shell"
+  exit 1
+fi
+
 if [ -z "$COGNITO_SUFFIX" ]; then
   echo "Please export the COGNITO_SUFFIX variable in your shell"
   exit 1
@@ -40,10 +50,12 @@ export TF_VAR_my_s3_state_bucket="${BUCKET}"
 export TF_VAR_my_s3_state_key="${KEY}"
 export TF_VAR_zone_name="${ZONE_NAME}"
 export TF_VAR_es_logs_instance_count="${ES_LOGS_INSTANCE_COUNT}"
+export TF_VAR_es_logs_instance_type="${ES_LOGS_INSTANCE_TYPE}"
+export TF_VAR_es_logs_ebs_volume_size_gb="${ES_LOGS_EBS_VOLUME_SIZE_GB}"
 export TF_VAR_cognito_suffix="${COGNITO_SUFFIX}"
-# if [ -z "${LOG_GROUP_ENVIRONMENTS}" ]; then 
-#   export TF_VAR_log_group_environments="${LOG_GROUP_ENVIRONMENTS}" 
-# fi
+if [ -z "${LOG_GROUP_ENVIRONMENTS}" ]; then
+  export TF_VAR_log_group_environments="${LOG_GROUP_ENVIRONMENTS}"
+fi
 
 terraform init -backend=true -backend-config=bucket="${BUCKET}" -backend-config=key="${KEY}" -backend-config=dynamodb_table="${LOCK_TABLE}" -backend-config=region="${REGION}"
-terraform apply -auto-approve
+terraform apply

--- a/iam/terraform/account-specific/bin/deploy-app.sh
+++ b/iam/terraform/account-specific/bin/deploy-app.sh
@@ -53,7 +53,7 @@ export TF_VAR_es_logs_instance_count="${ES_LOGS_INSTANCE_COUNT}"
 export TF_VAR_es_logs_instance_type="${ES_LOGS_INSTANCE_TYPE}"
 export TF_VAR_es_logs_ebs_volume_size_gb="${ES_LOGS_EBS_VOLUME_SIZE_GB}"
 export TF_VAR_cognito_suffix="${COGNITO_SUFFIX}"
-if [ -z "${LOG_GROUP_ENVIRONMENTS}" ]; then
+if [ -n "${LOG_GROUP_ENVIRONMENTS}" ]; then
   export TF_VAR_log_group_environments="${LOG_GROUP_ENVIRONMENTS}"
 fi
 

--- a/iam/terraform/account-specific/main/cognito.tf
+++ b/iam/terraform/account-specific/main/cognito.tf
@@ -18,6 +18,12 @@ resource "aws_cognito_user_pool_domain" "log_viewers" {
 resource "aws_cognito_identity_pool" "log_viewers" {
   identity_pool_name               = "kibana dashboard identity pool"
   allow_unauthenticated_identities = false
+
+  lifecycle {
+    ignore_changes = [
+      cognito_identity_providers # AWS Elasticsearch forces management itself
+    ]
+  }
 }
 
 resource "aws_iam_role" "es_kibana_role" {

--- a/iam/terraform/account-specific/main/elasticsearch.tf
+++ b/iam/terraform/account-specific/main/elasticsearch.tf
@@ -23,7 +23,7 @@ resource "aws_elasticsearch_domain" "efcms-logs" {
     tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
   }
 
-  ebs_options{
+  ebs_options {
     ebs_enabled = true
     volume_size = var.es_logs_ebs_volume_size_gb
   }

--- a/iam/terraform/account-specific/main/elasticsearch.tf
+++ b/iam/terraform/account-specific/main/elasticsearch.tf
@@ -7,7 +7,7 @@ resource "aws_elasticsearch_domain" "efcms-logs" {
   elasticsearch_version = "7.4"
 
   cluster_config {
-    instance_type = "t2.small.elasticsearch"
+    instance_type = var.es_logs_instance_type
     instance_count = var.es_logs_instance_count
   }
 
@@ -25,7 +25,7 @@ resource "aws_elasticsearch_domain" "efcms-logs" {
 
   ebs_options{
     ebs_enabled = true
-    volume_size = 10
+    volume_size = var.es_logs_ebs_volume_size_gb
   }
 
   snapshot_options {

--- a/iam/terraform/account-specific/main/lambda-logs-to-elasticsearch.tf
+++ b/iam/terraform/account-specific/main/lambda-logs-to-elasticsearch.tf
@@ -72,3 +72,10 @@ resource "aws_cloudwatch_log_subscription_filter" "cognito_authorizer_filter" {
   log_group_name  = "/aws/lambda/cognito_authorizer_lambda_${element(var.log_group_environments, count.index)}"
 }
 
+resource "aws_cloudwatch_log_subscription_filter" "migration_lambda_filter" {
+  count           = length(var.log_group_environments)
+  destination_arn = aws_lambda_function.logs_to_es.arn
+  filter_pattern  = ""
+  name            = "migration_${element(var.log_group_environments, count.index)}_lambda_filter"
+  log_group_name  = "/aws/lambda/migration_segments_lambda_${element(var.log_group_environments, count.index)}"
+}

--- a/iam/terraform/account-specific/main/variables.tf
+++ b/iam/terraform/account-specific/main/variables.tf
@@ -11,6 +11,16 @@ variable "es_logs_instance_count" {
   default = "1"
 }
 
+variable "es_logs_instance_type" {
+  type    = string
+  default = "t2.medium.elasticsearch"
+}
+
+variable "es_logs_ebs_volume_size_gb" {
+  type    = number
+  default = 20
+}
+
 variable "log_group_environments" {
   description = "deployment environments"
   type        = list(string)


### PR DESCRIPTION
These tweaks have been made to update our logging infrastructure; apply them to terraform to bring things back in line. This change goes hand-in-hand with an update to our [Court-specific environment documentation](https://github.com/ustaxcourt/ef-cms/wiki/AWS-environment-configuration) to document these values.