### PR TITLE
Add default throttling settings to API gateway.

### DIFF
--- a/web-api/terraform/api/api-public.tf
+++ b/web-api/terraform/api/api-public.tf
@@ -159,3 +159,14 @@ resource "aws_api_gateway_base_path_mapping" "api_public_mapping" {
   stage_name  = aws_api_gateway_deployment.api_public_deployment.stage_name
   domain_name = aws_api_gateway_domain_name.api_public_custom.domain_name
 }
+
+resource "aws_api_gateway_method_settings" "api_public_default" {
+  rest_api_id = aws_api_gateway_rest_api.gateway_for_api_public.id
+  stage_name  = aws_api_gateway_deployment.api_public_deployment.stage_name
+  method_path = "*/*"
+
+  settings {
+    throttling_burst_limit = 5000
+    throttling_rate_limit = 10000
+  }
+}

--- a/web-api/terraform/api/api.tf
+++ b/web-api/terraform/api/api.tf
@@ -326,3 +326,14 @@ resource "aws_api_gateway_base_path_mapping" "api_mapping" {
   stage_name  = aws_api_gateway_stage.api_stage.stage_name
   domain_name = aws_api_gateway_domain_name.api_custom.domain_name
 }
+
+resource "aws_api_gateway_method_settings" "api_default" {
+  rest_api_id = aws_api_gateway_rest_api.gateway_for_api.id
+  stage_name  = aws_api_gateway_stage.api_stage.stage_name
+  method_path = "*/*"
+
+  settings {
+    throttling_burst_limit = 5000
+    throttling_rate_limit = 10000
+  }
+}


### PR DESCRIPTION
Closes #459.

Using previously configured values through API Gateway console, so this PR does not introduce a behavior change (only codifies the configuration). These settings correspond to roughly 167 requests/second. These limits are applied across all clients, and are designed to protect the API services.

Requests exceeding the limit [will receive `429 Too Many Requests` responses](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-request-throttling.html). 