### PR TITLE
Increase async lambda’s memory to 5GB.

### DIFF
--- a/web-api/terraform/api/api-async.tf
+++ b/web-api/terraform/api/api-async.tf
@@ -7,7 +7,7 @@ resource "aws_lambda_function" "api_async_lambda" {
   s3_key           = "api_${var.current_color}.js.zip"
   source_code_hash = var.api_object_hash
   timeout          = "900"
-  memory_size      = "3008"
+  memory_size      = "5000"
 
   layers = [
     aws_lambda_layer_version.puppeteer_layer.arn


### PR DESCRIPTION
Closes #661.

Creating zip archives with trial sessions requires enough memory to hold all documents in memory, with the largest of documents being 2.14gb.