### PR TITLE
7466 - adding logic to support firmName updates

### DIFF
--- a/shared/src/business/useCases/users/updateUserContactInformationInteractor.js
+++ b/shared/src/business/useCases/users/updateUserContactInformationInteractor.js
@@ -23,7 +23,7 @@ const { UnauthorizedError } = require('../../../errors/errors');
  * @param {object} providers the providers object
  * @param {string} providers.contactInfo the contactInfo to update the contact info
  * @param {string} providers.userId the userId to update the contact info
- * @param {string} providers.firmName the firmName to update if a privatePractitioner is updating their info
+ * @param {string} providers.firmName firmName to update if a privatePractitioner is updating their info
  * @returns {Promise} an object is successful
  */
 const updateUserContactInformationHelper = async (

--- a/shared/src/business/useCases/users/updateUserContactInformationInteractor.test.js
+++ b/shared/src/business/useCases/users/updateUserContactInformationInteractor.test.js
@@ -48,6 +48,7 @@ describe('updateUserContactInformationInteractor', () => {
       birthYear: '1902',
       employer: EMPLOYER_OPTIONS[2],
       entityName: irsPractitionerEntityName,
+      firmName: 'broken',
       firstName: 'Roy',
       lastName: 'Rogers',
       originalBarState: 'OR',
@@ -303,5 +304,57 @@ describe('updateUserContactInformationInteractor', () => {
     ).toMatchObject({
       isUpdatingInformation: false,
     });
+  });
+
+  it('should update the firmName if user is a practitioner and firmName is passed in', async () => {
+    await updateUserContactInformationInteractor(applicationContext, {
+      contactInfo,
+      firmName: 'testing',
+      userId: 'f7d90c05-f6cd-442c-a168-202db587f16f',
+    });
+    expect(
+      applicationContext.getPersistenceGateway().updateUser.mock.calls[0][0]
+        .user,
+    ).toMatchObject({
+      firmName: 'testing',
+    });
+  });
+
+  it('should return early if the firmName and contact info was not changed', async () => {
+    applicationContext
+      .getPersistenceGateway()
+      .getUserById.mockImplementation(() => ({
+        ...mockUser,
+        contact: contactInfo,
+      }));
+
+    await updateUserContactInformationInteractor(applicationContext, {
+      contactInfo,
+      firmName: mockUser.firmName,
+      userId: 'f7d90c05-f6cd-442c-a168-202db587f16f',
+    });
+
+    expect(
+      applicationContext.getPersistenceGateway().updateUser,
+    ).not.toBeCalled();
+  });
+
+  it('should return early if the firmName and contact info was not changed', async () => {
+    applicationContext
+      .getPersistenceGateway()
+      .getUserById.mockImplementation(() => ({
+        ...mockUser,
+        contact: contactInfo,
+      }));
+
+    await updateUserContactInformationInteractor(applicationContext, {
+      contactInfo,
+      firmName: mockUser.firmName,
+      userId: 'f7d90c05-f6cd-442c-a168-202db587f16f',
+    });
+
+    expect(
+      applicationContext.getPersistenceGateway().updateUser,
+    ).not.toBeCalled();
   });
 });

--- a/shared/src/business/useCases/users/updateUserContactInformationInteractor.test.js
+++ b/shared/src/business/useCases/users/updateUserContactInformationInteractor.test.js
@@ -338,23 +338,4 @@ describe('updateUserContactInformationInteractor', () => {
       applicationContext.getPersistenceGateway().updateUser,
     ).not.toBeCalled();
   });
-
-  it('should return early if the firmName and contact info was not changed', async () => {
-    applicationContext
-      .getPersistenceGateway()
-      .getUserById.mockImplementation(() => ({
-        ...mockUser,
-        contact: contactInfo,
-      }));
-
-    await updateUserContactInformationInteractor(applicationContext, {
-      contactInfo,
-      firmName: mockUser.firmName,
-      userId: 'f7d90c05-f6cd-442c-a168-202db587f16f',
-    });
-
-    expect(
-      applicationContext.getPersistenceGateway().updateUser,
-    ).not.toBeCalled();
-  });
 });

--- a/shared/src/proxies/users/updateUserContactInformationProxy.js
+++ b/shared/src/proxies/users/updateUserContactInformationProxy.js
@@ -6,17 +6,22 @@ const { put } = require('../requests');
  * @param {object} providers the providers object
  * @param {object} providers.applicationContext the application context
  * @param {string} providers.contactInfo the contactInfo to update the contact info
