### PR TITLE
Logging improvements based on load testing.

### DIFF
--- a/web-api/src/app-public.js
+++ b/web-api/src/app-public.js
@@ -2,6 +2,7 @@ const awsServerlessExpressMiddleware = require('aws-serverless-express/middlewar
 const bodyParser = require('body-parser');
 const cors = require('cors');
 const express = require('express');
+const logger = require('./logger');
 const { lambdaWrapper } = require('./lambdaWrapper');
 const app = express();
 
@@ -18,6 +19,7 @@ app.use((req, res, next) => {
   return next();
 });
 app.use(awsServerlessExpressMiddleware.eventContext());
+app.use(logger());
 
 const {
   casePublicSearchLambda,

--- a/web-api/src/app.js
+++ b/web-api/src/app.js
@@ -2,6 +2,7 @@ const awsServerlessExpressMiddleware = require('aws-serverless-express/middlewar
 const bodyParser = require('body-parser');
 const cors = require('cors');
 const express = require('express');
+const logger = require('./logger');
 const { lambdaWrapper } = require('./lambdaWrapper');
 const app = express();
 
@@ -18,6 +19,7 @@ app.use((req, res, next) => {
   return next();
 });
 app.use(awsServerlessExpressMiddleware.eventContext());
+app.use(logger());
 
 const {
   addCaseToTrialSessionLambda,

--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -1242,7 +1242,7 @@ const gatewayMethods = {
   zipDocuments,
 };
 
-module.exports = (appContextUser, requestId) => {
+module.exports = (appContextUser, logger = createLogger()) => {
   let user;
 
   if (appContextUser) {
@@ -1253,13 +1253,13 @@ module.exports = (appContextUser, requestId) => {
     return user;
   };
 
-  const logger = createLogger({
-    environment: {
-      color: environment.currentColor,
-      stage: environment.stage,
-    },
-    requestId,
-  });
+  if (process.env.NODE_ENV === 'production') {
+    const authenticated = user && Object.keys(user).length;
+    logger.defaultMeta = logger.defaultMeta || {};
+    logger.defaultMeta.user = authenticated
+      ? user
+      : { role: 'unauthenticated' };
+  }
 
   return {
     barNumberGenerator,

--- a/web-api/src/cases/fileAndServeCourtIssuedDocumentLambda.js
+++ b/web-api/src/cases/fileAndServeCourtIssuedDocumentLambda.js
@@ -7,15 +7,11 @@ const { genericHandler } = require('../genericHandler');
  * @returns {Promise<*|undefined>} the api gateway response object containing the statusCode, body, and headers
  */
 exports.fileAndServeCourtIssuedDocumentLambda = event =>
-  genericHandler(
-    event,
-    async ({ applicationContext }) => {
-      return await applicationContext
-        .getUseCases()
-        .fileAndServeCourtIssuedDocumentInteractor({
-          ...JSON.parse(event.body),
-          applicationContext,
-        });
-    },
-    { logResults: false },
-  );
+  genericHandler(event, async ({ applicationContext }) => {
+    return await applicationContext
+      .getUseCases()
+      .fileAndServeCourtIssuedDocumentInteractor({
+        ...JSON.parse(event.body),
+        applicationContext,
+      });
+  });

--- a/web-api/src/documents/addCoversheetLambda.js
+++ b/web-api/src/documents/addCoversheetLambda.js
@@ -15,5 +15,5 @@ exports.addCoversheetLambda = event =>
         ...event.pathParameters,
       });
     },
-    { logEvent: true, logResults: false },
+    { logResults: false },
   );

--- a/web-api/src/documents/getDocumentDownloadUrlLambda.js
+++ b/web-api/src/documents/getDocumentDownloadUrlLambda.js
@@ -1,6 +1,4 @@
-const createApplicationContext = require('../applicationContext');
 const { genericHandler } = require('../genericHandler');
-const { getUserFromAuthHeader } = require('../middleware/apiGatewayHelper');
 
 /**
  * used for getting the download policy which is needed for users to download files directly from S3 via the UI
@@ -9,22 +7,11 @@ const { getUserFromAuthHeader } = require('../middleware/apiGatewayHelper');
  * @returns {Promise<*|undefined>} the api gateway response object containing the statusCode, body, and headers
  */
 exports.getDocumentDownloadUrlLambda = event =>
-  genericHandler(event, async () => {
-    const user = getUserFromAuthHeader(event);
-    const applicationContext = createApplicationContext(user);
-    try {
-      const results = await applicationContext
-        .getUseCases()
-        .getDownloadPolicyUrlInteractor({
-          applicationContext,
-          ...event.pathParameters,
-        });
-      applicationContext.logger.debug('User', user);
-      applicationContext.logger.debug('Results', results);
-      return results;
-    } catch (e) {
-      applicationContext.logger.error(e);
-      await applicationContext.notifyHoneybadger(e);
-      throw e;
-    }
+  genericHandler(event, async ({ applicationContext }) => {
+    return await applicationContext
+      .getUseCases()
+      .getDownloadPolicyUrlInteractor({
+        applicationContext,
+        ...event.pathParameters,
+      });
   });

--- a/web-api/src/documents/removePdfFromDocketEntryLambda.js
+++ b/web-api/src/documents/removePdfFromDocketEntryLambda.js
@@ -7,17 +7,11 @@ const { genericHandler } = require('../genericHandler');
  * @returns {Promise<*|undefined>} the api gateway response object containing the statusCode, body, and headers
  */
 exports.removePdfFromDocketEntryLambda = event =>
-  genericHandler(
-    event,
-    async ({ applicationContext }) => {
-      return await applicationContext
-        .getUseCases()
-        .removePdfFromDocketEntryInteractor({
-          applicationContext,
-          ...event.pathParameters,
-        });
-    },
-    {
-      logEvent: true,
-    },
-  );
+  genericHandler(event, async ({ applicationContext }) => {
+    return await applicationContext
+      .getUseCases()
+      .removePdfFromDocketEntryInteractor({
+        applicationContext,
+        ...event.pathParameters,
+      });
+  });

--- a/web-api/src/documents/removeSignatureFromDocumentLambda.js
+++ b/web-api/src/documents/removeSignatureFromDocumentLambda.js
@@ -7,17 +7,11 @@ const { genericHandler } = require('../genericHandler');
  * @returns {Promise<*|undefined>} the api gateway response object containing the statusCode, body, and headers
  */
 exports.removeSignatureFromDocumentLambda = event =>
-  genericHandler(
-    event,
-    async ({ applicationContext }) => {
-      return await applicationContext
-        .getUseCases()
-        .removeSignatureFromDocumentInteractor({
-          applicationContext,
-          ...event.pathParameters,
-        });
-    },
-    {
-      logEvent: true,
-    },
-  );
+  genericHandler(event, async ({ applicationContext }) => {
+    return await applicationContext
+      .getUseCases()
+      .removeSignatureFromDocumentInteractor({
+        applicationContext,
+        ...event.pathParameters,
+      });
+  });

--- a/web-api/src/documents/saveSignedDocumentLambda.js
+++ b/web-api/src/documents/saveSignedDocumentLambda.js
@@ -7,24 +7,16 @@ const { genericHandler } = require('../genericHandler');
  * @returns {Promise<*|undefined>} the api gateway response object containing the statusCode, body, and headers
  */
 exports.saveSignedDocumentLambda = event =>
-  genericHandler(
-    event,
-    async ({ applicationContext }) => {
-      const {
-        body,
-        pathParameters: { docketEntryId: originalDocketEntryId, docketNumber },
-      } = event;
+  genericHandler(event, async ({ applicationContext }) => {
+    const {
+      body,
+      pathParameters: { docketEntryId: originalDocketEntryId, docketNumber },
+    } = event;
 
-      return await applicationContext
-        .getUseCases()
-        .saveSignedDocumentInteractor({
-          applicationContext,
-          docketNumber,
-          originalDocketEntryId,
-          ...JSON.parse(body),
-        });
-    },
-    {
-      logEvent: true,
-    },
-  );
+    return await applicationContext.getUseCases().saveSignedDocumentInteractor({
+      applicationContext,
+      docketNumber,
+      originalDocketEntryId,
+      ...JSON.parse(body),
+    });
+  });

--- a/web-api/src/documents/serveExternallyFiledDocumentLambda.js
+++ b/web-api/src/documents/serveExternallyFiledDocumentLambda.js
@@ -7,17 +7,11 @@ const { genericHandler } = require('../genericHandler');
  * @returns {Promise<*|undefined>} the api gateway response object containing the statusCode, body, and headers
  */
 exports.serveExternallyFiledDocumentLambda = event =>
-  genericHandler(
-    event,
-    async ({ applicationContext }) => {
-      return await applicationContext
-        .getUseCases()
-        .serveExternallyFiledDocumentInteractor({
-          applicationContext,
-          ...event.pathParameters,
-        });
-    },
-    {
-      logEvent: true,
-    },
-  );
+  genericHandler(event, async ({ applicationContext }) => {
+    return await applicationContext
+      .getUseCases()
+      .serveExternallyFiledDocumentInteractor({
+        applicationContext,
+        ...event.pathParameters,
+      });
+  });

--- a/web-api/src/documents/strikeDocketEntryLambda.js
+++ b/web-api/src/documents/strikeDocketEntryLambda.js
@@ -7,22 +7,14 @@ const { genericHandler } = require('../genericHandler');
  * @returns {Promise<*|undefined>} the api gateway response object containing the statusCode, body, and headers
  */
 exports.strikeDocketEntryLambda = event =>
-  genericHandler(
-    event,
-    async ({ applicationContext }) => {
-      const {
-        pathParameters: { docketEntryId, docketNumber },
-      } = event;
+  genericHandler(event, async ({ applicationContext }) => {
+    const {
+      pathParameters: { docketEntryId, docketNumber },
+    } = event;
 
-      return await applicationContext
-        .getUseCases()
-        .strikeDocketEntryInteractor({
-          applicationContext,
-          docketEntryId,
-          docketNumber,
-        });
-    },
-    {
-      logEvent: true,
-    },
-  );
+    return await applicationContext.getUseCases().strikeDocketEntryInteractor({
+      applicationContext,
+      docketEntryId,
+      docketNumber,
+    });
+  });

--- a/web-api/src/documents/validatePdfLambda.js
+++ b/web-api/src/documents/validatePdfLambda.js
@@ -7,18 +7,11 @@ const { genericHandler } = require('../genericHandler');
  * @returns {Promise<*|undefined>} the api gateway response object containing the statusCode, body, and headers
  */
 exports.validatePdfLambda = event =>
-  genericHandler(
-    event,
-    async ({ applicationContext }) => {
-      const { key } = event.pathParameters || {};
+  genericHandler(event, async ({ applicationContext }) => {
+    const { key } = event.pathParameters || {};
 
-      return await applicationContext.getUseCases().validatePdfInteractor({
-        applicationContext,
-        key,
-      });
-    },
-    {
-      logEvent: true,
-      logResultsLabel: 'Validate PDF Result',
-    },
-  );
+    return await applicationContext.getUseCases().validatePdfInteractor({
+      applicationContext,
+      key,
+    });
+  });

--- a/web-api/src/documents/virusScanPdfLambda.js
+++ b/web-api/src/documents/virusScanPdfLambda.js
@@ -7,14 +7,8 @@ const { genericHandler } = require('../genericHandler');
  * @returns {Promise<*|undefined>} the api gateway response object containing the statusCode, body, and headers
  */
 exports.virusScanPdfLambda = event =>
-  genericHandler(
-    event,
-    async () => {
-      return {
-        message: 'skipping clamav virus scan',
-      };
-    },
-    {
-      logEvent: true,
-    },
-  );
+  genericHandler(event, async () => {
+    return {
+      message: 'skipping clamav virus scan',
+    };
+  });

--- a/web-api/src/genericHandler.js
+++ b/web-api/src/genericHandler.js
@@ -78,8 +78,10 @@ exports.genericHandler = (event, cb, options = {}) => {
           })
         : results;
 
-      if (logResults && applicationContext) {
-        applicationContext.logger.info(logResultsLabel, returnResults);
+      if (options.logResults !== false) {
+        applicationContext.logger.debug('Results:', {
+          results: returnResults,
+        });
       }
 
       return returnResults;

--- a/web-api/src/genericHandler.js
+++ b/web-api/src/genericHandler.js
@@ -45,38 +45,21 @@ exports.genericHandler = (event, cb, options = {}) => {
     const user = options.user || getUserFromAuthHeader(event);
     const applicationContext =
       options.applicationContext ||
-      createApplicationContext(user, event.requestId);
-    const {
-      isPublicUser,
-      logEvent = true,
-      logEventLabel = 'Event',
-      logResults = true,
-      logResultsLabel = 'Results',
-      logUser = true,
-      logUserLabel = 'User',
-      skipFiltering,
-    } = options;
+      createApplicationContext(user, event.logger);
+
+    delete event.logger;
 
     try {
-      if (logEvent && applicationContext) {
-        applicationContext.logger.info(logEventLabel, event);
-      }
-
-      if (logUser && applicationContext) {
-        let userToLog = user;
-        if (isPublicUser) {
-          userToLog = 'Public User';
-        }
-        applicationContext.logger.info(logUserLabel, userToLog);
-      }
+      applicationContext.logger.debug('Request:', {
+        request: event,
+        user,
+      });
 
       const results = await cb({ applicationContext, user });
 
-      const returnResults = !skipFiltering
-        ? exports.dataSecurityFilter(results, {
-            applicationContext,
-          })
-        : results;
+      const returnResults = exports.dataSecurityFilter(results, {
+        applicationContext,
+      });
 
       if (options.logResults !== false) {
         applicationContext.logger.debug('Results:', {

--- a/web-api/src/genericHandler.test.js
+++ b/web-api/src/genericHandler.test.js
@@ -8,7 +8,7 @@ const token =
 
 const MOCK_EVENT = {
   headers: {
-    Authorization: `Bearer ${token}`,
+    authorization: `Bearer ${token}`,
   },
 };
 
@@ -18,7 +18,6 @@ const MOCK_USER = {
 };
 
 let logged = [];
-let lastLoggedValue;
 
 // Suppress console output in test runner (RAE SAID THIS WOULD BE COOL)
 console.error = () => null;
@@ -39,12 +38,10 @@ function MockEntity(raw, { filtered = false }) {
 
 describe('genericHandler', () => {
   beforeEach(() => {
-    lastLoggedValue = null;
     logged = [];
 
-    applicationContext.logger.info.mockImplementation((label, value) => {
+    applicationContext.logger.debug.mockImplementation(label => {
       logged.push(label);
-      lastLoggedValue = value;
     });
     applicationContext.getEntityByName.mockImplementation(() => MockEntity);
   });
@@ -103,7 +100,7 @@ describe('genericHandler', () => {
     expect(setUser).toEqual(MOCK_USER);
   });
 
-  it('should log `user` and `results` and `event` by default', async () => {
+  it('should log `request` and `results` by default', async () => {
     const callback = () => null;
 
     await genericHandler(MOCK_EVENT, callback, {
@@ -111,60 +108,8 @@ describe('genericHandler', () => {
       user: MOCK_USER,
     });
 
-    expect(logged.includes('User')).toBeTruthy();
-    expect(logged.includes('Results')).toBeTruthy();
-    expect(logged.includes('Event')).toBeTruthy();
-  });
-
-  it('can optionally disable logging of `user`, `results`, and `event`', async () => {
-    const callback = () => null;
-
-    await genericHandler(MOCK_EVENT, callback, {
-      applicationContext,
-      logEvent: false,
-      logResults: false,
-      logUser: false,
-      user: MOCK_USER,
-    });
-
-    expect(logged.includes('User')).toBeFalsy();
-    expect(logged.includes('Results')).toBeFalsy();
-    expect(logged.includes('Event')).toBeFalsy();
-  });
-
-  it('can use a custom label for logged `user`, `results`, and `event` data', async () => {
-    const callback = () => null;
-
-    await genericHandler(MOCK_EVENT, callback, {
-      applicationContext,
-      logEvent: true,
-      logEventLabel: 'The thing that happened',
-      logResultsLabel: 'The stuff that came out',
-      logUserLabel: 'Who did the thing',
-      user: MOCK_USER,
-    });
-
-    expect(logged.includes('User')).toBeFalsy();
-    expect(logged.includes('Results')).toBeFalsy();
-    expect(logged.includes('Event')).toBeFalsy();
-
-    expect(logged.includes('The thing that happened')).toBeTruthy();
-    expect(logged.includes('The stuff that came out')).toBeTruthy();
-    expect(logged.includes('Who did the thing')).toBeTruthy();
-  });
-
-  it('logs the user as Public User when isPublicUser is true and logUser is not false (default is true)', async () => {
-    const callback = () => null;
-
-    await genericHandler(MOCK_EVENT, callback, {
-      applicationContext,
-      isPublicUser: true,
-      logResults: false, // by default, this is true - setting to false so only the user is logged (defaults to true)
-      user: {},
-    });
-
-    expect(logged.includes('User')).toBeTruthy();
-    expect(lastLoggedValue).toEqual('Public User');
+    expect(logged).toContain('Request:');
+    expect(logged).toContain('Results:');
   });
 
   it('returns the results of a successful execution', async () => {
@@ -178,23 +123,6 @@ describe('genericHandler', () => {
     });
 
     expect(JSON.parse(result.body)).toEqual('some data');
-  });
-
-  it('returns the results of a successful execution without attempting to filter if skipFiltering is true', async () => {
-    const callback = () => {
-      return Promise.resolve({ data: 'some data', entityName: 'Case' });
-    };
-
-    const result = await genericHandler(MOCK_EVENT, callback, {
-      applicationContext,
-      skipFiltering: true,
-      user: MOCK_USER,
-    });
-
-    expect(JSON.parse(result.body)).toEqual({
-      data: 'some data',
-      entityName: 'Case',
-    });
   });
 
   it('returns the results of a successful execution and filters via entity constructor if the return data contains entityName', async () => {

--- a/web-api/src/lambdaWrapper.js
+++ b/web-api/src/lambdaWrapper.js
@@ -5,24 +5,16 @@ export const lambdaWrapper = lambda => {
       path: req.path,
       pathParameters: req.params,
       queryStringParameters: req.query,
-      requestId: {
-        apiGateway: (((req.apiGateway || {}).event || {}).requestContext || {})
-          .requestId,
-        applicationLoadBalancer: req.headers['x-amzn-trace-id'],
-        lambda: ((req.apiGateway || {}).context || {}).awsRequestId,
-      },
     };
 
     req.setTimeout(20 * 60 * 1000); // 20 minute timeout (for async lambdas)
 
-    if (process.env.USTC_ENV === 'dev') {
-      console.log(`${req.method}: ${event.path}`);
-    }
-
     const response = await lambda({
       ...event,
       body: JSON.stringify(req.body),
+      logger: req.locals.logger,
     });
+
     res.status(response.statusCode);
 
     res.set({

--- a/web-api/src/lambdaWrapper.test.js
+++ b/web-api/src/lambdaWrapper.test.js
@@ -7,6 +7,7 @@ describe('lambdaWrapper', () => {
     req = {
       body: 'blank',
       headers: {},
+      locals: {},
       setTimeout: jest.fn(),
     };
     res = {
@@ -103,67 +104,6 @@ describe('lambdaWrapper', () => {
     expect(console.log).toHaveBeenCalledWith(
       'ERROR: we do not support this return type',
     );
-  });
-
-  describe('request IDs', () => {
-    it('passes request IDs to event if set', async () => {
-      // set by aws-serverless-express.eventContext()
-      req.apiGateway = {
-        context: {
-          awsRequestId: 'c840522b-1e43-4d03-995c-014d199fa237',
-        },
-        event: {
-          requestContext: {
-            requestId: '11ff704e-b35b-4472-8280-29be3fb957ca',
-          },
-        },
-      };
-
-      req.headers = {
-        'x-amzn-trace-id': 'Root=1-5fa1efc9-164cfd9602fe2b523bf82292;Sampled=0',
-      };
-
-      await lambdaWrapper(event => {
-        expect(event.requestId).toBeDefined();
-        expect(event.requestId.apiGateway).toBe(
-          '11ff704e-b35b-4472-8280-29be3fb957ca',
-        );
-        expect(event.requestId.applicationLoadBalancer).toBe(
-          'Root=1-5fa1efc9-164cfd9602fe2b523bf82292;Sampled=0',
-        );
-        expect(event.requestId.lambda).toBe(
-          'c840522b-1e43-4d03-995c-014d199fa237',
-        );
-
-        return {
-          body: null,
-          headers: {},
-        };
-      })(req, res);
-    });
-
-    it('doesn’t choke if request IDs are missing', async () => {
-      req.apiGateway = {
-        context: {},
-        event: {
-          requestContext: {},
-        },
-      };
-
-      req.headers = {};
-
-      await lambdaWrapper(event => {
-        expect(event.requestId).toBeDefined();
-        expect(event.requestId.apiGateway).not.toBeDefined();
-        expect(event.requestId.applicationLoadBalancer).not.toBeDefined();
-        expect(event.requestId.lambda).not.toBeDefined();
-
-        return {
-          body: null,
-          headers: {},
-        };
-      })(req, res);
-    });
   });
 
   it('sets request timeout to 20 minutes', async () => {

--- a/web-api/src/logger.js
+++ b/web-api/src/logger.js
@@ -1,0 +1,54 @@
+const { createLogger } = require('../../shared/src/utilities/createLogger');
+const { transports } = require('winston');
+
+const console = () =>
+  new transports.Console({
+    handleExceptions: true,
+    handleRejections: true,
+  });
+
+module.exports = (transport = console()) => (req, res, next) => {
+  const logger = createLogger(transport);
+
+  if (process.env.NODE_ENV === 'production') {
+    logger.defaultMeta = {
+      environment: {
+        color: process.env.CURRENT_COLOR || 'green',
+        stage: process.env.STAGE || 'local',
+      },
+      request: {
+        headers: req.headers,
+        method: req.method,
+        url: req.url,
+      },
+      requestId: {
+        apiGateway: (((req.apiGateway || {}).event || {}).requestContext || {})
+          .requestId,
+        applicationLoadBalancer: req.get('x-amzn-trace-id'),
+        lambda: ((req.apiGateway || {}).context || {}).awsRequestId,
+      },
+    };
+  }
+
+  logger.debug(`Request started: ${req.method} ${req.url}`);
+
+  req.locals = req.locals || {};
+  req.locals.logger = logger;
+  req.locals.startTime = new Date();
+
+  const { end } = res;
+
+  res.end = function () {
+    end.apply(this, arguments);
+    const responseTimeMs = new Date() - req.locals.startTime;
+
+    req.locals.logger.info(`Request ended: ${req.method} ${req.url}`, {
+      response: {
+        responseTimeMs,
+        statusCode: res.statusCode,
+      },
+    });
+  };
+
+  return next();
+};

--- a/web-api/src/logger.js
+++ b/web-api/src/logger.js
@@ -1,4 +1,5 @@
 const { createLogger } = require('../../shared/src/utilities/createLogger');
+const { get } = require('lodash');
 const { transports } = require('winston');
 
 const console = () =>
@@ -22,10 +23,9 @@ module.exports = (transport = console()) => (req, res, next) => {
         url: req.url,
       },
       requestId: {
-        apiGateway: (((req.apiGateway || {}).event || {}).requestContext || {})
-          .requestId,
+        apiGateway: get(req, 'apiGateway.event.requestContext.requestId'),
         applicationLoadBalancer: req.get('x-amzn-trace-id'),
-        lambda: ((req.apiGateway || {}).context || {}).awsRequestId,
+        lambda: get(req, 'apiGateway.context.awsRequestId'),
       },
     };
   }

--- a/web-api/src/logger.test.js
+++ b/web-api/src/logger.test.js
@@ -1,0 +1,146 @@
+const fs = require('fs');
+const logger = require('./logger');
+const { transports } = require('winston');
+
+describe('logger', () => {
+  let req, res, NODE_ENV;
+
+  beforeEach(() => {
+    ({ NODE_ENV } = process.env);
+
+    req = {
+      get: jest.fn(),
+      method: '',
+      url: '',
+    };
+
+    res = {
+      end: jest.fn(),
+      statusCode: 200,
+    };
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = NODE_ENV;
+  });
+
+  const subject = async (request, response) =>
+    new Promise(resolve => {
+      const middleware = logger(
+        new transports.Stream({
+          stream: fs.createWriteStream('/dev/null'),
+        }),
+      );
+      middleware(request, response, resolve);
+    });
+
+  it('creates a logger and exposes it on req.locals.logger', async () => {
+    await subject(req, res);
+
+    expect(req.locals.logger).toBeDefined();
+  });
+
+  it('defaults to using a console logger if not specified', async () => {
+    const middleware = logger();
+
+    jest.spyOn(console, 'log');
+    middleware(req, res, () => {
+      req.locals.logger.info('test', () => {
+        expect(console.log).toHaveBeenCalled();
+        console.log.mockRestore();
+      });
+    });
+  });
+
+  it('logs when a request completes with the response statusCode', async () => {
+    await subject(req, res);
+    const instance = req.locals.logger;
+
+    instance.info = jest.fn();
+
+    res.end();
+
+    expect(instance.info).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        response: expect.objectContaining({
+          statusCode: 200,
+        }),
+      }),
+    );
+  });
+
+  it('passes request IDs to event if set in production', async () => {
+    process.env.NODE_ENV = 'production';
+
+    // set by aws-serverless-express.eventContext()
+    req.apiGateway = {
+      context: {
+        awsRequestId: 'c840522b-1e43-4d03-995c-014d199fa237',
+      },
+      event: {
+        requestContext: {
+          requestId: '11ff704e-b35b-4472-8280-29be3fb957ca',
+        },
+      },
+    };
+
+    req.get.mockImplementation(key => {
+      if (key === 'x-amzn-trace-id') {
+        return 'Root=1-5fa1efc9-164cfd9602fe2b523bf82292;Sampled=0';
+      }
+    });
+
+    await subject(req, res);
+
+    expect(req.locals.logger.defaultMeta.requestId).toBeDefined();
+    expect(req.locals.logger.defaultMeta.requestId.apiGateway).toBe(
+      '11ff704e-b35b-4472-8280-29be3fb957ca',
+    );
+    expect(
+      req.locals.logger.defaultMeta.requestId.applicationLoadBalancer,
+    ).toBe('Root=1-5fa1efc9-164cfd9602fe2b523bf82292;Sampled=0');
+    expect(req.locals.logger.defaultMeta.requestId.lambda).toBe(
+      'c840522b-1e43-4d03-995c-014d199fa237',
+    );
+  });
+
+  it('doesn’t choke if request IDs are missing in production', async () => {
+    process.env.NODE_ENV = 'production';
+
+    await Promise.all(
+      [
+        { apiGateway: {} },
+        {
+          apiGateway: {
+            context: {},
+            event: {},
+          },
+        },
+        {
+          apiGateway: {
+            context: {},
+            event: {
+              requestContext: {},
+            },
+          },
+        },
+      ].map(async partialConfig => {
+        const request = { ...req, ...partialConfig };
+
+        await subject(request, res);
+
+        expect(request.locals.logger.defaultMeta.requestId).toBeDefined();
+        expect(
+          request.locals.logger.defaultMeta.requestId.apiGateway,
+        ).not.toBeDefined();
+        expect(
+          request.locals.logger.defaultMeta.requestId.applicationLoadBalancer,
+        ).not.toBeDefined();
+        expect(
+          request.locals.logger.defaultMeta.requestId.lambda,
+        ).not.toBeDefined();
+      }),
+    );
+  });
+});

--- a/web-api/src/public-api/casePublicSearchLambda.js
+++ b/web-api/src/public-api/casePublicSearchLambda.js
@@ -15,8 +15,5 @@ exports.casePublicSearchLambda = event =>
         ...event.queryStringParameters,
       });
     },
-    {
-      isPublicUser: true,
-      user: {},
-    },
+    { user: {} },
   );

--- a/web-api/src/public-api/getCaseForPublicDocketSearchLambda.js
+++ b/web-api/src/public-api/getCaseForPublicDocketSearchLambda.js
@@ -17,8 +17,5 @@ exports.getCaseForPublicDocketSearchLambda = event =>
           docketNumber: event.pathParameters.docketNumber,
         });
     },
-    {
-      isPublicUser: true,
-      user: {},
-    },
+    { user: {} },
   );

--- a/web-api/src/public-api/getPublicCaseLambda.js
+++ b/web-api/src/public-api/getPublicCaseLambda.js
@@ -15,8 +15,5 @@ exports.getPublicCaseLambda = event =>
         docketNumber: event.pathParameters.docketNumber,
       });
     },
-    {
-      isPublicUser: true,
-      user: {},
-    },
+    { user: {} },
   );

--- a/web-api/src/public-api/getPublicDocumentDownloadUrlLambda.js
+++ b/web-api/src/public-api/getPublicDocumentDownloadUrlLambda.js
@@ -1,5 +1,4 @@
 const { genericHandler } = require('../genericHandler');
-const { publicUser } = require('../../../shared/src/business/entities/User');
 
 /**
  * used for fetching a single case
@@ -18,5 +17,5 @@ exports.getPublicDocumentDownloadUrlLambda = event =>
           ...event.pathParameters,
         });
     },
-    { user: publicUser },
+    { user: {} },
   );

--- a/web-api/src/public-api/getPublicDocumentDownloadUrlLambda.js
+++ b/web-api/src/public-api/getPublicDocumentDownloadUrlLambda.js
@@ -1,5 +1,5 @@
-const createApplicationContext = require('../applicationContext');
 const { genericHandler } = require('../genericHandler');
+const { publicUser } = require('../../../shared/src/business/entities/User');
 
 /**
  * used for fetching a single case
@@ -8,20 +8,15 @@ const { genericHandler } = require('../genericHandler');
  * @returns {Promise<*|undefined>} the api gateway response object containing the statusCode, body, and headers
  */
 exports.getPublicDocumentDownloadUrlLambda = event =>
-  genericHandler(event, async () => {
-    const applicationContext = createApplicationContext({});
-    try {
-      const results = await applicationContext
+  genericHandler(
+    event,
+    async ({ applicationContext }) => {
+      return await applicationContext
         .getUseCases()
         .getPublicDownloadPolicyUrlInteractor({
           applicationContext,
           ...event.pathParameters,
         });
-      applicationContext.logger.debug('Results', results);
-      return results;
-    } catch (e) {
-      applicationContext.logger.error(e);
-      await applicationContext.notifyHoneybadger(e);
-      throw e;
-    }
-  });
+    },
+    { user: publicUser },
+  );

--- a/web-api/src/public-api/getPublicJudgesLambda.js
+++ b/web-api/src/public-api/getPublicJudgesLambda.js
@@ -16,9 +16,6 @@ exports.getPublicJudgesLambda = event => {
           applicationContext,
         });
     },
-    {
-      isPublicUser: true,
-      user: {},
-    },
+    { user: {} },
   );
 };

--- a/web-api/src/public-api/opinionPublicSearchLambda.js
+++ b/web-api/src/public-api/opinionPublicSearchLambda.js
@@ -17,8 +17,5 @@ exports.opinionPublicSearchLambda = event =>
           ...event.queryStringParameters,
         });
     },
-    {
-      isPublicUser: true,
-      user: {},
-    },
+    { user: {} },
   );

--- a/web-api/src/public-api/orderPublicSearchLambda.js
+++ b/web-api/src/public-api/orderPublicSearchLambda.js
@@ -17,8 +17,5 @@ exports.orderPublicSearchLambda = event =>
           ...event.queryStringParameters,
         });
     },
-    {
-      isPublicUser: true,
-      user: {},
-    },
+    { user: {} },
   );

