### PR TITLE
Ensure we attach a cover sheet for STIN documents upon e-Filing

### DIFF
--- a/shared/src/business/useCaseHelper/service/sendIrsSuperuserPetitionEmail.js
+++ b/shared/src/business/useCaseHelper/service/sendIrsSuperuserPetitionEmail.js
@@ -102,9 +102,10 @@ exports.sendIrsSuperuserPetitionEmail = async ({
     templateName: process.env.EMAIL_SERVED_PETITION_TEMPLATE,
   });
 
-  applicationContext.logger.info('served a petition', {
+  applicationContext.logger.info('served a document to the irs', {
     destination,
     docketEntryId,
     docketNumber,
+    eventCode,
   });
 };

--- a/shared/src/business/useCaseHelper/service/sendIrsSuperuserPetitionEmail.js
+++ b/shared/src/business/useCaseHelper/service/sendIrsSuperuserPetitionEmail.js
@@ -101,4 +101,10 @@ exports.sendIrsSuperuserPetitionEmail = async ({
     destinations: [destination],
     templateName: process.env.EMAIL_SERVED_PETITION_TEMPLATE,
   });
+
+  applicationContext.logger.info('served a petition', {
+    destination,
+    docketEntryId,
+    docketNumber,
+  });
 };

--- a/shared/src/business/useCases/createCaseInteractor.js
+++ b/shared/src/business/useCases/createCaseInteractor.js
@@ -246,5 +246,9 @@ exports.createCaseInteractor = async ({
     workItem: newWorkItem.validate().toRawObject(),
   });
 
+  applicationContext.logger.info('filed a new petition', {
+    docketNumber: caseToAdd.docketNumber,
+  });
+
   return new Case(caseToAdd, { applicationContext }).toRawObject();
 };

--- a/shared/src/business/useCases/filePetitionInteractor.js
+++ b/shared/src/business/useCases/filePetitionInteractor.js
@@ -72,21 +72,24 @@ exports.filePetitionInteractor = async ({
     );
   }
 
