### PR TITLE
8088 - Two Paged Notice of Trial Bug

### DIFF
--- a/shared/src/business/utilities/documentGenerators.test.js
+++ b/shared/src/business/utilities/documentGenerators.test.js
@@ -1,6 +1,7 @@
 jest.mock('./combineTwoPdfs');
 const fs = require('fs');
 const path = require('path');
+const sass = require('sass');
 const {
   addressLabelCoverSheet,
   caseInventoryReport,
@@ -35,7 +36,6 @@ const {
 } = require('../useCases/generatePdfFromHtmlInteractor');
 const { combineTwoPdfs } = require('./combineTwoPdfs');
 const { getChromiumBrowser } = require('./getChromiumBrowser');
-const { sass } = require('sass');
 
 describe('documentGenerators', () => {
   const testOutputPath = path.resolve(
@@ -402,18 +402,17 @@ describe('documentGenerators', () => {
         applicationContext,
         data: {
           caseCaptionExtension: 'Petitioner(s)',
-          caseTitle: 'Test Petitioner',
+          caseTitle:
+            'Milton Schwartz, Deceased, Neil Schwartz, Fiduciary and Ada Schwartz, Deceased, Neil Schwartz, Fiduciary, Petitioners',
           docketNumberWithSuffix: '123-45S',
           trialInfo: {
-            address1: '123 Some St.',
-            address2: 'Suite B',
-            city: 'Somecity',
-            courthouseName: 'Test Courthouse Name',
-            judge: 'Judge Dredd',
-            postalCode: '80008',
-            startDate: '02/02/2020',
-            startTime: '9:00 AM',
-            state: 'ZZ',
+            formattedJudge: 'Chief Special Trial Judge Carluzzo',
+            formattedStartDate: '01/01/2001',
+            formattedStartTime: '12:00 am',
+            joinPhoneNumber: '444-444-4444',
+            meetingId: 'sdsd',
+            password: '123',
+            trialLocation: 'Birmingham, Alabama',
           },
         },
       });
@@ -423,6 +422,10 @@ describe('documentGenerators', () => {
         writePdfFile('Notice_Trial_Issued', pdf);
         expect(applicationContext.getChromiumBrowser).toHaveBeenCalled();
       }
+
+      const { PDFDocument } = await applicationContext.getPdfLib();
+      const pdfDoc = await PDFDocument.load(new Uint8Array(pdf));
+      expect(pdfDoc.getPages().length).toEqual(1);
 
       expect(
         applicationContext.getUseCases().generatePdfFromHtmlInteractor,

--- a/shared/src/business/utilities/documentGenerators.test.js
+++ b/shared/src/business/utilities/documentGenerators.test.js
@@ -421,11 +421,10 @@ describe('documentGenerators', () => {
       if (process.env.PDF_OUTPUT) {
         writePdfFile('Notice_Trial_Issued', pdf);
         expect(applicationContext.getChromiumBrowser).toHaveBeenCalled();
+        const { PDFDocument } = await applicationContext.getPdfLib();
+        const pdfDoc = await PDFDocument.load(new Uint8Array(pdf));
+        expect(pdfDoc.getPages().length).toEqual(1);
       }
-
-      const { PDFDocument } = await applicationContext.getPdfLib();
-      const pdfDoc = await PDFDocument.load(new Uint8Array(pdf));
-      expect(pdfDoc.getPages().length).toEqual(1);
 
       expect(
         applicationContext.getUseCases().generatePdfFromHtmlInteractor,

--- a/shared/src/business/utilities/htmlGenerator/index.scss
+++ b/shared/src/business/utilities/htmlGenerator/index.scss
@@ -560,6 +560,18 @@ th {
   }
 }
 
+.notice-of-trial-title {
+  margin-bottom: 0px;
+}
+
+#notice-of-trial-pdf .info-box {
+  margin-bottom: 20px;
+}
+
+#notice-body > p {
+  margin-top: 0px;
+}
+
 @font-face {
   font-family: 'nimbus_roman';
   font-style: normal;

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/NoticeOfTrialIssued.jsx
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/NoticeOfTrialIssued.jsx
@@ -9,14 +9,14 @@ export const NoticeOfTrialIssued = ({
   trialInfo,
 }) => {
   return (
-    <>
+    <div id="notice-of-trial-pdf">
       <PrimaryHeader />
       <DocketHeader
         caseCaptionExtension={caseCaptionExtension}
         caseTitle={caseTitle}
         docketNumberWithSuffix={docketNumberWithSuffix}
       />
-      <h3>Notice Setting Case For Trial</h3>
+      <h3 className="notice-of-trial-title">Notice Setting Case For Trial</h3>
       <div>
         <div className="info-box info-box-trial" id="trial-info">
           <div className="info-box-header">Trial At</div>
@@ -51,12 +51,12 @@ export const NoticeOfTrialIssued = ({
         </p>
 
         <p className="text-underline">ACCESS REMOTE PROCEEDING</p>
-        <p>Your Meeting ID and Password for the remote proceeding is:</p>
+        <p>Your Meeting ID and Passcode for the remote proceeding are:</p>
         <p className="text-center">
           <b>Meeting ID:</b> {trialInfo.meetingId}
         </p>
         <p className="text-center">
-          <b>Password:</b> {trialInfo.password}
+          <b>Passcode:</b> {trialInfo.password}
         </p>
 
         <p>
@@ -65,12 +65,12 @@ export const NoticeOfTrialIssued = ({
             www.zoomgov.com
           </a>{' '}
           and click `Join a meeting` (blue box in the middle of the page). Enter
-          the Meeting ID and Password above when prompted.
+          the Meeting ID and Passcode above when prompted.
         </p>
 
         <p>
           Join by telephone: Call {trialInfo.joinPhoneNumber}. Enter the Meeting
-          ID and Password above when prompted.
+          ID and Passcode above when prompted.
         </p>
 
         <p>
@@ -87,6 +87,6 @@ export const NoticeOfTrialIssued = ({
           Clerk of the Court
         </p>
       </div>
-    </>
+    </div>
   );
 };


### PR DESCRIPTION
The bug was due to larger case captions causing extra lines to push the content down into two pages.  This issue will still happen with very large case captions, but this fix should address 95% of the average cases.

- reduced the margin bottom on 2 elements to leave more space
- renamed Password to Passcode `per Jessica's request`
- changed `is` to `are` to fix a grammar issue
- added a test to verify this PDF is 1 line 
- fixing an issue with this documentGenerators test not working

![Screen Shot 2021-04-09 at 11 29 26 AM](https://user-images.githubusercontent.com/1868782/114204147-d8cc3280-9926-11eb-8b3c-39b35e025608.png)
