### PR TITLE
Add WAFv2 firewall rule to block banned IP addresses.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,3 +52,4 @@ During routine operations of EF-CMS:
 
 - [Accessing log data in Kibana](operations/logging.md)
 - [Receiving system health alerts](operations/system-health-alerts.md)
+- [Blocking IP addresses](operations/ip-blocking.md)

--- a/docs/operations/ip-blocking.md
+++ b/docs/operations/ip-blocking.md
@@ -1,0 +1,62 @@
+# Blocking IP addresses
+
+This describes a mechanism to block access to EF-CMS, which can be used when an IP address is causing unexpected or unusual traffic. This is an augmentation to other, automated rate limiting and security measures which may also block access, and at best will be used sparingly.
+
+## How to block an IPv4 or IPv6 address
+
+Blocking is done through [AWS Web Application Firewall v2](https://docs.aws.amazon.com/waf/latest/APIReference/Welcome.html), and requests which match blocked patterns will receive `403 Forbidden` status codes when attempting to make API requests.
+
+### Using a bash script
+
+To block an IP address, run:
+
+```bash
+./web-api/ban-ip-address.sh [ENVIRONMENT] [IP ADDRESS]
+```
+
+For example:
+
+```bash
+./ban-ip-address.sh prod 192.0.2.4
+./ban-ip-address.sh prod 2001:0db8:0000:0000:0000:0000:0000:0000
+```
+
+The script accepts both IPv4 and IPv6 addresses.
+
+### Using the AWS console
+
+1. Log in to the [AWS WAF console](https://console.aws.amazon.com/wafv2/homev2/) and head to **AWS WAF > IP sets** to get started.
+
+2. Select the appropriate IP set for your environment and IP address type from the list — for example, if you’re looking to ban an IPv4 address in the `prod` environment, locate:
+
+    ```
+    banned_ipv4_ips_prod
+    ```
+
+3. Select **Add IP address** and enter the IP to block in CIDR format.
+
+    _Hint:_ To ban a single IP address in CIDR format, for IPv4 addresses add `/32` to the end. For IPv6 addresses, add `/128`.
+
+    See [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation) for more information.
+
+4. Save the IP set by clicking `Add`.
+
+5. Repeat this process for both `us-east-1` and `us-west-1` regions.
+
+## What happens to blocked requests?
+
+Blocked requests receive  `403 Forbidden` status codes and do not appear in our standard logs, because WAF stops the request from hitting our infrastructure.
+
+**Changes to blocked IPs take effect within seconds.**
+
+To see blocked requests:
+
+1. Log in to the [AWS WAF console](https://console.aws.amazon.com/wafv2/homev2/) and head to **AWS WAF > Web ACLs**.
+
+2. Select the appropriate ACL for your environment — for example, if you’re looking to see blocked requests in the `prod` environment, locate:
+
+    ```
+    apis_prod
+    ```
+
+3. Observe the graph. Series graphed ending in `BlockedRequests` indicate requests which were terminated, whereas those ending in `CountedRequests` are those which match rules and would be blocked, but they were allowed through (used for testing new rule sets, mostly).

--- a/web-api/ban-ip-address.sh
+++ b/web-api/ban-ip-address.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# This script adds an IP address to AWS WAF’s banned IP set, which blocks the IP
+# from making requests to the public and private API endpoints.
+#
+# Usage:
+#   ./ban-ip-address.sh [ENV] [IP]
+#
+# Examples:
+#   ./ban-ip-address.sh prod 192.0.2.4
+#   ./ban-ip-address.sh prod 2001:0db8:0000:0000:0000:0000:0000:0000
+#
+# Arguments:
+#   ENV: the environment name
+#   IP: the IP address in IPv4 or IPv6 format
+
+ENV=$1
+IP=$2
+
+if [ -z "$ENV" ]; then
+  echo "Pass the environment name as the first argument. Exiting!"
+  exit 1
+fi
+
+if [ -z "$IP" ]; then
+  echo "Pass an IPv4 or IPv6 address as the second argument. Exiting!"
+  exit 1
+fi
+
+IPv4=$(echo $IP | grep -Eoh "^\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}$")
+IPv6=$(echo $IP | grep -Eoh "^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$")
+
+if [ -z "$IPv4" ] && [ -z "$IPv6" ]; then
+  echo "Could not parse the IP address ($IP) as either an IPv4 or IPv6"
+  echo "address, exiting!"
+  exit 1
+fi
+
+if [ -n "$IPv4" ] && [ -n "$IPv6" ]; then
+  echo "Uh oh, parsed the IP address ($IP) as both an IPv4 and IPv6 address."
+  echo "This is a script bug, exiting!"
+  exit 1
+fi
+
+if [ -n "$IPv4" ]; then
+  IP_SET_NAME="banned_ipv4_ips_${ENV}"
+  IP_CIDR="${IPv4}/32"
+else
+  IP_SET_NAME="banned_ipv6_ips_${ENV}"
+  IP_CIDR="${IPv6}/128"
+fi
+
+echo "You’re about to block this single IP address from accessing"
+echo "the $ENV environment. That IP will still be able to access the"
+echo "front-end application, but all API requests will be blocked."
+echo
+
+read -p "Block $IP now? (y/N) " -r
+[[ ! $REPLY =~ ^[Yy]$ ]] && echo "Exiting." && exit 1
+
+export AWS_PAGER=''
+
+set -ex
+
+for REGION in east west; do
+  IP_SET_ID=$(aws wafv2 list-ip-sets --scope REGIONAL --region us-${REGION}-1 --query "IPSets[?Name == '${IP_SET_NAME}'].Id" --output text)
+  LOCK_TOKEN=$(aws wafv2 get-ip-set --scope REGIONAL --region us-${REGION}-1 --name ${IP_SET_NAME} --id ${IP_SET_ID} --query "LockToken" --output text)
+  CURRENT_ADDRESSES=$(aws wafv2 get-ip-set --scope REGIONAL --region us-${REGION}-1 --name ${IP_SET_NAME} --id ${IP_SET_ID} --query "IPSet.Addresses" --output text)
+
+  aws wafv2 update-ip-set --scope REGIONAL --region us-${REGION}-1 --name ${IP_SET_NAME} --id ${IP_SET_ID} --lock-token ${LOCK_TOKEN} --addresses ${CURRENT_ADDRESSES} ${IP_CIDR}
+done
+
+set +x
+
+echo
+echo
+echo "IP address $IP blocked in $ENV environment."
+echo

--- a/web-api/terraform/template/waf/main.tf
+++ b/web-api/terraform/template/waf/main.tf
@@ -7,6 +7,37 @@ resource "aws_wafv2_web_acl" "apis" {
   }
 
   rule {
+    name     = "block_banned_ip_addresses"
+    priority = 0
+
+    action {
+      block {}
+    }
+
+    statement {
+      or_statement {
+        statement {
+          ip_set_reference_statement {
+            arn = aws_wafv2_ip_set.banned_ipv4_ips.arn
+          }
+        }
+        statement {
+          ip_set_reference_statement {
+            arn = aws_wafv2_ip_set.banned_ipv6_ips.arn
+          }
+        }
+      }
+
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "block_banned_ip_addresses_${var.environment}"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  rule {
     name     = "per_ip_request_limit"
     priority = 1
 
@@ -78,5 +109,35 @@ resource "aws_wafv2_regex_pattern_set" "expensive_requests" {
 
   regular_expression {
     regex_string = "^/public-api/(order|opinion)-search"
+  }
+}
+
+resource "aws_wafv2_ip_set" "banned_ipv4_ips" {
+  name               = "banned_ipv4_ips_${var.environment}"
+  scope              = "REGIONAL"
+  ip_address_version = "IPV4"
+
+  # in CIDR notation, /32 = only the single specified IPv4 address
+  # this IP is a designated example IP and cannot match IPs in use
+  addresses          = ["192.0.2.0/32"]
+
+  lifecycle {
+    # Instructs Terrraform not to remove banned IPs when running Terraform updates
+    ignore_changes = [ addresses ]
+  }
+}
+
+resource "aws_wafv2_ip_set" "banned_ipv6_ips" {
+  name               = "banned_ipv6_ips_${var.environment}"
+  scope              = "REGIONAL"
+  ip_address_version = "IPV6"
+
+  # in CIDR notation, /128 = only the single specified IPv6 address
+  # this IP is a designated example IP and cannot match IPs in use
+  addresses          = ["2001:0db8:0000:0000:0000:0000:0000:0000/128"]
+
+  lifecycle {
+    # Instructs Terrraform not to remove banned IPs when running Terraform updates
+    ignore_changes = [ addresses ]
   }
 }


### PR DESCRIPTION
Closes #728.

This PR introduces a new firewall rule to block requests from specific IP addresses. There are example IPs deployed by default to demonstrate how to use the rules (they’re IPs in reserved "example" space, so they will never match incoming requests).

Additionally, this PR adds a bash script to quickly ban an IP address for an environment, and documentation showing how to see blocked requests and manually access the banned IPs through the AWS Console.

Deployed and tested in the `dev` environment. 