-  await Promise.all([
+  const [
+    ownershipDisclosureFileId,
+    petitionFileId,
+    stinFileId,
+  ] = await Promise.all([
     ownershipDisclosureFileUpload,
     petitionFileUpload,
     stinFileUpload,
   ]);
 
-  const stinFileId = await stinFileUpload;
   const caseDetail = await applicationContext
     .getUseCases()
     .createCaseInteractor({
       applicationContext,
-      ownershipDisclosureFileId: await ownershipDisclosureFileUpload,
-      petitionFileId: await petitionFileUpload,
+      ownershipDisclosureFileId,
+      petitionFileId,
       petitionMetadata,
-      stinFileId: await stinFileUpload,
+      stinFileId,
     });
 
   return {

--- a/shared/src/business/useCases/filePetitionInteractor.js
+++ b/shared/src/business/useCases/filePetitionInteractor.js
@@ -78,11 +78,19 @@ exports.filePetitionInteractor = async ({
     stinFileUpload,
   ]);
 
-  return await applicationContext.getUseCases().createCaseInteractor({
-    applicationContext,
-    ownershipDisclosureFileId: await ownershipDisclosureFileUpload,
-    petitionFileId: await petitionFileUpload,
-    petitionMetadata,
-    stinFileId: await stinFileUpload,
-  });
+  const stinFileId = await stinFileUpload;
+  const caseDetail = await applicationContext
+    .getUseCases()
+    .createCaseInteractor({
+      applicationContext,
+      ownershipDisclosureFileId: await ownershipDisclosureFileUpload,
+      petitionFileId: await petitionFileUpload,
+      petitionMetadata,
+      stinFileId: await stinFileUpload,
+    });
+
+  return {
+    caseDetail,
+    stinFileId,
+  };
 };

--- a/web-client/src/presenter/actions/createCaseAction.js
+++ b/web-client/src/presenter/actions/createCaseAction.js
@@ -69,11 +69,8 @@ export const createCaseAction = async ({
     .filter(d => d.isFileAttached)
     .map(d => d.docketEntryId);
 
+  // for security reasons, the STIN is not in the API response, but we already know the docketEntryId
   documentsThatNeedCoverSheet.push(stinFileId);
-  console.log(
-    'we are about to attach some rad coversheets!',
-    documentsThatNeedCoverSheet,
-  );
 
   await Promise.all(documentsThatNeedCoverSheet.map(addCoversheet));
 

--- a/web-client/src/presenter/actions/createCaseAction.test.js
+++ b/web-client/src/presenter/actions/createCaseAction.test.js
@@ -26,8 +26,54 @@ describe('createCaseAction', () => {
     email: 'petitioner1@example.com',
   });
 
-  it('should call filePetitionInteractor and addCoversheetInteractor with the petition metadata and files and call the success path when finished', async () => {
-    filePetitionInteractor.mockReturnValue(MOCK_CASE);
+  it('should call filePetitionInteractor and addCoversheetInteractor TWICE with the petition metadata and files and call the success path when finished', async () => {
+    filePetitionInteractor.mockReturnValue({
+      caseDetail: {
+        ...MOCK_CASE,
+        docketEntries: [
+          {
+            createdAt: '2020-12-21T17:21:39.718Z',
+            docketEntryId: 'ed1cb5ff-4761-4cca-b8ca-9464e540fee4',
+            documentTitle: 'Petition',
+            documentType: 'Petition',
+            entityName: 'DocketEntry',
+            eventCode: 'P',
+            filedBy: 'Petr. Mark Mikecotte',
+            filingDate: '2020-12-21T17:21:39.717Z',
+            index: 1,
+            isFileAttached: true,
+            isMinuteEntry: false,
+            isOnDocketRecord: true,
+            isStricken: false,
+            partyPrimary: true,
+            partySecondary: false,
+            privatePractitioners: [],
+            processingStatus: 'pending',
+            receivedAt: '2020-12-21T17:21:39.718Z',
+            userId: '7805d1ab-18d0-43ec-bafb-654e83405416',
+          },
+          {
+            createdAt: '2020-12-21T17:21:39.719Z',
+            docketEntryId: '2b1e5fb3-e7f2-48c4-9a43-4f856ae46d66',
+            documentTitle:
+              'Request for Place of Trial at Little Rock, Arkansas',
+            documentType: 'Request for Place of Trial',
+            entityName: 'DocketEntry',
+            eventCode: 'RQT',
+            filingDate: '2020-12-21T17:21:39.717Z',
+            index: 2,
+            isFileAttached: false,
+            isMinuteEntry: true,
+            isOnDocketRecord: true,
+            isStricken: false,
+            processingStatus: 'complete',
+            receivedAt: '2020-12-21T17:21:39.720Z',
+            userId: '7805d1ab-18d0-43ec-bafb-654e83405416',
+          },
+        ],
+      },
+      stinFileId: '123',
+    });
 
     await runAction(createCaseAction, {
       modules: {
@@ -53,7 +99,105 @@ describe('createCaseAction', () => {
       },
       stinFile: {},
     });
-    expect(addCoversheetInteractor).toBeCalled();
+    expect(addCoversheetInteractor).toHaveBeenCalledTimes(2);
+    expect(successStub).toBeCalled();
+  });
+
+  it('should call filePetitionInteractor and addCoversheetInteractor THREE times (when we have an ODS form) with the petition metadata and files and call the success path  finished', async () => {
+    filePetitionInteractor.mockReturnValue({
+      caseDetail: {
+        ...MOCK_CASE,
+        docketEntries: [
+          {
+            createdAt: '2020-12-21T17:21:39.718Z',
+            docketEntryId: 'ed1cb5ff-4761-4cca-b8ca-9464e540fee4',
+            documentTitle: 'Petition',
+            documentType: 'Petition',
+            entityName: 'DocketEntry',
+            eventCode: 'P',
+            filedBy: 'Petr. Com Pan Nee',
+            filingDate: '2020-12-21T17:21:39.717Z',
+            index: 1,
+            isFileAttached: true,
+            isMinuteEntry: false,
+            isOnDocketRecord: true,
+            isStricken: false,
+            partyPrimary: true,
+            partySecondary: false,
+            privatePractitioners: [],
+            processingStatus: 'pending',
+            receivedAt: '2020-12-21T17:21:39.718Z',
+            userId: '7805d1ab-18d0-43ec-bafb-654e83405416',
+          },
+          {
+            createdAt: '2020-12-21T17:21:39.719Z',
+            docketEntryId: '2b1e5fb3-e7f2-48c4-9a43-4f856ae46d66',
+            documentTitle:
+              'Request for Place of Trial at Little Rock, Arkansas',
+            documentType: 'Request for Place of Trial',
+            entityName: 'DocketEntry',
+            eventCode: 'RQT',
+            filingDate: '2020-12-21T17:21:39.717Z',
+            index: 2,
+            isFileAttached: false,
+            isMinuteEntry: true,
+            isOnDocketRecord: true,
+            isStricken: false,
+            processingStatus: 'complete',
+            receivedAt: '2020-12-21T17:21:39.720Z',
+            userId: '7805d1ab-18d0-43ec-bafb-654e83405416',
+          },
+          {
+            createdAt: '2020-12-21T22:13:58.658Z',
+            docketEntryId: 'aaec01d8-98e7-4534-959f-6c384c4cf0e0',
+            documentTitle: 'Ownership Disclosure Statement',
+            documentType: 'Ownership Disclosure Statement',
+            entityName: 'DocketEntry',
+            eventCode: 'DISC',
+            filedBy: 'Petr. Com Pan Nee',
+            filingDate: '2020-12-21T22:13:58.655Z',
+            index: 3,
+            isFileAttached: true,
+            isMinuteEntry: false,
+            isOnDocketRecord: true,
+            isStricken: false,
+            partyPrimary: true,
+            partySecondary: false,
+            privatePractitioners: [],
+            processingStatus: 'pending',
+            receivedAt: '2020-12-21T22:13:58.658Z',
+            userId: '7805d1ab-18d0-43ec-bafb-654e83405416',
+          },
+        ],
+      },
+      stinFileId: '123',
+    });
+
+    await runAction(createCaseAction, {
+      modules: {
+        presenter,
+      },
+      state: {
+        form: {
+          ownershipDisclosureFile: {},
+          petitionFile: {},
+          stinFile: {},
+          trialCities: [{ city: 'Birmingham', state: US_STATES.AL }],
+          ...MOCK_CASE,
+        },
+      },
+    });
+
+    expect(filePetitionInteractor).toBeCalled();
+    expect(filePetitionInteractor.mock.calls[0][0]).toMatchObject({
+      ownershipDisclosureFile: {},
+      petitionFile: {},
+      petitionMetadata: {
+        ...MOCK_CASE,
+      },
+      stinFile: {},
+    });
+    expect(addCoversheetInteractor).toHaveBeenCalledTimes(3); // STIN, Petition, and ODS
     expect(successStub).toBeCalled();
   });
 


### PR DESCRIPTION
To help resolve #684 , attach a coversheet to the STIN file. We already knew its UUID, but it wasn't part of the response from the server after filing a petition. Write a couple of tests to make sure we perform the correct number of cover sheet attachments.