### PR TITLE
DevEx 737: Non ISO compliant dates

### DIFF
--- a/shared/src/business/utilities/DateHandler.js
+++ b/shared/src/business/utilities/DateHandler.js
@@ -38,10 +38,11 @@ const prepareDateFromString = (dateString, inputFormat) => {
     dateString = createISODateString();
   }
   const dateFromMoment = moment.tz(dateString, inputFormat, USTC_TZ);
-  console.log('moment.tz result', dateFromMoment);
-  if (dateFromMoment.toString().includes('Invalid')) {
+  // If an invalid string is passed in, we're able to check the result and log so error is
+  // not silently swallowed
+  if (dateString !== null && dateFromMoment.toString().includes('Invalid')) {
     console.error('Invalid date', {
-      message: `moment cannot recognize string '${dateString}'`,
+      message: `moment cannot recognize dateString: [${dateString}] dateFromMoment: [${dateFromMoment}]`,
     });
   }
 
@@ -300,9 +301,11 @@ const computeDate = ({ day, month, year }) => {
   if (!PATTERNS.YYYYMMDD.test(dateToParse)) {
     return dateToParse;
   }
-  const preparedDateISO = prepareDateFromString(dateToParse, FORMATS.YYYYMMDD);
-  const yyyymmdd = formatDateString(preparedDateISO, FORMATS.YYYYMMDD);
-  return yyyymmdd;
+  const preparedAndFormattedDateISO = prepareDateFromString(
+    dateToParse,
+    FORMATS.YYYYMMDD,
+  ).format(FORMATS.YYYYMMDD);
+  return preparedAndFormattedDateISO;
 };
 
 module.exports = {

--- a/shared/src/business/utilities/DateHandler.js
+++ b/shared/src/business/utilities/DateHandler.js
@@ -40,12 +40,9 @@ const prepareDateFromString = (dateString, inputFormat) => {
   const dateFromMoment = moment.tz(dateString, inputFormat, USTC_TZ);
   // If an invalid string is passed in, we're able to check the result and log so error is
   // not silently swallowed
-  if (dateString !== null && !dateFromMoment.isValid()) {
-    console.error('Invalid date', {
-      message: `moment cannot recognize dateString: [${dateString}] dateFromMoment: [${dateFromMoment}]`,
-    });
+  if (dateString != null && !dateFromMoment.isValid()) {
+    console.error('Invalid date', dateString);
   }
-
   return dateFromMoment;
 };
 

--- a/shared/src/business/utilities/DateHandler.js
+++ b/shared/src/business/utilities/DateHandler.js
@@ -37,7 +37,15 @@ const prepareDateFromString = (dateString, inputFormat) => {
   if (dateString === undefined) {
     dateString = createISODateString();
   }
-  return moment.tz(dateString, inputFormat, USTC_TZ);
+  const dateFromMoment = moment.tz(dateString, inputFormat, USTC_TZ);
+  console.log('moment.tz result', dateFromMoment);
+  if (dateFromMoment.toString().includes('Invalid')) {
+    console.error('Invalid date', {
+      message: `moment cannot recognize string '${dateString}'`,
+    });
+  }
+
+  return dateFromMoment;
 };
 
 const calculateISODate = ({ dateString, howMuch = 0, units = 'days' }) => {

--- a/shared/src/business/utilities/DateHandler.js
+++ b/shared/src/business/utilities/DateHandler.js
@@ -40,7 +40,7 @@ const prepareDateFromString = (dateString, inputFormat) => {
   const dateFromMoment = moment.tz(dateString, inputFormat, USTC_TZ);
   // If an invalid string is passed in, we're able to check the result and log so error is
   // not silently swallowed
-  if (dateString !== null && dateFromMoment.toString().includes('Invalid')) {
+  if (dateString !== null && !dateFromMoment.isValid()) {
     console.error('Invalid date', {
       message: `moment cannot recognize dateString: [${dateString}] dateFromMoment: [${dateFromMoment}]`,
     });

--- a/shared/src/business/utilities/DateHandler.test.js
+++ b/shared/src/business/utilities/DateHandler.test.js
@@ -1,5 +1,6 @@
 const DateHandler = require('./DateHandler');
 const { FORMATS, PATTERNS } = DateHandler;
+const moment = require('moment');
 const {
   JoiValidationConstants,
 } = require('../../utilities/JoiValidationConstants');
@@ -26,6 +27,7 @@ describe('DateHandler', () => {
     it("Creates a new moment object for 'now' when given no inputs", () => {
       const myMoment = DateHandler.prepareDateFromString();
       expect(myMoment).toBeDefined();
+      expect(myMoment.isValid()).toBeTruthy();
     });
 
     it('Creates a new moment object for a given YYYY-MM-DD', () => {
@@ -39,6 +41,20 @@ describe('DateHandler', () => {
       const myMoment = DateHandler.prepareDateFromString(strictIsoStamp);
       const isoString = myMoment.toISOString();
       expect(isoString).toEqual(strictIsoStamp);
+    });
+
+    it('Should log an error if an invalid, non-null string is passed in', () => {
+      const BAD_DATE = 'ABCDEFG';
+      const spy = jest.spyOn(console, 'error').mockImplementation();
+
+      moment.suppressDeprecationWarnings = true;
+      const myMoment = DateHandler.prepareDateFromString(BAD_DATE);
+      moment.suppressDeprecationWarnings = false;
+
+      expect(myMoment.isValid()).toBeFalsy();
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(console.error).toBeCalledWith('Invalid date', BAD_DATE);
+      spy.mockRestore();
     });
   });
 

--- a/web-client/integration-tests/journey/docketClerkAddsTranscriptDocketEntryFromOrder.js
+++ b/web-client/integration-tests/journey/docketClerkAddsTranscriptDocketEntryFromOrder.js
@@ -2,6 +2,7 @@ import { applicationContextForClient as applicationContext } from '../../../shar
 import { formattedCaseDetail } from '../../src/presenter/computeds/formattedCaseDetail';
 import { runCompute } from 'cerebral/test';
 import { withAppContextDecorator } from '../../src/withAppContext';
+import moment from 'moment';
 
 export const docketClerkAddsTranscriptDocketEntryFromOrder = (
   test,
@@ -55,10 +56,18 @@ export const docketClerkAddsTranscriptDocketEntryFromOrder = (
       value: 'Anything',
     });
 
+    // suppressing moment deprecation warnings temporarily as moment returns an
+    // invalid object when called with a single day or month value
+    moment.suppressDeprecationWarnings = true;
+
     await test.runSequence('updateCourtIssuedDocketEntryFormValueSequence', {
       key: 'month',
       value: date.month,
     });
+
+    // re-enabling moment warnings here
+    moment.suppressDeprecationWarnings = false;
+
     await test.runSequence('updateCourtIssuedDocketEntryFormValueSequence', {
       key: 'day',
       value: date.day,

--- a/web-client/integration-tests/journey/docketClerkCreatesARemoteTrialSession.js
+++ b/web-client/integration-tests/journey/docketClerkCreatesARemoteTrialSession.js
@@ -37,7 +37,7 @@ export const docketClerkCreatesARemoteTrialSession = (test, overrides = {}) => {
 
     await test.runSequence('updateTrialSessionFormDataSequence', {
       key: 'month',
-      value: '13',
+      value: '12',
     });
 
     await test.runSequence('updateTrialSessionFormDataSequence', {
@@ -47,7 +47,7 @@ export const docketClerkCreatesARemoteTrialSession = (test, overrides = {}) => {
 
     await test.runSequence('updateTrialSessionFormDataSequence', {
       key: 'year',
-      value: '2025',
+      value: '1999',
     });
 
     await test.runSequence('updateTrialSessionFormDataSequence', {
@@ -69,13 +69,12 @@ export const docketClerkCreatesARemoteTrialSession = (test, overrides = {}) => {
 
     expect(test.getState('validationErrors')).toEqual({
       startDate: errorMessages.startDate[1],
-      term: errorMessages.term,
       trialLocation: errorMessages.trialLocation,
     });
 
     await test.runSequence('updateTrialSessionFormDataSequence', {
-      key: 'month',
-      value: '12',
+      key: 'year',
+      value: '2025',
     });
 
     await test.runSequence('validateTrialSessionSequence');

--- a/web-client/integration-tests/journey/docketClerkCreatesATrialSession.js
+++ b/web-client/integration-tests/journey/docketClerkCreatesATrialSession.js
@@ -37,7 +37,7 @@ export const docketClerkCreatesATrialSession = (test, overrides = {}) => {
 
     await test.runSequence('updateTrialSessionFormDataSequence', {
       key: 'month',
-      value: '13',
+      value: '12',
     });
 
     await test.runSequence('updateTrialSessionFormDataSequence', {
@@ -47,7 +47,7 @@ export const docketClerkCreatesATrialSession = (test, overrides = {}) => {
 
     await test.runSequence('updateTrialSessionFormDataSequence', {
       key: 'year',
-      value: '2025',
+      value: '1999',
     });
 
     await test.runSequence('updateTrialSessionFormDataSequence', {
@@ -89,13 +89,12 @@ export const docketClerkCreatesATrialSession = (test, overrides = {}) => {
 
     expect(test.getState('validationErrors')).toEqual({
       startDate: errorMessages.startDate[1],
-      term: errorMessages.term,
       trialLocation: errorMessages.trialLocation,
     });
 
     await test.runSequence('updateTrialSessionFormDataSequence', {
-      key: 'month',
-      value: '12',
+      key: 'year',
+      value: '2025',
     });
 
     await test.runSequence('validateTrialSessionSequence');


### PR DESCRIPTION
- Updated preparedAndFormattedDateISO function in dateHandler utility to avoid passing dates through moment twice, avoiding the deprecation warning that is triggered when passing an invalid object/string into moment.
- Added console error to dateHandler when moment returns an `Invalid` object, to avoid this being silently swallowed. 
- Requesting feedback on _need_ for console error. Is recorded ~dozen times in tests. 


- Updated test data to pass in invalid dates less frequently, since this is already covered in the dateHandler tests.
- Updated dateHandler tests for the new functionality.