### PR TITLE
Unskip tests for fixed bugs.

### DIFF
--- a/web-api/src/v1/getCaseLambda.test.js
+++ b/web-api/src/v1/getCaseLambda.test.js
@@ -43,8 +43,7 @@ describe('getCaseLambda', () => {
 
   // the 401 case is handled by API Gateway, and as such isn’t tested here.
 
-  // Currently returns a 500 instead of a 404; bug https://github.com/flexion/ef-cms/issues/6853
-  it.skip('returns 404 when the user is not authorized and the case is not found', async () => {
+  it('returns 404 when the user is not authorized and the case is not found', async () => {
     const user = { role: 'roleWithNoPermissions' };
     const applicationContext = createSilentAppContext(user);
 
@@ -106,8 +105,7 @@ describe('getCaseLambda', () => {
     expect(JSON.parse(response.body).userId).toBeUndefined();
   });
 
-  // Currently returns a 500 instead of a 404; bug https://github.com/flexion/ef-cms/issues/6853
-  it.skip('returns 404 when the docket number isn’t found', async () => {
+  it('returns 404 when the docket number isn’t found', async () => {
     const user = MOCK_USERS['b7d90c05-f6cd-442c-a168-202db587f16f'];
     const applicationContext = createSilentAppContext(user);
 

--- a/web-api/src/v1/getDocumentDownloadUrlLambda.test.js
+++ b/web-api/src/v1/getDocumentDownloadUrlLambda.test.js
@@ -49,8 +49,7 @@ describe('getDocumentDownloadUrlLambda', () => {
     expect(JSON.parse(response.body)).toHaveProperty('message', 'Unauthorized');
   });
 
-  // currently returns 200; bug https://github.com/flexion/ef-cms/issues/6854
-  it.skip('returns 404 when the docket number isn’t found', async () => {
+  it('returns 404 when the docket number isn’t found', async () => {
     const user = MOCK_USERS['b7d90c05-f6cd-442c-a168-202db587f16f'];
     const applicationContext = createSilentAppContext(user);
     const request = Object.assign({}, REQUEST_EVENT, {
@@ -92,9 +91,8 @@ describe('getDocumentDownloadUrlLambda', () => {
     );
   });
 
-  // currently returns 200; bug https://github.com/flexion/ef-cms/issues/6854
-  it.skip('returns 404 when the entity GUID isn’t found', async () => {
-    const user = MOCK_USERS['b7d90c05-f6cd-442c-a168-202db587f16f'];
+  it('returns 404 when the entity GUID isn’t found', async () => {
+    const user = MOCK_USERS['2eee98ac-613f-46bc-afd5-2574d1b15664'];
     const applicationContext = createSilentAppContext(user);
     const request = Object.assign({}, REQUEST_EVENT, {
       pathParameters: {

--- a/web-api/src/v1/marshallers/marshallCase.test.js
+++ b/web-api/src/v1/marshallers/marshallCase.test.js
@@ -79,4 +79,9 @@ describe('marshallCase', () => {
     expect(marshalled.practitioners).toBeDefined();
     expect(marshalled.respondents).toBeDefined();
   });
+
+  it('does not require any attributes to be set', () => {
+    const marshalled = marshallCase({});
+    expect(marshalled).toBeDefined();
+  });
 });


### PR DESCRIPTION
While in this area of the code base, noticed that https://github.com/flexion/ef-cms/issues/6853 and https://github.com/flexion/ef-cms/issues/6854 are now fixed; these tests should be enabled. Additionally, snuck in a quick test to cover optional attribute code branches in the v1 case marshaller.