### PR TITLE
Specify mime type for JSON text contents file.

### DIFF
--- a/shared/src/business/useCases/courtIssuedOrder/fileCourtIssuedOrderInteractor.js
+++ b/shared/src/business/useCases/courtIssuedOrder/fileCourtIssuedOrderInteractor.js
@@ -81,6 +81,7 @@ exports.fileCourtIssuedOrderInteractor = async ({
 
     await applicationContext.getPersistenceGateway().saveDocumentFromLambda({
       applicationContext,
+      contentType: 'application/json',
       document: Buffer.from(JSON.stringify(contentToStore)),
       key: documentContentsId,
       useTempBucket: false,

--- a/shared/src/business/useCases/migration/parseLegacyDocumentsInteractor.js
+++ b/shared/src/business/useCases/migration/parseLegacyDocumentsInteractor.js
@@ -61,6 +61,7 @@ exports.parseLegacyDocumentsInteractor = async ({
     // Save text contents to JSON file in S3
     await applicationContext.getPersistenceGateway().saveDocumentFromLambda({
       applicationContext,
+      contentType: 'application/json',
       document: Buffer.from(
         JSON.stringify({ documentContents: pdfTextContents }),
       ),

--- a/shared/src/business/useCases/migration/parseLegacyDocumentsInteractor.test.js
+++ b/shared/src/business/useCases/migration/parseLegacyDocumentsInteractor.test.js
@@ -130,14 +130,12 @@ describe('parseLegacyDocumentsInteractor', () => {
       docketNumber: mockDocketNumber,
     });
 
-    expect(
-      applicationContext.getPersistenceGateway().saveDocumentFromLambda.mock
-        .calls[0][0].key,
-    ).toEqual(mockUniqueID);
-    expect(
-      applicationContext.getPersistenceGateway().saveDocumentFromLambda.mock
-        .calls[0][0].document,
-    ).toEqual(
+    const saveParams = applicationContext.getPersistenceGateway()
+      .saveDocumentFromLambda.mock.calls[0][0];
+
+    expect(saveParams.key).toEqual(mockUniqueID);
+    expect(saveParams.contentType).toEqual('application/json');
+    expect(saveParams.document).toEqual(
       Buffer.from(JSON.stringify({ documentContents: mockPdfTextContents })),
     );
   });


### PR DESCRIPTION
For #581, this PR switches mime types for JSON-stringified text contents, both created in the routine application code path and in the bulk process for legacy documents. 

This enables us to more easily generate a list of orphaned documents in the future for cleanup. 