### PR TITLE
8078 - More explicit error logging, catch missing s3 files

### DIFF
--- a/shared/src/business/test/createTestApplicationContext.js
+++ b/shared/src/business/test/createTestApplicationContext.js
@@ -426,6 +426,7 @@ const createTestApplicationContext = ({ user } = {}) => {
     getWorkItemById: jest.fn().mockImplementation(getWorkItemByIdPersistence),
     incrementCounter,
     isEmailAvailable: jest.fn(),
+    isFileExists: jest.fn(),
     persistUser: jest.fn(),
     putWorkItemInOutbox: jest.fn().mockImplementation(putWorkItemInOutbox),
     removeItem: jest.fn().mockImplementation(removeItem),

--- a/shared/src/business/useCases/trialSessions/batchDownloadTrialSessionInteractor.test.js
+++ b/shared/src/business/useCases/trialSessions/batchDownloadTrialSessionInteractor.test.js
@@ -10,9 +10,10 @@ const { ROLES } = require('../../entities/EntityConstants');
 
 describe('batchDownloadTrialSessionInteractor', () => {
   let user;
+  let mockCase;
 
   beforeEach(() => {
-    const mockCase = {
+    mockCase = {
       ...MOCK_CASE,
     };
 
@@ -75,6 +76,10 @@ describe('batchDownloadTrialSessionInteractor', () => {
     applicationContext
       .getUseCases()
       .generateDocketRecordPdfInteractor.mockResolvedValue({});
+
+    applicationContext
+      .getPersistenceGateway()
+      .isFileExists.mockResolvedValue(true);
   });
 
   it('skips DocketEntry that are not in docketrecord or have documents in S3', async () => {
@@ -90,6 +95,7 @@ describe('batchDownloadTrialSessionInteractor', () => {
       extraFiles: expect.anything(),
       fileNames: expect.anything(),
       onEntry: expect.anything(),
+      onError: expect.anything(),
       onProgress: expect.anything(),
       onUploadStart: expect.anything(),
       s3Ids: [
@@ -99,6 +105,34 @@ describe('batchDownloadTrialSessionInteractor', () => {
       uploadToTempBucket: true,
       zipName: 'September_26_2019-Birmingham.zip',
     });
+  });
+
+  it('checks that the files to be zipped exist in persistence', async () => {
+    await batchDownloadTrialSessionInteractor(applicationContext, {
+      trialSessionId: '123',
+    });
+
+    expect(
+      applicationContext.getPersistenceGateway().isFileExists,
+    ).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws an error if a file to be zipped does not exist in persistence', async () => {
+    applicationContext
+      .getPersistenceGateway()
+      .isFileExists.mockResolvedValue(false);
+
+    await batchDownloadTrialSessionInteractor(applicationContext, {
+      trialSessionId: '123',
+    });
+
+    const errorCall = applicationContext.getNotificationGateway()
+      .sendNotificationToUser.mock.calls[0];
+
+    expect(errorCall).toBeTruthy();
+    expect(errorCall[0].message.error.message).toEqual(
+      `Batch Download Error: File ${mockCase.docketEntries[0].docketEntryId} for case ${mockCase.docketNumber} does not exist!`,
+    );
   });
 
   it('throws an Unauthorized error if the user role is not allowed to access the method', async () => {
@@ -170,6 +204,45 @@ describe('batchDownloadTrialSessionInteractor', () => {
       extraFiles: [],
       fileNames: [],
       onEntry: expect.anything(),
+      onError: expect.anything(),
+      onProgress: expect.anything(),
+      onUploadStart: expect.anything(),
+      s3Ids: [],
+      uploadToTempBucket: true,
+      zipName: 'September_26_2019-Birmingham.zip',
+    });
+  });
+
+  it('should filter removed cases from batch', async () => {
+    applicationContext
+      .getPersistenceGateway()
+      .getCalendaredCasesForTrialSession.mockReturnValue([
+        {
+          ...MOCK_CASE,
+          removedFromTrial: true,
+        },
+      ]);
+
+    await batchDownloadTrialSessionInteractor(applicationContext, {
+      trialSessionId: '123',
+    });
+
+    expect(
+      applicationContext.getPersistenceGateway().getTrialSessionById,
+    ).toHaveBeenCalled();
+    expect(
+      applicationContext.getPersistenceGateway()
+        .getCalendaredCasesForTrialSession,
+    ).toHaveBeenCalled();
+    expect(
+      applicationContext.getPersistenceGateway().zipDocuments,
+    ).toHaveBeenCalledWith({
+      applicationContext: expect.anything(),
+      extraFileNames: [],
+      extraFiles: [],
+      fileNames: [],
+      onEntry: expect.anything(),
+      onError: expect.anything(),
       onProgress: expect.anything(),
       onUploadStart: expect.anything(),
       s3Ids: [],

--- a/shared/src/persistence/s3/s3-zip.js
+++ b/shared/src/persistence/s3/s3-zip.js
@@ -71,6 +71,7 @@ s3Zip.archiveStream = function (stream, filesS3, filesZip, extras, extrasZip) {
   });
 
   archive.on('error', function (err) {
+    console.log('archive error', err);
     thisArchive.onError(err);
   });
 

--- a/shared/src/persistence/s3/s3-zip.js
+++ b/shared/src/persistence/s3/s3-zip.js
@@ -15,6 +15,7 @@ s3Zip.archive = function (opts, folder, filesS3, filesZip, extra, extraZip) {
   thisArchive.debug = opts.debug || false;
   thisArchive.onEntry = opts.onEntry || noop;
   thisArchive.onProgress = opts.onProgress || noop;
+  thisArchive.onError = opts.onError || noop;
 
   if ('s3' in opts) {
     connectionConfig = {
@@ -70,7 +71,7 @@ s3Zip.archiveStream = function (stream, filesS3, filesZip, extras, extrasZip) {
   });
 
   archive.on('error', function (err) {
-    thisArchive.debug && console.log('archive error', err);
+    thisArchive.onError(err);
   });
 
   archive.on('progress', thisArchive.onProgress);

--- a/shared/src/persistence/s3/zipDocuments.js
+++ b/shared/src/persistence/s3/zipDocuments.js
@@ -16,6 +16,7 @@ exports.zipDocuments = ({
   extraFiles,
   fileNames,
   onEntry,
+  onError,
   onProgress,
   onUploadStart,
   s3Ids,
@@ -56,6 +57,7 @@ exports.zipDocuments = ({
         {
           bucket: documentsBucket,
           onEntry,
+          onError,
           onProgress,
           region,
           s3: s3Client,


### PR DESCRIPTION
The issue, as reported, isn't necessarily solvable with this PR, as there is not enough information to diagnose - however, a few issues were identified in this archiving process that may be contributors - or will at least help produce information for diagnosing this and future problems as they arise.

- Ensures that removed cases do not make it into the batch.
- Ensures files being archived actually exist on s3 before proceeding.
- Ensures the process fails early when there's an error while archiving (bubbling the error to the pipe) - otherwise the error wasn't being displayed until the socket timed out (so it would just appear to hang on x%).