### PR TITLE
8096 - Fixing the PDF Filing Date

### DIFF
--- a/shared/src/business/useCases/generatePrintableFilingReceiptInteractor.js
+++ b/shared/src/business/useCases/generatePrintableFilingReceiptInteractor.js
@@ -13,6 +13,7 @@ const getDocumentInfo = ({ applicationContext, documentData }) => {
     certificateOfServiceDate: doc.certificateOfServiceDate,
     documentTitle: doc.documentTitle,
     filedBy: doc.filedBy,
+    filingDate: doc.filingDate,
     objections: doc.objections,
     receivedAt: doc.receivedAt,
   };
@@ -80,7 +81,7 @@ exports.generatePrintableFilingReceiptInteractor = async (
       docketNumberWithSuffix: caseEntity.docketNumberWithSuffix,
       filedAt: applicationContext
         .getUtilities()
-        .formatDateString(primaryDocument.receivedAt, 'DATE_TIME_TZ'),
+        .formatDateString(primaryDocument.filingDate, 'DATE_TIME_TZ'),
       filedBy: primaryDocument.filedBy,
       ...filingReceiptDocumentParams,
     },

--- a/shared/src/business/useCases/generatePrintableFilingReceiptInteractor.js
+++ b/shared/src/business/useCases/generatePrintableFilingReceiptInteractor.js
@@ -49,6 +49,7 @@ exports.generatePrintableFilingReceiptInteractor = async (
     doc => doc.docketEntryId === documentsFiled.primaryDocumentId,
   );
   primaryDocument.filedBy = primaryDocumentRecord.filedBy;
+  primaryDocument.filingDate = primaryDocumentRecord.filingDate;
 
   const filingReceiptDocumentParams = { document: primaryDocument };
 

--- a/shared/src/business/useCases/generatePrintableFilingReceiptInteractor.test.js
+++ b/shared/src/business/useCases/generatePrintableFilingReceiptInteractor.test.js
@@ -60,8 +60,13 @@ describe('generatePrintableFilingReceiptInteractor', () => {
 
     const receiptMockCall = applicationContext.getDocumentGenerators()
       .receiptOfFiling.mock.calls[0][0].data; // 'data' property of first arg (an object) of first call
+
+    const expectedFilingDateForamtted = applicationContext
+      .getUtilities()
+      .formatDateString(MOCK_CASE.docketEntries[0].filingDate, 'DATE_TIME_TZ');
+
     expect(receiptMockCall.filedBy).toBe(MOCK_CASE.contactPrimary.name);
-    expect(receiptMockCall.filedAt).toBe('04/08/21 3:13 pm ET');
+    expect(receiptMockCall.filedAt).toBe(expectedFilingDateForamtted);
   });
 
   it('acquires document information', async () => {

--- a/shared/src/business/useCases/generatePrintableFilingReceiptInteractor.test.js
+++ b/shared/src/business/useCases/generatePrintableFilingReceiptInteractor.test.js
@@ -61,6 +61,7 @@ describe('generatePrintableFilingReceiptInteractor', () => {
     const receiptMockCall = applicationContext.getDocumentGenerators()
       .receiptOfFiling.mock.calls[0][0].data; // 'data' property of first arg (an object) of first call
     expect(receiptMockCall.filedBy).toBe(MOCK_CASE.contactPrimary.name);
+    expect(receiptMockCall.filedAt).toBe('04/08/21 3:13 pm ET');
   });
 
   it('acquires document information', async () => {


### PR DESCRIPTION
-  fixing the pdf filing date by using the filingDate on the docket entry instead of receivedAt

<img width="671" alt="Screen Shot 2021-04-08 at 2 10 48 PM" src="https://user-images.githubusercontent.com/1891789/114090116-3ce1ee80-9874-11eb-8645-572ec7033425.png">
