### PR TITLE
Remove ClamAV smoke test.

### DIFF
--- a/cypress-smoketests/integration/health-check.spec.js
+++ b/cypress-smoketests/integration/health-check.spec.js
@@ -8,7 +8,6 @@ describe('Health check', () => {
       method: 'GET',
       url: `https://public-api-${DEPLOYING_COLOR}.${domain}/public-api/health`,
     }).should(response => {
-      expect(response.body.clamAV).to.be.false;
       expect(response.body.cognito).to.be.true;
       expect(response.body.dynamo.efcms).to.be.true;
       expect(response.body.dynamo.efcmsDeploy).to.be.true;


### PR DESCRIPTION
Following up from #650, this PR removes the smoke test assertion for `clamAV`, which has been removed as it is a no-op operation.

Fixes the [failed test run](https://app.circleci.com/pipelines/github/ustaxcourt/ef-cms/1439/workflows/5b1bda82-23a5-47e0-acc2-852d3e637430/jobs/14047/parallel-runs/0/steps/0-105) — sorry for breaking the tests! 🐑 