### PR TITLE
Improve Logging visibility for Blue/Green Migrations

### DIFF
--- a/web-api/migration-terraform/main/lambdas/migration-segments.js
+++ b/web-api/migration-terraform/main/lambdas/migration-segments.js
@@ -38,17 +38,17 @@ const dynamoDbDocumentClient = new AWS.DynamoDB.DocumentClient({
 const sqs = new AWS.SQS({ region: 'us-east-1' });
 
 const migrateRecords = async ({ documentClient, items }) => {
-  console.log('about to run migration 001');
+  applicationContext.logger.info('about to run migration 001');
   items = await migration0001(items, documentClient);
-  console.log('about to run migration 002');
+  applicationContext.logger.info('about to run migration 002');
   items = await migration0002(items, documentClient);
-  console.log('about to run migration 003');
+  applicationContext.logger.info('about to run migration 003');
   items = await migration0003(items, documentClient);
-  console.log('about to run migration 004');
+  applicationContext.logger.info('about to run migration 004');
   items = await migration0004(items, documentClient);
-  console.log('about to run migration 005');
+  applicationContext.logger.info('about to run migration 005');
   items = await migration0005(items, documentClient);
-  console.log('about to run migration 006');
+  applicationContext.logger.info('about to run migration 006');
   items = await migration0006(items, documentClient);
 
   return items;
@@ -72,7 +72,12 @@ const reprocessItems = async ({ documentClient, items }) => {
 };
 
 const processItems = async ({ documentClient, items }) => {
-  items = await migrateRecords({ documentClient, items });
+  try {
+    items = await migrateRecords({ documentClient, items });
+  } catch (err) {
+    applicationContext.logger.error('Error migrating records', err);
+    throw err;
+  }
 
   // your migration code goes here
   const chunks = chunk(items, MAX_DYNAMO_WRITE_SIZE);
@@ -117,7 +122,9 @@ const scanTableSegment = async (segment, totalSegments) => {
       })
       .promise()
       .then(async results => {
-        console.log('got some results', results.Items.length);
+        applicationContext.logger.info(
+          `${segment}/${totalSegments} got ${results.Items.length} results`,
+        );
         hasMoreResults = !!results.LastEvaluatedKey;
         lastKey = results.LastEvaluatedKey;
         await processItems({
@@ -133,9 +140,12 @@ exports.handler = async event => {
   const { body, receiptHandle } = Records[0];
   const { segment, totalSegments } = JSON.parse(body);
 
-  console.log(`about to process ${segment} of ${totalSegments}`);
+  applicationContext.logger.info(
+    `about to process ${segment} of ${totalSegments}`,
+  );
 
   await scanTableSegment(segment, totalSegments);
+  applicationContext.logger.info(`finishing ${segment} of ${totalSegments}`);
   await sqs
     .deleteMessage({
       QueueUrl: process.env.SEGMENTS_QUEUE_URL,

--- a/web-api/migration-terraform/main/migration-segments.tf
+++ b/web-api/migration-terraform/main/migration-segments.tf
@@ -18,10 +18,11 @@ resource "aws_lambda_function" "migration_segments_lambda" {
 
   environment {
     variables = {
-      SOURCE_TABLE       = var.source_table
-      ENVIRONMENT        = var.environment
-      SEGMENTS_QUEUE_URL = aws_sqs_queue.migration_segments_queue.id
       DESTINATION_TABLE  = var.destination_table
+      ENVIRONMENT        = var.environment
+      NODE_ENV           = "production"
+      SEGMENTS_QUEUE_URL = aws_sqs_queue.migration_segments_queue.id
+      SOURCE_TABLE       = var.source_table
     }
   }
 }

--- a/web-api/migration-terraform/main/migration.tf
+++ b/web-api/migration-terraform/main/migration.tf
@@ -19,8 +19,9 @@ resource "aws_lambda_function" "migration_lambda" {
   environment {
     variables = {
       ACCOUNT_ID        = data.aws_caller_identity.current.account_id
-      ENVIRONMENT       = var.environment
       DESTINATION_TABLE = var.destination_table
+      ENVIRONMENT       = var.environment
+      NODE_ENV          = "production"
     }
   }
 }


### PR DESCRIPTION
In order to have a better understanding of how a blue/green migration is performing, this PR introduces the `NODE_ENV` environmental variable to the Lambdas that perform the migration. This way anything logged using the Application logger will get indexed into Kibana. In doing so, I replaced the `console.log(...)` statements to use the Application logger and introduced a couple more logs.