### PR TITLE
Improve logging for PDF Scraping

### DIFF
--- a/shared/src/business/utilities/scrapePdfContents.js
+++ b/shared/src/business/utilities/scrapePdfContents.js
@@ -36,14 +36,16 @@ const scrapePdfContents = async ({ applicationContext, pdfBuffer }) => {
       }
 
       if (!isEmpty(pageText)) {
-        scrapedText = `${scrapedText}\n\n${pageText}`;
+        scrapedText += '\n\n' + pageText;
       }
     }
 
     return scrapedText;
   } catch (e) {
     const pdfjsVersion = pdfjsLib && pdfjsLib.version;
-    throw new Error(`Error scraping PDF with PDF.JS v${pdfjsVersion}`);
+    throw new Error(
+      `Error scraping PDF with PDF.JS v${pdfjsVersion} ${e.message}`,
+    );
   }
 };
 


### PR DESCRIPTION
To help understand why `pdfjs` is failing for some documents, let's pass along the error message.

Additionally, it looks like a significant (90%+) performance improvement to concatenate the string without template strings, which could make a difference for large PDFs (2000+) pages that had been reporting an error.