### PR TITLE
Updates to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pr-to-ustc.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr-to-ustc.md
@@ -1,10 +1,12 @@
-# Description
+# Sprint {##}
+## Issues
+---
+*List of issues the work in this PR encompasses*
 
-## Checklist
+## Data Migrations
+---
+*Describe any data migrations included and their purpose*
 
-- [ ] List all stories/issues that track the included changes
-- [ ] If any changes aren't connected to a story, document and briefly explain the change
-- [ ] All changes included are QA tested and closed in the originating repo
-- [ ] Tests are written for new/updated code, or it's been documented why the code isn't tested
-- [ ] At least one internal reviewer signed off on any commits contained in the PR
-- [ ] Impact analysis is done for the changes in each story - any significant changes which would impact users of the application/API or  infrastructure/ops  is highlighted and documented
+## Manual Deployment Steps
+---
+*List out and reference documentation to any manual deployment steps or other manual updates needing to be taken in relation to the included changes.*

--- a/.github/PULL_REQUEST_TEMPLATE/pr-to-ustc.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr-to-ustc.md
@@ -1,12 +1,9 @@
 # Sprint {##}
 ## Issues
----
 *List of issues the work in this PR encompasses*
 
 ## Data Migrations
----
 *Describe any data migrations included and their purpose*
 
 ## Manual Deployment Steps
----
 *List out and reference documentation to any manual deployment steps or other manual updates needing to be taken in relation to the included changes.*


### PR DESCRIPTION
This PR updates our GitHub pull request template to match the format Mike discussed with me. This template is meant to highlight the information we want to be documented in each sprint PR to help facilitate a shared understanding of the changes the PR introduces, plus any steps that are needed to be taken to ensure those changes are properly reflected in the court's environments. 

It is intended for the vendor team to use this template while crafting sprint PRs.