### PR TITLE
Improve stability of Case Deadlines

### DIFF
--- a/shared/src/business/useCases/getCaseDeadlinesInteractor.js
+++ b/shared/src/business/useCases/getCaseDeadlinesInteractor.js
@@ -54,39 +54,63 @@ exports.getCaseDeadlinesInteractor = async ({
     },
   );
 
-  // get the needed cases info data for caseDeadlines
-  const docketNumbers = Object.keys(
-    validatedCaseDeadlines.reduce((acc, item) => {
-      acc[item.docketNumber] = true;
-      return acc;
-    }, {}),
-  );
+  const caseMap = await getCasesByDocketNumbers({
+    applicationContext,
+    docketNumbers: validatedCaseDeadlines.map(item => item.docketNumber),
+  });
 
-  const allCaseData = await applicationContext
+  const afterCaseMapping = validatedCaseDeadlines
+    .filter(deadline => caseMap[deadline.docketNumber])
+    .map(deadline => ({
+      ...deadline,
+      ...pick(caseMap[deadline.docketNumber], [
+        'caseCaption',
+        'docketNumber',
+        'docketNumberSuffix',
+        'docketNumberWithSuffix',
+      ]),
+    }));
+
+  return { deadlines: afterCaseMapping, totalCount };
+};
+
+/**
+ * Helper function to grab all of the cases from persistence; only return the valid cases
+ *
+ * @param {object} providers The providers
+ * @param {object} providers.applicationContext the application context
+ * @param {array}  providers.docketNumbers an array of docket numbers to retrieve from persistence
+ * @returns {array} a validated array of cases
+ */
+const getCasesByDocketNumbers = async ({
+  applicationContext,
+  docketNumbers,
+}) => {
+  const caseData = await applicationContext
     .getPersistenceGateway()
     .getCasesByDocketNumbers({
       applicationContext,
       docketNumbers,
     });
 
-  const validatedCaseData = Case.validateRawCollection(allCaseData, {
-    applicationContext,
-  });
-
-  const caseMap = validatedCaseData.reduce((acc, item) => {
-    acc[item.docketNumber] = item;
-    return acc;
-  }, {});
-
-  const afterCaseMapping = validatedCaseDeadlines.map(deadline => ({
-    ...deadline,
-    ...pick(caseMap[deadline.docketNumber], [
-      'caseCaption',
-      'docketNumber',
-      'docketNumberSuffix',
-      'docketNumberWithSuffix',
-    ]),
-  }));
-
-  return { deadlines: afterCaseMapping, totalCount };
+  return caseData
+    .map(caseRecord => new Case(caseRecord, { applicationContext }))
+    .filter(caseEntity => {
+      try {
+        caseEntity.validate();
+        return true;
+      } catch (err) {
+        applicationContext.logger.error(
+          `getCasesByDocketNumber: case ${caseEntity.docketNumber} failed validation`,
+          {
+            message: caseEntity.getFormattedValidationErrors(),
+          },
+        );
+        return false;
+      }
+    })
+    .reduce((acc, item) => {
+      acc[item.docketNumber] = item;
+      return acc;
+    }, {});
 };

--- a/shared/src/business/useCases/getCaseDeadlinesInteractor.test.js
+++ b/shared/src/business/useCases/getCaseDeadlinesInteractor.test.js
@@ -7,6 +7,7 @@ const {
 } = require('../entities/EntityConstants');
 const { applicationContext } = require('../test/createTestApplicationContext');
 const { getCaseDeadlinesInteractor } = require('./getCaseDeadlinesInteractor');
