### PR TITLE
Fix environment setup scripts — only output a single table and domain name.

### DIFF
--- a/get-destination-elasticsearch.sh
+++ b/get-destination-elasticsearch.sh
@@ -13,7 +13,10 @@
 ENV=$1
 
 DESTINATION_TABLE_VERSION=$(aws dynamodb get-item --region us-east-1 --table-name "efcms-deploy-${ENV}" --key '{"pk":{"S":"destination-table-version"},"sk":{"S":"destination-table-version"}}' | jq -r ".Item.current.S")
-[ -z "$DESTINATION_TABLE_VERSION" ] && echo "efcms-search-${ENV}"
 
-echo "efcms-search-${ENV}-${DESTINATION_TABLE_VERSION}"
+if [ -z "$DESTINATION_TABLE_VERSION" ]; then
+  echo "efcms-search-${ENV}"
+else
+  echo "efcms-search-${ENV}-${DESTINATION_TABLE_VERSION}"
+fi
 

--- a/get-destination-table.sh
+++ b/get-destination-table.sh
@@ -13,6 +13,9 @@
 ENV=$1
 
 DESTINATION_TABLE_VERSION=$(aws dynamodb get-item --region us-east-1 --table-name "efcms-deploy-${ENV}" --key '{"pk":{"S":"destination-table-version"},"sk":{"S":"destination-table-version"}}' | jq -r ".Item.current.S")
-[ -z "$DESTINATION_TABLE_VERSION" ] && echo "efcms-${ENV}"
 
-echo "efcms-${ENV}-${DESTINATION_TABLE_VERSION}"
+if [ -z "$DESTINATION_TABLE_VERSION" ]; then
+  echo "efcms-${ENV}"
+else
+  echo "efcms-${ENV}-${DESTINATION_TABLE_VERSION}"
+fi


### PR DESCRIPTION
When hitting the default case, both echo statements are executed when only one should.