### PR TITLE
[hotfix] 8035: scale down scanned images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,14 +48,16 @@
         "convert-source-map": "^1.1.0",
         "fs-readdir-recursive": "^1.1.0",
         "glob": "^7.0.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.19",
         "make-dir": "^2.1.0",
         "slash": "^2.0.0",
         "source-map": "^0.5.0"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         }
       }
     },
@@ -90,7 +92,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.19",
         "semver": "7.0.0",
         "source-map": "^0.5.0"
       },
@@ -104,7 +106,9 @@
           }
         },
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "ms": {
           "version": "2.1.2",
@@ -283,11 +287,13 @@
         "@babel/template": "^7.12.13",
         "@babel/traverse": "^7.13.0",
         "@babel/types": "^7.13.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.19"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         }
       }
     },
@@ -1083,14 +1089,16 @@
       "integrity": "sha512-nswFANDBcO661RvGOHfVKVRBZIe9wJuFFIJYJWpO8LwYn8WI+h/2JZhceLvlxjxEvMH6/oGkEBgz5SnqUUMkCg==",
       "requires": {
         "find-cache-dir": "^2.0.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.19",
         "make-dir": "^2.1.0",
         "pirates": "^4.0.0",
         "source-map-support": "^0.5.16"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         }
       }
     },
@@ -1134,7 +1142,7 @@
         "@babel/types": "^7.13.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.19"
       },
       "dependencies": {
         "debug": {
@@ -1146,7 +1154,9 @@
           }
         },
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "ms": {
           "version": "2.1.2",
@@ -1161,12 +1171,14 @@
       "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         }
       }
     },
@@ -1189,11 +1201,13 @@
       "integrity": "sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==",
       "requires": {
         "exec-sh": "^0.3.2",
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.0"
       },
       "dependencies": {
         "minimist": {
-          "version": "^1.2.5"
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         }
       }
     },
@@ -3540,12 +3554,14 @@
       "requires": {
         "babel-runtime": "^6.26.0",
         "esutils": "^2.0.2",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.4",
         "to-fast-properties": "^1.0.3"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "to-fast-properties": {
           "version": "1.0.3",
@@ -4525,11 +4541,13 @@
       "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
       "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.14"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         }
       }
     },
@@ -5876,7 +5894,7 @@
         "is-installed-globally": "^0.3.2",
         "lazy-ass": "^1.6.0",
         "listr": "^0.14.3",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.19",
         "log-symbols": "^4.0.0",
         "minimist": "^1.2.5",
         "moment": "^2.29.1",
@@ -5984,10 +6002,14 @@
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
         },
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "minimist": {
-          "version": "^1.2.5"
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "ms": {
           "version": "2.1.2",
@@ -6194,7 +6216,9 @@
       },
       "dependencies": {
         "bl": {
-          "version": "^4.0.3",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
           "requires": {
             "buffer": "^5.5.0",
             "inherits": "^2.0.4"
@@ -6210,7 +6234,7 @@
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
           "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
           "requires": {
-            "bl": "^4.0.3",
+            "bl": "^1.0.0",
             "buffer-alloc": "^1.2.0",
             "end-of-stream": "^1.0.0",
             "fs-constants": "^1.0.0",
@@ -6220,10 +6244,13 @@
           },
           "dependencies": {
             "bl": {
-              "version": "^4.0.3",
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+              "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
               "requires": {
-                "readable-stream": "^2.3.5",
-                "safe-buffer": "^5.1.1"
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
               }
             }
           }
@@ -6491,11 +6518,13 @@
       "integrity": "sha512-1rT/kMpRoCCo1vmpbUgP0Bs1c4hMPNcOkE7Sgtw9AsfUSo+m6N13csS/OYgHglNffFueo5DVw5h47F97wON+CA==",
       "requires": {
         "deep-diff": "^1.0.2",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.19"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         }
       }
     },
@@ -6758,7 +6787,7 @@
       "requires": {
         "agentkeepalive": "^3.4.1",
         "chalk": "^1.0.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.10"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6779,7 +6808,9 @@
           }
         },
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "supports-color": {
           "version": "2.0.0",
@@ -7240,7 +7271,9 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "ms": {
           "version": "2.1.2",
@@ -7435,7 +7468,7 @@
         "comment-parser": "1.1.2",
         "debug": "^4.3.1",
         "jsdoctypeparser": "^9.0.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.20",
         "regextras": "^0.7.1",
         "semver": "^7.3.4",
         "spdx-expression-parse": "^3.0.1"
@@ -7450,7 +7483,9 @@
           }
         },
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "ms": {
           "version": "2.1.2",
@@ -7609,7 +7644,7 @@
             "js-yaml": "^3.13.1",
             "json-stable-stringify-without-jsonify": "^1.0.1",
             "levn": "^0.3.0",
-            "lodash": "^4.17.21",
+            "lodash": "^4.17.14",
             "minimatch": "^3.0.4",
             "mkdirp": "^0.5.1",
             "natural-compare": "^1.4.0",
@@ -7625,7 +7660,9 @@
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.21"
+              "version": "4.17.21",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+              "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
             }
           }
         },
