### PR TITLE
HotFix - Setting attributes in cognito as writable explicitly

### DIFF
--- a/web-api/terraform/template/cognito.tf
+++ b/web-api/terraform/template/cognito.tf
@@ -114,6 +114,26 @@ resource "aws_cognito_user_pool_client" "client" {
   supported_identity_providers = ["COGNITO"]
 
   user_pool_id = aws_cognito_user_pool.pool.id
+
+  write_attributes = [
+    "address",
+    "birthdate",
+    "email",
+    "family_name",
+    "gender",
+    "given_name",
+    "locale", 
+    "middle_name", 
+    "name",
+    "nickname",
+    "phone_number",
+    "picture",
+    "preferred_username",
+    "profile",
+    "updated_at",
+    "website",
+    "zoneinfo",
+  ]
 }
 
 resource "aws_cognito_user_pool_domain" "main" {
@@ -224,6 +244,26 @@ resource "aws_cognito_user_pool_client" "irs_client" {
   supported_identity_providers = ["COGNITO"]
 
   user_pool_id = aws_cognito_user_pool.irs_pool.id
+
+  write_attributes = [
+    "address",
+    "birthdate",
+    "email",
+    "family_name",
+    "gender",
+    "given_name",
+    "locale", 
+    "middle_name", 
+    "name",
+    "nickname",
+    "phone_number",
+    "picture",
+    "preferred_username",
+    "profile",
+    "updated_at",
+    "website",
+    "zoneinfo",
+  ]
 }
 
 resource "aws_cognito_user_pool_domain" "irs" {


### PR DESCRIPTION
- setting explicit write_attributes for the default cognito attributes so that it does NOT allow people to overwrite their custom:role or custom:userId