### PR TITLE
Add logging to authorizer, allowing us to see failed API authorization attempts.

### DIFF
--- a/iam/terraform/account-specific/main/lambda-logs-to-elasticsearch.tf
+++ b/iam/terraform/account-specific/main/lambda-logs-to-elasticsearch.tf
@@ -79,3 +79,19 @@ resource "aws_cloudwatch_log_subscription_filter" "migration_lambda_filter" {
   name            = "migration_${element(var.log_group_environments, count.index)}_lambda_filter"
   log_group_name  = "/aws/lambda/migration_segments_lambda_${element(var.log_group_environments, count.index)}"
 }
+
+resource "aws_cloudwatch_log_subscription_filter" "api_stage_logs_blue" {
+  count           = length(var.log_group_environments)
+  destination_arn = aws_lambda_function.logs_to_es.arn
+  filter_pattern  = ""
+  name            = "api_stage_logs_lambda_filter"
+  log_group_name  = "/aws/apigateway/gateway_api_${element(var.log_group_environments, count.index)}_blue"
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "api_stage_logs_green" {
+  count           = length(var.log_group_environments)
+  destination_arn = aws_lambda_function.logs_to_es.arn
+  filter_pattern  = ""
+  name            = "api_stage_logs_lambda_filter"
+  log_group_name  = "/aws/apigateway/gateway_api_${element(var.log_group_environments, count.index)}_green"
+}

--- a/shared/src/utilities/createLogger.js
+++ b/shared/src/utilities/createLogger.js
@@ -17,14 +17,13 @@ const redact = format(logEntry => {
   return copy;
 });
 
-const console = () => new transports.Console();
-
-exports.createLogger = (transport = console()) => {
+exports.createLogger = opts => {
   const options = {
     defaultMeta: {},
     level: process.env.LOG_LEVEL || 'debug',
     levels: config.syslog.levels,
-    transports: [transport],
+    transports: [new transports.Console()],
+    ...opts,
   };
 
   const formatters = [errors({ stack: true }), redact()];

--- a/web-api/src/logger.js
+++ b/web-api/src/logger.js
@@ -2,14 +2,16 @@ const { createLogger } = require('../../shared/src/utilities/createLogger');
 const { get } = require('lodash');
 const { transports } = require('winston');
 
+let cache;
 const console = () =>
-  new transports.Console({
+  cache ||
+  (cache = new transports.Console({
     handleExceptions: true,
     handleRejections: true,
-  });
+  }));
 
 module.exports = (transport = console()) => (req, res, next) => {
-  const logger = createLogger(transport);
+  const logger = createLogger({ transports: [transport] });
 
   if (process.env.NODE_ENV === 'production') {
     logger.defaultMeta = {

--- a/web-api/terraform/api/api.tf
+++ b/web-api/terraform/api/api.tf
@@ -200,12 +200,67 @@ resource "aws_api_gateway_deployment" "api_deployment" {
     aws_api_gateway_authorizer.custom_authorizer
   ]
   rest_api_id       = aws_api_gateway_rest_api.gateway_for_api.id
-  stage_name        = var.environment
-  stage_description = "Deployed at ${timestamp()}"
 
   lifecycle {
     create_before_destroy = true
   }
+}
+
+resource "aws_api_gateway_stage" "api_stage" {
+  rest_api_id   = aws_api_gateway_rest_api.gateway_for_api.id
+  stage_name    = var.environment
+  description   = "Deployed at ${timestamp()}"
+  deployment_id = aws_api_gateway_deployment.api_deployment.id
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.api_stage_logs.arn
+
+    format = jsonencode({
+      level = "info"
+      message = "API Gateway Access Log"
+
+      environment = {
+        stage = var.environment
+        color = var.current_color
+      }
+
+      requestId = {
+        apiGateway = "$context.requestId"
+        lambda = "$context.integration.requestId"
+        authorizer = "$context.authorizer.requestId"
+      }
+
+      request = {
+        headers = {
+          x-forwarded-for = "$context.identity.sourceIp"
+          user-agent = "$context.identity.userAgent"
+        }
+        method = "$context.httpMethod"
+      }
+
+      authorizer = {
+        error = "$context.authorizer.error"
+        responseTimeMs = "$context.authorizer.integrationLatency"
+        statusCode = "$context.authorizer.status"
+      }
+
+      response = {
+        responseTimeMs = "$context.responseLatency"
+        responseLength = "$context.responseLength"
+        statusCode = "$context.status"
+      }
+
+      metadata = {
+        apiId = "$context.apiId"
+        resourcePath = "$context.resourcePath"
+        resourceId = "$context.resourceId"
+      }
+    })
+  }
+}
+
+resource "aws_cloudwatch_log_group" "api_stage_logs" {
+  name = "/aws/apigateway/${aws_api_gateway_rest_api.gateway_for_api.name}"
 }
 
 resource "aws_acm_certificate" "api_gateway_cert" {

--- a/web-api/terraform/template/lambdas/cognito-authorizer.js
+++ b/web-api/terraform/template/lambdas/cognito-authorizer.js
@@ -1,88 +1,137 @@
 const axios = require('axios');
 const jwk = require('jsonwebtoken');
 const jwkToPem = require('jwk-to-pem');
+const {
+  createLogger,
+} = require('../../../../shared/src/utilities/createLogger');
+const { transports } = require('winston');
+
+const transport = new transports.Console({
+  handleExceptions: true,
+  handleRejections: true,
+});
 
 const issMain = `https://cognito-idp.us-east-1.amazonaws.com/${process.env.USER_POOL_ID_MAIN}`;
 const issIrs = `https://cognito-idp.us-east-1.amazonaws.com/${process.env.USER_POOL_ID_IRS}`;
 
-const generatePolicy = (principalId, effect, resource) => {
-  const authResponse = {};
-  authResponse.principalId = principalId;
-  if (effect && resource) {
-    const policyDocument = {};
-    policyDocument.Version = '2012-10-17';
-    policyDocument.Statement = [];
-    const statementOne = {};
-    statementOne.Action = 'execute-api:Invoke';
-    statementOne.Effect = effect;
-    statementOne.Resource = resource;
-    policyDocument.Statement[0] = statementOne;
-    authResponse.policyDocument = policyDocument;
-  }
-  return authResponse;
-};
-
-const verify = (methodArn, token, keys, kid, iss, cb) => {
-  const k = keys.keys.find(k => k.kid === kid);
-
-  if (!k) {
-    throw new Error(
-      `The key used to sign the authorization token '${kid}' was not found in user pool keys '${iss}/.well-known/jwks.json'.`,
-    );
-  }
-
-  const pem = jwkToPem(k);
-
-  jwk.verify(token, pem, { issuer: [issMain, issIrs] }, (err, decoded) => {
-    if (err) {
-      console.log('Unauthorized user:', err.message);
-      cb('Unauthorized');
-    } else {
-      cb(
-        null,
-        generatePolicy(
-          decoded.sub,
-          'Allow',
-          methodArn.split('/').slice(0, 2).join('/') + '/*',
-        ),
-      );
-    }
+const getLogger = context => {
+  return createLogger({
+    defaultMeta: {
+      requestId: {
+        authorizer: context.awsRequestId,
+      },
+    },
+    transports: [transport],
   });
 };
 
-let keyCache = {};
-
-exports.handler = (event, context, cb) => {
-  console.log('Auth function invoked');
-
-  let requestToken = null;
+const getToken = event => {
   if (event.queryStringParameters && event.queryStringParameters.token) {
-    requestToken = event.queryStringParameters.token;
+    return event.queryStringParameters.token;
   } else if (event.authorizationToken) {
-    requestToken = event.authorizationToken.substring(7);
+    return event.authorizationToken.substring(7);
+  }
+};
+
+const decodeToken = requestToken => {
+  const { header, payload } = jwk.decode(requestToken, { complete: true });
+  return { iss: payload.iss, kid: header.kid };
+};
+
+let keyCache = {};
+const getKeysForIssuer = async iss => {
+  if (keyCache[iss]) {
+    return keyCache[iss];
   }
 
-  if (requestToken) {
-    const { header, payload } = jwk.decode(requestToken, { complete: true });
-    const { iss } = payload;
-    const { kid } = header;
-    if (keyCache[iss]) {
-      verify(event.methodArn, requestToken, keyCache[iss], kid, iss, cb);
-    } else {
-      axios
-        .get(`${iss}/.well-known/jwks.json`)
-        .then(response => {
-          keyCache[iss] = response.data;
-          verify(event.methodArn, requestToken, keyCache[iss], kid, iss, cb);
-        })
-        .catch(error => {
-          console.log('Request error:', error);
-          // eslint-disable-next-line promise/no-callback-in-promise
-          cb('Unauthorized');
-        });
-    }
-  } else {
-    console.log('No authorizationToken found in the header.');
-    cb('Unauthorized');
+  const response = await axios.get(`${iss}/.well-known/jwks.json`);
+
+  return (keyCache[iss] = response.data.keys);
+};
+
+const verify = async (key, token) => {
+  return new Promise((resolve, reject) => {
+    const pem = jwkToPem(key);
+    const options = { issuer: [issMain, issIrs] };
+
+    jwk.verify(token, pem, options, (err, payload) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(payload);
+      }
+    });
+  });
+};
+
+exports.handler = async (event, context) => {
+  const logger = getLogger(context);
+  const token = getToken(event);
+
+  if (!token) {
+    logger.info('No authorizationToken found in the header');
+
+    throw new Error('Unauthorized'); // Magic string to return 401
   }
+
+  const { iss, kid } = decodeToken(token);
+
+  let keys;
+  try {
+    keys = await getKeysForIssuer(iss);
+  } catch (error) {
+    logger.warn(
+      'Could not fetch keys for token issuer, considering request unauthorized',
+      error,
+    );
+
+    throw new Error('Unauthorized'); // Magic string to return 401
+  }
+
+  const key = keys.find(k => k.kid === kid);
+
+  if (!key) {
+    logger.warn(
+      'The key used to sign the authorization token was not found in the user pool’s keys, considering request unauthorized',
+      {
+        issuer: iss,
+        keys,
+        requestedKeyId: kid,
+      },
+    );
+
+    throw new Error('Unauthorized'); // Magic string to return 401
+  }
+
+  let payload;
+  try {
+    payload = await verify(key, token);
+  } catch (error) {
+    logger.warn(
+      'The token is not valid, considering request unauthorized',
+      error,
+    );
+
+    throw new Error('Unauthorized'); // Magic string to return 401
+  }
+
+  const policy = {
+    policyDocument: {
+      Statement: [
+        {
+          Action: 'execute-api:Invoke',
+          Effect: 'Allow',
+          Resource: event.methodArn.split('/').slice(0, 2).join('/') + '/*',
+        },
+      ],
+      Version: '2012-10-17',
+    },
+    principalId: payload.sub,
+  };
+
+  logger.info('Request authorized', {
+    metadata: { policy },
+  });
+
+  return policy;
 };

--- a/web-api/terraform/template/lambdas/cognito-authorizer.test.js
+++ b/web-api/terraform/template/lambdas/cognito-authorizer.test.js
@@ -1,0 +1,217 @@
+jest.mock('jwk-to-pem', () => jest.fn());
+
+const axios = require('axios');
+const jwk = require('jsonwebtoken');
+const jwkToPem = require('jwk-to-pem');
+const { handler } = require('./cognito-authorizer');
+
+describe('cognito-authorizer', () => {
+  let event, context;
+
+  beforeEach(() => {
+    jest.spyOn(axios, 'get').mockImplementation(() => {});
+    jest.spyOn(jwk, 'decode').mockImplementation(token => {
+      // This test code does not need to be resistant to timing attacks.
+      // eslint-disable-next-line security/detect-possible-timing-attacks
+      if (token === 'tokenValue') {
+        return {
+          header: { kid: 'key-identifier' },
+          payload: { iss: `issuer-url-${Math.random()}` },
+        };
+      } else {
+        throw new Error('token not passed to jek.decode');
+      }
+    });
+    jest.spyOn(jwk, 'verify').mockImplementation(() => {});
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    event = {
+      authorizationToken: 'Bearer tokenValue',
+      methodArn:
+        'arn:aws:execute-api:us-east-1:aws-account-id:api-gateway-id/stage/GET/path',
+      type: 'TOKEN',
+    };
+
+    context = {
+      awsRequestId: 'request-id',
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // eslint-disable-next-line jest/no-done-callback
+  it('returns unauthorized when token is missing', done => {
+    event.authorizationToken = '';
+
+    handler(event, context, err => {
+      expect(err).toBe('Unauthorized');
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('No authorizationToken found'),
+      );
+      done();
+    });
+  });
+
+  // desired: returns unauthorized if there is an error in contacting the issuer
+  it('throws an error if there is an error in contacting the issuer', () => {
+    axios.get.mockImplementation(() => {
+      throw new Error('any error');
+    });
+
+    expect(() => {
+      handler(event, context, () => {});
+    }).toThrow();
+  });
+
+  // eslint-disable-next-line jest/no-done-callback
+  it('returns unauthorized if the issuer doesn’t return data in expected format', done => {
+    axios.get.mockImplementation(() => {
+      return Promise.resolve({ data: null });
+    });
+
+    handler(event, context, err => {
+      expect(err).toBe('Unauthorized');
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('Request error'),
+        expect.any(Error),
+      );
+      done();
+    });
+  });
+
+  // eslint-disable-next-line jest/no-done-callback
+  it('returns unauthorized if issuer is not the cognito user pools', done => {
+    axios.get.mockImplementation(() => {
+      return Promise.resolve({
+        data: { keys: [{ kid: 'not-expected-key-identifier' }] },
+      });
+    });
+
+    handler(event, context, err => {
+      expect(err).toBe('Unauthorized');
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('Request error'),
+        expect.any(Error),
+      );
+      done();
+    });
+  });
+
+  // eslint-disable-next-line jest/no-done-callback
+  it('returns unauthorized if token is not verified', done => {
+    axios.get.mockImplementation(() => {
+      return Promise.resolve({
+        data: { keys: [{ kid: 'key-identifier' }] },
+      });
+    });
+
+    jwkToPem.mockImplementation(key => {
+      if (key.kid !== 'key-identifier') {
+        throw new Error('wrong key was given');
+      }
+
+      return 'test-pem';
+    });
+
+    jwk.verify.mockImplementation((token, pem, options, callback) => {
+      if (token !== 'tokenValue' || pem !== 'test-pem') {
+        throw new Error('wrong token or pem was passed to verification');
+      }
+
+      expect(options.issuer).toBeDefined();
+      callback(new Error('verification failed'));
+    });
+
+    handler(event, context, err => {
+      expect(err).toBe('Unauthorized');
+
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('Unauthorized user'),
+        'verification failed',
+      );
+      done();
+    });
+  });
+
+  // eslint-disable-next-line jest/no-done-callback
+  it('returns IAM policy to allow invoking requested lambda when authorized', done => {
+    axios.get.mockImplementation(() => {
+      return Promise.resolve({
+        data: { keys: [{ kid: 'key-identifier' }] },
+      });
+    });
+
+    jwkToPem.mockImplementation(key => {
+      if (key.kid !== 'key-identifier') {
+        throw new Error('wrong key was given');
+      }
+
+      return 'test-pem';
+    });
+
+    jwk.verify.mockImplementation((token, pem, options, callback) => {
+      if (token !== 'tokenValue' || pem !== 'test-pem') {
+        throw new Error('wrong token or pem was passed to verification');
+      }
+
+      expect(options.issuer).toBeDefined();
+      callback(null, { sub: 'test-sub' });
+    });
+
+    handler(event, context, (err, policy) => {
+      expect(err).toBe(null);
+      expect(policy).toStrictEqual(
+        expect.objectContaining({
+          policyDocument: {
+            Statement: [
+              {
+                Action: 'execute-api:Invoke',
+                Effect: 'Allow',
+                Resource:
+                  'arn:aws:execute-api:us-east-1:aws-account-id:api-gateway-id/stage/*',
+              },
+            ],
+            Version: '2012-10-17',
+          },
+          principalId: 'test-sub',
+        }),
+      );
+      done();
+    });
+  });
+
+  // eslint-disable-next-line jest/no-done-callback
+  it('caches keys for issuers', done => {
+    jest.spyOn(jwk, 'decode').mockImplementation(() => {
+      return {
+        header: { kid: 'identifier-to-cache' },
+        payload: { iss: 'issuer-url' },
+      };
+    });
+
+    axios.get.mockImplementation(() => {
+      return Promise.resolve({
+        data: { keys: [{ kid: 'identifier-to-cache' }] },
+      });
+    });
+
+    jwkToPem.mockImplementation(() => 'test-pem');
+
+    jwk.verify.mockImplementation((token, pem, options, callback) => {
+      callback(null, { sub: 'test-sub' });
+    });
+
+    handler(event, context, () => {
+      // First call is not cached
+      expect(axios.get).toHaveBeenCalledTimes(1);
+
+      handler(event, context, () => {
+        // Second call is cached
+        expect(axios.get).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Related to #541, this PR allows us to trace requests from API Gateway through the authorizer to the lambda functions. 

- Adds API Gateway logs for every request in https://github.com/ustaxcourt/ef-cms/commit/3ead08378045eba89ad21a894926991a00092d73. 
  - This is needed because the authorizer function is only passed a token with no request data associated with it, and its request identifier is unique to the authorizer itself. 
  - These follow the same JSON logging format as the application, and will appear in Kibana as an `info` level message `API Gateway Access Log`, and associate the authorizer’s request ID with the API Gateway request ID and the lambda function’s request ID. 
- Adds `winston`-based logging to the authorizer function in https://github.com/ustaxcourt/ef-cms/commit/0e6cc57c532edf4ac75eda9ec9adc16fc4acc063. 
  - This was a more dramatic change than I had hoped, because the current authorizer passes a callback around to various functions, leaving multiple response points. This meant that there was no one place I could use a `logger` instance.
  - Instead of passing a `logger` back and forth between functions, I opted to refactor. 
  - Because of refactoring, I implemented tests before refactoring in https://github.com/ustaxcourt/ef-cms/commit/67326bf5c6548cb4fdd2758cabc66a512c0a0655 to ensure the behavior remained consistent.
  - I also took this opportunity to use `async` and `await` instead of callbacks for this lambda, following the same convention used elsewhere in the application. 

## Getting Terraform to run

I don’t yet have a great set of steps to get the Terraform to apply cleanly, and that bums me out but I’m opening this PR now. The core difficulty is that the API Gateway Stage was not under Terraform management before (it was created ✨ automagically ✨ by AWS by referencing it by name), and this PR brings it under Terraform management.

There are two paths we can take, and I took a somewhat middle-ground approach when running this against `dev` (which is why I don’t know reproduction steps super well). I think to get the reproduction steps right, I’ll need to do this against another environment. 

### Path 1: Import the existing API Gateway Stage into Terraform.

This is a straightforward Terraform command, if we can get Terraform configured correctly for the environment. I believe the command to run is (the module path may be slightly incorrect, but Terraform will tell us if the resource is not known before applying any changes): 

```bash
# Update the API Gateway IDs (like "1wl1nuwlji" — see in the AWS Console) 
# for each color/region combo.

terraform import module.ef-cms_apis.module.api-east-green.aws_api_gateway_stage.api_stage [API GATEWAY ID]/[ENV]
terraform import module.ef-cms_apis.module.api-east-blue.aws_api_gateway_stage.api_stage [API GATEWAY ID]/[ENV]
terraform import module.ef-cms_apis.module.api-west-green.aws_api_gateway_stage.api_stage [API GATEWAY ID]/[ENV]
terraform import module.ef-cms_apis.module.api-west-blue.aws_api_gateway_stage.api_stage [API GATEWAY ID]/[ENV]
```

To run these commands, we need to set these Terraform variables (and I’m unsure of all of their correct settings, but we should be able to trace them down — and hacking `web-api/terraform/bin/deploy-app.sh` may be the easiest way): 

```bash
export TF_VAR_dns_domain=$EFCMS_DOMAIN
export TF_VAR_zone_name=$ZONE_NAME
export TF_VAR_environment=$ENVIRONMENT
export TF_VAR_cognito_suffix=$COGNITO_SUFFIX
export TF_VAR_email_dmarc_policy=$EMAIL_DMARC_POLICY
export TF_VAR_es_instance_count=$ES_INSTANCE_COUNT
export TF_VAR_es_instance_type=$ES_INSTANCE_TYPE
export TF_VAR_honeybadger_key=$CIRCLE_HONEYBADGER_API_KEY
export TF_VAR_irs_superuser_email=$IRS_SUPERUSER_EMAIL
export TF_VAR_deploying_color=$DEPLOYING_COLOR
export TF_VAR_blue_table_name=$BLUE_TABLE_NAME
export TF_VAR_green_table_name=$GREEN_TABLE_NAME
export TF_VAR_blue_elasticsearch_domain=$BLUE_ELASTICSEARCH_DOMAIN
export TF_VAR_green_elasticsearch_domain=$GREEN_ELASTICSEARCH_DOMAIN
export TF_VAR_destination_table=$DESTINATION_TABLE
export TF_VAR_disable_emails=$DISABLE_EMAILS
export TF_VAR_es_volume_size=$ES_VOLUME_SIZE
```

After these commands are run successfully, we’ll need to unmap the `api.[EFCMS_DOMAIN]` API Gateway configuration, as it points to the API Deployment and will prevent it from updating to accept the Stage updates. 

> Error: error deleting API Gateway Deployment (cyl75l): BadRequestException: Active stages pointing to this deployment must be moved or deleted

This is not managed by Terraform, and so Terraform does not know the record exists and cannot update it for us. To do so, head to the AWS Console > API Gateway > Custom domain names > `api.[EFCMS_DOMAIN]` > API mappings > Configure API mappings > X (delete the existing mapping, and save). 

Then, run a deploy. 

Then, re-create the manually deleted records using part of the switch environment script: 

```bash
# Update with the correct environment variables

EFCMS_DOMAIN=dev.ef-cms.ustaxcourt.gov DEPLOYING_COLOR=blue ENV=dev node web-client/switch-api-colors.js
```

### Path 2: Delete the API Stage.

This will allow Terraform to create a new resource without conflicting with the existing API stage.

> Error: Error creating API Gateway Stage: ConflictException: Stage already exists

Start by unmapping the `api.[EFCMS_DOMAIN]` API Gateway configuration as above, as it points to the API Deployment and will prevent it from being deleted. 

This is not managed by Terraform, and so Terraform does not know the record exists and cannot update it for us. To do so, head to the AWS Console > API Gateway > Custom domain names > `api.[EFCMS_DOMAIN]` > API mappings > Configure API mappings > X (delete the existing mapping, and save). 

Then, use the console to delete the 4 API Stages that correspond to this environment. Head to AWS Console > API Gateway > APIs > `gateway_api_[ENV]_blue` > Stages > [ENV] > Delete Stage (in the top right). Repeat for `gateway_api_[ENV]_green`. Use the region selector in the top right corner of the screen to switch to `us-west-1` (or to `us-east-1`, if you’re already in west) and repeat for the same two API Gateway configurations here. 

Then, run a deploy. 

Then, re-create the manually deleted records using part of the switch environment script: 

```bash
# Update with the correct environment variables

EFCMS_DOMAIN=dev.ef-cms.ustaxcourt.gov DEPLOYING_COLOR=blue ENV=dev node web-client/switch-api-colors.js
```