+ * @param {string} providers.firmName an optional firmName if a privatePractitioner is updating their info
  * @param {string} providers.userId the userId to update the contact info
  * @returns {Promise<*>} the promise of the api call
  */
 exports.updateUserContactInformationInteractor = ({
   applicationContext,
   contactInfo,
+  firmName,
   userId,
 }) => {
   return put({
     applicationContext,
-    body: contactInfo,
+    body: {
+      contactInfo,
+      firmName,
+    },
     endpoint: `/async/users/${userId}/contact-info`,
   });
 };

--- a/web-api/src/users/updateUserContactInformationLambda.js
+++ b/web-api/src/users/updateUserContactInformationLambda.js
@@ -8,10 +8,12 @@ const { genericHandler } = require('../genericHandler');
  */
 exports.updateUserContactInformationLambda = event =>
   genericHandler(event, async ({ applicationContext }) => {
+    const { contactInfo, firmName } = JSON.parse(event.body);
     return await applicationContext
       .getUseCases()
       .updateUserContactInformationInteractor(applicationContext, {
-        contactInfo: JSON.parse(event.body),
+        contactInfo,
+        firmName,
         userId: (event.pathParameters || event.path).userId,
       });
   });

--- a/web-client/src/presenter/actions/setUserOnFormAction.js
+++ b/web-client/src/presenter/actions/setUserOnFormAction.js
@@ -13,6 +13,7 @@ export const setUserOnFormAction = async ({ props, store }) => {
   store.set(state.form, {
     barNumber: props.user.barNumber,
     contact: props.user.contact,
+    firmName: props.user.firmName,
     name: props.user.name,
   });
 };

--- a/web-client/src/presenter/actions/setUserOnFormAction.test.js
+++ b/web-client/src/presenter/actions/setUserOnFormAction.test.js
@@ -14,6 +14,7 @@ describe('setUserOnFormAction', () => {
           contact: {
             address1: '123 Main St',
           },
+          firmName: 'testing',
           name: 'Test User',
           userId: '123',
         },
@@ -25,6 +26,7 @@ describe('setUserOnFormAction', () => {
       contact: {
         address1: '123 Main St',
       },
+      firmName: 'testing',
       name: 'Test User',
     });
   });

--- a/web-client/src/presenter/actions/updateUserContactInformationAction.js
+++ b/web-client/src/presenter/actions/updateUserContactInformationAction.js
@@ -19,6 +19,7 @@ export const updateUserContactInformationAction = async ({
     .updateUserContactInformationInteractor({
       applicationContext,
       contactInfo: formUser.contact,
+      firmName: formUser.firmName,
       userId: currentUser.userId,
     });
 };

--- a/web-client/src/presenter/actions/updateUserContactInformationAction.test.js
+++ b/web-client/src/presenter/actions/updateUserContactInformationAction.test.js
@@ -13,10 +13,25 @@ describe('updateUserContactInformationAction', () => {
       modules: {
         presenter,
       },
-      state: { form: { contact: {} } },
+      state: {
+        form: {
+          contact: { address1: '999 Jump St' },
+          firmName: 'testing',
+        },
+      },
     });
     expect(
       applicationContext.getUseCases().updateUserContactInformationInteractor,
     ).toHaveBeenCalled();
+    expect(
+      applicationContext.getUseCases().updateUserContactInformationInteractor
+        .mock.calls[0][0],
+    ).toMatchObject({
+      contactInfo: {
+        address1: '999 Jump St',
+      },
+      firmName: 'testing',
+      userId: 'a805d1ab-18d0-43ec-bafb-654e83405416',
+    });
   });
 });

--- a/web-client/src/presenter/computeds/userContactEditHelper.js
+++ b/web-client/src/presenter/computeds/userContactEditHelper.js
@@ -1,0 +1,10 @@
+import { state } from 'cerebral';
+
+export const userContactEditHelper = (get, applicationContext) => {
+  const user = get(state.user);
+  const { USER_ROLES } = applicationContext.getConstants();
+
+  return {
+    showFirmName: USER_ROLES.privatePractitioner === user.role,
+  };
+};

