### PR TITLE
Add multi-field mapping on messages.

### DIFF
--- a/aws/lambdas/LogsToElasticSearch_info/index-template.md
+++ b/aws/lambdas/LogsToElasticSearch_info/index-template.md
@@ -41,7 +41,12 @@ PUT _template/cwl
       "level": { "type": "keyword" },
       "logGroup": { "type": "keyword" },
       "logStream": { "type": "keyword" },
-      "message": { "type": "text" },
+      "message": {
+        "type": "text",
+        "fields": {
+          "raw": { "type": "keyword" }
+        }
+      },
       "requestId": {
         "properties": {
           "apiGateway": { "type": "keyword" },


### PR DESCRIPTION
This indexes log messages in two ways: 

- It leaves the existing full-text index. This gives us the ability to search the log messages with free-text search.
- It adds a keyword index, which gives us the ability to aggregate based on the log message. For error dashboards, we can use the error message to group similar errors together. 

This change has already been applied to the staging AWS account. 