### PR TITLE
DevEx-737

### DIFF
--- a/shared/src/business/utilities/DateHandler.js
+++ b/shared/src/business/utilities/DateHandler.js
@@ -291,7 +291,7 @@ const computeDate = ({ day, month, year }) => {
   const ddPadded = `${day}`.padStart(2, '0');
   const dateToParse = `${yyyyPadded}-${mmPadded}-${ddPadded}`;
   if (!PATTERNS.YYYYMMDD.test(dateToParse)) {
-    return dateToParse;
+    return undefined;
   }
   return prepareDateFromString(dateToParse, FORMATS.ISO).toISOString();
 };

--- a/shared/src/business/utilities/DateHandler.test.js
+++ b/shared/src/business/utilities/DateHandler.test.js
@@ -437,13 +437,13 @@ describe('DateHandler', () => {
       expect(result).toBe('1993-03-09T05:00:00.000Z');
     });
 
-    it('should return "undefined-mm-dd" when year is not provided', () => {
+    it('should return undefined when year, month, or day is not provided', () => {
       const result = DateHandler.computeDate({
         day: '5',
         month: '11',
       });
 
-      expect(result).toBe('undefined-11-05');
+      expect(result).toBe(undefined);
     });
 
     it('should return null if not provided values for all of day, month, and year', () => {

--- a/web-client/src/presenter/actions/FileDocument/computeCertificateOfServiceFormDateAction.test.js
+++ b/web-client/src/presenter/actions/FileDocument/computeCertificateOfServiceFormDateAction.test.js
@@ -38,7 +38,7 @@ describe('computeCertificateOfServiceFormDateAction', () => {
     );
   });
 
-  it('should set certificateOfServiceDate to undefined-MM-DD if state.form has month and day', async () => {
+  it('should set certificateOfServiceDate to undefined if state.form has year, month, or day', async () => {
     const result = await runAction(computeCertificateOfServiceFormDateAction, {
       modules: {
         presenter,
@@ -51,9 +51,7 @@ describe('computeCertificateOfServiceFormDateAction', () => {
       },
     });
 
-    expect(result.state.form.certificateOfServiceDate).toEqual(
-      'undefined-12-05',
-    );
+    expect(result.state.form.certificateOfServiceDate).toEqual(undefined);
   });
 
   it('should set certificateOfServiceDate for secondary and supporting documents', async () => {


### PR DESCRIPTION
- Simplest possible refactor that avoids passing bad strings into moment, and eliminates strings with `undefined` being passed around for validation.