### PR TITLE
8101: reapply the 'focusable' class to the progressbar

### DIFF
--- a/web-client/src/ustc-ui/ProgressBar/ProgressBar.jsx
+++ b/web-client/src/ustc-ui/ProgressBar/ProgressBar.jsx
@@ -10,7 +10,7 @@ export const ProgressBar = props => {
 
   return (
     <progress
-      className="usa-sr-only"
+      className="focusable usa-sr-only"
       max="100"
       tabIndex="-1"
       value={value}


### PR DESCRIPTION
Re-apply the 'focusable' class to the progress element to ensure that the `<Focus>` element can do its job.