+const { MOCK_CASE } = require('../../test/mockCase');
 const { User } = require('../entities/User');
 
 describe('getCaseDeadlinesInteractor', () => {
@@ -161,5 +162,108 @@ describe('getCaseDeadlinesInteractor', () => {
       pageSize: 50,
       startDate: START_DATE,
     });
+  });
+
+  it('logs an error for any case that fails validation and includes all cases that pass validation', async () => {
+    applicationContext
+      .getPersistenceGateway()
+      .getCasesByDocketNumbers.mockReturnValue([
+        ...mockCases,
+        {
+          ...MOCK_CASE,
+          docketNumber: '2000-20',
+          hearings: [
+            {
+              address1: '200 Second St NW',
+              caseOrder: [
+                {
+                  addedToSessionAt: '2020-12-23T14:21:54.970Z',
+                  calendarNotes: 'Remote Subpoena Hearing',
+                  docketNumber: '2000-20',
+                  isManuallyAdded: true,
+                },
+              ],
+              city: 'Washington',
+              courthouseName: 'US Tax Courthouse',
+              createdAt: '2020-12-23T14:20:52.766Z',
+              entityName: 'TrialSession',
+              isCalendared: true,
+              judge: {
+                name: 'Carluzzo',
+                userId: 'a22f4615-1234-4321-9284-30af3e22e715',
+              },
+              maxCases: '100',
+              postalCode: '20217',
+              // missing proceedingType; should throw an error!
+              sessionType: 'Special',
+              startDate: '2021-01-27T05:00:00.000Z',
+              startTime: '13:00',
+              state: 'DC',
+              term: 'Winter',
+              termYear: '2021',
+              trialClerk: {
+                name: 'Aisha Miller',
+                userId: '1e68fefe-asdf-fdsa-b08d-d806dd85c979',
+              },
+              trialLocation: 'Washington, District of Columbia',
+              trialSessionId: 'bac57bdb-1123-3321-81e3-b6fb6c337c3c',
+            },
+          ],
+        },
+      ]);
+
+    applicationContext
+      .getPersistenceGateway()
+      .getCaseDeadlinesByDateRange.mockReturnValue({
+        foundDeadlines: [
+          ...mockDeadlines,
+          {
+            associatedJudge: 'Judge Carluzzo',
+            caseDeadlineId: 'c63d6904-1234-4321-8259-9f8f65824bb7',
+            createdAt: '2019-02-01T21:40:46.415Z',
+            deadlineDate: '2019-04-01T21:40:46.415Z',
+            description: 'Yet anotherA deadline!',
+            docketNumber: '2000-20',
+          },
+        ],
+        totalCount: 3,
+      });
+
+    const result = await getCaseDeadlinesInteractor({
+      applicationContext,
+    });
+
+    expect(result).toEqual({
+      deadlines: [
+        {
+          associatedJudge: 'Judge Buch',
+          caseCaption: 'A caption, Petitioner',
+          caseDeadlineId: '22c0736f-c4c5-4ab5-97c3-e41fb06bbc2f',
+          createdAt: '2019-01-01T21:40:46.415Z',
+          deadlineDate: '2019-03-01T21:40:46.415Z',
+          description: 'A deadline!',
+          docketNumber: '101-19',
+          docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.LIEN_LEVY,
+          docketNumberWithSuffix: '101-19L',
+          entityName: 'CaseDeadline',
+          sortableDocketNumber: 19000101,
+        },
+        {
+          associatedJudge: 'Judge Carluzzo',
+          caseCaption: 'Another caption, Petitioner',
+          caseDeadlineId: 'c63d6904-5314-4372-8259-9f8f65824bb7',
+          createdAt: '2019-02-01T21:40:46.415Z',
+          deadlineDate: '2019-04-01T21:40:46.415Z',
+          description: 'A different deadline!',
+          docketNumber: '102-19',
+          docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.LIEN_LEVY,
+          docketNumberWithSuffix: '102-19L',
+          entityName: 'CaseDeadline',
+          sortableDocketNumber: 19000102,
+        },
+      ],
+      totalCount: 3,
+    });
+    expect(applicationContext.logger.error).toBeCalled();
   });
 });

--- a/shared/src/persistence/dynamo/cases/getCasesByDocketNumbers.js
+++ b/shared/src/persistence/dynamo/cases/getCasesByDocketNumbers.js
@@ -1,4 +1,5 @@
 const { getCaseByDocketNumber } = require('./getCaseByDocketNumber');
+
 /**
  * getCasesByDocketNumbers
  *

--- a/shared/src/persistence/dynamo/cases/getCasesByDocketNumbers.js
+++ b/shared/src/persistence/dynamo/cases/getCasesByDocketNumbers.js
@@ -1,5 +1,4 @@
-const client = require('../../dynamodbClientService');
-
+const { getCaseByDocketNumber } = require('./getCaseByDocketNumber');
 /**
  * getCasesByDocketNumbers
  *
@@ -12,11 +11,9 @@ exports.getCasesByDocketNumbers = async ({
   applicationContext,
   docketNumbers,
 }) => {
-  return await client.batchGet({
-    applicationContext,
-    keys: docketNumbers.map(docketNumber => ({
-      pk: `case|${docketNumber}`,
-      sk: `case|${docketNumber}`,
-    })),
-  });
+  return await Promise.all(
+    docketNumbers.map(docketNumber =>
+      getCaseByDocketNumber({ applicationContext, docketNumber }),
+    ),
+  );
 };

--- a/shared/src/persistence/dynamo/cases/getCasesByDocketNumbers.test.js
+++ b/shared/src/persistence/dynamo/cases/getCasesByDocketNumbers.test.js
@@ -4,29 +4,14 @@ const {
 const { getCasesByDocketNumbers } = require('./getCasesByDocketNumbers');
 
 describe('getCasesByDocketNumbers', () => {
-  it('should call batchGet with keys for docket numbers passed in', async () => {
+  it('should call query once for each docket number passed in', async () => {
     await getCasesByDocketNumbers({
       applicationContext,
-      docketNumbers: ['123-20', '124-20'],
+      docketNumbers: ['123-20', '124-20', '2000-20'],
     });
 
-    expect(
-      applicationContext.getDocumentClient().batchGet.mock.calls[0][0],
-    ).toMatchObject({
-      RequestItems: {
-        'efcms-local': {
-          Keys: [
-            {
-              pk: 'case|123-20',
-              sk: 'case|123-20',
-            },
-            {
-              pk: 'case|124-20',
-              sk: 'case|124-20',
-            },
-          ],
-        },
-      },
-    });
+    expect(applicationContext.getDocumentClient().query.mock.calls.length).toBe(
+      3,
+    );
   });
 });


### PR DESCRIPTION
In order to satisfy #796 , this PR aims to make the interactor that retrieves case deadlines more stable by functioning for all cases that pass validation. It will log a helpful message to help troubleshoot and fix any cases that fail validation. And in doing this, it reuses the `getCaseByDocketNumber(...)` function that makes use of `aggregateCaseItems(...)` rather than relying on the compiled `case|${docketNumber}` record.

Added a test to test the above functionality. Also changed the test for getCasesByDocketNumbers to reflect the new approach.