@@ -7780,13 +7817,15 @@
           "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
           "requires": {
             "ajv": "^6.10.2",
-            "lodash": "^4.17.21",
+            "lodash": "^4.17.14",
             "slice-ansi": "^2.1.0",
             "string-width": "^3.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.21"
+              "version": "4.17.21",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+              "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
             }
           }
         },
@@ -7820,7 +7859,7 @@
       "requires": {
         "globals": "^13.0.0",
         "hunspell-spellchecker": "^1.0.2",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "globals": {
@@ -7832,7 +7871,9 @@
           }
         },
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "type-fest": {
           "version": "0.20.2",
@@ -8952,7 +8993,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "^1.2.5"
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         }
       }
     },
@@ -9822,7 +9865,7 @@
         "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.19",
         "mute-stream": "0.0.8",
         "run-async": "^2.4.0",
         "rxjs": "^6.6.0",
@@ -9901,7 +9944,9 @@
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "onetime": {
           "version": "5.1.2",
@@ -12177,7 +12222,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "^1.2.5"
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         }
       }
     },
@@ -13218,7 +13265,9 @@
       }
     },
     "lodash": {
-      "version": "^4.17.21"
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.clone": {
       "version": "4.5.0",
@@ -13735,7 +13784,7 @@
         "decamelize": "^1.1.2",
         "loud-rejection": "^1.0.0",
         "map-obj": "^1.0.1",
-        "minimist": "^1.2.5",
+        "minimist": "^1.1.3",
         "normalize-package-data": "^2.3.4",
         "object-assign": "^4.0.1",
         "read-pkg-up": "^1.0.1",
@@ -13765,7 +13814,9 @@
           }
         },
         "minimist": {
-          "version": "^1.2.5"
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "path-exists": {
           "version": "2.1.0",
@@ -14016,7 +14067,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "^1.2.5"
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         }
       }
     },
@@ -15091,8 +15144,8 @@
         "cheerio": "~1.0.0-rc.3",
         "commander": "~2.20.3",
         "globby": "~6.1.0",
-        "lodash": "^4.17.21",
-        "node-fetch": "^2.6.1",
+        "lodash": "~4.17.20",
+        "node-fetch": "~2.6.0",
         "pa11y": "~5.3.0",
         "protocolify": "~3.0.0",
         "puppeteer": "~1.20.0",
@@ -15117,11 +15170,13 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
           "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "requires": {
-            "lodash": "^4.17.21"
+            "lodash": "^4.17.14"
           },
           "dependencies": {
             "lodash": {
-              "version": "^4.17.21"
+              "version": "4.17.21",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+              "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
             }
           }
         },
@@ -15163,7 +15218,9 @@
           }
         },
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "mime": {
           "version": "2.5.2",
@@ -15176,7 +15233,9 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node-fetch": {
-          "version": "^2.6.1"
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         },
         "pify": {
           "version": "2.3.0",
@@ -15480,16 +15539,20 @@
           "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "^1.2.0"
           },
           "dependencies": {
             "minimist": {
-              "version": "^1.2.5"
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
             }
           }
         },
         "node-forge": {
-          "version": "^0.10.0"
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
         },
         "postcss": {
           "version": "7.0.35",
@@ -15692,19 +15755,24 @@
             "string-width": "^2.0.0",
             "which-module": "^2.0.0",
             "y18n": "^3.2.1",
-            "yargs-parser": "^18.1.3"
+            "yargs-parser": "^9.0.2"
           },
           "dependencies": {
             "yargs-parser": {
-              "version": "^18.1.3",
+              "version": "18.1.3",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+              "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
               "requires": {
-                "camelcase": "^4.1.0"
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
               }
             }
           }
         },
         "yargs-parser": {
-          "version": "^18.1.3",
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
           "requires": {
             "decamelize": "^1.2.0"
           }
@@ -17453,12 +17521,14 @@
       "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-5.0.1.tgz",
       "integrity": "sha512-Y9fUFkIhfrm6i0Ta3n+89j56EFqaNRdUKqXyRp6kvTcSXnmgEjaVowCXH+JBe9+YKWqd4nc28r2sgwnzJalccA==",
       "requires": {
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.14",
         "postcss": "^7.0.17"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "postcss": {
           "version": "7.0.35",
@@ -18078,7 +18148,9 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node-fetch": {
-          "version": "^2.6.1"
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         },
         "p-locate": {
           "version": "4.1.0",
@@ -18194,7 +18266,9 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node-fetch": {
-          "version": "^2.6.1"
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         },
         "p-locate": {
           "version": "4.1.0",
@@ -18349,12 +18423,14 @@
       "integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=",
       "requires": {
         "buffer-equal": "0.0.1",
-        "minimist": "^1.2.5",
+        "minimist": "^1.1.3",
         "through2": "^2.0.0"
       },
       "dependencies": {
         "minimist": {
-          "version": "^1.2.5"
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         }
       }
     },
@@ -18425,12 +18501,14 @@
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
-          "version": "^1.2.5"
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         }
       }
     },
