### PR TITLE
Increase signal-to-noise ratio on system health alarms.

### DIFF
--- a/web-client/terraform/main/main.tf
+++ b/web-client/terraform/main/main.tf
@@ -170,6 +170,7 @@ resource "aws_route53_health_check" "public_ui_health_check" {
   resource_path     = "/"
   failure_threshold = "2"
   request_interval  = "30"
+  regions           = [ "us-east-1", "us-west-1", "us-west-2" ] # Minimum of three regions required
 }
 
 resource "aws_cloudwatch_metric_alarm" "ui_health_check" {
@@ -198,6 +199,7 @@ resource "aws_route53_health_check" "ui_health_check" {
   resource_path     = "/"
   failure_threshold = "2"
   request_interval  = "30"
+  regions           = [ "us-east-1", "us-west-1", "us-west-2" ] # Minimum of three regions required
 }
 
 resource "aws_cloudwatch_metric_alarm" "status_health_check" {
@@ -228,4 +230,5 @@ resource "aws_route53_health_check" "status_health_check" {
   request_interval   = "30"
   invert_healthcheck = true
   search_string      = "false" # Search for any JSON property returning "false"
+  regions            = [ "us-east-1", "us-west-1", "us-west-2" ] # Minimum of three regions required
 }

--- a/web-client/terraform/main/main.tf
+++ b/web-client/terraform/main/main.tf
@@ -168,7 +168,7 @@ resource "aws_route53_health_check" "public_ui_health_check" {
   port              = 443
   type              = "HTTPS"
   resource_path     = "/"
-  failure_threshold = "2"
+  failure_threshold = "3"
   request_interval  = "30"
   regions           = [ "us-east-1", "us-west-1", "us-west-2" ] # Minimum of three regions required
 }
@@ -197,7 +197,7 @@ resource "aws_route53_health_check" "ui_health_check" {
   port              = 443
   type              = "HTTPS"
   resource_path     = "/"
-  failure_threshold = "2"
+  failure_threshold = "3"
   request_interval  = "30"
   regions           = [ "us-east-1", "us-west-1", "us-west-2" ] # Minimum of three regions required
 }
@@ -226,7 +226,7 @@ resource "aws_route53_health_check" "status_health_check" {
   port               = 443
   type               = "HTTPS_STR_MATCH"
   resource_path      = "/public-api/health"
-  failure_threshold  = "2"
+  failure_threshold  = "3"
   request_interval   = "30"
   invert_healthcheck = true
   search_string      = "false" # Search for any JSON property returning "false"


### PR DESCRIPTION
Closes #712.

We have seen instability in our alarms for the system health endpoint due to the Dynamsoft EC2 host failing — there were a few contributing factors, but since we do not have user reports of failure, the remaining issues appear to be intermittent network issues. Continuing onward with this theory until we receive user reported issues. 

This PR applies two changes: 

1. **Specify regions to deploy the Health Check.** This results in a significant [overall reduction of health pings](https://github.com/ustaxcourt/ef-cms/issues/712#issuecomment-760954580). 
    - The default regions are:
      1. US East (N. Virginia)
      2. US West (N. California)
      3. US West (Oregon)
      4. EU (Ireland)
      5. Asia Pacific (Singapore)
      6. Asia Pacific (Sydney)
      7. Asia Pacific (Tokyo)
      8. South America (São Paulo)
    - The new regions are (minimum 3 required):
      1. US East (N. Virginia)
      2. US West (N. California)
      3. US West (Oregon)
2. **Increases the failure threshold to 3.** The alarm will now be triggered after one minute and 30 seconds of observed downtime in any of the above regions. 

Confirmed the changes on `exp1`.