### PR TITLE
Admin User Scripts for Glue Project

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
   },
   "scripts": {
     "admin:lookup-user": "node shared/admin-tools/glue/lookup-user.js",
+    "admin:become-user": "node shared/admin-tools/glue/become-user.js",
     "build:all": "npm run clean && npm run build:assets && npm run build:client:no-sourcemaps",
     "build:assets": "node shared/createModule.js",
     "build:client:no-sourcemaps": "USTC_ENV=prod parcel build --no-source-maps web-client/src/index.pug",

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     ]
   },
   "scripts": {
+    "admin:lookup-user": "node shared/admin-tools/glue/lookup-user.js",
     "build:all": "npm run clean && npm run build:assets && npm run build:client:no-sourcemaps",
     "build:assets": "node shared/createModule.js",
     "build:client:no-sourcemaps": "USTC_ENV=prod parcel build --no-source-maps web-client/src/index.pug",

--- a/shared/admin-tools/glue/become-user.js
+++ b/shared/admin-tools/glue/become-user.js
@@ -1,0 +1,123 @@
+/**
+ * This script is to grant the user running it the ability to become the specified
+ * UserId by utilizing the custom:userId attribute
+ */
+const { checkEnvVar, getVersion } = require('../util');
+const { CognitoIdentityServiceProvider, DynamoDB } = require('aws-sdk');
+
+const { COGNITO_USER_EMAIL, COGNITO_USER_POOL, ENV } = process.env;
+
+checkEnvVar(
+  COGNITO_USER_POOL,
+  'You must have COGNITO_USER_POOL set in your environment',
+);
+checkEnvVar(
+  COGNITO_USER_EMAIL,
+  'You must have COGNITO_USER_EMAIL set in your environment; This is the email address you use for Cognito',
+);
+checkEnvVar(ENV, 'You must have ENV set in your environment; (e.g., mig)');
+
+/**
+ * This script is to grant the user running it the ability to search for a UserId
+ * in the system.
+ */
+
+const usage = () => {
+  console.log(`Assume the account of another user in the system. 
+
+  You must have the following Environment variables set:
+
+  - ENV: The name of the environment you are working with (mig)
+  - COGNITO_USER_EMAIL: The email address you use to access this environment (your.email@example.com)
+  - COGNITO_USER_POOL: The Cognito User Pool for the environment (us-east-1_ABCdefGHI)
+  
+  Usage:
+
+  You can assume the role of any user's role with the following command. The script will randomly choose between
+  users in the system that match the specified role
+
+  $ npm run admin:become-user <USER_ID>
+  
+  - USER_ID: The specific UUID of the user in the system 
+
+  You must have the following 
+
+  Example:
+
+  $ npm run admin:become-user 7331b076-4321-1234-4321-abc123def456
+
+`);
+  process.exit();
+};
+
+if (process.argv.length < 3) {
+  usage();
+}
+
+/**
+ * Lookup a role for the specified userId
+ *
+ * @param {String} userId The unique identifier of the user
+ * @returns {String} The role found for the user
+ */
+const lookupRoleForUser = async userId => {
+  const dynamodb = new DynamoDB({ region: 'us-east-1' });
+  const version = await getVersion(ENV);
+  const TableName = `efcms-${ENV}-${version}`;
+  const data = await dynamodb
+    .getItem({
+      ExpressionAttributeNames: {
+        '#role': 'role',
+      },
+      Key: {
+        pk: {
+          S: `user|${userId}`,
+        },
+        sk: {
+          S: `user|${userId}`,
+        },
+      },
+      ProjectionExpression: '#role',
+      TableName,
+    })
+    .promise();
+
+  if (!data) {
+    throw new Error(`Could not find a user for ${userId}`);
+  }
+  return data.Item.role.S;
+};
+
+(async () => {
+  try {
+    const userId = process.argv[2];
+    const role = await lookupRoleForUser(userId);
+    const params = {
+      UserAttributes: [
+        {
+          Name: 'custom:role',
+          Value: role,
+        },
+        {
+          Name: 'custom:userId',
+          Value: userId,
+        },
+      ],
+      UserPoolId: COGNITO_USER_POOL,
+      Username: COGNITO_USER_EMAIL,
+    };
+
+    console.log(params);
+
+    const cognitoidentityserviceprovider = new CognitoIdentityServiceProvider({
+      region: 'us-east-1',
+    });
+    const result = await cognitoidentityserviceprovider
+      .adminUpdateUserAttributes(params)
+      .promise();
+    console.log(result);
+    console.log('SUCCESS: Please log out and log back in again');
+  } catch (err) {
+    console.log('ERROR: ', err);
+  }
+})();

--- a/shared/admin-tools/glue/become-user.js
+++ b/shared/admin-tools/glue/become-user.js
@@ -1,6 +1,15 @@
 /**
  * This script is to grant the user running it the ability to become the specified
  * UserId by utilizing the custom:userId attribute
+ *
+ * You must have the following Environment variables set:
+ * - ENV: The name of the environment you are working with (mig)
+ * - COGNITO_USER_EMAIL: The email address you use to access this environment (your.email@example.com)
+ * - COGNITO_USER_POOL: The Cognito User Pool for the environment (us-east-1_ExAmPlES)
+ *
+ * Example usage:
+ *
+ * $ npm run admin:become-user 432143213-4321-1234-4321-432143214321
  */
 const { checkEnvVar, getVersion } = require('../util');
 const { CognitoIdentityServiceProvider, DynamoDB } = require('aws-sdk');
@@ -16,11 +25,6 @@ checkEnvVar(
   'You must have COGNITO_USER_EMAIL set in your environment; This is the email address you use for Cognito',
 );
 checkEnvVar(ENV, 'You must have ENV set in your environment; (e.g., mig)');
-
-/**
- * This script is to grant the user running it the ability to search for a UserId
- * in the system.
- */
 
 const usage = () => {
   console.log(`Assume the account of another user in the system. 

--- a/shared/admin-tools/glue/lookup-user.js
+++ b/shared/admin-tools/glue/lookup-user.js
@@ -1,0 +1,59 @@
+/**
+ * This script is to grant the user running it the ability to search for a UserId
+ * in the system.
+ */
+
+const { getClient } = require('../../../web-api/elasticsearch/client');
+
+if (process.argv.length < 4) {
+  console.log(`Lookup User IDs and roles for the specified environment.
+  
+  Usage:
+
+  $ npm run admin:lookup-user -- <ENV> <ROLE> [<NAME>]
+  
+  - ENV: The environment to search (e.g., mig)
+  - ROLE: The role to find
+
+  Example:
+
+  $ npm run admin:lookup-user -- mig admissionsClerk "Joe Burns"
+
+`);
+  process.exit();
+}
+
+const environmentName = process.argv[2];
+const role = process.argv[3];
+const userName = process.argv[4];
+
+(async () => {
+  const esClient = await getClient({ environmentName });
+  const query = userName
+    ? {
+        bool: {
+          must: [
+            { match: { 'role.S': role } },
+            { match: { 'name.S': userName } },
+          ],
+        },
+      }
+    : {
+        match: { 'role.S': role },
+      };
+
+  const results = await esClient.search({
+    body: { query },
+    index: 'efcms-user',
+  });
+
+  const users = results.hits.hits.map(hit => {
+    return {
+      Email: hit['_source']['email'].S,
+      Name: hit['_source']['name'].S,
+      UserId: hit['_source']['userId'].S,
+    };
+  });
+
+  console.table(users);
+})();

--- a/shared/admin-tools/glue/lookup-user.js
+++ b/shared/admin-tools/glue/lookup-user.js
@@ -1,6 +1,13 @@
 /**
- * This script is to grant the user running it the ability to search for a UserId
- * in the system.
+ * This script is to help search for users belonging to a certain role in the
+ * environment designated by the ENV environment variable
+ *
+ * You must have the following Environment variables set:
+ * - ENV: The name of the environment you are working with (mig)
+ *
+ * Example usage:
+ *
+ * $ npm run admin:lookup-user docketClerk "Beth"
  */
 
 const { checkEnvVar } = require('../util');

--- a/shared/admin-tools/util.js
+++ b/shared/admin-tools/util.js
@@ -1,0 +1,41 @@
+const { DynamoDB } = require('aws-sdk');
+/**
+ * This function makes it easy to lookup the current version so that we can perform searches against it
+ *
+ * @param {String} environmentName The environment we are going to lookup the current color
+ * @returns {String} The current version of the application
+ */
+exports.getVersion = async environmentName => {
+  const dynamodb = new DynamoDB({ region: 'us-east-1' });
+  const result = await dynamodb
+    .getItem({
+      Key: {
+        pk: {
+          S: 'source-table-version',
+        },
+        sk: {
+          S: 'source-table-version',
+        },
+      },
+      TableName: `efcms-deploy-${environmentName}`,
+    })
+    .promise();
+
+  if (!result || !result.Item) {
+    throw 'Could not determine the current version';
+  }
+  return result.Item.current.S;
+};
+
+/**
+ * Simple function to help ensure that a value is truthy before allowing the process to continue
+ *
+ * @param {String} value The value to ensure is truthy
+ * @param {String} message The message to relay if the value is not truthy
+ */
+exports.checkEnvVar = (value, message) => {
+  if (!value) {
+    console.log(message);
+    process.exit(1);
+  }
+};

--- a/web-api/elasticsearch/client.js
+++ b/web-api/elasticsearch/client.js
@@ -22,9 +22,7 @@ const getHost = async DomainName => {
 
     return result.DomainStatus.Endpoint;
   } catch (err) {
-    console.log(err);
-    console.log(`could not find resource for ${DomainName}`);
-    // if we care about it, throw it...
+    console.error(`could not find resource for ${DomainName}`, err);
   }
 };
 
@@ -33,7 +31,7 @@ const cache = {
 };
 
 /**
- * This gets an Elasticsearch Client that can hopefully perform queries against
+ * This gets an Elasticsearch Client to perform search queries
  *
  * @param {Object} providers providers
  * @param {String} providers.environmentName The name of the environment


### PR DESCRIPTION
In order to finish up #682 , these scripts help developers who have the required AWS privileges lookup and assume the identity of certain users in the designated environment. There are two scripts, which have their own documentation for usage, that allow users with access to perform ES queries as well as certain Cognito API calls. These scripts are included in `package.json`.

```bash
$ npm run admin:lookup-user docketClerk "Remington"
$ npm run admin:become-user uuiduuid-uuid-uuid-uuiduuiduuid
```
