### PR TITLE
Update with index mapping change.

### DIFF
--- a/aws/lambdas/LogsToElasticSearch_info/index-template.md
+++ b/aws/lambdas/LogsToElasticSearch_info/index-template.md
@@ -27,7 +27,11 @@ PUT _template/cwl
   "index_patterns": ["cwl-*"],
   "mappings": {
     "properties": {
-      "metadata": { "type": "object", "dynamic": false },
+      "metadata": { 
+        "type": "object", 
+        "dynamic": false,
+        "enabled": false
+      },
       "environment": {
         "properties": {
           "color": { "type": "keyword" },


### PR DESCRIPTION
Already applied via Kibana console. I thought the previous changes would have blocked indexing of the `metadata` field, alas, it didn’t. 

This change completely prevents the field from entering the index — it is still stored in the original object, and is visible in Kibana by looking at the JSON representation of the log entry.