### PR TITLE
Refactor for applicationContext

### DIFF
--- a/shared/src/business/useCases/users/getJudgeForUserChambersInteractor.js
+++ b/shared/src/business/useCases/users/getJudgeForUserChambersInteractor.js
@@ -29,8 +29,7 @@ exports.getJudgeForUserChambersInteractor = async ({
 
     const sectionUsers = await applicationContext
       .getUseCases()
-      .getUsersInSectionInteractor({
-        applicationContext,
+      .getUsersInSectionInteractor(applicationContext, {
         section: chambersSection,
       });
 

--- a/shared/src/business/useCases/users/getJudgeForUserChambersInteractor.test.js
+++ b/shared/src/business/useCases/users/getJudgeForUserChambersInteractor.test.js
@@ -56,9 +56,11 @@ describe('getJudgeForUserChambersInteractor', () => {
       });
     applicationContext
       .getUseCases()
-      .getUsersInSectionInteractor.mockImplementation(async ({ section }) => {
-        return allUsers.filter(user => user.section === section);
-      });
+      .getUsersInSectionInteractor.mockImplementation(
+        async (appContext, { section }) => {
+          return allUsers.filter(user => user.section === section);
+        },
+      );
   });
 
   it('Fetches the judge associated with a given chambers user', async () => {

--- a/shared/src/proxies/users/getUsersInSectionProxy.js
+++ b/shared/src/proxies/users/getUsersInSectionProxy.js
@@ -8,7 +8,7 @@ const { get } = require('../requests');
  * @param {string} providers.section the section to get the users
  * @returns {Promise<*>} the promise of the api call
  */
-exports.getUsersInSectionInteractor = ({ applicationContext, section }) => {
+exports.getUsersInSectionInteractor = (applicationContext, { section }) => {
   return get({
     applicationContext,
     endpoint: `/sections/${section}/users`,

--- a/web-client/integration-tests/chambersViewsWorkingCopyTrialSession.test.js
+++ b/web-client/integration-tests/chambersViewsWorkingCopyTrialSession.test.js
@@ -1,0 +1,18 @@
+import { chambersViewsTrialSessionWorkingCopy } from './journey/chambersViewsTrialSessionWorkingCopy';
+import { loginAs, setupTest } from './helpers';
+
+const test = setupTest();
+
+describe('Chambers dashboard', () => {
+  beforeAll(() => {
+    jest.setTimeout(30000);
+    test.trialSessionId = '959c4338-0fac-42eb-b0eb-d53b8d0195cc';
+  });
+
+  afterAll(() => {
+    test.closeSocket();
+  });
+
+  loginAs(test, 'colvinsChambers@example.com');
+  chambersViewsTrialSessionWorkingCopy(test);
+});

--- a/web-client/integration-tests/journey/chambersViewsTrialSessionWorkingCopy.js
+++ b/web-client/integration-tests/journey/chambersViewsTrialSessionWorkingCopy.js
@@ -1,0 +1,9 @@
+export const chambersViewsTrialSessionWorkingCopy = test => {
+  return it('Chambers views trial session working copy', async () => {
+    await test.runSequence('gotoTrialSessionWorkingCopySequence', {
+      trialSessionId: test.trialSessionId,
+    });
+
+    expect(test.getState('currentPage')).toEqual('TrialSessionWorkingCopy');
+  });
+};

--- a/web-client/src/presenter/actions/getUsersInSectionAction.js
+++ b/web-client/src/presenter/actions/getUsersInSectionAction.js
@@ -23,8 +23,7 @@ export const getUsersInSectionAction = ({ section }) =>
     }
     const users = await applicationContext
       .getUseCases()
-      .getUsersInSectionInteractor({
-        applicationContext,
+      .getUsersInSectionInteractor(applicationContext, {
         section: sectionToGet,
       });
 

--- a/web-client/src/presenter/actions/getUsersInSectionAction.js
+++ b/web-client/src/presenter/actions/getUsersInSectionAction.js
@@ -23,7 +23,8 @@ export const getUsersInSectionAction = ({ section }) =>
     }
     const users = await applicationContext
       .getUseCases()
-      .getUsersInSectionInteractor(applicationContext, {
+      .getUsersInSectionInteractor({
+        applicationContext,
         section: sectionToGet,
       });
 

--- a/web-client/src/presenter/actions/getUsersInSectionAction.test.js
+++ b/web-client/src/presenter/actions/getUsersInSectionAction.test.js
@@ -22,7 +22,7 @@ describe('getUsersInSectionAction', () => {
 
     expect(
       applicationContext.getUseCases().getUsersInSectionInteractor.mock
-        .calls[0][0].section,
+        .calls[0][1].section,
     ).toBe(mockSection);
   });
 
@@ -43,7 +43,7 @@ describe('getUsersInSectionAction', () => {
 
     expect(
       applicationContext.getUseCases().getUsersInSectionInteractor.mock
-        .calls[0][0].section,
+        .calls[0][1].section,
     ).toBe(mockSection);
   });
 

--- a/web-client/src/presenter/actions/getUsersInSectionAction.test.js
+++ b/web-client/src/presenter/actions/getUsersInSectionAction.test.js
@@ -22,7 +22,7 @@ describe('getUsersInSectionAction', () => {
 
     expect(
       applicationContext.getUseCases().getUsersInSectionInteractor.mock
-        .calls[0][1].section,
+        .calls[0][0].section,
     ).toBe(mockSection);
   });
 
@@ -43,7 +43,7 @@ describe('getUsersInSectionAction', () => {
 
     expect(
       applicationContext.getUseCases().getUsersInSectionInteractor.mock
-        .calls[0][1].section,
+        .calls[0][0].section,
     ).toBe(mockSection);
   });
 

--- a/web-client/src/presenter/actions/getUsersInSelectedSectionAction.js
+++ b/web-client/src/presenter/actions/getUsersInSelectedSectionAction.js
@@ -17,8 +17,7 @@ export const getUsersInSelectedSectionAction = async ({
   }
   const users = await applicationContext
     .getUseCases()
-    .getUsersInSectionInteractor({
-      applicationContext,
+    .getUsersInSectionInteractor(applicationContext, {
       section: props.section,
     });
 

--- a/web-client/src/presenter/actions/getUsersInSelectedSectionAction.js
+++ b/web-client/src/presenter/actions/getUsersInSelectedSectionAction.js
@@ -17,7 +17,8 @@ export const getUsersInSelectedSectionAction = async ({
   }
   const users = await applicationContext
     .getUseCases()
-    .getUsersInSectionInteractor(applicationContext, {
+    .getUsersInSectionInteractor({
+      applicationContext,
       section: props.section,
     });
 

--- a/web-client/src/presenter/actions/getUsersInSelectedSectionAction.test.js
+++ b/web-client/src/presenter/actions/getUsersInSelectedSectionAction.test.js
@@ -43,7 +43,7 @@ describe('getUsersInSelectedSectionAction', () => {
 
     expect(
       applicationContext.getUseCases().getUsersInSectionInteractor.mock
-        .calls[0][0],
+        .calls[0][1],
     ).toMatchObject({
       section: SECTION,
     });

--- a/web-client/src/presenter/actions/getUsersInSelectedSectionAction.test.js
+++ b/web-client/src/presenter/actions/getUsersInSelectedSectionAction.test.js
@@ -43,7 +43,7 @@ describe('getUsersInSelectedSectionAction', () => {
 
     expect(
       applicationContext.getUseCases().getUsersInSectionInteractor.mock
-        .calls[0][1],
+        .calls[0][0],
     ).toMatchObject({
       section: SECTION,
     });


### PR DESCRIPTION
Looks like during recent refactor for pulling applicationContext out of providers object left some missing. 