@@ -18485,12 +18563,14 @@
       "integrity": "sha512-jzoq57Mt216sCOr59OC6aMgmckdAh3BgKgEqYI/FcS26JwCMlXMgGu7Dc7TApzObax9dwOWbr6lT8cEWxigyVA==",
       "requires": {
         "@types/quill": "^1.3.10",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.4",
         "quill": "^1.3.7"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         }
       }
     },
@@ -18917,11 +18997,13 @@
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
       "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.19"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         }
       }
     },
@@ -18960,11 +19042,13 @@
       "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
       "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.14"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         }
       }
     },
@@ -19148,7 +19232,7 @@
         "he": "^1.2.0",
         "koa": "^2.7.0",
         "koa-logger": "^3.2.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.5",
         "statuses": "^2.0.0",
         "winston": "^3.0.0"
       },
@@ -19177,7 +19261,9 @@
           }
         },
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "statuses": {
           "version": "2.0.1",
@@ -19221,12 +19307,14 @@
         "execa": "^1.0.0",
         "fb-watchman": "^2.0.0",
         "micromatch": "^3.1.4",
-        "minimist": "^1.2.5",
+        "minimist": "^1.1.1",
         "walker": "~1.0.5"
       },
       "dependencies": {
         "minimist": {
-          "version": "^1.2.5"
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         }
       }
     },
@@ -20424,7 +20512,9 @@
           }
         },
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "map-obj": {
           "version": "4.2.0",
@@ -20447,11 +20537,17 @@
             "redent": "^3.0.0",
             "trim-newlines": "^3.0.0",
             "type-fest": "^0.18.0",
-            "yargs-parser": "^18.1.3"
+            "yargs-parser": "^20.2.3"
           },
           "dependencies": {
             "yargs-parser": {
-              "version": "^18.1.3"
+              "version": "18.1.3",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+              "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+              "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+              }
             }
           }
         },
@@ -20706,7 +20802,9 @@
           "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="
         },
         "yargs-parser": {
-          "version": "^18.1.3",
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
@@ -20740,13 +20838,15 @@
       "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-3.1.1.tgz",
       "integrity": "sha512-4gP/r8j/6JGZ/LL41b2sYtQqfwZl4VSqTp7WeIwI67v/OXNQ08dnn64BGXNwAUSgb2+YIvIOxQaMzqMyQMzoyQ==",
       "requires": {
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.15",
         "postcss": "^7.0.17",
         "postcss-sorting": "^5.0.1"
       },
       "dependencies": {
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "postcss": {
           "version": "7.0.35",
@@ -21009,7 +21109,7 @@
       "integrity": "sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==",
       "requires": {
         "ajv": "^7.0.2",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.20",
         "slice-ansi": "^4.0.0",
         "string-width": "^4.2.0"
       },
@@ -21062,7 +21162,9 @@
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         },
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "slice-ansi": {
           "version": "4.0.0",
@@ -21137,7 +21239,9 @@
       },
       "dependencies": {
         "bl": {
-          "version": "^4.0.3",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
           "requires": {
             "buffer": "^5.5.0",
             "inherits": "^2.0.4",
@@ -21477,7 +21581,7 @@
       "requires": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
       },
       "dependencies": {
@@ -21486,16 +21590,20 @@
           "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "^1.2.0"
           },
           "dependencies": {
             "minimist": {
-              "version": "^1.2.5"
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
             }
           }
         },
         "minimist": {
-          "version": "^1.2.5"
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         }
       }
     },
@@ -21620,7 +21728,7 @@
         "is-absolute-url": "^3.0.1",
         "is-html": "^1.1.0",
         "jsdom": "^14.1.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.15",
         "postcss": "^7.0.17",
         "postcss-selector-parser": "6.0.2",
         "request": "^2.88.0"
@@ -21749,7 +21857,9 @@
           }
         },
         "lodash": {
-          "version": "^4.17.21"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "optionator": {
           "version": "0.8.3",
@@ -22722,7 +22832,7 @@
         "string-width": "^4.2.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.3"
+        "yargs-parser": "^18.1.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -22784,7 +22894,9 @@
           }
         },
         "yargs-parser": {
-          "version": "^18.1.3",
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,16 +48,14 @@
         "convert-source-map": "^1.1.0",
         "fs-readdir-recursive": "^1.1.0",
         "glob": "^7.0.0",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "make-dir": "^2.1.0",
         "slash": "^2.0.0",
         "source-map": "^0.5.0"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         }
       }
     },
