### PR TITLE
Tune down es one step for production

### DIFF
--- a/get-es-instance-type.sh
+++ b/get-es-instance-type.sh
@@ -33,7 +33,7 @@ elif [[ $BRANCH == 'master' ]] ; then
 elif [[ $BRANCH == 'dawson' ]] ; then
   echo "t2.small.elasticsearch"
 elif [[ $BRANCH == 'prod' ]] ; then
-  echo "m5.2xlarge.elasticsearch"
+  echo "m5.xlarge.elasticsearch"
 else
   exit 1;
 fi


### PR DESCRIPTION
Based on observed usage, our ES cluster is over-provisioned. We do not need the firepower that we are currently paying for. This tunes it down one step to `xlarge` from `2xlarge`.