### PR TITLE
Add alert for the application’s status endpoint.

### DIFF
--- a/shared/src/business/useCases/health/getHealthCheckInteractor.js
+++ b/shared/src/business/useCases/health/getHealthCheckInteractor.js
@@ -163,12 +163,6 @@ const getEmailServiceStatus = async ({ applicationContext }) => {
   }
 };
 
-const getClamAVStatus = async () => {
-  // eslint-disable-next-line spellcheck/spell-checker
-  // TODO - implement once #6282 (Implement ClamAV Fargate Solution) has been completed
-  return false;
-};
-
 /**
  * getHealthCheckInteractor
  *
@@ -195,12 +189,7 @@ exports.getHealthCheckInteractor = async ({ applicationContext }) => {
     applicationContext,
   });
 
-  const clamAVStatus = await getClamAVStatus({
-    applicationContext,
-  });
-
   return {
-    clamAV: clamAVStatus,
     cognito: cognitoStatus,
     dynamo: {
       efcms: dynamoStatus,

--- a/shared/src/business/useCases/health/getHealthCheckInteractor.test.js
+++ b/shared/src/business/useCases/health/getHealthCheckInteractor.test.js
@@ -40,7 +40,6 @@ describe('getHealthCheckInteractor', () => {
     });
 
     expect(status).toEqual({
-      clamAV: false,
       cognito: true,
       dynamo: {
         efcms: true,
@@ -110,7 +109,6 @@ describe('getHealthCheckInteractor', () => {
       },
     });
     expect(status).toEqual({
-      clamAV: false,
       cognito: false,
       dynamo: {
         efcms: false,

--- a/web-client/integration-tests-public/journey/unauthedUserViewsHealthCheck.js
+++ b/web-client/integration-tests-public/journey/unauthedUserViewsHealthCheck.js
@@ -4,7 +4,6 @@ export const unauthedUserViewsHealthCheck = test => {
 
     expect(test.getState('health')).toEqual(
       expect.objectContaining({
-        clamAV: expect.anything(),
         cognito: expect.anything(),
         dynamo: expect.objectContaining({
           efcms: expect.anything(),


### PR DESCRIPTION
Closes #250.

This asserts that all checks returned by the system health endpoint return successfully. 

Note: 

 - This PR removes the ClamAV status check from the API, as it is hardcoded to return `false` (thus failing the alert). However, I’ve left the UI implementation of the ClamAV security check, so it still shows failing in the UI at https://stg.ef-cms.ustaxcourt.gov/health.