@@ -92,7 +90,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "semver": "7.0.0",
         "source-map": "^0.5.0"
       },
@@ -106,9 +104,7 @@
           }
         },
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         },
         "ms": {
           "version": "2.1.2",
@@ -287,13 +283,11 @@
         "@babel/template": "^7.12.13",
         "@babel/traverse": "^7.13.0",
         "@babel/types": "^7.13.0",
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.21"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         }
       }
     },
@@ -1089,16 +1083,14 @@
       "integrity": "sha512-nswFANDBcO661RvGOHfVKVRBZIe9wJuFFIJYJWpO8LwYn8WI+h/2JZhceLvlxjxEvMH6/oGkEBgz5SnqUUMkCg==",
       "requires": {
         "find-cache-dir": "^2.0.0",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "make-dir": "^2.1.0",
         "pirates": "^4.0.0",
         "source-map-support": "^0.5.16"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         }
       }
     },
@@ -1142,7 +1134,7 @@
         "@babel/types": "^7.13.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.21"
       },
       "dependencies": {
         "debug": {
@@ -1154,9 +1146,7 @@
           }
         },
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         },
         "ms": {
           "version": "2.1.2",
@@ -1171,14 +1161,12 @@
       "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         }
       }
     },
@@ -1201,13 +1189,11 @@
       "integrity": "sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==",
       "requires": {
         "exec-sh": "^0.3.2",
-        "minimist": "^1.2.0"
+        "minimist": "^1.2.5"
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "version": "^1.2.5"
         }
       }
     },
@@ -3554,14 +3540,12 @@
       "requires": {
         "babel-runtime": "^6.26.0",
         "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
+        "lodash": "^4.17.21",
         "to-fast-properties": "^1.0.3"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         },
         "to-fast-properties": {
           "version": "1.0.3",
@@ -4541,13 +4525,11 @@
       "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
       "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "^4.17.21"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         }
       }
     },
@@ -5894,7 +5876,7 @@
         "is-installed-globally": "^0.3.2",
         "lazy-ass": "^1.6.0",
         "listr": "^0.14.3",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
         "minimist": "^1.2.5",
         "moment": "^2.29.1",
@@ -6002,14 +5984,10 @@
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
         },
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         },
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "version": "^1.2.5"
         },
         "ms": {
           "version": "2.1.2",
@@ -6216,9 +6194,7 @@
       },
       "dependencies": {
         "bl": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+          "version": "^4.0.3",
           "requires": {
             "buffer": "^5.5.0",
             "inherits": "^2.0.4"
@@ -6234,7 +6210,7 @@
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
           "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
           "requires": {
-            "bl": "^1.0.0",
+            "bl": "^4.0.3",
             "buffer-alloc": "^1.2.0",
             "end-of-stream": "^1.0.0",
             "fs-constants": "^1.0.0",
@@ -6244,9 +6220,7 @@
           },
           "dependencies": {
             "bl": {
-              "version": "1.2.3",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
-              "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+              "version": "^4.0.3",
               "requires": {
                 "readable-stream": "^2.3.5",
                 "safe-buffer": "^5.1.1"
@@ -6517,13 +6491,11 @@
       "integrity": "sha512-1rT/kMpRoCCo1vmpbUgP0Bs1c4hMPNcOkE7Sgtw9AsfUSo+m6N13csS/OYgHglNffFueo5DVw5h47F97wON+CA==",
       "requires": {
         "deep-diff": "^1.0.2",
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.21"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         }
       }
     },
@@ -6786,7 +6758,7 @@
       "requires": {
         "agentkeepalive": "^3.4.1",
         "chalk": "^1.0.0",
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.21"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6807,9 +6779,7 @@
           }
         },
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         },
         "supports-color": {
           "version": "2.0.0",
@@ -7270,9 +7240,7 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         },
         "ms": {
           "version": "2.1.2",
@@ -7467,7 +7435,7 @@
         "comment-parser": "1.1.2",
         "debug": "^4.3.1",
         "jsdoctypeparser": "^9.0.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "regextras": "^0.7.1",
         "semver": "^7.3.4",
         "spdx-expression-parse": "^3.0.1"
@@ -7482,9 +7450,7 @@
           }
         },
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         },
         "ms": {
           "version": "2.1.2",
@@ -7643,7 +7609,7 @@
             "js-yaml": "^3.13.1",
             "json-stable-stringify-without-jsonify": "^1.0.1",
             "levn": "^0.3.0",
-            "lodash": "^4.17.14",
+            "lodash": "^4.17.21",
             "minimatch": "^3.0.4",
             "mkdirp": "^0.5.1",
             "natural-compare": "^1.4.0",
@@ -7659,9 +7625,7 @@
           },
           "dependencies": {
             "lodash": {
-              "version": "4.17.21",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-              "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+              "version": "^4.17.21"
             }
           }
         },
