### PR TITLE
Restrict USWDS to patch-level versions of ~2.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "stylelint-config-standard": "^20.0.0",
     "swagger-cli": "^4.0.4",
     "tmp": "^0.2.1",
-    "uswds": "~2.10.3",
+    "uswds": "~2.10.1",
     "uuid": "^8.3.2",
     "websocket": "^1.0.33",
     "wicg-inert": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "stylelint-config-standard": "^20.0.0",
     "swagger-cli": "^4.0.4",
     "tmp": "^0.2.1",
-    "uswds": "^2.10.1",
+    "uswds": "~2.10.3",
     "uuid": "^8.3.2",
     "websocket": "^1.0.33",
     "wicg-inert": "^3.1.1",


### PR DESCRIPTION
Upgrading to USWDS version `^2.11.x` introduces unexpected changes to icons, so we're keeping it as `~2.10` for now.
Symptom of upgrading to 2.11 seen below:
![Screen Shot 2021-03-18 at 10 23 16 AM](https://user-images.githubusercontent.com/2445917/111662312-cd7d5f80-87dd-11eb-9a06-660809e3266e.png)
