### PR TITLE
Reduce WAFv2 regex pattern sets.

### DIFF
--- a/web-api/terraform/api/api-public.tf
+++ b/web-api/terraform/api/api-public.tf
@@ -233,5 +233,5 @@ resource "aws_api_gateway_method_settings" "api_public_default" {
 
 resource "aws_wafv2_web_acl_association" "api_public_association" {
   resource_arn = aws_api_gateway_stage.api_public_stage.arn
-  web_acl_arn  = aws_wafv2_web_acl.apis.arn
+  web_acl_arn  = var.web_acl_arn
 }

--- a/web-api/terraform/api/api.tf
+++ b/web-api/terraform/api/api.tf
@@ -344,5 +344,5 @@ resource "aws_api_gateway_method_settings" "api_default" {
 
 resource "aws_wafv2_web_acl_association" "association" {
   resource_arn = aws_api_gateway_stage.api_stage.arn
-  web_acl_arn  = aws_wafv2_web_acl.apis.arn
+  web_acl_arn  = var.web_acl_arn
 }

--- a/web-api/terraform/api/variables.tf
+++ b/web-api/terraform/api/variables.tf
@@ -101,3 +101,7 @@ variable "create_streams" {
 variable "stream_arn" {
   type = string
 }
+
+variable "web_acl_arn" {
+  type = string
+}

--- a/web-api/terraform/template/main-east.tf
+++ b/web-api/terraform/template/main-east.tf
@@ -275,6 +275,14 @@ resource "aws_route53_record" "public_api_route53_main_east_regional_record" {
   }
 }
 
+module "api-east-waf" {
+  environment = var.environment
+  providers = {
+    aws = aws.us-east-1
+  }
+  source = "./waf/"
+}
+
 module "api-east-green" {
   api_object             = null_resource.api_east_object
   api_public_object      = null_resource.api_public_east_object
@@ -311,6 +319,7 @@ module "api-east-green" {
   create_cron            = 1
   create_streams         = 1
   stream_arn             = data.aws_dynamodb_table.green_dynamo_table.stream_arn
+  web_acl_arn            = module.api-east-waf.web_acl_arn
 }
 
 module "api-east-blue" {
@@ -349,6 +358,7 @@ module "api-east-blue" {
   create_cron            = 1
   create_streams         = 1
   stream_arn             = data.aws_dynamodb_table.blue_dynamo_table.stream_arn
+  web_acl_arn            = module.api-east-waf.web_acl_arn
 }
 
 

--- a/web-api/terraform/template/main-west.tf
+++ b/web-api/terraform/template/main-west.tf
@@ -213,6 +213,14 @@ resource "aws_route53_record" "public_api_route53_main_west_regional_record" {
   }
 }
 
+module "api-west-waf" {
+  environment = var.environment
+  providers = {
+    aws = aws.us-west-1
+  }
+  source = "./waf/"
+}
+
 module "api-west-green" {
   api_object             = null_resource.api_west_object
   api_public_object      = null_resource.api_public_west_object
@@ -249,6 +257,7 @@ module "api-west-green" {
   create_cron            = 0
   create_streams         = 0
   stream_arn             = ""
+  web_acl_arn            = module.api-west-waf.web_acl_arn
 }
 
 module "api-west-blue" {
@@ -287,6 +296,7 @@ module "api-west-blue" {
   create_cron            = 0
   create_streams         = 0
   stream_arn             = ""
+  web_acl_arn            = module.api-west-waf.web_acl_arn
 }
 
 

--- a/web-api/terraform/template/waf/main.tf
+++ b/web-api/terraform/template/waf/main.tf
@@ -1,5 +1,5 @@
 resource "aws_wafv2_web_acl" "apis" {
-  name  = "apis_${var.environment}_${var.current_color}"
+  name  = "apis_${var.environment}"
   scope = "REGIONAL"
 
   default_action {
@@ -23,7 +23,7 @@ resource "aws_wafv2_web_acl" "apis" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "per_ip_request_limit_${var.environment}_${var.current_color}"
+      metric_name                = "per_ip_request_limit_${var.environment}"
       sampled_requests_enabled   = false
     }
   }
@@ -60,20 +60,20 @@ resource "aws_wafv2_web_acl" "apis" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "per_ip_expensive_request_limit_${var.environment}_${var.current_color}"
+      metric_name                = "per_ip_expensive_request_limit_${var.environment}"
       sampled_requests_enabled   = false
     }
   }
 
   visibility_config {
     cloudwatch_metrics_enabled = false
-    metric_name                = "wafv2_${var.environment}_${var.current_color}"
+    metric_name                = "wafv2_${var.environment}"
     sampled_requests_enabled   = false
   }
 }
 
 resource "aws_wafv2_regex_pattern_set" "expensive_requests" {
-  name = "expensive_requests_${var.environment}_${var.current_color}"
+  name = "expensive_requests_${var.environment}"
   scope = "REGIONAL"
 
   regular_expression {

--- a/web-api/terraform/template/waf/output.tf
+++ b/web-api/terraform/template/waf/output.tf
@@ -1,0 +1,3 @@
+output "web_acl_arn" {
+  value = aws_wafv2_web_acl.apis.arn
+}

--- a/web-api/terraform/template/waf/variables.tf
+++ b/web-api/terraform/template/waf/variables.tf
@@ -1,0 +1,3 @@
+variable "environment" {
+  type = string
+}


### PR DESCRIPTION
This configures the regex pattern sets per-environment instead of per-color, resulting in a 1/2 reduction of resources. There is a [hard cap of 10 pattern sets per account per region](https://docs.aws.amazon.com/waf/latest/developerguide/limits.html) for… reasons!?… and this ensures we can support up to 10 environments per account.