--- a/web-client/src/presenter/computeds/userContactEditHelper.test.js
+++ b/web-client/src/presenter/computeds/userContactEditHelper.test.js
@@ -1,0 +1,34 @@
+import { ROLES } from '../../../../shared/src/business/entities/EntityConstants';
+import { applicationContext } from '../../applicationContext';
+import { runCompute } from 'cerebral/test';
+import { userContactEditHelper as userContactEditHelperComputed } from './userContactEditHelper';
+import { withAppContextDecorator } from '../../withAppContext';
+
+const userContactEditHelper = withAppContextDecorator(
+  userContactEditHelperComputed,
+  applicationContext,
+);
+
+describe('userContactEditHelper', () => {
+  it('returns true for showFirmName if role is privatePractitioner', () => {
+    const result = runCompute(userContactEditHelper, {
+      state: {
+        user: {
+          role: ROLES.privatePractitioner,
+        },
+      },
+    });
+    expect(result.showFirmName).toBeTruthy();
+  });
+
+  it('returns false for showFirmName if role is NOT privatePractitioner', () => {
+    const result = runCompute(userContactEditHelper, {
+      state: {
+        user: {
+          role: ROLES.irsPractitioner,
+        },
+      },
+    });
+    expect(result.showFirmName).toBeFalsy();
+  });
+});

--- a/web-client/src/presenter/state.js
+++ b/web-client/src/presenter/state.js
@@ -94,6 +94,7 @@ import { trialSessionWorkingCopyHelper } from './computeds/trialSessionWorkingCo
 import { trialSessionsHelper } from './computeds/trialSessionsHelper';
 import { trialSessionsSummaryHelper } from './computeds/trialSessionsSummaryHelper';
 import { updateCaseModalHelper } from './computeds/updateCaseModalHelper';
+import { userContactEditHelper } from './computeds/userContactEditHelper';
 import { userContactEditProgressHelper } from './computeds/userContactEditProgressHelper';
 import { viewAllDocumentsHelper } from './computeds/viewAllDocumentsHelper';
 import { workQueueHelper } from './computeds/workQueueHelper';
@@ -195,6 +196,7 @@ const helpers = {
   trialSessionsHelper,
   trialSessionsSummaryHelper,
   updateCaseModalHelper,
+  userContactEditHelper,
   userContactEditProgressHelper,
   viewAllDocumentsHelper,
   workQueueHelper,

--- a/web-client/src/views/Practitioners/PractitionerContactForm.jsx
+++ b/web-client/src/views/Practitioners/PractitionerContactForm.jsx
@@ -109,7 +109,6 @@ export const PractitionerContactForm = connect(
             </FormGroup>
           </div>
         </div>
-
         {createPractitionerUserHelper.isAddingPractitioner && (
           <FormGroup errorText={validationErrors.email}>
             <label className="usa-label" htmlFor="email">

--- a/web-client/src/views/UserContactEdit.jsx
+++ b/web-client/src/views/UserContactEdit.jsx
@@ -1,5 +1,6 @@
 import { Button } from '../ustc-ui/Button/Button';
 import { ErrorNotification } from './ErrorNotification';
+import { FormGroup } from '../ustc-ui/FormGroup/FormGroup';
 import { Hint } from '../ustc-ui/Hint/Hint';
 import { UserContactEditForm } from './UserContactEditForm';
 import { connect } from '@cerebral/react';
@@ -12,11 +13,15 @@ export const UserContactEdit = connect(
     navigateBackSequence: sequences.navigateBackSequence,
     submitUpdateUserContactInformationSequence:
       sequences.submitUpdateUserContactInformationSequence,
+    updateFormValueSequence: sequences.updateFormValueSequence,
+    userContactEditHelper: state.userContactEditHelper,
   },
   function UserContactEdit({
     form,
     navigateBackSequence,
     submitUpdateUserContactInformationSequence,
+    updateFormValueSequence,
+    userContactEditHelper,
   }) {
     return (
       <>
@@ -46,6 +51,27 @@ export const UserContactEdit = connect(
                 {form.name} ({form.barNumber})
               </p>
             </div>
+            {userContactEditHelper.showFirmName && (
+              <FormGroup>
+                <label className="usa-label" htmlFor="firmName">
+                  Firm name <span className="usa-hint">(optional)</span>
+                </label>
+                <input
+                  autoCapitalize="none"
+                  className="usa-input"
+                  id="firmName"
+                  name="firmName"
+                  type="text"
+                  value={form.firmName || ''}
+                  onChange={e => {
+                    updateFormValueSequence({
+                      key: e.target.name,
+                      value: e.target.value,
+                    });
+                  }}
+                />
+              </FormGroup>
+            )}
             <UserContactEditForm
               bind="form"
               changeCountryTypeSequenceName="countryTypeUserContactChangeSequence"


### PR DESCRIPTION
Displaying the Firm Name input box for privatePractitioners on the edit contact information page.  This required adding in some logic to the proxy & interaction to handle updates to only the firmName by itself so that it didn't go and generate changeOfAddress pdfs.

![Screen Shot 2021-04-15 at 5 16 28 PM](https://user-images.githubusercontent.com/1868782/114939362-518f2b00-9e0e-11eb-802a-46f30d523107.png)