@@ -7816,15 +7780,13 @@
           "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
           "requires": {
             "ajv": "^6.10.2",
-            "lodash": "^4.17.14",
+            "lodash": "^4.17.21",
             "slice-ansi": "^2.1.0",
             "string-width": "^3.0.0"
           },
           "dependencies": {
             "lodash": {
-              "version": "4.17.21",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-              "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+              "version": "^4.17.21"
             }
           }
         },
@@ -7858,7 +7820,7 @@
       "requires": {
         "globals": "^13.0.0",
         "hunspell-spellchecker": "^1.0.2",
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.21"
       },
       "dependencies": {
         "globals": {
@@ -7870,9 +7832,7 @@
           }
         },
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         },
         "type-fest": {
           "version": "0.20.2",
@@ -8992,9 +8952,7 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "version": "^1.2.5"
         }
       }
     },
@@ -9864,7 +9822,7 @@
         "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "mute-stream": "0.0.8",
         "run-async": "^2.4.0",
         "rxjs": "^6.6.0",
@@ -9943,9 +9901,7 @@
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         },
         "onetime": {
           "version": "5.1.2",
@@ -12221,9 +12177,7 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "version": "^1.2.5"
         }
       }
     },
@@ -13264,9 +13218,7 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "^4.17.21"
     },
     "lodash.clone": {
       "version": "4.5.0",
@@ -13783,7 +13735,7 @@
         "decamelize": "^1.1.2",
         "loud-rejection": "^1.0.0",
         "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
+        "minimist": "^1.2.5",
         "normalize-package-data": "^2.3.4",
         "object-assign": "^4.0.1",
         "read-pkg-up": "^1.0.1",
@@ -13813,9 +13765,7 @@
           }
         },
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "version": "^1.2.5"
         },
         "path-exists": {
           "version": "2.1.0",
@@ -14066,9 +14016,7 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "version": "^1.2.5"
         }
       }
     },
@@ -15143,8 +15091,8 @@
         "cheerio": "~1.0.0-rc.3",
         "commander": "~2.20.3",
         "globby": "~6.1.0",
-        "lodash": "~4.17.20",
-        "node-fetch": "~2.6.0",
+        "lodash": "^4.17.21",
+        "node-fetch": "^2.6.1",
         "pa11y": "~5.3.0",
         "protocolify": "~3.0.0",
         "puppeteer": "~1.20.0",
@@ -15169,13 +15117,11 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
           "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "requires": {
-            "lodash": "^4.17.14"
+            "lodash": "^4.17.21"
           },
           "dependencies": {
             "lodash": {
-              "version": "4.17.21",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-              "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+              "version": "^4.17.21"
             }
           }
         },
@@ -15217,9 +15163,7 @@
           }
         },
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         },
         "mime": {
           "version": "2.5.2",
@@ -15232,9 +15176,7 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+          "version": "^2.6.1"
         },
         "pify": {
           "version": "2.3.0",
@@ -15538,20 +15480,16 @@
           "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "^1.2.5"
           },
           "dependencies": {
             "minimist": {
-              "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+              "version": "^1.2.5"
             }
           }
         },
         "node-forge": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+          "version": "^0.10.0"
         },
         "postcss": {
           "version": "7.0.35",
@@ -15754,13 +15692,11 @@
             "string-width": "^2.0.0",
             "which-module": "^2.0.0",
             "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
+            "yargs-parser": "^18.1.3"
           },
           "dependencies": {
             "yargs-parser": {
-              "version": "9.0.2",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-              "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+              "version": "^18.1.3",
               "requires": {
                 "camelcase": "^4.1.0"
               }
@@ -15768,9 +15704,7 @@
           }
         },
         "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "version": "^18.1.3",
           "requires": {
             "decamelize": "^1.2.0"
           }
