### PR TITLE
Update docketEntry instead of case to remove race condition.

### DIFF
--- a/shared/src/business/useCases/migration/parseLegacyDocumentsInteractor.js
+++ b/shared/src/business/useCases/migration/parseLegacyDocumentsInteractor.js
@@ -74,8 +74,10 @@ exports.parseLegacyDocumentsInteractor = async ({
 
   foundDocketEntry.documentContentsId = documentContentsId;
 
-  await applicationContext.getPersistenceGateway().updateCase({
+  await applicationContext.getPersistenceGateway().updateDocketEntry({
     applicationContext,
-    caseToUpdate: caseEntity.validate().toRawObject(),
+    docketEntryId: foundDocketEntry.docketEntryId,
+    docketNumber: caseEntity.docketNumber,
+    document: foundDocketEntry,
   });
 };

--- a/shared/src/business/useCases/migration/parseLegacyDocumentsInteractor.test.js
+++ b/shared/src/business/useCases/migration/parseLegacyDocumentsInteractor.test.js
@@ -150,15 +150,13 @@ describe('parseLegacyDocumentsInteractor', () => {
     });
 
     expect(
-      applicationContext.getPersistenceGateway().updateCase.mock.calls[0][0]
-        .caseToUpdate.docketEntries,
+      applicationContext.getPersistenceGateway().updateDocketEntry.mock
+        .calls[0][0].document,
     ).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          docketEntryId: mockDocketEntryId,
-          documentContentsId: mockUniqueID,
-        }),
-      ]),
+      expect.objectContaining({
+        docketEntryId: mockDocketEntryId,
+        documentContentsId: mockUniqueID,
+      }),
     );
   });
 });


### PR DESCRIPTION
For #581, this removes a race condition where two docketEntries on a single case have dueling writes.

I’m not sure how to exercise this endpoint to test it beyond the existing tests. 