### PR TITLE
8108: track previously-focused element

### DIFF
--- a/web-client/src/ustc-ui/FocusLock/FocusLock.jsx
+++ b/web-client/src/ustc-ui/FocusLock/FocusLock.jsx
@@ -5,30 +5,41 @@ const appRoot =
   window.document.getElementById('app') ||
   window.document.getElementById('app-public');
 const tabbableSelector =
-  'a:enabled,button:enabled,input:enabled,select:enabled,textarea:enabled';
+  'a:enabled,button:enabled,input:enabled,select:enabled,textarea:enabled,h1[tabindex],h2[tabindex],h3[tabindex],h4[tabindex],.focusable[tabindex]';
 
 export const FocusLock = ({ children }) => {
   const el = useRef(null);
+
+  const previousElementWithFocus =
+    (window.document.hasFocus() &&
+      window.document.activeElement !== window.document.body &&
+      window.document.activeElement !== window.document.documentElement &&
+      window.document.activeElement) ||
+    {};
+
+  const getLockedTabbables = () => {
+    const lockedElements = el.current.querySelectorAll(tabbableSelector);
+    return {
+      first: lockedElements.item(0),
+      last: lockedElements.item(lockedElements.length - 1),
+    };
+  };
 
   const onKey = event => {
     if (event.keyCode != 9 || !el.current.contains(event.target)) {
       // not tab key on element within this component
       return;
     }
-    const lockedElements = el.current.querySelectorAll(tabbableSelector);
-    const [firstTabbable, lastTabbable] = [
-      lockedElements.item(0),
-      lockedElements.item(lockedElements.length - 1),
-    ];
-    if (event.target == firstTabbable && event.shiftKey) {
+    const tabbables = getLockedTabbables();
+    if (event.target == tabbables.first && event.shiftKey) {
       // shift-tab when on firstTabbable: move focus to lastTabbable
-      lastTabbable.focus();
+      tabbables.last.focus();
       event.preventDefault();
       return false;
     }
-    if (event.target == lastTabbable && !event.shiftKey) {
+    if (event.target == tabbables.last && !event.shiftKey) {
       // tab (without shift) when on lastTabbable: move focus to firstTabbable
-      firstTabbable.focus();
+      tabbables.first.focus();
       event.preventDefault();
       return false;
     }
@@ -39,11 +50,13 @@ export const FocusLock = ({ children }) => {
     appRoot.inert = true; // leverages wicg-inert polyfill
     appRoot.setAttribute('aria-hidden', 'true');
     window.document.addEventListener('keydown', onKey);
+    getLockedTabbables().first.focus();
 
     return () => {
       appRoot.inert = false;
       appRoot.setAttribute('aria-hidden', 'false');
       window.document.removeEventListener('keydown', onKey);
+      previousElementWithFocus.focus && previousElementWithFocus.focus();
     };
   }, []);
 


### PR DESCRIPTION
when FocusLock is removed from DOM, place focus back on the element which last had focus prior to FocusLock
attempt to set focus on first focusable child on render