@@ -17519,14 +17453,12 @@
       "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-5.0.1.tgz",
       "integrity": "sha512-Y9fUFkIhfrm6i0Ta3n+89j56EFqaNRdUKqXyRp6kvTcSXnmgEjaVowCXH+JBe9+YKWqd4nc28r2sgwnzJalccA==",
       "requires": {
-        "lodash": "^4.17.14",
+        "lodash": "^4.17.21",
         "postcss": "^7.0.17"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         },
         "postcss": {
           "version": "7.0.35",
@@ -18146,9 +18078,7 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+          "version": "^2.6.1"
         },
         "p-locate": {
           "version": "4.1.0",
@@ -18264,9 +18194,7 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+          "version": "^2.6.1"
         },
         "p-locate": {
           "version": "4.1.0",
@@ -18421,14 +18349,12 @@
       "integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=",
       "requires": {
         "buffer-equal": "0.0.1",
-        "minimist": "^1.1.3",
+        "minimist": "^1.2.5",
         "through2": "^2.0.0"
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "version": "^1.2.5"
         }
       }
     },
@@ -18499,14 +18425,12 @@
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.5",
         "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "version": "^1.2.5"
         }
       }
     },
@@ -18561,14 +18485,12 @@
       "integrity": "sha512-jzoq57Mt216sCOr59OC6aMgmckdAh3BgKgEqYI/FcS26JwCMlXMgGu7Dc7TApzObax9dwOWbr6lT8cEWxigyVA==",
       "requires": {
         "@types/quill": "^1.3.10",
-        "lodash": "^4.17.4",
+        "lodash": "^4.17.21",
         "quill": "^1.3.7"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         }
       }
     },
@@ -18995,13 +18917,11 @@
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
       "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
       "requires": {
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.21"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         }
       }
     },
@@ -19040,13 +18960,11 @@
       "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
       "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "^4.17.21"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         }
       }
     },
@@ -19230,7 +19148,7 @@
         "he": "^1.2.0",
         "koa": "^2.7.0",
         "koa-logger": "^3.2.0",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.21",
         "statuses": "^2.0.0",
         "winston": "^3.0.0"
       },
@@ -19259,9 +19177,7 @@
           }
         },
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         },
         "statuses": {
           "version": "2.0.1",
@@ -19305,14 +19221,12 @@
         "execa": "^1.0.0",
         "fb-watchman": "^2.0.0",
         "micromatch": "^3.1.4",
-        "minimist": "^1.1.1",
+        "minimist": "^1.2.5",
         "walker": "~1.0.5"
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "version": "^1.2.5"
         }
       }
     },
@@ -20510,9 +20424,7 @@
           }
         },
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         },
         "map-obj": {
           "version": "4.2.0",
@@ -20535,13 +20447,11 @@
             "redent": "^3.0.0",
             "trim-newlines": "^3.0.0",
             "type-fest": "^0.18.0",
-            "yargs-parser": "^20.2.3"
+            "yargs-parser": "^18.1.3"
           },
           "dependencies": {
             "yargs-parser": {
-              "version": "20.2.7",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
-              "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw=="
+              "version": "^18.1.3"
             }
           }
         },
@@ -20796,9 +20706,7 @@
           "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="
         },
         "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "version": "^18.1.3",
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
@@ -20832,15 +20740,13 @@
       "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-3.1.1.tgz",
       "integrity": "sha512-4gP/r8j/6JGZ/LL41b2sYtQqfwZl4VSqTp7WeIwI67v/OXNQ08dnn64BGXNwAUSgb2+YIvIOxQaMzqMyQMzoyQ==",
       "requires": {
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "postcss": "^7.0.17",
         "postcss-sorting": "^5.0.1"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         },
         "postcss": {
           "version": "7.0.35",
@@ -21103,7 +21009,7 @@
       "integrity": "sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==",
       "requires": {
         "ajv": "^7.0.2",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "slice-ansi": "^4.0.0",
         "string-width": "^4.2.0"
       },
@@ -21156,9 +21062,7 @@
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         },
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         },
         "slice-ansi": {
           "version": "4.0.0",
@@ -21233,9 +21137,7 @@
       },
       "dependencies": {
         "bl": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+          "version": "^4.0.3",
           "requires": {
             "buffer": "^5.5.0",
             "inherits": "^2.0.4",
@@ -21575,7 +21477,7 @@
       "requires": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.5",
         "strip-bom": "^3.0.0"
       },
       "dependencies": {
@@ -21584,20 +21486,16 @@
           "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "^1.2.5"
           },
           "dependencies": {
             "minimist": {
-              "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+              "version": "^1.2.5"
             }
           }
         },
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "version": "^1.2.5"
         }
       }
     },
@@ -21722,7 +21620,7 @@
         "is-absolute-url": "^3.0.1",
         "is-html": "^1.1.0",
         "jsdom": "^14.1.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "postcss": "^7.0.17",
         "postcss-selector-parser": "6.0.2",
         "request": "^2.88.0"
