### PR TITLE
Elasticsearch optimization: only index contents of Orders and Opinions

### DIFF
--- a/get-es-volume-size.sh
+++ b/get-es-volume-size.sh
@@ -25,15 +25,15 @@ elif [[ $BRANCH == 'irs' ]] ; then
 elif [[ $BRANCH == 'staging' ]] ; then
   echo "10"
 elif [[ $BRANCH == 'test' ]] ; then
-  echo "100"
+  echo "350"
 elif [[ $BRANCH == 'migration' ]] ; then
-  echo "100"
+  echo "350"
 elif [[ $BRANCH == 'master' ]] ; then
   echo "100"
 elif [[ $BRANCH == 'dawson' ]] ; then
   echo "100"
 elif [[ $BRANCH == 'prod' ]] ; then
-  echo "100"
+  echo "350"
 else
   exit 1;
 fi

--- a/shared/src/business/useCases/processStreamRecordsInteractor.js
+++ b/shared/src/business/useCases/processStreamRecordsInteractor.js
@@ -2,6 +2,11 @@ const AWS = require('aws-sdk');
 const { flattenDeep, get, partition } = require('lodash');
 const { omit } = require('lodash');
 
+const {
+  OPINION_EVENT_CODES,
+  ORDER_EVENT_CODES,
+} = require('../entities/EntityConstants');
+
 const filterRecords = record => {
   // to prevent global tables writing extra data
   const NEW_TIME_KEY = 'dynamodb.NewImage.aws:rep:updatetime.N';
@@ -166,7 +171,11 @@ const processDocketEntries = async ({
         record.dynamodb.NewImage,
       );
 
-      if (fullDocketEntry.documentContentsId) {
+      const isSearchable =
+        OPINION_EVENT_CODES.includes(fullDocketEntry.eventCode) ||
+        ORDER_EVENT_CODES.includes(fullDocketEntry.eventCode);
+
+      if (isSearchable && fullDocketEntry.documentContentsId) {
         // TODO: for performance, we should not re-index doc contents if we do not have to (use a contents hash?)
         try {
           const buffer = await utils.getDocument({

--- a/shared/src/business/useCases/processStreamRecordsInteractor.test.js
+++ b/shared/src/business/useCases/processStreamRecordsInteractor.test.js
@@ -560,9 +560,10 @@ describe('processStreamRecordsInteractor', () => {
       ]);
     });
 
-    it('fetches the document from persistence if the entry has a documentContentsId', async () => {
+    it('fetches the document from persistence if the entry is an opinion and has a documentContentsId', async () => {
       docketEntryData.documentContentsId = '123';
       docketEntryDataMarshalled.documentContentsId = { S: '123' };
+      docketEntryDataMarshalled.eventCode = { S: 'TCOP' };
 
       await processDocketEntries({
         applicationContext,
@@ -582,6 +583,110 @@ describe('processStreamRecordsInteractor', () => {
       });
 
       expect(mockGetDocument).toHaveBeenCalled();
+
+      const docketEntryCase = {
+        ...caseDataMarshalled,
+      };
+      delete docketEntryCase.docketEntries;
+
+      expect(
+        applicationContext.getPersistenceGateway().bulkIndexRecords.mock
+          .calls[0][0].records,
+      ).toEqual([
+        {
+          dynamodb: {
+            Keys: {
+              pk: { S: docketEntryData.pk },
+              sk: { S: docketEntryData.sk },
+            },
+            NewImage: {
+              ...docketEntryDataMarshalled,
+              case_relations: {
+                name: 'document',
+                parent: 'case|123_case|123|mapping',
+              },
+            },
+          },
+          eventName: 'MODIFY',
+        },
+      ]);
+    });
+
+    it('fetches the document from persistence if the entry is an order and has a documentContentsId', async () => {
+      docketEntryData.documentContentsId = '123';
+      docketEntryDataMarshalled.documentContentsId = { S: '123' };
+      docketEntryDataMarshalled.eventCode = { S: 'OAJ' };
+
+      await processDocketEntries({
+        applicationContext,
+        docketEntryRecords: [
+          {
+            dynamodb: {
+              Keys: {
+                pk: { S: docketEntryData.pk },
+                sk: { S: docketEntryData.sk },
+              },
+              NewImage: docketEntryDataMarshalled,
+            },
+            eventName: 'MODIFY',
+          },
+        ],
+        utils,
+      });
+
+      expect(mockGetDocument).toHaveBeenCalled();
+
+      const docketEntryCase = {
+        ...caseDataMarshalled,
+      };
+      delete docketEntryCase.docketEntries;
+
+      expect(
+        applicationContext.getPersistenceGateway().bulkIndexRecords.mock
+          .calls[0][0].records,
+      ).toEqual([
+        {
+          dynamodb: {
+            Keys: {
+              pk: { S: docketEntryData.pk },
+              sk: { S: docketEntryData.sk },
+            },
+            NewImage: {
+              ...docketEntryDataMarshalled,
+              case_relations: {
+                name: 'document',
+                parent: 'case|123_case|123|mapping',
+              },
+            },
+          },
+          eventName: 'MODIFY',
+        },
+      ]);
+    });
+
+    it('does NOT index the contents of a document if it is not an order or an opinion', async () => {
+      docketEntryData.documentContentsId = '123';
+      docketEntryDataMarshalled.documentContentsId = { S: '123' };
+      docketEntryDataMarshalled.eventCode = { S: 'APW' };
+
+      await processDocketEntries({
+        applicationContext,
+        docketEntryRecords: [
+          {
+            dynamodb: {
+              Keys: {
+                pk: { S: docketEntryData.pk },
+                sk: { S: docketEntryData.sk },
+              },
+              NewImage: docketEntryDataMarshalled,
+            },
+            eventName: 'MODIFY',
+          },
+        ],
+        utils,
+      });
+
+      expect(mockGetDocument).not.toHaveBeenCalled();
 
       const docketEntryCase = {
         ...caseDataMarshalled,


### PR DESCRIPTION
To help satisfy #669 , this additional check only indexes the `documentContents` of Orders and Opinions into the `efcms-docket-entry` index. Other docket entries will still be indexed, but their `documentContents` will be ignored as they are not used. One test was changed and two introduced to test this functionality.