### PR TITLE
7594: migration to add proceeding type to case hearing records

### DIFF
--- a/web-api/migration-terraform/main/lambdas/migration-segments.js
+++ b/web-api/migration-terraform/main/lambdas/migration-segments.js
@@ -3,6 +3,9 @@ const createApplicationContext = require('../../../src/applicationContext');
 const {
   migrateItems: migration0013,
 } = require('./migrations/0013-trial-session-default-proceedingType');
+const {
+  migrateItems: migration0014,
+} = require('./migrations/0014-hearings-proceeding-type');
 const { chunk, isEmpty } = require('lodash');
 
 const MAX_DYNAMO_WRITE_SIZE = 25;
@@ -26,6 +29,8 @@ const sqs = new AWS.SQS({ region: 'us-east-1' });
 const migrateRecords = async ({ documentClient, items }) => {
   applicationContext.logger.info('about to run migration 0013');
   items = await migration0013(items, documentClient);
+  applicationContext.logger.info('about to run migration 0014');
+  items = await migration0014(items, documentClient);
 
   return items;
 };

--- a/web-api/migration-terraform/main/lambdas/migrations/0014-hearings-proceeding-type.js
+++ b/web-api/migration-terraform/main/lambdas/migrations/0014-hearings-proceeding-type.js
@@ -1,0 +1,61 @@
+const createApplicationContext = require('../../../../src/applicationContext');
+const {
+  TrialSession,
+} = require('../../../../../shared/src/business/entities/trialSessions/TrialSession');
+const applicationContext = createApplicationContext({});
+
+const migrateItems = async (items, documentClient) => {
+  const itemsAfter = [];
+  for (const item of items) {
+    if (
+      item.pk.startsWith('case|') &&
+      item.sk.startsWith('hearing|') &&
+      !item.proceedingType
+    ) {
+      const trialSessionRecord = await documentClient
+        .get({
+          Key: {
+            pk: `trial-session|${item.trialSessionId}`,
+            sk: `trial-session|${item.trialSessionId}`,
+          },
+          TableName: process.env.SOURCE_TABLE,
+        })
+        .promise()
+        .then(res => {
+          return res.Item;
+        });
+
+      if (!trialSessionRecord) {
+        throw new Error(
+          `Trial session with id ${item.trialSessionId} not found`,
+        );
+      }
+
+      const trialSessionEntity = new TrialSession(
+        { ...item, proceedingType: trialSessionRecord.proceedingType },
+        {
+          applicationContext,
+        },
+      );
+
+      itemsAfter.push({
+        ...item,
+        ...trialSessionEntity.validate().toRawObject(),
+      });
+
+      const docketNumber = item.pk.split('|')[1];
+      applicationContext.logger.info(
+        `migrating hearing for case ${docketNumber} and trial session id ${item.trialSessionId}`,
+        {
+          ...item,
+          ...trialSessionEntity.validate().toRawObject(),
+        },
+      );
+    } else {
+      itemsAfter.push(item);
+    }
+  }
+  return itemsAfter;
+};
+
+exports.migrateItems = migrateItems;

--- a/web-api/migration-terraform/main/lambdas/migrations/0014-hearings-proceeding-type.test.js
+++ b/web-api/migration-terraform/main/lambdas/migrations/0014-hearings-proceeding-type.test.js
@@ -1,0 +1,97 @@
+const {
+  DEFAULT_PROCEEDING_TYPE,
+  SESSION_TYPES,
+  TRIAL_SESSION_PROCEEDING_TYPES,
+} = require('../../../../../shared/src/business/entities/EntityConstants');
+const { migrateItems } = require('./0014-hearings-proceeding-type');
+
+describe('migrateItems', () => {
+  let documentClient;
+
+  const TRIAL_SESSION_ID = 'f08f8666-0f12-4d61-b699-fc495403983a';
+
+  const MOCK_CASE_HEARING = {
+    maxCases: 100,
+    pk: 'case|105-20',
+    sessionType: SESSION_TYPES.motionHearing,
+    sk: `hearing|${TRIAL_SESSION_ID}`,
+    startDate: '2025-12-01T00:00:00.000Z',
+    term: 'Fall',
+    termYear: '2025',
+    trialLocation: 'Birmingham, Alabama',
+    trialSessionId: TRIAL_SESSION_ID,
+  };
+
+  beforeEach(() => {
+    documentClient = {
+      get: () => ({
+        promise: async () => ({
+          Item: {
+            ...MOCK_CASE_HEARING,
+            proceedingType: TRIAL_SESSION_PROCEEDING_TYPES.inPerson,
+          },
+        }),
+      }),
+    };
+  });
+
+  it('should return and not modify records that are NOT case hearing records', async () => {
+    const items = [
+      {
+        pk: 'user|6d74eadc-0181-4ff5-826c-305200e8733d',
+        sk: 'user|6d74eadc-0181-4ff5-826c-305200e8733d',
+      },
+    ];
+
+    const results = await migrateItems(items, documentClient);
+
+    expect(results).toEqual(
+      expect.arrayContaining([
+        {
+          pk: 'user|6d74eadc-0181-4ff5-826c-305200e8733d',
+          sk: 'user|6d74eadc-0181-4ff5-826c-305200e8733d',
+        },
+      ]),
+    );
+  });
+
+  it('should return and not modify records that are case hearing records with an existing proceedingType', async () => {
+    const mockCaseHearingRecord = {
+      ...MOCK_CASE_HEARING,
+      proceedingType: DEFAULT_PROCEEDING_TYPE,
+    };
+
+    const items = [mockCaseHearingRecord];
+
+    const results = await migrateItems(items, documentClient);
+
+    expect(results).toEqual([mockCaseHearingRecord]);
+  });
+
+  it('should migrate case hearing records that do not have an existing proceedingType', async () => {
+    const items = [MOCK_CASE_HEARING];
+
+    const results = await migrateItems(items, documentClient);
+
+    expect(results[0]).toMatchObject({
+      ...MOCK_CASE_HEARING,
+      proceedingType: TRIAL_SESSION_PROCEEDING_TYPES.inPerson,
+    });
+  });
+
+  it('should throw an error if the trial session record is not found', async () => {
+    documentClient = {
+      get: () => ({
+        promise: async () => ({
+          Item: undefined,
+        }),
+      }),
+    };
+
+    const items = [MOCK_CASE_HEARING];
+
+    await expect(migrateItems(items, documentClient)).rejects.toThrow(
+      `Trial session with id ${TRIAL_SESSION_ID} not found`,
+    );
+  });
+});


### PR DESCRIPTION
Addresses issue where hearings on a case were failing validation due to a missing `proceedingType` field. This issue was preventing judges from viewing the trial session working copy or associated cases.