### PR TITLE
Retry Failed Service Emails

### DIFF
--- a/shared/src/dispatchers/ses/sendBulkTemplatedEmail.js
+++ b/shared/src/dispatchers/ses/sendBulkTemplatedEmail.js
@@ -1,4 +1,6 @@
-const MAX_SES_RETRIES = 10;
+const { backOff } = require('../../tools/helpers');
+
+const MAX_SES_RETRIES = 6;
 
 /**
  * calls SES.sendBulkTemplatedEmail
@@ -85,6 +87,9 @@ exports.sendWithRetry = async ({
       .join(',');
     throw `Could not complete service to ${failures}`;
   }
+
+  // exponential back-off
+  await backOff(retryCount);
 
   await exports.sendWithRetry({
     applicationContext,

--- a/shared/src/dispatchers/ses/sendBulkTemplatedEmail.js
+++ b/shared/src/dispatchers/ses/sendBulkTemplatedEmail.js
@@ -46,7 +46,7 @@ exports.sendBulkTemplatedEmail = async ({
 
     await exports.sendWithRetry({ applicationContext, params });
   } catch (err) {
-    applicationContext.logger.error(`Error sending email: ${err.message}`, err);
+    applicationContext.logger.error(`Error sending email: ${err}`, err);
   }
 };
 
@@ -80,8 +80,10 @@ exports.sendWithRetry = async ({
   }
 
   if (retryCount >= MAX_SES_RETRIES) {
-    const failures = retryCount.map(dest => dest.ToAddresses[0]).join(',');
-    throw `Could not complete service to email addresses ${failures}}`;
+    const failures = needToRetry
+      .map(dest => dest.Destination.ToAddresses[0])
+      .join(',');
+    throw `Could not complete service to ${failures}`;
   }
 
   await exports.sendWithRetry({

--- a/shared/src/dispatchers/ses/sendBulkTemplatedEmail.js
+++ b/shared/src/dispatchers/ses/sendBulkTemplatedEmail.js
@@ -1,7 +1,5 @@
 const { backOff } = require('../../tools/helpers');
 
-const MAX_SES_RETRIES = 6;
-
 /**
  * calls SES.sendBulkTemplatedEmail
  *
@@ -53,7 +51,7 @@ exports.sendBulkTemplatedEmail = async ({
 };
 
 /**
- * Sends the email via SES with a MAX_SES_RETRIES = 10;
+ * Sends the email via SES, and retry `MAX_SES_RETRIES` number of times
  *
  * @param {object} providers the providers object
  * @param {object} providers.applicationContext application context
@@ -66,6 +64,7 @@ exports.sendWithRetry = async ({
   retryCount = 0,
 }) => {
   const SES = applicationContext.getEmailClient();
+  const { MAX_SES_RETRIES } = applicationContext.getConstants();
 
   applicationContext.logger.info('Bulk Email Params', params);
   const response = await SES.sendBulkTemplatedEmail(params).promise();

--- a/shared/src/dispatchers/ses/sendBulkTemplatedEmail.js
+++ b/shared/src/dispatchers/ses/sendBulkTemplatedEmail.js
@@ -74,7 +74,7 @@ exports.sendWithRetry = async ({
   const needToRetry = response.Status.map((attempt, index) => {
     // AWS returns 'Success' and helpful identifier upon successful send
     return attempt.Status !== 'Success' ? params.Destinations[index] : false;
-  }).filter(row => !!row);
+  }).filter(Boolean);
 
   if (needToRetry.length === 0) {
     return;

--- a/shared/src/dispatchers/ses/sendBulkTemplatedEmail.test.js
+++ b/shared/src/dispatchers/ses/sendBulkTemplatedEmail.test.js
@@ -163,7 +163,7 @@ describe('sendBulkTemplatedEmail', () => {
     ).toHaveBeenCalledTimes(2);
   });
 
-  it('should retry a failed mailing', async () => {
+  it('should retry a failed mailing 10 times, and then throw an error', async () => {
     applicationContext.getEmailClient().sendBulkTemplatedEmail.mockReturnValue({
       promise: () =>
         Promise.resolve({
@@ -222,5 +222,8 @@ describe('sendBulkTemplatedEmail', () => {
       applicationContext.getEmailClient().sendBulkTemplatedEmail,
     ).toHaveBeenCalledTimes(11);
     expect(applicationContext.logger.error).toHaveBeenCalledTimes(1);
+    expect(applicationContext.logger.error.mock.calls[0][0]).toEqual(
+      'Error sending email: Could not complete service to test.email@example.com,test.email2@example.com,test.email3@example.com',
+    );
   });
 });

--- a/shared/src/dispatchers/ses/sendBulkTemplatedEmail.test.js
+++ b/shared/src/dispatchers/ses/sendBulkTemplatedEmail.test.js
@@ -72,4 +72,155 @@ describe('sendBulkTemplatedEmail', () => {
     expect(applicationContext.logger.error.mock.calls.length).toEqual(1);
     expect(applicationContext.logger.info).toHaveBeenCalledTimes(1);
   });
+
+  it('should retry a failed mailing', async () => {
+    applicationContext
+      .getEmailClient()
+      .sendBulkTemplatedEmail.mockReturnValueOnce({
+        promise: () =>
+          Promise.resolve({
+            ResponseMetadata: {
+              RequestId:
+                '01000176a9ec8d81-a80255bb-8ab4-4049-ba1f-6abd5b7a8098-000000',
+            },
+            Status: [
+              {
+                MessageId:
+                  '01000176a9ec8d81-a80255bb-8ab4-4049-ba1f-6abd5b7a8098-000000',
+                Status: 'Success',
+              },
+              {
+                Error: 'Unknown error occurred. Please try again later',
+                Status: 'Failed',
+              },
+              {
+                Error: 'Unknown error occurred. Please try again later',
+                Status: 'Failed',
+              },
+            ],
+          }),
+      });
+
+    await sendBulkTemplatedEmail({
+      applicationContext,
+      destinations: [
+        {
+          email: 'test.email@example.com',
+          templateData: {
+            name: 'Guy Fieri',
+            welcomeMessage: 'Welcome to Flavortown',
+            whoAmI: 'The Sauce Boss',
+          },
+        },
+        {
+          email: 'test.email2@example.com',
+          templateData: {
+            name: 'Guy Fieri',
+            welcomeMessage: 'Welcome to Flavortown',
+            whoAmI: 'The Sauce Boss',
+          },
+        },
+        {
+          email: 'test.email3@example.com',
+          templateData: {
+            name: 'Guy Fieri',
+            welcomeMessage: 'Welcome to Flavortown',
+            whoAmI: 'The Sauce Boss',
+          },
+        },
+      ],
+      templateName: 'case_served',
+    });
+    expect(
+      applicationContext.getEmailClient().sendBulkTemplatedEmail.mock
+        .calls[1][0],
+    ).toMatchObject({
+      Destinations: [
+        {
+          Destination: {
+            ToAddresses: ['test.email2@example.com'],
+          },
+          ReplacementTemplateData: JSON.stringify({
+            name: 'Guy Fieri',
+            welcomeMessage: 'Welcome to Flavortown',
+            whoAmI: 'The Sauce Boss',
+          }),
+        },
+        {
+          Destination: {
+            ToAddresses: ['test.email3@example.com'],
+          },
+          ReplacementTemplateData: JSON.stringify({
+            name: 'Guy Fieri',
+            welcomeMessage: 'Welcome to Flavortown',
+            whoAmI: 'The Sauce Boss',
+          }),
+        },
+      ],
+    });
+    expect(
+      applicationContext.getEmailClient().sendBulkTemplatedEmail,
+    ).toHaveBeenCalledTimes(2);
+  });
+
+  it('should retry a failed mailing', async () => {
+    applicationContext.getEmailClient().sendBulkTemplatedEmail.mockReturnValue({
+      promise: () =>
+        Promise.resolve({
+          ResponseMetadata: {
+            RequestId:
+              '01000176a9ec8d81-a80255bb-8ab4-4049-ba1f-6abd5b7a8098-000000',
+          },
+          Status: [
+            {
+              Error: 'Unknown error occurred. Please try again later',
+              Status: 'Failed',
+            },
+            {
+              Error: 'Unknown error occurred. Please try again later',
+              Status: 'Failed',
+            },
+            {
+              Error: 'Unknown error occurred. Please try again later',
+              Status: 'Failed',
+            },
+          ],
+        }),
+    });
+
+    await sendBulkTemplatedEmail({
+      applicationContext,
+      destinations: [
+        {
+          email: 'test.email@example.com',
+          templateData: {
+            name: 'Guy Fieri',
+            welcomeMessage: 'Welcome to Flavortown',
+            whoAmI: 'The Sauce Boss',
+          },
+        },
+        {
+          email: 'test.email2@example.com',
+          templateData: {
+            name: 'Guy Fieri',
+            welcomeMessage: 'Welcome to Flavortown',
+            whoAmI: 'The Sauce Boss',
+          },
+        },
+        {
+          email: 'test.email3@example.com',
+          templateData: {
+            name: 'Guy Fieri',
+            welcomeMessage: 'Welcome to Flavortown',
+            whoAmI: 'The Sauce Boss',
+          },
+        },
+      ],
+      templateName: 'case_served',
+    });
+    expect(
+      applicationContext.getEmailClient().sendBulkTemplatedEmail,
+    ).toHaveBeenCalledTimes(11);
+    expect(applicationContext.logger.error).toHaveBeenCalledTimes(1);
+  });
 });

--- a/shared/src/dispatchers/ses/sendBulkTemplatedEmail.test.js
+++ b/shared/src/dispatchers/ses/sendBulkTemplatedEmail.test.js
@@ -220,10 +220,10 @@ describe('sendBulkTemplatedEmail', () => {
     });
     expect(
       applicationContext.getEmailClient().sendBulkTemplatedEmail,
-    ).toHaveBeenCalledTimes(11);
+    ).toHaveBeenCalledTimes(7);
     expect(applicationContext.logger.error).toHaveBeenCalledTimes(1);
     expect(applicationContext.logger.error.mock.calls[0][0]).toEqual(
       'Error sending email: Could not complete service to test.email@example.com,test.email2@example.com,test.email3@example.com',
     );
-  });
+  }, 30000);
 });

--- a/shared/src/tools/helpers.js
+++ b/shared/src/tools/helpers.js
@@ -36,9 +36,29 @@ const whitespaceCleanup = str => {
   return str;
 };
 
+/**
+ * Returns a promise that resolves itself after the specified number of milliseconds
+ *
+ * @param {number} ms The number of milliseconds to wait before resolving the promise
+ * @returns {Promise} resolves itself after the specified number of ms
+ */
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * To improve the success rate of retry attempts, this function is available to
+ * pause the application before attempting to retry a failed operation with AWS.
+ * The higher the retryCount, the longer we wait.
+ *
+ * @param {number} retryCount how many times we have retried this task
+ * @returns {Promise} resolves once the sleep timeout has elapsed
+ */
+const backOff = retryCount => sleep(Math.pow(2, retryCount) * 100);
+
 module.exports = {
+  backOff,
   gatherRecords,
   getCsvOptions,
+  sleep,
   sortableTitle,
   whitespaceCleanup,
 };

--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -1340,6 +1340,7 @@ module.exports = (appContextUser, logger = createLogger()) => {
       CASE_STATUSES: Object.values(CASE_STATUS_TYPES),
       MAX_SEARCH_CLIENT_RESULTS,
       MAX_SEARCH_RESULTS,
+      MAX_SES_RETRIES: 6,
       OPEN_CASE_STATUSES: Object.values(CASE_STATUS_TYPES).filter(
         status => status !== CASE_STATUS_TYPES.closed,
       ),


### PR DESCRIPTION
In order to satisfy #874, this PR ensures that we re-attempt any failures reported by SES. It sets an arbitrary number of retries to 6, giving us a total of 7 attempts to send service email. Should a message be un-sendable after that many attempts, we log an error the logs. 

This PR also introduces a couple of new helper functions that facilitate the reattempts. This is advisory practice for handling failures with AWS to avoid throttling.

- `sleep` simply takes the number of milliseconds as a parameter, and returns a Promise that resolves itself after the specified number of milliseconds
- `backOff` calls this new `sleep` function with a calculated number of milliseconds based on the number of times we have retried. The calculation is `(2 ^ retryCount) * 100ms`.

#878 attempts to go a step further and put the application / SES in an unhealthy status if we get repeated failures sending. 