@@ -21851,9 +21749,7 @@
           }
         },
         "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+          "version": "^4.17.21"
         },
         "optionator": {
           "version": "0.8.3",
@@ -22826,7 +22722,7 @@
         "string-width": "^4.2.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
+        "yargs-parser": "^18.1.3"
       },
       "dependencies": {
         "ansi-regex": {
@@ -22888,9 +22784,7 @@
           }
         },
         "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "version": "^18.1.3",
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6244,13 +6244,12 @@
           },
           "dependencies": {
             "bl": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-              "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+              "version": "1.2.3",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+              "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
               "requires": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
+                "readable-stream": "^2.3.5",
+                "safe-buffer": "^5.1.1"
               }
             }
           }
@@ -8979,6 +8978,11 @@
       "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
       "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM="
     },
+    "glur": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/glur/-/glur-1.1.2.tgz",
+      "integrity": "sha1-8g6jbbEDv8KSNDkh8fkeg8NGdok="
+    },
     "gonzales-pe": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
@@ -9586,6 +9590,14 @@
       "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
       "requires": {
         "minimatch": "^3.0.4"
+      }
+    },
+    "image-blob-reduce": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/image-blob-reduce/-/image-blob-reduce-2.2.2.tgz",
+      "integrity": "sha512-4pfusXGLRfMyASVr/nvHxHoYDcB+VbfYnOrLdK2VWO56yhkLvSP9l2HXwYIJUFBw4bPqQoZPWFm7rz01lgaOgA==",
+      "requires": {
+        "pica": "^6.1.1"
       }
     },
     "imagemin": {
@@ -14098,6 +14110,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "multimath": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/multimath/-/multimath-2.0.0.tgz",
+      "integrity": "sha512-toRx66cAMJ+Ccz7pMIg38xSIrtnbozk0dchXezwQDMgQmbGpfxjtv68H+L00iFL8hxDaVjrmwAFSb3I6bg8Q2g==",
+      "requires": {
+        "glur": "^1.1.2",
+        "object-assign": "^4.1.1"
+      }
+    },
     "mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -15737,12 +15758,11 @@
           },
           "dependencies": {
             "yargs-parser": {
-              "version": "18.1.3",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-              "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+              "version": "9.0.2",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+              "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
               "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
+                "camelcase": "^4.1.0"
               }
             }
           }
@@ -15968,6 +15988,17 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/physical-cpu-count/-/physical-cpu-count-2.0.0.tgz",
       "integrity": "sha1-GN4vl+S/epVRrXURlCtUlverpmA="
+    },
+    "pica": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/pica/-/pica-6.1.1.tgz",
+      "integrity": "sha512-dmjQheDGFOl+30rQhN3NM3MyDNjeOZvco6IL3ZVYgyVDmhgvcSCGOAsydRCIaZ36mcXO7ci0XFeD+h6unEcBvA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "multimath": "^2.0.0",
+        "object-assign": "^4.1.1",
+        "webworkify": "^1.5.0"
+      }
     },
     "picomatch": {
       "version": "2.2.2",
@@ -20508,13 +20539,9 @@
           },
           "dependencies": {
             "yargs-parser": {
-              "version": "18.1.3",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-              "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-              "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
-              }
+              "version": "20.2.7",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+              "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw=="
             }
           }
         },
@@ -22480,6 +22507,11 @@
         "utf-8-validate": "^5.0.2",
         "yaeti": "^0.0.6"
       }
+    },
+    "webworkify": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/webworkify/-/webworkify-1.5.0.tgz",
+      "integrity": "sha512-AMcUeyXAhbACL8S2hqqdqOLqvJ8ylmIbNwUIqQujRSouf4+eUFaXbG6F1Rbu+srlJMmxQWsiU7mOJi0nMBfM1g=="
     },
     "whatwg-encoding": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "http-aws-es": "^6.0.0",
     "husky": "^5.1.3",
     "i": "^0.3.6",
+    "image-blob-reduce": "^2.2.2",
     "imagemin": "^7.0.1",
     "imagemin-pngquant": "^9.0.2",
     "jest": "^26.6.3",

--- a/shared/src/business/test/createTestApplicationContext.js
+++ b/shared/src/business/test/createTestApplicationContext.js
@@ -208,6 +208,12 @@ const createTestApplicationContext = ({ user } = {}) => {
     }),
   };
 
+  const mockGetReduceImageBlobValue = {
+    default: jest.fn().mockReturnValue({
+      toBlob: jest.fn(),
+    }),
+  };
+
   const mockGetUtilities = appContextProxy({
     aggregatePartiesForService: jest
       .fn()
@@ -544,6 +550,7 @@ const createTestApplicationContext = ({ user } = {}) => {
       },
     })),
     getQueueService: mockGetQueueService,
