### PR TITLE
Mmeyer elastic mappings

### DIFF
--- a/shared/src/business/utilities/aggregateCommonQueryParams.js
+++ b/shared/src/business/utilities/aggregateCommonQueryParams.js
@@ -79,12 +79,12 @@ const aggregateCommonQueryParams = ({
       bool: {
         should: [
           {
-            match: {
+            term: {
               'contactPrimary.M.countryType.S': countryType,
             },
           },
           {
-            match: {
+            term: {
               'contactSecondary.M.countryType.S': countryType,
             },
           },
@@ -97,12 +97,12 @@ const aggregateCommonQueryParams = ({
       bool: {
         should: [
           {
-            match: {
+            term: {
               'contactPrimary.M.state.S': petitionerState,
             },
           },
           {
-            match: {
+            term: {
               'contactSecondary.M.state.S': petitionerState,
             },
           },

--- a/shared/src/business/utilities/aggregateCommonQueryParams.test.js
+++ b/shared/src/business/utilities/aggregateCommonQueryParams.test.js
@@ -102,12 +102,12 @@ describe('aggregateCommonQueryParams', () => {
           bool: {
             should: [
               {
-                match: {
+                term: {
                   'contactPrimary.M.countryType.S': COUNTRY_TYPES.DOMESTIC,
                 },
               },
               {
-                match: {
+                term: {
                   'contactSecondary.M.countryType.S': COUNTRY_TYPES.DOMESTIC,
                 },
               },
@@ -135,12 +135,12 @@ describe('aggregateCommonQueryParams', () => {
           bool: {
             should: [
               {
-                match: {
+                term: {
                   'contactPrimary.M.state.S': US_STATES.AR,
                 },
               },
               {
-                match: {
+                term: {
                   'contactSecondary.M.state.S': US_STATES.AR,
                 },
               },

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearch.js
@@ -46,16 +46,8 @@ exports.advancedDocumentSearch = async ({
   const docketEntryQueryParams = [
     {
       bool: {
-        must_not: [
-          {
-            term: { 'isStricken.BOOL': true },
-          },
-        ],
-        should: documentEventCodes.map(eventCode => ({
-          term: {
-            'eventCode.S': eventCode,
-          },
-        })),
+        must: [{ terms: { 'eventCode.S': documentEventCodes } }],
+        must_not: [{ term: { 'isStricken.BOOL': true } }],
       },
     },
   ];

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearch.js
@@ -52,7 +52,7 @@ exports.advancedDocumentSearch = async ({
           },
         ],
         should: documentEventCodes.map(eventCode => ({
-          match: {
+          term: {
             'eventCode.S': eventCode,
           },
         })),
@@ -92,7 +92,7 @@ exports.advancedDocumentSearch = async ({
 
   if (docketNumber) {
     caseQueryParams.has_parent.query.bool.must = {
-      match: { 'docketNumber.S': { operator: 'and', query: docketNumber } },
+      term: { 'docketNumber.S': docketNumber },
     };
   } else if (caseTitleOrPetitioner) {
     caseQueryParams.has_parent.query.bool.must = {
@@ -142,12 +142,7 @@ exports.advancedDocumentSearch = async ({
 
   if (opinionType) {
     docketEntryQueryParams.push({
-      match: {
-        'documentType.S': {
-          operator: 'and',
-          query: opinionType,
-        },
-      },
+      term: { 'documentType.S': opinionType },
     });
   }
 
@@ -186,8 +181,7 @@ exports.advancedDocumentSearch = async ({
       query: {
         bool: {
           must: [
-            { match: { 'pk.S': 'case|' } },
-            { match: { 'sk.S': 'docket-entry|' } },
+            { term: { 'entityName.S': 'DocketEntry' } },
             {
               exists: {
                 field: 'servedAt',

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearch.test.js
@@ -37,8 +37,7 @@ describe('advancedDocumentSearch', () => {
   });
 
   const orderQueryParams = [
-    { match: { 'pk.S': 'case|' } },
-    { match: { 'sk.S': 'docket-entry|' } },
+    { term: { 'entityName.S': 'DocketEntry' } },
     {
       exists: {
         field: 'servedAt',
@@ -53,12 +52,12 @@ describe('advancedDocumentSearch', () => {
         ],
         should: [
           {
-            match: {
+            term: {
               'eventCode.S': orderEventCodes[0],
             },
           },
           {
-            match: {
+            term: {
               'eventCode.S': orderEventCodes[1],
             },
           },
@@ -68,8 +67,7 @@ describe('advancedDocumentSearch', () => {
   ];
 
   const opinionQueryParams = [
-    { match: { 'pk.S': 'case|' } },
-    { match: { 'sk.S': 'docket-entry|' } },
+    { term: { 'entityName.S': 'DocketEntry' } },
     {
       exists: {
         field: 'servedAt',
@@ -84,12 +82,12 @@ describe('advancedDocumentSearch', () => {
         ],
         should: [
           {
-            match: {
+            term: {
               'eventCode.S': opinionEventCodes[0],
             },
           },
           {
-            match: {
+            term: {
               'eventCode.S': opinionEventCodes[1],
             },
           },
@@ -133,8 +131,8 @@ describe('advancedDocumentSearch', () => {
 
     if (docketNumber) {
       query.bool.must = {
-        match: {
-          'docketNumber.S': { operator: 'and', query: docketNumber },
+        term: {
+          'docketNumber.S': docketNumber,
         },
       };
     }
@@ -257,15 +255,12 @@ describe('advancedDocumentSearch', () => {
       ...orderQueryParams,
       getCaseMappingQueryParams(), // match all parents
       {
-        match: {
-          'documentType.S': {
-            operator: 'and',
-            query: 'Summary Opinion',
-          },
+        term: {
+          'documentType.S': 'Summary Opinion',
         },
       },
     ];
-    expectation[4].has_parent.query.bool.must_not = [
+    expectation[3].has_parent.query.bool.must_not = [
       { term: { 'isSealed.BOOL': true } },
     ];
 
@@ -286,15 +281,12 @@ describe('advancedDocumentSearch', () => {
       ...orderQueryParams,
       getCaseMappingQueryParams(), // match all parents
       {
-        match: {
-          'documentType.S': {
-            operator: 'and',
-            query: 'Summary Opinion',
-          },
+        term: {
+          'documentType.S': 'Summary Opinion',
         },
       },
     ];
-    expectation[4].has_parent.query.bool.must_not = [
+    expectation[3].has_parent.query.bool.must_not = [
       { term: { 'isSealed.BOOL': true } },
     ];
     expect(

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearch.test.js
@@ -45,23 +45,14 @@ describe('advancedDocumentSearch', () => {
     },
     {
       bool: {
-        must_not: [
+        must: [
           {
-            term: { 'isStricken.BOOL': true },
-          },
-        ],
-        should: [
-          {
-            term: {
-              'eventCode.S': orderEventCodes[0],
-            },
-          },
-          {
-            term: {
-              'eventCode.S': orderEventCodes[1],
+            terms: {
+              'eventCode.S': [orderEventCodes[0], orderEventCodes[1]],
             },
           },
         ],
+        must_not: [{ term: { 'isStricken.BOOL': true } }],
       },
     },
   ];
@@ -75,21 +66,16 @@ describe('advancedDocumentSearch', () => {
     },
     {
       bool: {
+        must: [
+          {
+            terms: {
+              'eventCode.S': [opinionEventCodes[0], opinionEventCodes[1]],
+            },
+          },
+        ],
         must_not: [
           {
             term: { 'isStricken.BOOL': true },
-          },
-        ],
-        should: [
-          {
-            term: {
-              'eventCode.S': opinionEventCodes[0],
-            },
-          },
-          {
-            term: {
-              'eventCode.S': opinionEventCodes[1],
-            },
           },
         ],
       },

--- a/shared/src/persistence/elasticsearch/fetchPendingItems.js
+++ b/shared/src/persistence/elasticsearch/fetchPendingItems.js
@@ -41,8 +41,7 @@ exports.fetchPendingItems = async ({ applicationContext, judge, page }) => {
       query: {
         bool: {
           must: [
-            { match: { 'pk.S': 'case|' } },
-            { match: { 'sk.S': 'docket-entry|' } },
+            { term: { 'entityName.S': 'DocketEntry' } },
             { term: { 'pending.BOOL': true } },
             hasParentParam,
           ],

--- a/shared/src/persistence/elasticsearch/fetchPendingItems.test.js
+++ b/shared/src/persistence/elasticsearch/fetchPendingItems.test.js
@@ -17,7 +17,7 @@ describe('fetchPendingItems', () => {
     expect(search).toHaveBeenCalledTimes(1);
     const searchQuery =
       search.mock.calls[0][0].searchParameters.body.query.bool.must;
-    expect(searchQuery.length).toBe(5);
+    expect(searchQuery.length).toBe(4);
   });
 
   it('returns results from a query with a judge', async () => {
@@ -33,7 +33,7 @@ describe('fetchPendingItems', () => {
     expect(search).toHaveBeenCalledTimes(1);
     const searchQuery =
       search.mock.calls[0][0].searchParameters.body.query.bool.must;
-    expect(searchQuery[3].has_parent.query.bool.must[0]).toMatchObject({
+    expect(searchQuery[2].has_parent.query.bool.must[0]).toMatchObject({
       match_phrase: { 'associatedJudge.S': 'Dredd' },
     });
   });
@@ -48,7 +48,7 @@ describe('fetchPendingItems', () => {
     const searchQuery =
       search.mock.calls[0][0].searchParameters.body.query.bool.must;
 
-    expect(searchQuery[4]).toMatchObject({
+    expect(searchQuery[3]).toMatchObject({
       bool: {
         minimum_should_match: 1,
         should: [

--- a/shared/src/persistence/elasticsearch/getBlockedCases.js
+++ b/shared/src/persistence/elasticsearch/getBlockedCases.js
@@ -30,7 +30,6 @@ exports.getBlockedCases = async ({ applicationContext, trialLocation }) => {
           bool: {
             must: [
               { term: { 'preferredTrialCity.S': trialLocation } },
-              { term: { 'entityName.S': 'Case' } },
               {
                 bool: {
                   should: [

--- a/shared/src/persistence/elasticsearch/getBlockedCases.js
+++ b/shared/src/persistence/elasticsearch/getBlockedCases.js
@@ -29,9 +29,8 @@ exports.getBlockedCases = async ({ applicationContext, trialLocation }) => {
         query: {
           bool: {
             must: [
-              { match_phrase: { 'preferredTrialCity.S': trialLocation } },
-              { match: { 'pk.S': 'case|' } },
-              { match: { 'sk.S': 'case|' } },
+              { term: { 'preferredTrialCity.S': trialLocation } },
+              { term: { 'entityName.S': 'Case' } },
               {
                 bool: {
                   should: [

--- a/shared/src/persistence/elasticsearch/getBlockedCases.test.js
+++ b/shared/src/persistence/elasticsearch/getBlockedCases.test.js
@@ -19,7 +19,7 @@ describe('getBlockedCases', () => {
     const searchQuery =
       search.mock.calls[0][0].searchParameters.body.query.bool.must;
     expect(searchQuery[0]).toMatchObject({
-      match_phrase: { 'preferredTrialCity.S': 'Memphis, TN' },
+      term: { 'preferredTrialCity.S': 'Memphis, TN' },
     });
   });
 });

--- a/shared/src/persistence/elasticsearch/getCaseInventoryReport.js
+++ b/shared/src/persistence/elasticsearch/getCaseInventoryReport.js
@@ -40,14 +40,14 @@ exports.getCaseInventoryReport = async ({
         bool: {
           must: [
             {
-              match: { 'entityName.S': 'Case' },
+              term: { 'entityName.S': 'Case' },
             },
-            { match: { 'pk.S': 'case|' } },
-            { match: { 'sk.S': 'case|' } },
           ],
-          must_not: {
-            match: { 'status.S': 'Closed' },
-          },
+          must_not: [
+            {
+              term: { 'status.S': 'Closed' },
+            },
+          ],
         },
       },
       size,
@@ -65,7 +65,7 @@ exports.getCaseInventoryReport = async ({
 
   if (status) {
     searchParameters.body.query.bool.must.push({
-      match_phrase: { 'status.S': status },
+      term: { 'status.S': status },
     });
   }
 

--- a/shared/src/persistence/elasticsearch/getCaseInventoryReport.js
+++ b/shared/src/persistence/elasticsearch/getCaseInventoryReport.js
@@ -38,11 +38,7 @@ exports.getCaseInventoryReport = async ({
       from,
       query: {
         bool: {
-          must: [
-            {
-              term: { 'entityName.S': 'Case' },
-            },
-          ],
+          must: [],
           must_not: [
             {
               term: { 'status.S': 'Closed' },

--- a/shared/src/persistence/elasticsearch/getCaseInventoryReport.test.js
+++ b/shared/src/persistence/elasticsearch/getCaseInventoryReport.test.js
@@ -61,9 +61,6 @@ describe('getCaseInventoryReport', () => {
     expect(searchSpy).toHaveBeenCalled();
     expect(searchSpy.mock.calls[0][0].body.query.bool.must).toEqual([
       {
-        term: { 'entityName.S': 'Case' },
-      },
-      {
         match_phrase: { 'associatedJudge.S': CHIEF_JUDGE },
       },
     ]);
@@ -104,7 +101,6 @@ describe('getCaseInventoryReport', () => {
 
     expect(searchSpy).toHaveBeenCalled();
     expect(searchSpy.mock.calls[0][0].body.query.bool.must).toEqual([
-      { term: { 'entityName.S': 'Case' } },
       {
         term: { 'status.S': CASE_STATUS_TYPES.new },
       },
@@ -145,9 +141,6 @@ describe('getCaseInventoryReport', () => {
 
     expect(searchSpy).toHaveBeenCalled();
     expect(searchSpy.mock.calls[0][0].body.query.bool.must).toEqual([
-      {
-        term: { 'entityName.S': 'Case' },
-      },
       {
         match_phrase: { 'associatedJudge.S': CHIEF_JUDGE },
       },
@@ -255,9 +248,6 @@ describe('getCaseInventoryReport', () => {
 
     expect(searchSpy).toHaveBeenCalled();
     expect(searchSpy.mock.calls[0][0].body.query.bool.must).toEqual([
-      {
-        term: { 'entityName.S': 'Case' },
-      },
       {
         match_phrase: { 'associatedJudge.S': CHIEF_JUDGE },
       },

--- a/shared/src/persistence/elasticsearch/getCaseInventoryReport.test.js
+++ b/shared/src/persistence/elasticsearch/getCaseInventoryReport.test.js
@@ -61,10 +61,8 @@ describe('getCaseInventoryReport', () => {
     expect(searchSpy).toHaveBeenCalled();
     expect(searchSpy.mock.calls[0][0].body.query.bool.must).toEqual([
       {
-        match: { 'entityName.S': 'Case' },
+        term: { 'entityName.S': 'Case' },
       },
-      { match: { 'pk.S': 'case|' } },
-      { match: { 'sk.S': 'case|' } },
       {
         match_phrase: { 'associatedJudge.S': CHIEF_JUDGE },
       },
@@ -106,11 +104,9 @@ describe('getCaseInventoryReport', () => {
 
     expect(searchSpy).toHaveBeenCalled();
     expect(searchSpy.mock.calls[0][0].body.query.bool.must).toEqual([
-      { match: { 'entityName.S': 'Case' } },
-      { match: { 'pk.S': 'case|' } },
-      { match: { 'sk.S': 'case|' } },
+      { term: { 'entityName.S': 'Case' } },
       {
-        match_phrase: { 'status.S': CASE_STATUS_TYPES.new },
+        term: { 'status.S': CASE_STATUS_TYPES.new },
       },
     ]);
 
@@ -150,15 +146,13 @@ describe('getCaseInventoryReport', () => {
     expect(searchSpy).toHaveBeenCalled();
     expect(searchSpy.mock.calls[0][0].body.query.bool.must).toEqual([
       {
-        match: { 'entityName.S': 'Case' },
+        term: { 'entityName.S': 'Case' },
       },
-      { match: { 'pk.S': 'case|' } },
-      { match: { 'sk.S': 'case|' } },
       {
         match_phrase: { 'associatedJudge.S': CHIEF_JUDGE },
       },
       {
-        match_phrase: { 'status.S': CASE_STATUS_TYPES.new },
+        term: { 'status.S': CASE_STATUS_TYPES.new },
       },
     ]);
 
@@ -262,10 +256,8 @@ describe('getCaseInventoryReport', () => {
     expect(searchSpy).toHaveBeenCalled();
     expect(searchSpy.mock.calls[0][0].body.query.bool.must).toEqual([
       {
-        match: { 'entityName.S': 'Case' },
+        term: { 'entityName.S': 'Case' },
       },
-      { match: { 'pk.S': 'case|' } },
-      { match: { 'sk.S': 'case|' } },
       {
         match_phrase: { 'associatedJudge.S': CHIEF_JUDGE },
       },

--- a/shared/src/persistence/elasticsearch/getCasesByUserId.js
+++ b/shared/src/persistence/elasticsearch/getCasesByUserId.js
@@ -21,26 +21,15 @@ exports.getCasesByUserId = async ({ applicationContext, userId }) => {
         _source: source,
         query: {
           bool: {
-            must: [
+            should: [
               {
-                term: { 'entityName.S': 'Case' },
+                term: { 'privatePractitioners.L.M.userId.S': `${userId}` },
               },
               {
-                bool: {
-                  should: [
-                    {
-                      term: {
-                        'privatePractitioners.L.M.userId.S': `${userId}`,
-                      },
-                    },
-                    {
-                      term: { 'irsPractitioners.L.M.userId.S': `${userId}` },
-                    },
-                    {
-                      term: { 'userId.S': `${userId}` },
-                    },
-                  ],
-                },
+                term: { 'irsPractitioners.L.M.userId.S': `${userId}` },
+              },
+              {
+                term: { 'userId.S': `${userId}` },
               },
             ],
           },

--- a/shared/src/persistence/elasticsearch/getCasesByUserId.js
+++ b/shared/src/persistence/elasticsearch/getCasesByUserId.js
@@ -22,16 +22,24 @@ exports.getCasesByUserId = async ({ applicationContext, userId }) => {
         query: {
           bool: {
             must: [
-              { match: { 'pk.S': 'case|' } },
-              { match: { 'sk.S': 'case|' } },
               {
-                query_string: {
-                  fields: [
-                    'privatePractitioners.L.M.userId.S',
-                    'irsPractitioners.L.M.userId.S',
-                    'userId.S',
+                term: { 'entityName.S': 'Case' },
+              },
+              {
+                bool: {
+                  should: [
+                    {
+                      term: {
+                        'privatePractitioners.L.M.userId.S': `${userId}`,
+                      },
+                    },
+                    {
+                      term: { 'irsPractitioners.L.M.userId.S': `${userId}` },
+                    },
+                    {
+                      term: { 'userId.S': `${userId}` },
+                    },
                   ],
-                  query: `"${userId}"`,
                 },
               },
             ],

--- a/shared/src/persistence/elasticsearch/getCasesByUserId.test.js
+++ b/shared/src/persistence/elasticsearch/getCasesByUserId.test.js
@@ -20,16 +20,22 @@ describe('getCasesByUserId', () => {
     ).toMatchObject({
       bool: {
         must: [
-          { match: { 'pk.S': 'case|' } },
-          { match: { 'sk.S': 'case|' } },
+          { term: { 'entityName.S': 'Case' } },
           {
-            query_string: {
-              fields: [
-                'privatePractitioners.L.M.userId.S',
-                'irsPractitioners.L.M.userId.S',
-                'userId.S',
+            bool: {
+              should: [
+                {
+                  term: {
+                    'privatePractitioners.L.M.userId.S': `${userId}`,
+                  },
+                },
+                {
+                  term: { 'irsPractitioners.L.M.userId.S': `${userId}` },
+                },
+                {
+                  term: { 'userId.S': `${userId}` },
+                },
               ],
-              query: `"${userId}"`,
             },
           },
         ],

--- a/shared/src/persistence/elasticsearch/getCasesByUserId.test.js
+++ b/shared/src/persistence/elasticsearch/getCasesByUserId.test.js
@@ -19,24 +19,17 @@ describe('getCasesByUserId', () => {
       applicationContext.getSearchClient().search.mock.calls[0][0].body.query,
     ).toMatchObject({
       bool: {
-        must: [
-          { term: { 'entityName.S': 'Case' } },
+        should: [
           {
-            bool: {
-              should: [
-                {
-                  term: {
-                    'privatePractitioners.L.M.userId.S': `${userId}`,
-                  },
-                },
-                {
-                  term: { 'irsPractitioners.L.M.userId.S': `${userId}` },
-                },
-                {
-                  term: { 'userId.S': `${userId}` },
-                },
-              ],
+            term: {
+              'privatePractitioners.L.M.userId.S': `${userId}`,
             },
+          },
+          {
+            term: { 'irsPractitioners.L.M.userId.S': `${userId}` },
+          },
+          {
+            term: { 'userId.S': `${userId}` },
           },
         ],
       },

--- a/shared/src/persistence/elasticsearch/getIndexedCasesForUser.js
+++ b/shared/src/persistence/elasticsearch/getIndexedCasesForUser.js
@@ -37,11 +37,6 @@ exports.getIndexedCasesForUser = async ({
               },
             },
             {
-              term: {
-                'entityName.S': 'UserCase',
-              },
-            },
-            {
               bool: {
                 should: statuses.map(statusStr => ({
                   term: {

--- a/shared/src/persistence/elasticsearch/getIndexedCasesForUser.js
+++ b/shared/src/persistence/elasticsearch/getIndexedCasesForUser.js
@@ -32,16 +32,19 @@ exports.getIndexedCasesForUser = async ({
         bool: {
           must: [
             {
-              match: {
-                'pk.S': { operator: 'and', query: `user|${userId}` },
+              term: {
+                'pk.S': `user|${userId}`,
               },
             },
-            { match: { 'sk.S': 'case|' } },
-            { match: { 'gsi1pk.S': 'user-case|' } },
+            {
+              term: {
+                'entityName.S': 'UserCase',
+              },
+            },
             {
               bool: {
                 should: statuses.map(statusStr => ({
-                  match: {
+                  term: {
                     'status.S': statusStr,
                   },
                 })),

--- a/shared/src/persistence/elasticsearch/getIndexedCasesForUser.js
+++ b/shared/src/persistence/elasticsearch/getIndexedCasesForUser.js
@@ -37,12 +37,8 @@ exports.getIndexedCasesForUser = async ({
               },
             },
             {
-              bool: {
-                should: statuses.map(statusStr => ({
-                  term: {
-                    'status.S': statusStr,
-                  },
-                })),
+              terms: {
+                'status.S': statuses,
               },
             },
           ],

--- a/shared/src/persistence/elasticsearch/getIndexedCasesForUser.test.js
+++ b/shared/src/persistence/elasticsearch/getIndexedCasesForUser.test.js
@@ -32,23 +32,11 @@ describe('getIndexedCasesForUser', () => {
         },
       },
       {
-        bool: {
-          should: [
-            {
-              term: {
-                'status.S': CASE_STATUS_TYPES.new,
-              },
-            },
-            {
-              term: {
-                'status.S': CASE_STATUS_TYPES.jurisdictionRetained,
-              },
-            },
-            {
-              term: {
-                'status.S': CASE_STATUS_TYPES.calendared,
-              },
-            },
+        terms: {
+          'status.S': [
+            CASE_STATUS_TYPES.new,
+            CASE_STATUS_TYPES.jurisdictionRetained,
+            CASE_STATUS_TYPES.calendared,
           ],
         },
       },
@@ -77,14 +65,8 @@ describe('getIndexedCasesForUser', () => {
         },
       },
       {
-        bool: {
-          should: [
-            {
-              term: {
-                'status.S': CASE_STATUS_TYPES.closed,
-              },
-            },
-          ],
+        terms: {
+          'status.S': [CASE_STATUS_TYPES.closed],
         },
       },
     ]);

--- a/shared/src/persistence/elasticsearch/getIndexedCasesForUser.test.js
+++ b/shared/src/persistence/elasticsearch/getIndexedCasesForUser.test.js
@@ -27,38 +27,30 @@ describe('getIndexedCasesForUser', () => {
         .bool.must,
     ).toMatchObject([
       {
-        match: {
-          'pk.S': {
-            operator: 'and',
-            query: `user|${mockUserId}`,
-          },
+        term: {
+          'pk.S': `user|${mockUserId}`,
         },
       },
       {
-        match: {
-          'sk.S': 'case|',
-        },
-      },
-      {
-        match: {
-          'gsi1pk.S': 'user-case|',
+        term: {
+          'entityName.S': 'UserCase',
         },
       },
       {
         bool: {
           should: [
             {
-              match: {
+              term: {
                 'status.S': CASE_STATUS_TYPES.new,
               },
             },
             {
-              match: {
+              term: {
                 'status.S': CASE_STATUS_TYPES.jurisdictionRetained,
               },
             },
             {
-              match: {
+              term: {
                 'status.S': CASE_STATUS_TYPES.calendared,
               },
             },
@@ -85,28 +77,20 @@ describe('getIndexedCasesForUser', () => {
         .bool.must,
     ).toMatchObject([
       {
-        match: {
-          'pk.S': {
-            operator: 'and',
-            query: `user|${mockUserId}`,
-          },
+        term: {
+          'pk.S': `user|${mockUserId}`,
         },
       },
       {
-        match: {
-          'sk.S': 'case|',
-        },
-      },
-      {
-        match: {
-          'gsi1pk.S': 'user-case|',
+        term: {
+          'entityName.S': 'UserCase',
         },
       },
       {
         bool: {
           should: [
             {
-              match: {
+              term: {
                 'status.S': CASE_STATUS_TYPES.closed,
               },
             },

--- a/shared/src/persistence/elasticsearch/getIndexedCasesForUser.test.js
+++ b/shared/src/persistence/elasticsearch/getIndexedCasesForUser.test.js
@@ -32,11 +32,6 @@ describe('getIndexedCasesForUser', () => {
         },
       },
       {
-        term: {
-          'entityName.S': 'UserCase',
-        },
-      },
-      {
         bool: {
           should: [
             {
@@ -79,11 +74,6 @@ describe('getIndexedCasesForUser', () => {
       {
         term: {
           'pk.S': `user|${mockUserId}`,
-        },
-      },
-      {
-        term: {
-          'entityName.S': 'UserCase',
         },
       },
       {

--- a/shared/src/persistence/elasticsearch/getPractitionersByName.js
+++ b/shared/src/persistence/elasticsearch/getPractitionersByName.js
@@ -19,22 +19,20 @@ exports.getPractitionersByName = async ({ applicationContext, name }) => {
       query: {
         bool: {
           must: [
-            { match: { 'pk.S': 'user|' } },
-            { match: { 'sk.S': 'user|' } },
+            {
+              terms: {
+                'role.S': [
+                  ROLES.irsPractitioner,
+                  ROLES.privatePractitioner,
+                  ROLES.inactivePractitioner,
+                ],
+              },
+            },
             {
               simple_query_string: {
                 default_operator: 'and',
                 fields: ['name.S'],
                 query: name,
-              },
-            },
-            {
-              bool: {
-                should: [
-                  { match: { 'role.S': ROLES.irsPractitioner } },
-                  { match: { 'role.S': ROLES.privatePractitioner } },
-                  { match: { 'role.S': ROLES.inactivePractitioner } },
-                ],
               },
             },
           ],

--- a/shared/src/persistence/elasticsearch/getReadyForTrialCases.js
+++ b/shared/src/persistence/elasticsearch/getReadyForTrialCases.js
@@ -17,19 +17,8 @@ exports.getReadyForTrialCases = async ({ applicationContext }) => {
       body: {
         _source: ['docketNumber'],
         query: {
-          bool: {
-            must: [
-              {
-                match: {
-                  'status.S': {
-                    operator: 'and',
-                    query: CASE_STATUS_TYPES.generalDocket,
-                  },
-                },
-              },
-              { match: { 'pk.S': 'case|' } },
-              { match: { 'sk.S': 'case|' } },
-            ],
+          term: {
+            'status.S': CASE_STATUS_TYPES.generalDocket,
           },
         },
         size: 5000,

--- a/shared/src/persistence/elasticsearch/getReadyForTrialCases.test.js
+++ b/shared/src/persistence/elasticsearch/getReadyForTrialCases.test.js
@@ -21,14 +21,9 @@ describe('getReadyForTrialCases', () => {
       applicationContext,
     });
 
-    expect(
-      search.mock.calls[0][0].searchParameters.body.query.bool.must[0],
-    ).toMatchObject({
-      match: {
-        'status.S': {
-          operator: 'and',
-          query: CASE_STATUS_TYPES.generalDocket,
-        },
+    expect(search.mock.calls[0][0].searchParameters.body.query).toMatchObject({
+      term: {
+        'status.S': CASE_STATUS_TYPES.generalDocket,
       },
     });
   });

--- a/shared/src/persistence/elasticsearch/messages/getCompletedSectionInboxMessages.js
+++ b/shared/src/persistence/elasticsearch/messages/getCompletedSectionInboxMessages.js
@@ -13,12 +13,10 @@ exports.getCompletedSectionInboxMessages = async ({
         bool: {
           must: [
             {
-              match: {
-                'completedBySection.S': { operator: 'and', query: section },
-              },
+              term: { 'completedBySection.S': section },
             },
             {
-              match: { 'isCompleted.BOOL': true },
+              term: { 'isCompleted.BOOL': true },
             },
             {
               range: {

--- a/shared/src/persistence/elasticsearch/messages/getCompletedUserInboxMessages.js
+++ b/shared/src/persistence/elasticsearch/messages/getCompletedUserInboxMessages.js
@@ -13,12 +13,10 @@ exports.getCompletedUserInboxMessages = async ({
         bool: {
           must: [
             {
-              match: {
-                'completedByUserId.S': { operator: 'and', query: userId },
-              },
+              term: { 'completedByUserId.S': userId },
             },
             {
-              match: { 'isCompleted.BOOL': true },
+              term: { 'isCompleted.BOOL': true },
             },
             {
               range: {

--- a/shared/src/persistence/elasticsearch/messages/getSectionInboxMessages.js
+++ b/shared/src/persistence/elasticsearch/messages/getSectionInboxMessages.js
@@ -7,12 +7,10 @@ exports.getSectionInboxMessages = async ({ applicationContext, section }) => {
         bool: {
           must: [
             {
-              match: {
-                'toSection.S': { operator: 'and', query: section },
-              },
+              term: { 'toSection.S': section },
             },
             {
-              match: { 'isRepliedTo.BOOL': false },
+              term: { 'isRepliedTo.BOOL': false },
             },
           ],
         },

--- a/shared/src/persistence/elasticsearch/messages/getSectionOutboxMessages.js
+++ b/shared/src/persistence/elasticsearch/messages/getSectionOutboxMessages.js
@@ -10,9 +10,7 @@ exports.getSectionOutboxMessages = async ({ applicationContext, section }) => {
         bool: {
           must: [
             {
-              match: {
-                'fromSection.S': { operator: 'and', query: section },
-              },
+              term: { 'fromSection.S': section },
             },
             {
               range: {

--- a/shared/src/persistence/elasticsearch/messages/getUserInboxMessages.js
+++ b/shared/src/persistence/elasticsearch/messages/getUserInboxMessages.js
@@ -7,15 +7,13 @@ exports.getUserInboxMessages = async ({ applicationContext, userId }) => {
         bool: {
           must: [
             {
-              match: {
-                'toUserId.S': { operator: 'and', query: userId },
-              },
+              term: { 'toUserId.S': userId },
             },
             {
-              match: { 'isRepliedTo.BOOL': false },
+              term: { 'isRepliedTo.BOOL': false },
             },
             {
-              match: { 'isCompleted.BOOL': false },
+              term: { 'isCompleted.BOOL': false },
             },
           ],
         },

--- a/shared/src/persistence/elasticsearch/messages/getUserInboxMessages.test.js
+++ b/shared/src/persistence/elasticsearch/messages/getUserInboxMessages.test.js
@@ -31,7 +31,7 @@ describe('getUserInboxMessages', () => {
     ).toEqual(
       expect.arrayContaining([
         {
-          match: {
+          term: {
             'isCompleted.BOOL': false,
           },
         },

--- a/shared/src/persistence/elasticsearch/messages/getUserOutboxMessages.js
+++ b/shared/src/persistence/elasticsearch/messages/getUserOutboxMessages.js
@@ -10,9 +10,7 @@ exports.getUserOutboxMessages = async ({ applicationContext, userId }) => {
         bool: {
           must: [
             {
-              match: {
-                'fromUserId.S': { operator: 'and', query: userId },
-              },
+              term: { 'fromUserId.S': userId },
             },
             {
               range: {

--- a/shared/src/persistence/elasticsearch/workitems/getDocumentQCInboxForSection.js
+++ b/shared/src/persistence/elasticsearch/workitems/getDocumentQCInboxForSection.js
@@ -11,20 +11,13 @@ exports.getDocumentQCInboxForSection = async ({
         bool: {
           must: [
             {
-              match: {
+              term: {
                 'pk.S': `section|${section}`,
               },
             },
             {
-              match: {
-                'sk.S': 'work-item|',
-              },
-            },
-            {
               term: {
-                'section.S': {
-                  value: section,
-                },
+                'section.S': section,
               },
             },
           ],

--- a/shared/src/persistence/elasticsearch/workitems/getDocumentQCInboxForSection.test.js
+++ b/shared/src/persistence/elasticsearch/workitems/getDocumentQCInboxForSection.test.js
@@ -26,20 +26,13 @@ describe('getDocumentQCInboxForSection', () => {
             bool: {
               must: [
                 {
-                  match: {
+                  term: {
                     'pk.S': 'section|docket',
                   },
                 },
                 {
-                  match: {
-                    'sk.S': 'work-item|',
-                  },
-                },
-                {
                   term: {
-                    'section.S': {
-                      value: 'docket',
-                    },
+                    'section.S': 'docket',
                   },
                 },
               ],
@@ -76,7 +69,7 @@ describe('getDocumentQCInboxForSection', () => {
     });
 
     expect(
-      search.mock.calls[0][0].searchParameters.body.query.bool.must[3],
+      search.mock.calls[0][0].searchParameters.body.query.bool.must[2],
     ).toEqual({
       match: {
         'associatedJudge.S': mockJudgeName,

--- a/shared/src/persistence/elasticsearch/workitems/getDocumentQCInboxForUser.js
+++ b/shared/src/persistence/elasticsearch/workitems/getDocumentQCInboxForUser.js
@@ -7,13 +7,8 @@ exports.getDocumentQCInboxForUser = async ({ applicationContext, userId }) => {
         bool: {
           must: [
             {
-              match: {
+              term: {
                 'pk.S': `user|${userId}`,
-              },
-            },
-            {
-              match: {
-                'sk.S': 'work-item|',
               },
             },
           ],

--- a/shared/src/persistence/elasticsearch/workitems/getDocumentQCInboxForUser.test.js
+++ b/shared/src/persistence/elasticsearch/workitems/getDocumentQCInboxForUser.test.js
@@ -21,13 +21,8 @@ describe('getDocumentQCInboxForUser', () => {
             bool: {
               must: [
                 {
-                  match: {
+                  term: {
                     'pk.S': 'user|123',
-                  },
-                },
-                {
-                  match: {
-                    'sk.S': 'work-item|',
                   },
                 },
               ],

--- a/web-api/elasticsearch/efcms-case-deadline-mappings.js
+++ b/web-api/elasticsearch/efcms-case-deadline-mappings.js
@@ -4,7 +4,7 @@ module.exports = {
       type: 'text',
     },
     'caseDeadlineId.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'deadlineDate.S': {
       type: 'date',
@@ -13,10 +13,10 @@ module.exports = {
       type: 'text',
     },
     'docketNumber.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'entityName.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'sortableDocketNumber.N': {
       fields: {

--- a/web-api/elasticsearch/efcms-case-mappings.js
+++ b/web-api/elasticsearch/efcms-case-mappings.js
@@ -28,10 +28,10 @@ module.exports = {
       type: 'date',
     },
     'contactPrimary.M.contactId.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'contactPrimary.M.countryType.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'contactPrimary.M.name.S': {
       type: 'text',
@@ -40,34 +40,34 @@ module.exports = {
       type: 'text',
     },
     'contactPrimary.M.state.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'contactSecondary.M.contactId.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'contactSecondary.M.countryType.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'contactSecondary.M.name.S': {
       type: 'text',
     },
     'contactSecondary.M.state.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'docketEntries.L.M.createdAt.S': {
       type: 'date',
     },
     'docketEntries.L.M.docketEntryId.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'docketEntries.L.M.documentType.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'docketEntries.L.M.entityName.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'docketEntries.L.M.eventCode.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'docketEntries.L.M.filedBy.S': {
       type: 'text',
@@ -94,19 +94,19 @@ module.exports = {
       type: 'date',
     },
     'docketEntries.L.M.userId.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'docketNumber.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'docketNumberSuffix.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'docketNumberWithSuffix.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'entityName.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'hasPendingItems.BOOL': {
       type: 'boolean',
@@ -115,16 +115,16 @@ module.exports = {
       type: 'text',
     },
     'irsPractitioners.L.M.userId.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'pk.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'preferredTrialCity.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'privatePractitioners.L.M.userId.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'receivedAt.S': {
       type: 'date',
@@ -133,7 +133,7 @@ module.exports = {
       type: 'date',
     },
     'sk.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'sortableDocketNumber.N': {
       fields: {
@@ -144,10 +144,10 @@ module.exports = {
       type: 'integer',
     },
     'status.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'userId.S': {
-      type: 'text',
+      type: 'keyword',
     },
   },
 };

--- a/web-api/elasticsearch/efcms-docket-entry-mappings.js
+++ b/web-api/elasticsearch/efcms-docket-entry-mappings.js
@@ -69,7 +69,7 @@ module.exports = {
       type: 'text',
     },
     'numberOfPages.N': {
-      type: 'text',
+      type: 'integer',
     },
     'pending.BOOL': {
       type: 'boolean',

--- a/web-api/elasticsearch/efcms-docket-entry-mappings.js
+++ b/web-api/elasticsearch/efcms-docket-entry-mappings.js
@@ -19,16 +19,16 @@ module.exports = {
       type: 'text',
     },
     'docketEntryId.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'docketNumber.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'docketNumberSuffix.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'docketNumberWithSuffix.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'documentContents.S': {
       analyzer: 'ustc_analyzer',
@@ -39,13 +39,13 @@ module.exports = {
       type: 'text',
     },
     'documentType.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'entityName.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'eventCode.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'filingDate.S': {
       type: 'date',
@@ -54,7 +54,7 @@ module.exports = {
       type: 'text',
     },
     'irsPractitioners.L.M.userId.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'isLegacyServed.BOOL': {
       type: 'boolean',
@@ -75,10 +75,10 @@ module.exports = {
       type: 'boolean',
     },
     'pk.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'privatePractitioners.L.M.userId.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'receivedAt.S': {
       type: 'date',
@@ -93,7 +93,7 @@ module.exports = {
       type: 'text',
     },
     'sk.S': {
-      type: 'text',
+      type: 'keyword',
     },
   },
 };

--- a/web-api/elasticsearch/efcms-message-mappings.js
+++ b/web-api/elasticsearch/efcms-message-mappings.js
@@ -1,7 +1,7 @@
 module.exports = {
   properties: {
     'caseStatus.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'caseTitle.S': {
       type: 'text',
@@ -13,10 +13,10 @@ module.exports = {
       type: 'text',
     },
     'completedBySection.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'completedByUserId.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'completedMessage.S': {
       type: 'text',
@@ -25,19 +25,19 @@ module.exports = {
       type: 'date',
     },
     'docketNumberWithSuffix.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'entityName.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'from.S': {
       type: 'text',
     },
     'fromSection.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'fromUserId.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'indexedTimestamp.N': {
       type: 'text',
@@ -52,7 +52,7 @@ module.exports = {
       type: 'text',
     },
     'parentMessageId.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'subject.S': {
       type: 'text',
@@ -61,10 +61,10 @@ module.exports = {
       type: 'text',
     },
     'toSection.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'toUserId.S': {
-      type: 'text',
+      type: 'keyword',
     },
   },
 };

--- a/web-api/elasticsearch/efcms-user-case-mappings.js
+++ b/web-api/elasticsearch/efcms-user-case-mappings.js
@@ -10,31 +10,31 @@ module.exports = {
       type: 'date',
     },
     'docketNumber.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'docketNumberWithSuffix.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'entityName.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'gsi1pk.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'indexedTimestamp.N': {
       type: 'text',
     },
     'leadDocketNumber.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'pk.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'sk.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'status.S': {
-      type: 'text',
+      type: 'keyword',
     },
   },
 };

--- a/web-api/elasticsearch/efcms-user-mappings.js
+++ b/web-api/elasticsearch/efcms-user-mappings.js
@@ -1,16 +1,16 @@
 module.exports = {
   properties: {
     'admissionsStatus.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'barNumber.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'contact.M.state.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'entityName.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'indexedTimestamp.N': {
       type: 'text',
@@ -19,13 +19,13 @@ module.exports = {
       type: 'text',
     },
     'pk.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'role.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'sk.S': {
-      type: 'text',
+      type: 'keyword',
     },
   },
 };

--- a/web-api/elasticsearch/efcms-work-item-mappings.js
+++ b/web-api/elasticsearch/efcms-work-item-mappings.js
@@ -10,7 +10,7 @@ module.exports = {
       type: 'text',
     },
     'docketNumber.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'highPriority.BOOL': {
       type: 'boolean',
@@ -25,13 +25,13 @@ module.exports = {
       type: 'boolean',
     },
     'pk.S': {
-      type: 'text',
+      type: 'keyword',
     },
     'section.S': {
       type: 'text',
     },
     'sk.S': {
-      type: 'text',
+      type: 'keyword',
     },
   },
 };


### PR DESCRIPTION
This changes the mappings of many of the Elasticsearch indexes to move fields that should not be analyzed as full-text,(which causes both on original input and query text to be tokenization), in preference of `keyword` fields which are stored whole and intended for exact match searches. 

Currently, fields that are UUIDs are stored as text fields. This means they are entered in the Elasticsearch index as a bunch of tokens. For example, a field like `docket-entry|5bd2f4eb-e08a-41e4-8d18-13b9ffd4514c` will be stored in the index as seven  independent tokens: `['docket', 'entry', '5bd2f4eb', 'e08a', 41e4', '8d18', '13b9ffd4514c']`. Searching for this with a `match` query will find the original document, but it is expensive (it requires seven term queries under the hood) and can result in results that do not exactly match the uuid -- for example if only a couple tokens match. Changing the default operator to `and` reduces the chances of matching incorrect documents (it will require all tokens, but does not necessarily in the same order), but it does not improve the cost.

By changing these to `keyword` fields we will only add a singe token token to the index — the exact match:  `docket-entry|5bd2f4eb-e08a-41e4-8d18-13b9ffd4514c`. This has a side-effect of not breaking matches like `{"match": {"pk.S": "docket-entry|"}}` because `docket` and `entry` are no longer independent terms in the index. It seems like this can be avoided by matching on `entityName` when/if this kind of match is needed.

This PR changes a few other fields to keyword fields such as event codes, and case statuses. Like UUIDs, we will never need to match individual tokens from these fields, i.e. we *never* want a search for case status `General Docket - At Issue (Ready for Trial)` by searching for the token `general` and we don't want `General Docket - Not at Issue` to ever match. In other words we are never asking for a score — "how well does the query match?"; we are always asking for a yes/no — "does this query match?"

A couple of the fields are less clear, for example: `preferredTrialCity`. This changes `preferredTrialCity` to a keyword because the exact values are enforced by the Case schema. However this may be incorrect if we expect user input such as `"reno, nv"` to match the value `"Reno, Nevada"`. 

In addition to the changes to the mapping types, this removes many matches in queries that appear unnecessary such as matching for `match: { 'sk.S': 'case|' }` in the `efcms-case` index. It appears *all* cases in the index match this query. One place this is a little unclear is the `efcms-work-item` index. Queries such as `'pk.S':  "section|docket"` appear to always have an `sk.S` of the form `'work-item|'` so this match has been removed. Reviewers should take a critical look at these.