### PR TITLE
ustc-581: increase sqs visibility and retention

### DIFF
--- a/web-api/terraform/template/sqs.tf
+++ b/web-api/terraform/template/sqs.tf
@@ -1,6 +1,6 @@
 resource "aws_sqs_queue" "migrate_legacy_documents_queue" {
   name                       = "migrate_legacy_documents_queue_${var.environment}"
-  visibility_timeout_seconds = "70"
+  visibility_timeout_seconds = "930"
 
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.migrate_legacy_documents_dl_queue.arn

--- a/web-api/terraform/template/sqs.tf
+++ b/web-api/terraform/template/sqs.tf
@@ -1,6 +1,7 @@
 resource "aws_sqs_queue" "migrate_legacy_documents_queue" {
   name                       = "migrate_legacy_documents_queue_${var.environment}"
-  visibility_timeout_seconds = "930"
+  visibility_timeout_seconds = 930
+  message_retention_seconds  = 1209600
 
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.migrate_legacy_documents_dl_queue.arn


### PR DESCRIPTION
A recent deploy failed to the migration environment because we had adjusted the settings for the SQS queue in the console to have a retention time of 14 days. Unfortunately, this cleared out the queue. And the Lambda has been reconfigured to have a timeout time of 15 minutes. Terraform was [unable to update in place](https://app.circleci.com/pipelines/github/ustaxcourt/ef-cms/1353/workflows/d5bb12a2-a3ea-41a0-b3e3-62b47b4920f8/jobs/13120) the queue because its visibility timeout needs to be greater than the Lambda timeout. This fixes that, and helps keep our queue lasting longer.