### PR TITLE
Fix v1 and v2 Case API to match Docs

### DIFF
--- a/web-api/src/v1/getCaseLambda.test.js
+++ b/web-api/src/v1/getCaseLambda.test.js
@@ -1,10 +1,4 @@
 const createApplicationContext = require('../applicationContext');
-const {
-  CONTACT_TYPES,
-} = require('../../../shared/src/business/entities/EntityConstants');
-const {
-  getContactPrimary,
-} = require('../../../shared/src/business/entities/cases/Case');
 const { getCaseLambda } = require('./getCaseLambda');
 const { MOCK_CASE } = require('../../../shared/src/test/mockCase');
 const { MOCK_USERS } = require('../../../shared/src/test/mockUsers');
@@ -102,12 +96,9 @@ describe('getCaseLambda', () => {
       expect.any(String),
     );
     expect(JSON.parse(response.body).assignedJudge).toBeUndefined();
-
-    const contactPrimary = getContactPrimary(JSON.parse(response.body));
-
-    expect(contactPrimary.address1).toBeUndefined();
-    expect(contactPrimary.name).toBeDefined();
-    expect(contactPrimary.state).toBeDefined();
+    expect(JSON.parse(response.body).contactPrimary.address1).toBeUndefined();
+    expect(JSON.parse(response.body).contactPrimary.name).toBeDefined();
+    expect(JSON.parse(response.body).contactPrimary.state).toBeDefined();
     expect(JSON.parse(response.body).noticeOfTrialDate).toBeUndefined();
     expect(JSON.parse(response.body).status).toBeUndefined();
     expect(JSON.parse(response.body).trialLocation).toBeUndefined();
@@ -165,6 +156,8 @@ describe('getCaseLambda', () => {
   });
 
   it('returns the case in v1 format', async () => {
+    // Careful! Changing this test would mean that the v1 format is changing;
+    // this would mean breaking changes for any user of the v1 API
     const user = MOCK_USERS['b7d90c05-f6cd-442c-a168-202db587f16f'];
     const applicationContext = createSilentAppContext(user);
 
@@ -187,24 +180,21 @@ describe('getCaseLambda', () => {
     expect(JSON.parse(response.body)).toMatchObject({
       caseCaption: 'Test Petitioner, Petitioner',
       caseType: 'Other',
+      contactPrimary: {
+        address1: '123 Main St',
+        city: 'Somewhere',
+        email: 'petitioner@example.com',
+        name: 'Test Petitioner',
+        phone: '1234567',
+        postalCode: '12345',
+        state: 'TN',
+      },
       docketEntries: [],
       docketNumber: '101-18',
       docketNumberSuffix: null,
       filingType: 'Myself',
       noticeOfTrialDate: '2020-10-20T01:38:43.489Z',
       partyType: 'Petitioner',
-      petitioners: [
-        {
-          address1: '123 Main St',
-          city: 'Somewhere',
-          contactType: CONTACT_TYPES.primary,
-          email: 'petitioner@example.com',
-          name: 'Test Petitioner',
-          phone: '1234567',
-          postalCode: '12345',
-          state: 'TN',
-        },
-      ],
       practitioners: [],
       preferredTrialCity: 'Washington, District of Columbia',
       respondents: [],

--- a/web-api/src/v1/marshallers/marshallCase.js
+++ b/web-api/src/v1/marshallers/marshallCase.js
@@ -1,3 +1,7 @@
+const {
+  getContactPrimary,
+  getContactSecondary,
+} = require('../../../../shared/src/business/entities/cases/Case');
 const { marshallContact } = require('./marshallContact');
 const { marshallDocketEntry } = require('./marshallDocketEntry');
 const { marshallPractitioner } = require('./marshallPractitioner');
@@ -10,9 +14,17 @@ const { marshallPractitioner } = require('./marshallPractitioner');
  * @returns {object} the v1 representation of a case
  */
 exports.marshallCase = caseObject => {
+  const contactPrimary = getContactPrimary(caseObject) || undefined;
+  const contactSecondary = getContactSecondary(caseObject) || undefined;
   return {
     caseCaption: caseObject.caseCaption,
     caseType: caseObject.caseType,
+    contactPrimary: contactPrimary
+      ? marshallContact(contactPrimary)
+      : undefined,
+    contactSecondary: contactSecondary
+      ? marshallContact(contactSecondary)
+      : undefined,
     docketEntries: (caseObject.docketEntries || []).map(marshallDocketEntry),
     docketNumber: caseObject.docketNumber,
     docketNumberSuffix: caseObject.docketNumberSuffix,
@@ -20,7 +32,6 @@ exports.marshallCase = caseObject => {
     leadDocketNumber: caseObject.leadDocketNumber,
     noticeOfTrialDate: caseObject.noticeOfTrialDate,
     partyType: caseObject.partyType,
-    petitioners: (caseObject.petitioners || []).map(marshallContact),
     practitioners: (caseObject.privatePractitioners || []).map(
       marshallPractitioner,
     ),

--- a/web-api/src/v1/marshallers/marshallCase.test.js
+++ b/web-api/src/v1/marshallers/marshallCase.test.js
@@ -12,6 +12,8 @@ describe('marshallCase', () => {
     expect(Object.keys(marshallCase(MOCK_CASE)).sort()).toEqual([
       'caseCaption',
       'caseType',
+      'contactPrimary',
+      'contactSecondary',
       'docketEntries',
       'docketNumber',
       'docketNumberSuffix',
@@ -19,7 +21,6 @@ describe('marshallCase', () => {
       'leadDocketNumber',
       'noticeOfTrialDate',
       'partyType',
-      'petitioners',
       'practitioners',
       'preferredTrialCity',
       'respondents',
@@ -58,7 +59,8 @@ describe('marshallCase', () => {
     expect(mock.sortableDocketNumber).toBeDefined();
     expect(mock.status).toBeDefined();
     expect(mock.trialLocation).toBeDefined();
-
+    expect(mock.contactPrimary).not.toBeDefined();
+    expect(mock.contactSecondary).not.toBeDefined();
     expect(mock.petitioners).toBeDefined();
     expect(mock.docketEntries).toBeDefined();
     expect(mock.irsPractitioners).toBeDefined();
@@ -80,8 +82,8 @@ describe('marshallCase', () => {
     expect(marshalled.trialLocation).toEqual(mock.trialLocation);
 
     // Exact format asserted in other tests.
-    expect(marshalled.petitioners).toBeDefined();
-    expect(marshalled.petitioners.length).toEqual(2);
+    expect(marshalled.contactPrimary).toBeDefined();
+    expect(marshalled.contactSecondary).toBeDefined();
     expect(marshalled.docketEntries).toBeDefined();
     expect(marshalled.practitioners).toBeDefined();
     expect(marshalled.respondents).toBeDefined();

--- a/web-api/src/v2/marshallers/marshallCase.js
+++ b/web-api/src/v2/marshallers/marshallCase.js
@@ -1,6 +1,11 @@
+const {
+  getContactPrimary,
+  getContactSecondary,
+} = require('../../../../shared/src/business/entities/cases/Case');
 const { marshallContact } = require('./marshallContact');
 const { marshallDocketEntry } = require('./marshallDocketEntry');
 const { marshallPractitioner } = require('./marshallPractitioner');
+
 
 /**
  * The returned object is specified by the v2 API and any changes to these properties
@@ -10,16 +15,23 @@ const { marshallPractitioner } = require('./marshallPractitioner');
  * @returns {object} the v2 representation of a case
  */
 exports.marshallCase = caseObject => {
+  const contactPrimary = getContactPrimary(caseObject) || undefined;
+  const contactSecondary = getContactSecondary(caseObject) || undefined;
   return {
     caseCaption: caseObject.caseCaption,
     caseType: caseObject.caseType,
+    contactPrimary: contactPrimary
+      ? marshallContact(contactPrimary)
+      : undefined,
+    contactSecondary: contactSecondary
+      ? marshallContact(contactSecondary)
+      : undefined,
     docketEntries: (caseObject.docketEntries || []).map(marshallDocketEntry),
     docketNumber: caseObject.docketNumber,
     docketNumberSuffix: caseObject.docketNumberSuffix,
     filingType: caseObject.filingType,
     leadDocketNumber: caseObject.leadDocketNumber,
     partyType: caseObject.partyType,
-    petitioners: (caseObject.petitioners || []).map(marshallContact),
     practitioners: (caseObject.privatePractitioners || []).map(
       marshallPractitioner,
     ),

--- a/web-api/src/v2/marshallers/marshallCase.test.js
+++ b/web-api/src/v2/marshallers/marshallCase.test.js
@@ -12,13 +12,14 @@ describe('marshallCase', () => {
     expect(Object.keys(marshallCase(MOCK_CASE)).sort()).toEqual([
       'caseCaption',
       'caseType',
+      'contactPrimary',
+      'contactSecondary',
       'docketEntries',
       'docketNumber',
       'docketNumberSuffix',
       'filingType',
       'leadDocketNumber',
       'partyType',
-      'petitioners',
       'practitioners',
       'preferredTrialCity',
       'respondents',
@@ -61,7 +62,8 @@ describe('marshallCase', () => {
     expect(mock.status).toBeDefined();
     expect(mock.trialDate).toBeDefined();
     expect(mock.trialLocation).toBeDefined();
-
+    expect(mock.contactPrimary).not.toBeDefined();
+    expect(mock.contactSecondary).not.toBeDefined();
     expect(mock.petitioners).toBeDefined();
     expect(mock.docketEntries).toBeDefined();
     expect(mock.irsPractitioners).toBeDefined();
@@ -82,9 +84,9 @@ describe('marshallCase', () => {
     expect(marshalled.trialDate).toEqual(mock.trialDate);
     expect(marshalled.trialLocation).toEqual(mock.trialLocation);
 
-    // Exact format asserted in other tests.
-    expect(marshalled.petitioners).toBeDefined();
-    expect(marshalled.petitioners.length).toEqual(2);
+    // Exact format asserted in other tests. 
+    expect(marshalled.contactPrimary).toBeDefined();
+    expect(marshalled.contactSecondary).toBeDefined();
     expect(marshalled.docketEntries).toBeDefined();
     expect(marshalled.practitioners).toBeDefined();
     expect(marshalled.respondents).toBeDefined();


### PR DESCRIPTION
The refactoring would have caused breaking changes to the v1 and v2 API switching contactPrimary and contactSecondary to the petitioners array format. This PR ensures that the case objects are marshaled back to the format that the docs specify. 