### PR TITLE
Add v2 API endpoints.

### DIFF
--- a/docs/api/v2.yaml
+++ b/docs/api/v2.yaml
@@ -1,0 +1,258 @@
+openapi: 3.0.0
+servers:
+  - url: https://api.dawson.ustaxcourt.gov/v2
+    description: Production server (v2)
+  - url: https://api.irs.ef-cms.ustaxcourt.gov/v2
+    description: IRS test server (v2)
+info:
+  description: This API enables access to the data found in Dawson, and is currently limited access. Contact Dawson support for feature requests.
+  version: "2"
+  title: Dawson API
+  contact:
+    name: Dawson support
+    email: dawson.support@ustaxcourt.gov
+tags:
+  - name: irs
+    description: Endpoints provided for IRS access.
+security:
+  - bearerAuth: []
+paths:
+  /cases/{docketNumber}:
+    get:
+      summary: fetches a case
+      operationId: fetchCase
+      tags:
+        - irs
+      description: |
+        By passing in a docket number, you can retrieve details about that case
+      parameters:
+        - in: path
+          name: docketNumber
+          description: The case's docket number.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: case object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Case'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /cases/{docketNumber}/entries/{docketEntryId}/document-download-url:
+    get:
+      summary: fetches a temporary file download url
+      operationId: fetchCaseDocketEntryDownloadUrl
+      tags:
+        - irs
+      description: |
+        By passing in a docket number and a docket entry ID, you can retrieve a signed, temporary URL to retrieve the attached document.
+      parameters:
+        - in: path
+          name: docketNumber
+          description: The case's docket number.
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: docketEntryId
+          description: The ID for the docket entry on the case.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: document download url
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocketEntryDownloadUrl'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '500':
+          $ref: '#/components/responses/ServerError'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  responses:
+    UnauthorizedError:
+      description: credentials were not provided or are invalid
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    ForbiddenError:
+      description: your credentials cannot access this resource
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotFoundError:
+      description: not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    ServerError:
+      description: the server encountered an error when processing your request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+  schemas:
+    Case:
+      type: object
+      properties:
+        caseCaption:
+          type: string
+          example: Private practitioner & Annalise, Deceased, Private practitioner, Surviving Spouse, Petitioners
+        caseType:
+          type: string
+          example: Deficiency
+        contactPrimary:
+          $ref: '#/components/schemas/Contact'
+        contactSecondary:
+          $ref: '#/components/schemas/Contact'
+        docketNumber:
+          type: string
+          example: '384-20'
+        docketNumberSuffix:
+          type: string
+        docketEntries:
+          type: array
+          items:
+            $ref: '#/components/schemas/DocketEntry'
+        filingType:
+          type: string
+          example: Petitioner and spouse
+        leadDocketNumber:
+          type: string
+          example: '383-20'
+        partyType:
+          type: string
+          example: Petitioner & deceased spouse
+        practitioners:
+          type: array
+          items:
+            $ref: '#/components/schemas/Practitioner'
+        preferredTrialCity:
+          type: string
+          example: Mobile, Alabama
+        respondents:
+          type: array
+          items:
+            $ref: '#/components/schemas/Practitioner'
+        serviceIndicator:
+          type: string
+          example: "Electronic"
+          enum:
+            - Electronic
+            - None
+            - Paper
+        sortableDocketNumber:
+          type: integer
+          example: 20000384
+        status:
+          type: string
+          example: New
+        trialDate:
+          type: string
+          format: date-time
+          example: '2016-08-29T09:12:33.001Z'
+        trialLocation:
+          type: string
+    Contact:
+      type: object
+      properties:
+        name:
+          type: string
+        phone:
+          type: string
+        email:
+          type: string
+        address1:
+          type: string
+        address2:
+          type: string
+        address3:
+          type: string
+        city:
+          type: string
+        state:
+          type: string
+        postalCode:
+          type: string
+    DocketEntry:
+      type: object
+      properties:
+        docketEntryId:
+          type: string
+          format: guidv4
+          example: 2621672d-cf3f-4ddd-ba50-92513b2fba76
+        isFileAttached:
+          type: boolean
+          example: true
+        index:
+          type: integer
+          example: 1
+        eventCode:
+          type: string
+          example: P
+        eventCodeDescription:
+          type: string
+          example: Petition
+        filedBy:
+          type: string
+          example: Petrs. Private practitioner & Annalise
+        filingDate:
+          type: string
+          format: date-time
+          example: '2016-08-29T09:12:33.001Z'
+        servedAt:
+          type: string
+          format: date-time
+          example: '2016-08-29T09:12:33.001Z'
+    Practitioner:
+      type: object
+      properties:
+        barNumber:
+          type: string
+          example: PT1234
+        contact:
+          $ref: '#/components/schemas/Contact'
+        email:
+          type: string
+          example: privatePractitioner1@example.com
+        name:
+          type: string
+          example: Test private practitioner1
+        serviceIndicator:
+          type: string
+          example: Electronic
+    DocketEntryDownloadUrl:
+      type: object
+      properties:
+        url:
+          type: string
+          format: url
+          example: 'https://app.dawson.ustaxcourt.gov/documents/4a6e9284-88aa-4954-9aa9-8e0e0fdd764e?AWSAccessKeyId=EXAMPLE&Expires=1601661807&Signature=EXAMPLE&x-amz-security-token=EXAMPLE'
+    Error:
+      type: object
+      properties:
+        message:
+          type: string