--- a/web-api/src/public-api/todaysOpinionsLambda.js
+++ b/web-api/src/public-api/todaysOpinionsLambda.js
@@ -16,8 +16,5 @@ exports.todaysOpinionsLambda = event =>
           applicationContext,
         });
     },
-    {
-      isPublicUser: true,
-      user: {},
-    },
+    { user: {} },
   );

--- a/web-api/src/v1/getCaseLambda.test.js
+++ b/web-api/src/v1/getCaseLambda.test.js
@@ -20,13 +20,13 @@ const REQUEST_EVENT = {
 };
 
 const createSilentAppContext = user => {
-  const applicationContext = createApplicationContext(user);
-  applicationContext.environment.dynamoDbTableName = 'mocked';
-
-  applicationContext.logger = {
+  const applicationContext = createApplicationContext(user, {
+    debug: jest.fn(),
     error: jest.fn(),
     info: jest.fn(),
-  };
+  });
+
+  applicationContext.environment.dynamoDbTableName = 'mocked';
 
   return applicationContext;
 };

--- a/web-api/src/v1/getDocumentDownloadUrlLambda.test.js
+++ b/web-api/src/v1/getDocumentDownloadUrlLambda.test.js
@@ -13,13 +13,13 @@ const REQUEST_EVENT = {
 };
 
 const createSilentAppContext = user => {
-  const applicationContext = createApplicationContext(user);
-  applicationContext.environment.dynamoDbTableName = 'mocked';
-
-  applicationContext.logger = {
+  const applicationContext = createApplicationContext(user, {
+    debug: jest.fn(),
     error: jest.fn(),
     info: jest.fn(),
-  };
+  });
+
+  applicationContext.environment.dynamoDbTableName = 'mocked';
 
   return applicationContext;
 };


### PR DESCRIPTION
This PR gets us most of the way to #541:

- Improves error formatting for errors logged as instances of Error (`applicationContext.logger.error(new Error())`) so their messages and stack traces appear in the logs.
- Adds log handlers for uncaught exceptions and uncaught promise rejections, so they appear in logs as well.
- Always logs incoming requests and their headers.
- Always logs outgoing response statusCodes and the overall response time in milliseconds (required changing where the logger was instantiated, moving it to ExpressJS middleware instead of in the applicationContext (which still has a reference to it)). We’ll now be able to see every request which hits the API, even those which do not match routes, and their response codes in the logs.

Will drop a few inline comments below, too. 