### PR TITLE
8156 - Bug - Trial Session Download Logging

### DIFF
--- a/shared/src/business/useCases/trialSessions/batchDownloadTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/batchDownloadTrialSessionInteractor.js
@@ -19,7 +19,7 @@ const { UnauthorizedError } = require('../../../errors/errors');
  */
 const batchDownloadTrialSessionInteractor = async (
   applicationContext,
-  { trialSessionId },
+  { trialSessionId, verifyFiles = false },
 ) => {
   const user = applicationContext.getCurrentUser();
 
@@ -89,17 +89,19 @@ const batchDownloadTrialSessionInteractor = async (
         (myDoc = documentMap[aDocketRecord.docketEntryId])
       ) {
         // check that all file exists before continuing
-        const isFileExists = await applicationContext
-          .getPersistenceGateway()
-          .isFileExists({
-            applicationContext,
-            key: aDocketRecord.docketEntryId,
-          });
+        if (verifyFiles) {
+          const isFileExists = await applicationContext
+            .getPersistenceGateway()
+            .isFileExists({
+              applicationContext,
+              key: aDocketRecord.docketEntryId,
+            });
 
-        if (!isFileExists) {
-          throw new Error(
-            `Batch Download Error: File ${aDocketRecord.docketEntryId} for case ${caseToBatch.docketNumber} does not exist!`,
-          );
+          if (!isFileExists) {
+            throw new Error(
+              `Batch Download Error: File ${aDocketRecord.docketEntryId} for case ${caseToBatch.docketNumber} does not exist!`,
+            );
+          }
         }
 
         const docDate = formatDateString(
@@ -258,11 +260,12 @@ const batchDownloadTrialSessionInteractor = async (
  */
 exports.batchDownloadTrialSessionInteractor = async (
   applicationContext,
-  { trialSessionId },
+  { trialSessionId, verifyFiles = false },
 ) => {
   try {
     await batchDownloadTrialSessionInteractor(applicationContext, {
       trialSessionId,
+      verifyFiles,
     });
   } catch (error) {
     const { userId } = applicationContext.getCurrentUser();

--- a/shared/src/business/useCases/trialSessions/batchDownloadTrialSessionInteractor.test.js
+++ b/shared/src/business/useCases/trialSessions/batchDownloadTrialSessionInteractor.test.js
@@ -107,9 +107,10 @@ describe('batchDownloadTrialSessionInteractor', () => {
     });
   });
 
-  it('checks that the files to be zipped exist in persistence', async () => {
+  it('checks that the files to be zipped exist in persistence when verifyFiles param is true', async () => {
     await batchDownloadTrialSessionInteractor(applicationContext, {
       trialSessionId: '123',
+      verifyFiles: true,
     });
 
     expect(
@@ -117,7 +118,48 @@ describe('batchDownloadTrialSessionInteractor', () => {
     ).toHaveBeenCalledTimes(2);
   });
 
-  it('throws an error if a file to be zipped does not exist in persistence', async () => {
+  it('throws an error if a file to be zipped does not exist in persistence when verifyFiles param is true', async () => {
+    applicationContext
+      .getPersistenceGateway()
+      .isFileExists.mockResolvedValue(false);
+
+    await batchDownloadTrialSessionInteractor(applicationContext, {
+      trialSessionId: '123',
+      verifyFiles: true,
+    });
+
+    const errorCall = applicationContext.getNotificationGateway()
+      .sendNotificationToUser.mock.calls[0];
+
+    expect(
+      applicationContext.getPersistenceGateway().isFileExists,
+    ).toHaveBeenCalled();
+    expect(errorCall).toBeTruthy();
+    expect(errorCall[0].message.error.message).toEqual(
+      `Batch Download Error: File ${mockCase.docketEntries[0].docketEntryId} for case ${mockCase.docketNumber} does not exist!`,
+    );
+  });
+
+  it('does not check for missing files or throw an associated error if a file to be zipped does not exist in persistence when verifyFiles param is false', async () => {
+    applicationContext
+      .getPersistenceGateway()
+      .isFileExists.mockResolvedValue(false);
+
+    await batchDownloadTrialSessionInteractor(applicationContext, {
+      trialSessionId: '123',
+      verifyFiles: false,
+    });
+
+    const errorCall = applicationContext.getNotificationGateway()
+      .sendNotificationToUser.mock.calls[0];
+
+    expect(
+      applicationContext.getPersistenceGateway().isFileExists,
+    ).not.toHaveBeenCalled();
+    expect(errorCall[0].message.error).toBeUndefined();
+  });
+
+  it('does not check for missing files or throw an associated error if a file to be zipped does not exist in persistence when verifyFiles param is undefined', async () => {
     applicationContext
       .getPersistenceGateway()
       .isFileExists.mockResolvedValue(false);
@@ -129,10 +171,10 @@ describe('batchDownloadTrialSessionInteractor', () => {
     const errorCall = applicationContext.getNotificationGateway()
       .sendNotificationToUser.mock.calls[0];
 
-    expect(errorCall).toBeTruthy();
-    expect(errorCall[0].message.error.message).toEqual(
-      `Batch Download Error: File ${mockCase.docketEntries[0].docketEntryId} for case ${mockCase.docketNumber} does not exist!`,
-    );
+    expect(
+      applicationContext.getPersistenceGateway().isFileExists,
+    ).not.toHaveBeenCalled();
+    expect(errorCall[0].message.error).toBeUndefined();
   });
 
   it('throws an Unauthorized error if the user role is not allowed to access the method', async () => {

--- a/web-api/src/trialSessions/batchDownloadTrialSessionLambda.js
+++ b/web-api/src/trialSessions/batchDownloadTrialSessionLambda.js
@@ -9,10 +9,12 @@ const { genericHandler } = require('../genericHandler');
 exports.batchDownloadTrialSessionLambda = event =>
   genericHandler(event, async ({ applicationContext }) => {
     const { trialSessionId } = event.pathParameters || event.path;
+    const { verifyFiles } = JSON.parse(event.body);
 
     return await applicationContext
       .getUseCases()
       .batchDownloadTrialSessionInteractor(applicationContext, {
         trialSessionId,
+        verifyFiles,
       });
   });


### PR DESCRIPTION
https://github.com/ustaxcourt/ef-cms/pull/1104

> We've discovered that when testing this on very large trial sessions with cases with lots of docket entries, this process is a bit slow. One option was to add some kind of indicator that this is being done, but after chatting with @klohman about it, it seemed like doing this step on every download was impacting users far more than the few that will fail.
> 
> There was already better error handling / logging in a previous issue related to downloads, the intent of these code changes on top of that was for diagnosing when cases fail due to unreachable documents - something that did happen, but should not happen that often.
> 
> To both provide a better user experience and preserve the diagnostic value in checking the files first that logging was left in place in this PR, but wrapped in a conditional that can be passed via a REST client on an offending trial session to generate better logs in the system.