--- a/web-api/src/app.js
+++ b/web-api/src/app.js
@@ -163,6 +163,9 @@ const {
   getDocumentDownloadUrlLambda: v1GetDocumentDownloadUrlLambda,
 } = require('./v1/getDocumentDownloadUrlLambda');
 const {
+  getDocumentDownloadUrlLambda: v2GetDocumentDownloadUrlLambda,
+} = require('./v2/getDocumentDownloadUrlLambda');
+const {
   getDocumentQCInboxForSectionLambda,
 } = require('./workitems/getDocumentQCInboxForSectionLambda');
 const {
@@ -368,6 +371,7 @@ const { forwardMessageLambda } = require('./messages/forwardMessageLambda');
 const { getBlockedCasesLambda } = require('./reports/getBlockedCasesLambda');
 const { getCaseLambda } = require('./cases/getCaseLambda');
 const { getCaseLambda: v1GetCaseLambda } = require('./v1/getCaseLambda');
+const { getCaseLambda: v2GetCaseLambda } = require('./v2/getCaseLambda');
 const { getClosedCasesLambda } = require('./cases/getClosedCasesLambda');
 const { getInternalUsersLambda } = require('./users/getInternalUsersLambda');
 const { getMessageThreadLambda } = require('./messages/getMessageThreadLambda');
@@ -966,6 +970,15 @@ app.get('/v1/cases/:docketNumber', lambdaWrapper(v1GetCaseLambda));
 app.get(
   '/v1/cases/:docketNumber/entries/:key/document-download-url',
   lambdaWrapper(v1GetDocumentDownloadUrlLambda),
+);
+
+/**
+ * v2 API
+ */
+app.get('/v2/cases/:docketNumber', lambdaWrapper(v2GetCaseLambda));
+app.get(
+  '/v2/cases/:docketNumber/entries/:key/document-download-url',
+  lambdaWrapper(v2GetDocumentDownloadUrlLambda),
 );
 
 /**

--- a/web-api/src/v2/getCaseLambda.js
+++ b/web-api/src/v2/getCaseLambda.js
@@ -1,0 +1,28 @@
+const { genericHandler } = require('../genericHandler');
+const { marshallCase } = require('./marshallers/marshallCase');
+const { v2ApiWrapper } = require('./v2ApiWrapper');
+
+/**
+ * used for fetching a single case and returning it in v1 api format
+ *
+ * @param {object} event the AWS event object
+ * @param {object} options options to optionally pass to the genericHandler
+ * @returns {Promise<*|undefined>} the api gateway response object containing the statusCode, body, and headers
+ */
+exports.getCaseLambda = (event, options = {}) =>
+  genericHandler(
+    event,
+    async ({ applicationContext }) => {
+      return v2ApiWrapper(async () => {
+        const caseObject = await applicationContext
+          .getUseCases()
+          .getCaseInteractor({
+            applicationContext,
+            docketNumber: event.pathParameters.docketNumber,
+          });
+
+        return marshallCase(caseObject);
+      });
+    },
+    options,
+  );

--- a/web-api/src/v2/getCaseLambda.test.js
+++ b/web-api/src/v2/getCaseLambda.test.js
@@ -1,0 +1,267 @@
+const createApplicationContext = require('../applicationContext');
+const {
+  MOCK_CASE_WITH_TRIAL_SESSION,
+} = require('../../../shared/src/test/mockCase');
+const {
+  MOCK_COMPLEX_CASE,
+} = require('../../../shared/src/test/mockComplexCase');
+const {
+  MOCK_PRACTITIONER,
+  MOCK_USERS,
+} = require('../../../shared/src/test/mockUsers');
+const { getCaseLambda } = require('./getCaseLambda');
+
+const mockDynamoCaseRecord = Object.assign({}, MOCK_CASE_WITH_TRIAL_SESSION, {
+  entityName: 'Case',
+  pk: 'case|101-18',
+  sk: 'case|23',
+});
+
+mockDynamoCaseRecord.contactPrimary.serviceIndicator = 'Electronic';
+
+const mockIrsPractitionerRecord = Object.assign(
+  {},
+  MOCK_COMPLEX_CASE.irsPractitioners[0],
+  {
+    entityName: 'IrsPractitioner',
+    pk: 'case|101-18',
+    sk: 'irsPractitioner|23',
+  },
+);
+
+const mockPrivatePractitionerRecord = Object.assign({}, MOCK_PRACTITIONER, {
+  entityName: 'PrivatePractitioner',
+  pk: 'case|101-18',
+  serviceIndicator: 'Paper',
+  sk: 'privatePractitioner|23',
+});
+
+const REQUEST_EVENT = {
+  body: {},
+  headers: {},
+  path: '',
+  pathParameters: {
+    docketNumber: '123-30',
+  },
+  queryStringParameters: {},
+};
+
+const createSilentAppContext = user => {
+  const applicationContext = createApplicationContext(user, {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  });
+
+  applicationContext.environment.dynamoDbTableName = 'mocked';
+
+  return applicationContext;
+};
+
+describe('getCaseLambda', () => {
+  let CI;
+  // disable logging by mimicking CI for this test
+  beforeAll(() => {
+    ({ CI } = process.env);
+    process.env.CI = true;
+  });
+
+  afterAll(() => (process.env.CI = CI));
+
+  // the 401 case is handled by API Gateway, and as such isn’t tested here.
+
+  it('returns 404 when the user is not authorized and the case is not found', async () => {
+    const user = { role: 'roleWithNoPermissions' };
+    const applicationContext = createSilentAppContext(user);
+
+    // Case is retrieved before determining authorization
+    applicationContext.getDocumentClient = jest.fn().mockReturnValue({
+      query: jest.fn().mockReturnValue({
+        promise: jest.fn().mockReturnValue(
+          Promise.resolve({
+            Items: [], // no items with docket number is found
+          }),
+        ),
+      }),
+    });
+
+    const response = await getCaseLambda(REQUEST_EVENT, {
+      applicationContext,
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(response.body)).toHaveProperty(
+      'message',
+      expect.any(String),
+    );
+  });
+
+  it('returns 200 when the user is not associated and the case is found', async () => {
+    const user = { role: 'roleWithNoPermissions' };
+    const applicationContext = createSilentAppContext(user);
+
+    // Case is retrieved before determining authorization
+    applicationContext.getDocumentClient = jest.fn().mockReturnValue({
+      query: jest.fn().mockReturnValue({
+        promise: jest.fn().mockReturnValue(
+          Promise.resolve({
+            Items: [mockDynamoCaseRecord],
+          }),
+        ),
+      }),
+    });
+
+    const response = await getCaseLambda(REQUEST_EVENT, {
+      applicationContext,
+    });
+
+    expect(response.statusCode).toBe('200');
+    expect(response.headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(response.body)).toHaveProperty(
+      'caseCaption',
+      expect.any(String),
+    );
+    expect(JSON.parse(response.body).assignedJudge).toBeUndefined();
+    expect(JSON.parse(response.body).contactPrimary.address1).toBeUndefined();
+    expect(JSON.parse(response.body).contactPrimary.name).toBeDefined();
+    expect(JSON.parse(response.body).contactPrimary.state).toBeDefined();
+    expect(JSON.parse(response.body).status).toBeUndefined();
+    expect(JSON.parse(response.body).trialDate).toBeUndefined();
+    expect(JSON.parse(response.body).trialLocation).toBeUndefined();
+    expect(JSON.parse(response.body).userId).toBeUndefined();
+  });
+
+  it('returns 404 when the docket number isn’t found', async () => {
+    const user = MOCK_USERS['b7d90c05-f6cd-442c-a168-202db587f16f'];
+    const applicationContext = createSilentAppContext(user);
+
+    applicationContext.getDocumentClient = jest.fn().mockReturnValue({
+      query: jest.fn().mockReturnValue({
+        promise: jest.fn().mockReturnValue(
+          Promise.resolve({
+            Items: [], // no items with docket number is found
+          }),
+        ),
+      }),
+    });
+
+    const response = await getCaseLambda(REQUEST_EVENT, {
+      applicationContext,
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(response.body)).toHaveProperty(
+      'message',
+      expect.any(String),
+    );
+  });
+
+  it('returns 500 on an unexpected error', async () => {
+    const user = MOCK_USERS['b7d90c05-f6cd-442c-a168-202db587f16f'];
+    const applicationContext = createSilentAppContext(user);
+
+    applicationContext.getDocumentClient = jest.fn().mockReturnValue({
+      query: jest.fn().mockReturnValue({
+        promise: jest
+          .fn()
+          .mockReturnValue(Promise.reject(new Error('test error'))),
+      }),
+    });
+
+    const response = await getCaseLambda(REQUEST_EVENT, {
+      applicationContext,
+    });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(response.body)).toHaveProperty(
+      'message',
+      expect.any(String),
+    );
+  });
+
+  it('returns the case in v2 format', async () => {
+    const user = MOCK_USERS['b7d90c05-f6cd-442c-a168-202db587f16f'];
+    const applicationContext = createSilentAppContext(user);
+
+    applicationContext.getDocumentClient = jest.fn().mockReturnValue({
+      query: jest.fn().mockReturnValue({
+        promise: jest.fn().mockReturnValue(
+          Promise.resolve({
+            Items: [
+              mockDynamoCaseRecord,
+              mockIrsPractitionerRecord,
+              mockPrivatePractitionerRecord,
+            ],
+          }),
+        ),
+      }),
+    });
+
+    const response = await getCaseLambda(REQUEST_EVENT, {
+      applicationContext,
+    });
+
+    expect(response.statusCode).toBe('200');
+    expect(response.headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(response.body)).toMatchObject({
+      caseCaption: 'Test Petitioner, Petitioner',
+      caseType: 'Other',
+      contactPrimary: {
+        address1: '123 Main St',
+        city: 'Somewhere',
+        email: 'petitioner@example.com',
+        name: 'Test Petitioner',
+        phone: '1234567',
+        postalCode: '12345',
+        serviceIndicator: 'Electronic',
+        state: 'TN',
+      },
+      docketEntries: [],
+      docketNumber: '101-18',
+      docketNumberSuffix: null,
+      filingType: 'Myself',
+      partyType: 'Petitioner',
+      practitioners: [
+        {
+          barNumber: 'AB1111',
+          contact: {
+            address1: '234 Main St',
+            address2: 'Apartment 4',
+            address3: 'Under the stairs',
+            city: 'Chicago',
+            phone: '+1 (555) 555-5555',
+            postalCode: '61234',
+            state: 'IL',
+          },
+          email: 'ab@example.com',
+          name: 'Test Attorney',
+          serviceIndicator: 'Paper',
+        },
+      ],
+      preferredTrialCity: 'Washington, District of Columbia',
+      respondents: [
+        {
+          barNumber: 'VS0062',
+          contact: {
+            address1: '016 Miller Loop Apt. 494',
+            address2: 'Apt. 835',
+            city: 'Cristianville',
+            phone: '001-016-669-6532x5946',
+            postalCode: '68117',
+            state: 'NE',
+          },
+          email: 'adam22@yahoo.com',
+          name: 'Isaac Benson',
+          serviceIndicator: 'Electronic',
+        },
+      ],
+      sortableDocketNumber: 18000101,
+      status: 'Calendared',
+      trialDate: '2020-03-01T00:00:00.000Z',
+      trialLocation: 'Washington, District of Columbia',
+    });
+  });
+});

--- a/web-api/src/v2/getDocumentDownloadUrlLambda.js
+++ b/web-api/src/v2/getDocumentDownloadUrlLambda.js
@@ -1,0 +1,30 @@
+const {
+  marshallDocumentDownloadUrl,
+} = require('./marshallers/marshallDocumentDownloadUrl');
+const { genericHandler } = require('../genericHandler');
+const { v2ApiWrapper } = require('./v2ApiWrapper');
+
+/**
+ * used for getting the download policy which is needed for consumers to download files directly from S3
+ *
+ * @param {object} event the AWS event object
+ * @param {object} options options to optionally pass to the genericHandler
+ * @returns {Promise<*|undefined>} the api gateway response object containing the statusCode, body, and headers
+ */
+exports.getDocumentDownloadUrlLambda = (event, options = {}) =>
+  genericHandler(
+    event,
+    async ({ applicationContext }) => {
+      return v2ApiWrapper(async () => {
+        const urlObject = await applicationContext
+          .getUseCases()
+          .getDownloadPolicyUrlInteractor({
+            applicationContext,
+            ...event.pathParameters,
+          });
+
+        return marshallDocumentDownloadUrl(urlObject);
+      });
+    },
+    options,
+  );

--- a/web-api/src/v2/getDocumentDownloadUrlLambda.test.js
+++ b/web-api/src/v2/getDocumentDownloadUrlLambda.test.js
@@ -1,0 +1,236 @@
+const createApplicationContext = require('../applicationContext');
+const {
+  getDocumentDownloadUrlLambda,
+} = require('./getDocumentDownloadUrlLambda');
+const { MOCK_USERS } = require('../../../shared/src/test/mockUsers');
+
+const REQUEST_EVENT = {
+  body: {},
+  headers: {},
+  path: '',
+  pathParameters: {},
+  queryStringParameters: {},
+};
+
+const createSilentAppContext = user => {
+  const applicationContext = createApplicationContext(user, {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  });
+
+  applicationContext.environment.dynamoDbTableName = 'mocked';
+
+  return applicationContext;
+};
+
+describe('getDocumentDownloadUrlLambda', () => {
+  let CI;
+  // disable logging by mimicking CI for this test
+  beforeAll(() => {
+    ({ CI } = process.env);
+    process.env.CI = true;
+  });
+
+  afterAll(() => (process.env.CI = CI));
+
+  // the 401 case is handled by API Gateway, and as such isn’t tested here.
+
+  it('returns 403 when the user is not authorized', async () => {
+    const user = { role: 'roleWithNoPermissions' };
+    const applicationContext = createSilentAppContext(user);
+
+    const response = await getDocumentDownloadUrlLambda(REQUEST_EVENT, {
+      applicationContext,
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(response.body)).toHaveProperty('message', 'Unauthorized');
+  });
+
+  it('returns 404 when the docket number isn’t found', async () => {
+    const user = MOCK_USERS['b7d90c05-f6cd-442c-a168-202db587f16f'];
+    const applicationContext = createSilentAppContext(user);
+    const request = Object.assign({}, REQUEST_EVENT, {
+      pathParameters: {
+        docketNumber: '1234-19',
+        key: '530d4b65-620a-489d-8414-6623653ebb3a',
+      },
+    });
+
+    applicationContext.getDocumentClient = jest.fn().mockReturnValue({
+      query: jest.fn().mockReturnValue({
+        promise: jest.fn().mockReturnValue(
+          Promise.resolve({
+            Items: [], // no items with docket number is found
+          }),
+        ),
+      }),
+    });
+
+    applicationContext.getPersistenceGateway().getDownloadPolicyUrl = jest
+      .fn()
+      .mockImplementation(({ key, useTempBucket }) => {
+        return {
+          url: `https://example.com/download-policy-url/${
+            useTempBucket ? 'temp-' : ''
+          }bucket/item/${key}`,
+        };
+      });
+
+    const response = await getDocumentDownloadUrlLambda(request, {
+      applicationContext,
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(response.body)).toHaveProperty(
+      'message',
+      expect.any(String),
+    );
+  });
+
+  it('returns 404 when the entity GUID isn’t found', async () => {
+    const user = MOCK_USERS['2eee98ac-613f-46bc-afd5-2574d1b15664'];
+    const applicationContext = createSilentAppContext(user);
+    const request = Object.assign({}, REQUEST_EVENT, {
+      pathParameters: {
+        docketNumber: '123-30',
+        key: '530d4b65-620a-489d-8414-6623653ebb3a',
+      },
+    });
+
+    applicationContext.getDocumentClient = jest.fn().mockReturnValue({
+      query: jest.fn().mockReturnValue({
+        promise: jest.fn().mockReturnValue(
+          Promise.resolve({
+            Items: [
+              {
+                docketNumber: '123-20',
+                judgeUserId: 'ce92c582-186f-45a7-a5f5-e1cec03521ad',
+                pk: 'case|123-20',
+                sk: 'case|23',
+                status: 'New',
+              },
+              {
+                archived: false,
+                // docket entry does not match the requested entry
+                docketEntryId: '26c6a0e5-5d11-45f0-9904-04d103ada04f',
+                pk: 'case|123-20',
+                sk: 'docket-entry|124',
+              },
+            ],
+          }),
+        ),
+      }),
+    });
+
+    applicationContext.getPersistenceGateway().getDownloadPolicyUrl = jest
+      .fn()
+      .mockImplementation(({ key, useTempBucket }) => {
+        return {
+          url: `https://example.com/download-policy-url/${
+            useTempBucket ? 'temp-' : ''
+          }bucket/item/${key}`,
+        };
+      });
+
+    const response = await getDocumentDownloadUrlLambda(request, {
+      applicationContext,
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(response.body)).toHaveProperty(
+      'message',
+      expect.any(String),
+    );
+  });
+
+  it('returns 500 on an unexpected error', async () => {
+    const user = MOCK_USERS['b7d90c05-f6cd-442c-a168-202db587f16f'];
+    const applicationContext = createSilentAppContext(user);
+    const request = Object.assign({}, REQUEST_EVENT, {
+      pathParameters: {
+        docketNumber: '123-30',
+        key: '530d4b65-620a-489d-8414-6623653ebb3a',
+      },
+    });
+
+    applicationContext.getDocumentClient = jest.fn().mockReturnValue({
+      query: jest.fn().mockReturnValue({
+        promise: jest
+          .fn()
+          .mockReturnValue(Promise.reject(new Error('test error'))),
+      }),
+    });
+
+    const response = await getDocumentDownloadUrlLambda(request, {
+      applicationContext,
+    });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(response.body)).toHaveProperty(
+      'message',
+      expect.any(String),
+    );
+  });
+
+  it('returns the document download URL in v2 format', async () => {
+    const user = MOCK_USERS['b7d90c05-f6cd-442c-a168-202db587f16f'];
+    const applicationContext = createSilentAppContext(user);
+    const request = Object.assign({}, REQUEST_EVENT, {
+      pathParameters: {
+        docketNumber: '123-30',
+        key: '26c6a0e5-5d11-45f0-9904-04d103ada04f',
+      },
+    });
+
+    applicationContext.getDocumentClient = jest.fn().mockReturnValue({
+      query: jest.fn().mockReturnValue({
+        promise: jest.fn().mockReturnValue(
+          Promise.resolve({
+            Items: [
+              {
+                docketNumber: '123-20',
+                judgeUserId: 'ce92c582-186f-45a7-a5f5-e1cec03521ad',
+                pk: 'case|123-20',
+                sk: 'case|23',
+                status: 'New',
+              },
+              {
+                archived: false,
+                docketEntryId: '26c6a0e5-5d11-45f0-9904-04d103ada04f',
+                pk: 'case|123-20',
+                sk: 'docket-entry|124',
+              },
+            ],
+          }),
+        ),
+      }),
+    });
+
+    applicationContext.getPersistenceGateway().getDownloadPolicyUrl = jest
+      .fn()
+      .mockImplementation(({ key, useTempBucket }) => {
+        return {
+          url: `https://example.com/download-policy-url/${
+            useTempBucket ? 'temp-' : ''
+          }bucket/item/${key}`,
+        };
+      });
+
+    const response = await getDocumentDownloadUrlLambda(request, {
+      applicationContext,
+    });
+
+    expect(response.statusCode).toBe('200');
+    expect(response.headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(response.body)).toHaveProperty(
+      'url',
+      'https://example.com/download-policy-url/bucket/item/26c6a0e5-5d11-45f0-9904-04d103ada04f',
+    );
+  });
+});

--- a/web-api/src/v2/marshallers/marshallCase.js
+++ b/web-api/src/v2/marshallers/marshallCase.js
@@ -1,0 +1,38 @@
+const { marshallContact } = require('./marshallContact');
+const { marshallDocketEntry } = require('./marshallDocketEntry');
+const { marshallPractitioner } = require('./marshallPractitioner');
+
+/**
+ * The returned object is specified by the v2 API and any changes to these properties
+ * beyond additions must be accompanied by a version increase.
+ *
+ * @param {object} caseObject the most up-to-date representation of a case
+ * @returns {object} the v2 representation of a case
+ */
+exports.marshallCase = caseObject => {
+  return {
+    caseCaption: caseObject.caseCaption,
+    caseType: caseObject.caseType,
+    contactPrimary: caseObject.contactPrimary
+      ? marshallContact(caseObject.contactPrimary)
+      : undefined,
+    contactSecondary: caseObject.contactSecondary
+      ? marshallContact(caseObject.contactSecondary)
+      : undefined,
+    docketEntries: (caseObject.docketEntries || []).map(marshallDocketEntry),
+    docketNumber: caseObject.docketNumber,
+    docketNumberSuffix: caseObject.docketNumberSuffix,
+    filingType: caseObject.filingType,
+    leadDocketNumber: caseObject.leadDocketNumber,
+    partyType: caseObject.partyType,
+    practitioners: (caseObject.privatePractitioners || []).map(
+      marshallPractitioner,
+    ),
+    preferredTrialCity: caseObject.preferredTrialCity,
+    respondents: (caseObject.irsPractitioners || []).map(marshallPractitioner),
+    sortableDocketNumber: caseObject.sortableDocketNumber,
+    status: caseObject.status,
+    trialDate: caseObject.trialDate,
+    trialLocation: caseObject.trialLocation,
+  };
+};

--- a/web-api/src/v2/marshallers/marshallCase.test.js
+++ b/web-api/src/v2/marshallers/marshallCase.test.js
@@ -1,0 +1,87 @@
+const { marshallCase } = require('./marshallCase');
+const { MOCK_CASE } = require('../../../../shared/src/test/mockCase');
+
+describe('marshallCase', () => {
+  it('returns a case object with the expected properties', () => {
+    expect(Object.keys(marshallCase(MOCK_CASE)).sort()).toEqual([
+      'caseCaption',
+      'caseType',
+      'contactPrimary',
+      'contactSecondary',
+      'docketEntries',
+      'docketNumber',
+      'docketNumberSuffix',
+      'filingType',
+      'leadDocketNumber',
+      'partyType',
+      'practitioners',
+      'preferredTrialCity',
+      'respondents',
+      'sortableDocketNumber',
+      'status',
+      'trialDate',
+      'trialLocation',
+    ]);
+  });
+
+  it('marshalls from the current case format', () => {
+    const mock = Object.assign({}, MOCK_CASE, {
+      contactSecondary: Object.assign({}, MOCK_CASE.contactPrimary),
+      docketEntries: [],
+      docketNumber: '123-19L',
+      docketNumberSuffix: 'L',
+      irsPractitioners: [],
+      leadDocketNumber: '122-19L',
+      privatePractitioners: [],
+      sortableDocketNumber: 201900123,
+      trialDate: '2019-12-08T00:00:00.000Z',
+      trialLocation: 'Woodstock, Connecticut',
+    });
+
+    expect(mock.caseCaption).toBeDefined();
+    expect(mock.caseType).toBeDefined();
+    expect(mock.docketNumber).toBeDefined();
+    expect(mock.docketNumberSuffix).toBeDefined();
+    expect(mock.filingType).toBeDefined();
+    expect(mock.leadDocketNumber).toBeDefined();
+    expect(mock.partyType).toBeDefined();
+    expect(mock.preferredTrialCity).toBeDefined();
+    expect(mock.sortableDocketNumber).toBeDefined();
+    expect(mock.status).toBeDefined();
+    expect(mock.trialDate).toBeDefined();
+    expect(mock.trialLocation).toBeDefined();
+
+    expect(mock.contactPrimary).toBeDefined();
+    expect(mock.contactSecondary).toBeDefined();
+    expect(mock.docketEntries).toBeDefined();
+    expect(mock.irsPractitioners).toBeDefined();
+    expect(mock.privatePractitioners).toBeDefined();
+
+    const marshalled = marshallCase(mock);
+
+    expect(marshalled.caseCaption).toEqual(mock.caseCaption);
+    expect(marshalled.caseType).toEqual(mock.caseType);
+    expect(marshalled.docketNumber).toEqual(mock.docketNumber);
+    expect(marshalled.docketNumberSuffix).toEqual(mock.docketNumberSuffix);
+    expect(marshalled.filingType).toEqual(mock.filingType);
+    expect(marshalled.leadDocketNumber).toEqual(mock.leadDocketNumber);
+    expect(marshalled.partyType).toEqual(mock.partyType);
+    expect(marshalled.preferredTrialCity).toEqual(mock.preferredTrialCity);
+    expect(marshalled.sortableDocketNumber).toEqual(mock.sortableDocketNumber);
+    expect(marshalled.status).toEqual(mock.status);
+    expect(marshalled.trialDate).toEqual(mock.trialDate);
+    expect(marshalled.trialLocation).toEqual(mock.trialLocation);
+
+    // Exact format asserted in other tests.
+    expect(marshalled.contactPrimary).toBeDefined();
+    expect(marshalled.contactSecondary).toBeDefined();
+    expect(marshalled.docketEntries).toBeDefined();
+    expect(marshalled.practitioners).toBeDefined();
+    expect(marshalled.respondents).toBeDefined();
+  });
+
+  it('does not require any attributes to be set', () => {
+    const marshalled = marshallCase({});
+    expect(marshalled).toBeDefined();
+  });
+});

--- a/web-api/src/v2/marshallers/marshallContact.js
+++ b/web-api/src/v2/marshallers/marshallContact.js
@@ -1,0 +1,21 @@
+/**
+ * The returned object is specified by the v2 API and any changes to these properties
+ * beyond additions must be accompanied by a version increase.
+ *
+ * @param {object} contactObject the most up-to-date representation of a contact
+ * @returns {object} the v2 representation of a contact
+ */
+exports.marshallContact = contactObject => {
+  return {
+    address1: contactObject.address1,
+    address2: contactObject.address2,
+    address3: contactObject.address3,
+    city: contactObject.city,
+    email: contactObject.email,
+    name: contactObject.name,
+    phone: contactObject.phone,
+    postalCode: contactObject.postalCode,
+    serviceIndicator: contactObject.serviceIndicator,
+    state: contactObject.state,
+  };
+};

--- a/web-api/src/v2/marshallers/marshallContact.test.js
+++ b/web-api/src/v2/marshallers/marshallContact.test.js
@@ -1,0 +1,53 @@
+const { marshallContact } = require('./marshallContact');
+const { MOCK_CASE } = require('../../../../shared/src/test/mockCase');
+const MOCK_CONTACT = Object.assign({}, MOCK_CASE.contactPrimary, {
+  serviceIndicator: 'Electronic',
+});
+
+describe('marshallContact', () => {
+  it('returns a contact object with the expected properties', () => {
+    expect(Object.keys(marshallContact(MOCK_CONTACT)).sort()).toEqual([
+      'address1',
+      'address2',
+      'address3',
+      'city',
+      'email',
+      'name',
+      'phone',
+      'postalCode',
+      'serviceIndicator',
+      'state',
+    ]);
+  });
+
+  it('marshalls from the current contact format', () => {
+    const mock = Object.assign({}, MOCK_CONTACT, {
+      address2: 'address2',
+      address3: 'address3',
+    });
+
+    expect(mock.address1).toBeDefined();
+    expect(mock.address2).toBeDefined();
+    expect(mock.address3).toBeDefined();
+    expect(mock.city).toBeDefined();
+    expect(mock.email).toBeDefined();
+    expect(mock.name).toBeDefined();
+    expect(mock.phone).toBeDefined();
+    expect(mock.postalCode).toBeDefined();
+    expect(mock.serviceIndicator).toBeDefined();
+    expect(mock.state).toBeDefined();
+
+    const marshalled = marshallContact(mock);
+
+    expect(marshalled.address1).toEqual(mock.address1);
+    expect(marshalled.address2).toEqual(mock.address2);
+    expect(marshalled.address3).toEqual(mock.address3);
+    expect(marshalled.city).toEqual(mock.city);
+    expect(marshalled.email).toEqual(mock.email);
+    expect(marshalled.name).toEqual(mock.name);
+    expect(marshalled.phone).toEqual(mock.phone);
+    expect(marshalled.postalCode).toEqual(mock.postalCode);
+    expect(marshalled.serviceIndicator).toEqual(mock.serviceIndicator);
+    expect(marshalled.state).toEqual(mock.state);
+  });
+});

--- a/web-api/src/v2/marshallers/marshallDocketEntry.js
+++ b/web-api/src/v2/marshallers/marshallDocketEntry.js
@@ -1,0 +1,19 @@
+/**
+ * The returned object is specified by the v2 API and any changes to these properties
+ * beyond additions must be accompanied by a version increase.
+ *
+ * @param {object} docketEntryObject the most up-to-date representation of a docketEntry
+ * @returns {object} the v2 representation of a docketEntry
+ */
+exports.marshallDocketEntry = docketEntryObject => {
+  return {
+    docketEntryId: docketEntryObject.docketEntryId,
+    eventCode: docketEntryObject.eventCode,
+    eventCodeDescription: docketEntryObject.documentType,
+    filedBy: docketEntryObject.filedBy,
+    filingDate: docketEntryObject.filingDate,
+    index: docketEntryObject.index,
+    isFileAttached: docketEntryObject.isFileAttached || false,
+    servedAt: docketEntryObject.servedAt,
+  };
+};

--- a/web-api/src/v2/marshallers/marshallDocketEntry.test.js
+++ b/web-api/src/v2/marshallers/marshallDocketEntry.test.js
@@ -1,0 +1,48 @@
+const { marshallDocketEntry } = require('./marshallDocketEntry');
+const { MOCK_DOCUMENTS } = require('../../../../shared/src/test/mockDocuments');
+const MOCK_DOCUMENT = MOCK_DOCUMENTS[0];
+
+describe('marshallDocketEntry', () => {
+  it('returns a docketEntry object with the expected properties', () => {
+    expect(Object.keys(marshallDocketEntry(MOCK_DOCUMENT)).sort()).toEqual([
+      'docketEntryId',
+      'eventCode',
+      'eventCodeDescription',
+      'filedBy',
+      'filingDate',
+      'index',
+      'isFileAttached',
+      'servedAt',
+    ]);
+  });
+
+  it('marshalls from the current docketEntry format', () => {
+    const mock = Object.assign({}, MOCK_DOCUMENT, {
+      servedAt: '2018-12-21T20:49:28.192Z',
+    });
+
+    expect(mock.docketEntryId).toBeDefined();
+    expect(mock.eventCode).toBeDefined();
+    expect(mock.documentType).toBeDefined();
+    expect(mock.filedBy).toBeDefined();
+    expect(mock.filingDate).toBeDefined();
+    expect(mock.index).toBeDefined();
+    expect(mock.isFileAttached).toBeDefined();
+    expect(mock.servedAt).toBeDefined();
+
+    const marshalled = marshallDocketEntry(mock);
+
+    expect(marshalled.docketEntryId).toEqual(mock.docketEntryId);
+    expect(marshalled.eventCode).toEqual(mock.eventCode);
+    expect(marshalled.eventCodeDescription).toEqual(mock.documentType);
+    expect(marshalled.filedBy).toEqual(mock.filedBy);
+    expect(marshalled.filingDate).toEqual(mock.filingDate);
+    expect(marshalled.index).toEqual(mock.index);
+    expect(marshalled.isFileAttached).toEqual(mock.isFileAttached);
+    expect(marshalled.servedAt).toEqual(mock.servedAt);
+  });
+
+  it('sets a default value for isFileAttached if it is not specified', () => {
+    expect(marshallDocketEntry({}).isFileAttached).toBe(false);
+  });
+});

--- a/web-api/src/v2/marshallers/marshallDocumentDownloadUrl.js
+++ b/web-api/src/v2/marshallers/marshallDocumentDownloadUrl.js
@@ -1,0 +1,12 @@
+/**
+ * The returned object is specified by the v2 API and any changes to these properties
+ * beyond additions must be accompanied by a version increase.
+ *
+ * @param {object} urlObject the most up-to-date representation of a url
+ * @returns {object} the v2 representation of a url
+ */
+exports.marshallDocumentDownloadUrl = urlObject => {
+  return {
+    url: urlObject.url,
+  };
+};

--- a/web-api/src/v2/marshallers/marshallDocumentDownloadUrl.test.js
+++ b/web-api/src/v2/marshallers/marshallDocumentDownloadUrl.test.js
@@ -1,0 +1,22 @@
+const {
+  marshallDocumentDownloadUrl,
+} = require('./marshallDocumentDownloadUrl');
+const MOCK_URL = {
+  url: 'https://example.com/path?queryparam=passed',
+};
+
+describe('marshallDocumentDownloadUrl', () => {
+  it('returns a url object with the expected properties', () => {
+    expect(Object.keys(marshallDocumentDownloadUrl(MOCK_URL)).sort()).toEqual([
+      'url',
+    ]);
+  });
+
+  it('marshalls from the current url format', () => {
+    expect(MOCK_URL.url).toBeDefined();
+
+    const marshalled = marshallDocumentDownloadUrl(MOCK_URL);
+
+    expect(marshalled.url).toEqual(MOCK_URL.url);
+  });
+});

--- a/web-api/src/v2/marshallers/marshallPractitioner.js
+++ b/web-api/src/v2/marshallers/marshallPractitioner.js
@@ -1,0 +1,20 @@
+const { marshallContact } = require('./marshallContact');
+
+/**
+ * The returned object is specified by the v2 API and any changes to these properties
+ * beyond additions must be accompanied by a version increase.
+ *
+ * @param {object} practitionerObject the most up-to-date representation of a practitioner
+ * @returns {object} the v2 representation of a practitioner
+ */
+exports.marshallPractitioner = practitionerObject => {
+  return {
+    barNumber: practitionerObject.barNumber,
+    contact: practitionerObject.contact
+      ? marshallContact(practitionerObject.contact)
+      : undefined,
+    email: practitionerObject.email,
+    name: practitionerObject.name,
+    serviceIndicator: practitionerObject.serviceIndicator,
+  };
+};

--- a/web-api/src/v2/marshallers/marshallPractitioner.test.js
+++ b/web-api/src/v2/marshallers/marshallPractitioner.test.js
@@ -1,0 +1,40 @@
+const { marshallPractitioner } = require('./marshallPractitioner');
+const { MOCK_CASE } = require('../../../../shared/src/test/mockCase');
+const { MOCK_USERS } = require('../../../../shared/src/test/mockUsers');
+const MOCK_CONTACT = MOCK_CASE.contactPrimary;
+const MOCK_PRACTITIONER = MOCK_USERS['330d4b65-620a-489d-8414-6623653ebc4f'];
+const {
+  SERVICE_INDICATOR_TYPES,
+} = require('../../../../shared/src/business/entities/EntityConstants');
+
+describe('marshallPractitioner', () => {
+  it('returns a practitioner object with the expected properties', () => {
+    expect(
+      Object.keys(marshallPractitioner(MOCK_PRACTITIONER)).sort(),
+    ).toEqual(['barNumber', 'contact', 'email', 'name', 'serviceIndicator']);
+  });
+
+  it('marshalls from the current practitioner format', () => {
+    const mock = Object.assign({}, MOCK_PRACTITIONER, {
+      contact: MOCK_CONTACT,
+      email: MOCK_CONTACT.email,
+      serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+    });
+
+    expect(mock.barNumber).toBeDefined();
+    expect(mock.contact).toBeDefined();
+    expect(mock.email).toBeDefined();
+    expect(mock.name).toBeDefined();
+    expect(mock.serviceIndicator).toBeDefined();
+
+    const marshalled = marshallPractitioner(mock);
+
+    expect(marshalled.barNumber).toEqual(mock.barNumber);
+    expect(marshalled.email).toEqual(mock.email);
+    expect(marshalled.name).toEqual(mock.name);
+    expect(marshalled.serviceIndicator).toEqual(mock.serviceIndicator);
+
+    // Exact format asserted in other tests.
+    expect(marshalled.contact).toBeDefined();
+  });
+});

--- a/web-api/src/v2/v2ApiWrapper.js
+++ b/web-api/src/v2/v2ApiWrapper.js
@@ -1,0 +1,44 @@
+/**
+ * Errors returned by the v2 API. The structure of this object
+ * and returned response codes are considered part of the API version
+ * and should not change without incrementing the API version.
+ *
+ * The returned messages themselves are not part of the API version.
+ *
+ * 401: returned by API Gateway
+ * 403: returned by wrapping UnauthorizedError
+ * 404: returned by wrapping NotFoundError
+ * 500: returned by wrapping any Error which doesn't specify a statusCode.
+ */
+const V2_API_ERROR_STATUS_CODES = [401, 403, 404, 500];
+
+class v2ApiError extends Error {
+  constructor(error) {
+    super();
+    this.statusCode = V2_API_ERROR_STATUS_CODES.includes(error.statusCode)
+      ? error.statusCode
+      : 500;
+    this.message = {
+      message: error.message || 'An unexpected error occurred',
+      toString: function () {
+        return this.message;
+      },
+    };
+    this.stack = error.stack;
+  }
+}
+
+exports.v2ApiWrapper = async handler => {
+  try {
+    return await handler();
+  } catch (e) {
+    // Workaround until https://github.com/ustaxcourt/ef-cms/pull/462 is resolved
+    // (API returning 400 instead of 404 on unknown cases)
+    if (e.message.includes('The Case entity was invalid')) {
+      e.statusCode = 404;
+      e.message = 'Case not found';
+    }
+
+    throw new v2ApiError(e);
+  }
+};

--- a/web-api/src/v2/v2ApiWrapper.test.js
+++ b/web-api/src/v2/v2ApiWrapper.test.js
@@ -1,0 +1,55 @@
+const { v2ApiWrapper } = require('./v2ApiWrapper');
+
+describe('v2ApiWrapper', () => {
+  const throwWithStatus = (statusCode, message = 'Test error') => () => {
+    const err = new Error(message);
+    err.statusCode = statusCode;
+    throw err;
+  };
+
+  test('errors thrown during execution are 500s and serialized as the expected v1 error object', async () => {
+    try {
+      await v2ApiWrapper(throwWithStatus(undefined));
+    } catch (err) {
+      /* eslint-disable jest/no-try-expect */
+      expect(JSON.stringify(err.message)).toBe('{"message":"Test error"}');
+      expect(err.statusCode).toBe(500);
+      /* eslint-enable jest/no-try-expect */
+    }
+  });
+
+  test('errors with status code of 401, 403, 404, or 500 are preserved', async () => {
+    await expect(() => v2ApiWrapper(throwWithStatus(401))).rejects.toThrow(
+      expect.objectContaining({ statusCode: 401 }),
+    );
+
+    await expect(() => v2ApiWrapper(throwWithStatus(403))).rejects.toThrow(
+      expect.objectContaining({ statusCode: 403 }),
+    );
+
+    await expect(() => v2ApiWrapper(throwWithStatus(404))).rejects.toThrow(
+      expect.objectContaining({ statusCode: 404 }),
+    );
+
+    await expect(() => v2ApiWrapper(throwWithStatus(500))).rejects.toThrow(
+      expect.objectContaining({ statusCode: 500 }),
+    );
+  });
+
+  test('errors with a status code not indicated by the v1 spec are 500s', async () => {
+    await expect(() => v2ApiWrapper(throwWithStatus(405))).rejects.toThrow(
+      expect.objectContaining({ statusCode: 500 }),
+    );
+    await expect(() => v2ApiWrapper(throwWithStatus(503))).rejects.toThrow(
+      expect.objectContaining({ statusCode: 500 }),
+    );
+  });
+
+  // Workaround until https://github.com/ustaxcourt/ef-cms/pull/462 is resolved
+  // (API returning 400 instead of 404 on unknown cases)
+  test('Case validation errors are converted to 404s', async () => {
+    await expect(() =>
+      v2ApiWrapper(throwWithStatus(400, 'The Case entity was invalid')),
+    ).rejects.toThrow(expect.objectContaining({ statusCode: 404 }));
+  });
+});


### PR DESCRIPTION
Summarizing the changes requested in #779:

| Request | Result |
|---------|-------|
| Case: do not include `case.noticeOfTrialDate` | Removed in v2 API |
| Case: include `case.trialDate` | Added in v2 API |
| Case: include `case.trialLocation` | No change, already included in v1 API |
| Case: include `case.preferredTrialCity` | No change, already included in v1 API |
| Petitioner contact: include `contact.serviceIndicator` | Added in v2 API |
| Practitioner: include `practitioner.serviceIndicator` | No change, already included in v1 API |

**Note to reviewer:** there is a good amount of duplication between the v1 API and the v2 API, by design. This ensures that we can easily remove the `v1` API without changing the `v2` API in any way. Unfortunately, this makes it a little hard to see the changes between the v1 and v2 API. I’ve [diffed the files in the v1 API and v2 API folders for easier review](https://gist.github.com/adunkman/3149bf1e3d7d45f0df3529b27f2dba27).