### PR TITLE
8091 - Missing Query Permission

### DIFF
--- a/iam/terraform/environment-specific/main/migration.tf
+++ b/iam/terraform/environment-specific/main/migration.tf
@@ -47,6 +47,7 @@ resource "aws_iam_role_policy" "migration_policy" {
                 "dynamodb:GetShardIterator",
                 "dynamodb:ListShards",
                 "dynamodb:ListStreams",
+                "dynamodb:Query",
                 "dynamodb:PutItem",
                 "dynamodb:Scan"
             ],

--- a/iam/terraform/environment-specific/main/migration.tf
+++ b/iam/terraform/environment-specific/main/migration.tf
@@ -121,6 +121,7 @@ resource "aws_iam_role_policy" "migration_segments_policy" {
                 "dynamodb:ListShards",
                 "dynamodb:ListStreams",
                 "dynamodb:PutItem",
+                "dynamodb:Query",
                 "dynamodb:Scan"
             ],
             "Resource": [


### PR DESCRIPTION
This permission was missing, but we've ran migrations in the past that used the query command, so we are thinking it was once manually added in the AWS dashboard but never updated here?  