+    getReduceImageBlob: jest.fn().mockReturnValue(mockGetReduceImageBlobValue),
     getScanner: jest.fn().mockReturnValue(mockGetScannerReturnValue),
     getScannerResourceUri: jest.fn().mockReturnValue(scannerResourcePath),
     getSearchClient: appContextProxy(),

--- a/shared/src/persistence/dynamsoft/getScannerInterface.js
+++ b/shared/src/persistence/dynamsoft/getScannerInterface.js
@@ -1,6 +1,8 @@
 let DWObject = null;
 let dynamsoftLoader = null;
 
+import * as reduce from 'image-blob-reduce';
+
 exports.getScannerInterface = () => {
   const completeScanSession = async () => {
     DWObject.RemoveAllImages();
@@ -143,8 +145,16 @@ exports.getScannerInterface = () => {
 
         return Promise.all(promises)
           .then(async blobs => {
+            const COVER_SHEET_WIDTH_IN_PX = 866;
+
+            const scaledDownBlobs = await Promise.all(
+              blobs.map(blob =>
+                reduce.default().toBlob(blob, { max: COVER_SHEET_WIDTH_IN_PX }),
+              ),
+            );
+
             const blobBuffers = await Promise.all(
-              blobs.map(applicationContext.convertBlobToUInt8Array),
+              scaledDownBlobs.map(applicationContext.convertBlobToUInt8Array),
             );
 
             response.scannedBuffer = blobBuffers;

--- a/shared/src/persistence/dynamsoft/getScannerInterface.js
+++ b/shared/src/persistence/dynamsoft/getScannerInterface.js
@@ -1,8 +1,6 @@
 let DWObject = null;
 let dynamsoftLoader = null;
 
-import * as reduce from 'image-blob-reduce';
-
 exports.getScannerInterface = () => {
   const completeScanSession = async () => {
     DWObject.RemoveAllImages();
@@ -149,7 +147,10 @@ exports.getScannerInterface = () => {
 
             const scaledDownBlobs = await Promise.all(
               blobs.map(blob =>
-                reduce.default().toBlob(blob, { max: COVER_SHEET_WIDTH_IN_PX }),
+                applicationContext
+                  .getReduceImageBlob()
+                  .default()
+                  .toBlob(blob, { max: COVER_SHEET_WIDTH_IN_PX }),
               ),
             );
 

--- a/shared/src/persistence/dynamsoft/getScannerInterface.test.js
+++ b/shared/src/persistence/dynamsoft/getScannerInterface.test.js
@@ -224,6 +224,9 @@ describe('getScannerInterface', () => {
       scanMode: SCAN_MODES.FLATBED,
     });
     expect(DWObject.IfDuplexEnabled).toEqual(false);
+    expect(
+      applicationContext.getReduceImageBlob().default().toBlob,
+    ).toHaveBeenCalled();
   });
 
   it('can enable flatbed scanning by calling startScanSession with scanMode set to `FLATBED`', async () => {
@@ -241,6 +244,9 @@ describe('getScannerInterface', () => {
       scanMode: SCAN_MODES.FEEDER,
     });
     expect(DWObject.IfFeederEnabled).toEqual(true);
+    expect(
+      applicationContext.getReduceImageBlob().default().toBlob,
+    ).toHaveBeenCalled();
   });
 
   it('should scan from feeder when calling startScanSession with scanMode set to `DUPLEX`', async () => {
@@ -253,6 +259,9 @@ describe('getScannerInterface', () => {
     });
     expect(DWObject.IfDuplexEnabled).toEqual(true);
     expect(DWObject.IfFeederEnabled).toEqual(true);
+    expect(
+      applicationContext.getReduceImageBlob().default().toBlob,
+    ).toHaveBeenCalled();
   });
 
   it('should attempt to load the dynamsoft libraries', async () => {

--- a/web-client/src/applicationContext.js
+++ b/web-client/src/applicationContext.js
@@ -1,3 +1,4 @@
+import * as reduce from 'image-blob-reduce';
 import { BroadcastChannel } from 'broadcast-channel';
 import {
   Case,
@@ -586,6 +587,7 @@ const applicationContext = {
     };
   },
   getPublicSiteUrl,
+  getReduceImageBlob: () => reduce,
   getScanner: async () => {
     if (process.env.NO_SCANNER) {
       const scanner = await import(


### PR DESCRIPTION
Addresses https://github.com/flexion/ef-cms/issues/8035
Scaled down scanned images to match the coversheet. 

![image](https://user-images.githubusercontent.com/1116426/112375599-7847bf00-8cb1-11eb-8442-b8fd240d0739.png)
