### PR TITLE
Bug fix: authorizer error messages.

### DIFF
--- a/web-api/terraform/template/lambdas/cognito-authorizer.js
+++ b/web-api/terraform/template/lambdas/cognito-authorizer.js
@@ -83,7 +83,7 @@ exports.handler = async (event, context) => {
   try {
     keys = await getKeysForIssuer(iss);
   } catch (error) {
-    logger.warn(
+    logger.warning(
       'Could not fetch keys for token issuer, considering request unauthorized',
       error,
     );
@@ -94,7 +94,7 @@ exports.handler = async (event, context) => {
   const key = keys.find(k => k.kid === kid);
 
   if (!key) {
-    logger.warn(
+    logger.warning(
       'The key used to sign the authorization token was not found in the user pool’s keys, considering request unauthorized',
       {
         issuer: iss,
@@ -110,7 +110,7 @@ exports.handler = async (event, context) => {
   try {
     payload = await verify(key, token);
   } catch (error) {
-    logger.warn(
+    logger.warning(
       'The token is not valid, considering request unauthorized',
       error,
     );


### PR DESCRIPTION
Closes #607.

This PR adjusts the mocking pattern used to mock the Winston transport instead of the logger instance, exposing the improper method bug as observed in #607. It then follows-up to fix the method. 😉 

Thanks for catching, @mark-meyer!