### PR TITLE
Add Cloudwatch Alarms for Elasticsearch clusters.

### DIFF
--- a/iam/terraform/account-specific/main/elasticsearch.tf
+++ b/iam/terraform/account-specific/main/elasticsearch.tf
@@ -142,3 +142,16 @@ resource "aws_cognito_identity_pool_roles_attachment" "log_viewers" {
     "authenticated" = aws_iam_role.log_viewers_auth.arn
   }
 }
+
+locals {
+  instance_size_in_mb = aws_elasticsearch_domain.efcms-logs.ebs_options[0].volume_size * 1000
+}
+
+module "logs_alarms" {
+  source = "github.com/dubiety/terraform-aws-elasticsearch-cloudwatch-sns-alarms.git?ref=v1.0.4"
+  domain_name = aws_elasticsearch_domain.efcms-logs.domain_name
+  alarm_name_prefix = "${aws_elasticsearch_domain.efcms-logs.domain_name}: "
+  free_storage_space_threshold = local.instance_size_in_mb * 0.25
+  create_sns_topic = false
+  sns_topic = aws_sns_topic.system_health_alarms.arn
+}

--- a/web-api/terraform/main/main.tf
+++ b/web-api/terraform/main/main.tf
@@ -21,6 +21,11 @@ terraform {
   }
 }
 
+data "aws_sns_topic" "system_health_alarms" {
+  // account-level resource
+  name = "system_health_alarms"
+}
+
 module "ef-cms_apis" {
   source                     = "../template/"
   environment                = var.environment
@@ -40,4 +45,5 @@ module "ef-cms_apis" {
   destination_table          = var.destination_table
   disable_emails             = var.disable_emails
   es_volume_size             = var.es_volume_size
+  alert_sns_topic_arn        = data.aws_sns_topic.system_health_alarms.arn
 }

--- a/web-api/terraform/template/elasticsearch/elasticsearch.tf
+++ b/web-api/terraform/template/elasticsearch/elasticsearch.tf
@@ -49,3 +49,16 @@ resource "aws_elasticsearch_domain" "efcms-search" {
     log_type                 = "ES_APPLICATION_LOGS"
   }
 }
+
+locals {
+  instance_size_in_mb = aws_elasticsearch_domain.efcms-search.ebs_options[0].volume_size * 1000
+}
+
+module "logs_alarms" {
+  source = "github.com/dubiety/terraform-aws-elasticsearch-cloudwatch-sns-alarms.git?ref=v1.0.4"
+  domain_name = aws_elasticsearch_domain.efcms-search.domain_name
+  alarm_name_prefix = "${aws_elasticsearch_domain.efcms-search.domain_name}: "
+  free_storage_space_threshold = local.instance_size_in_mb * 0.25
+  create_sns_topic = false
+  sns_topic = var.alert_sns_topic_arn
+}

--- a/web-api/terraform/template/elasticsearch/variables.tf
+++ b/web-api/terraform/template/elasticsearch/variables.tf
@@ -17,3 +17,7 @@ variable "es_instance_type" {
 variable "es_volume_size" {
   type = number
 }
+
+variable "alert_sns_topic_arn" {
+  type = string
+}

--- a/web-api/terraform/template/main.tf
+++ b/web-api/terraform/template/main.tf
@@ -39,11 +39,12 @@ module "dynamo_table_beta" {
 module "elasticsearch_alpha" {
   source = "./elasticsearch"
 
-  environment       = var.environment
-  domain_name       = "efcms-search-${var.environment}-alpha"
-  es_instance_count = var.es_instance_count
-  es_instance_type  = var.es_instance_type
-  es_volume_size    = var.es_volume_size
+  environment         = var.environment
+  domain_name         = "efcms-search-${var.environment}-alpha"
+  es_instance_count   = var.es_instance_count
+  es_instance_type    = var.es_instance_type
+  es_volume_size      = var.es_volume_size
+  alert_sns_topic_arn = var.alert_sns_topic_arn
 
   providers = {
     aws.us-east-1 = aws.us-east-1
@@ -53,11 +54,12 @@ module "elasticsearch_alpha" {
 module "elasticsearch_beta" {
   source = "./elasticsearch"
 
-  environment       = var.environment
-  domain_name       = "efcms-search-${var.environment}-beta"
-  es_instance_count = var.es_instance_count
-  es_instance_type  = var.es_instance_type
-  es_volume_size    = var.es_volume_size
+  environment         = var.environment
+  domain_name         = "efcms-search-${var.environment}-beta"
+  es_instance_count   = var.es_instance_count
+  es_instance_type    = var.es_instance_type
+  es_volume_size      = var.es_volume_size
+  alert_sns_topic_arn = var.alert_sns_topic_arn
 
   providers = {
     aws.us-east-1 = aws.us-east-1

--- a/web-api/terraform/template/variables.tf
+++ b/web-api/terraform/template/variables.tf
@@ -75,3 +75,7 @@ variable "log_level" {
   type    = string
   default = "info"
 }
+
+variable "alert_sns_topic_arn" {
+  type = string
+}


### PR DESCRIPTION
Re: https://github.com/ustaxcourt/ef-cms/issues/250.

This includes both account-level alarms for the logging cluster as well as alarms for each environment’s cluster.

- This has already been run for the staging AWS account & the `dev` branch.