### PR TITLE
7552: sort trial session cases for report according to docket number

### DIFF
--- a/shared/src/business/useCases/trialSessions/generateTrialCalendarPdfInteractor.js
+++ b/shared/src/business/useCases/trialSessions/generateTrialCalendarPdfInteractor.js
@@ -1,7 +1,9 @@
 const {
+  compareCasesByDocketNumber,
+} = require('../../utilities/getFormattedTrialSessionDetails');
+const {
   saveFileAndGenerateUrl,
 } = require('../../useCaseHelper/saveFileAndGenerateUrl');
-const { compareStrings } = require('../../utilities/sortFunctions');
 
 /**
  * generateTrialCalendarPdfInteractor
@@ -92,14 +94,10 @@ const getPractitionerName = practitioner => {
   return `${name}${barNumberFormatted}`;
 };
 
-const byCreatedAt = (a, b) => {
-  return compareStrings(a.createdAt, b.createdAt);
-};
-
 exports.formatCases = ({ applicationContext, calendaredCases }) => {
   const formattedOpenCases = calendaredCases
     .filter(calendaredCase => !calendaredCase.removedFromTrial)
-    .sort(byCreatedAt)
+    .sort(compareCasesByDocketNumber)
     .map(openCase => {
       return {
         caseTitle: applicationContext.getCaseTitle(openCase.caseCaption || ''),

--- a/shared/src/business/useCases/trialSessions/generateTrialCalendarPdfInteractor.test.js
+++ b/shared/src/business/useCases/trialSessions/generateTrialCalendarPdfInteractor.test.js
@@ -115,7 +115,7 @@ describe('generateTrialCalendarPdfInteractor', () => {
   });
 
   describe('format cases', () => {
-    it('should filter out cases not removed from trial', () => {
+    it('should filter out cases that have been removed from trial', () => {
       const result = formatCases({
         applicationContext,
         calendaredCases: mockCases,

--- a/shared/src/business/useCases/trialSessions/generateTrialCalendarPdfInteractor.test.js
+++ b/shared/src/business/useCases/trialSessions/generateTrialCalendarPdfInteractor.test.js
@@ -10,22 +10,20 @@ const { US_STATES } = require('../../entities/EntityConstants');
 
 describe('generateTrialCalendarPdfInteractor', () => {
   const mockPdfUrl = { url: 'www.example.com' };
+  // deliberately *not* automatically sorted by docket number for test purposes
   const mockCases = [
     {
       ...MOCK_CASE,
-      createdAt: '2013-03-01T21:40:46.415Z',
-      docketNumber: '101-18',
-      docketNumberWithSuffix: '101-18',
-    },
-    {
-      ...MOCK_CASE,
-      createdAt: '2011-01-01T21:40:46.415Z',
       docketNumber: '102-19',
       docketNumberWithSuffix: '102-19W',
     },
     {
       ...MOCK_CASE,
-      createdAt: '2012-02-01T21:40:46.415Z',
+      docketNumber: '101-18',
+      docketNumberWithSuffix: '101-18',
+    },
+    {
+      ...MOCK_CASE,
       docketNumber: '123-20',
       docketNumberWithSuffix: '123-20W',
       removedFromTrial: true,
@@ -123,13 +121,13 @@ describe('generateTrialCalendarPdfInteractor', () => {
       expect(mockCases.find(m => m.removedFromTrial)).toBeTruthy(); // there is a case in the mocks which is removed from trial
       expect(result.find(m => m.docketNumber === '123-20')).toBeFalsy();
     });
-    it('should sort cases by ascending date using createdAt', () => {
+    it('should sort cases by ascending docket number', () => {
       const result = formatCases({
         applicationContext,
         calendaredCases: mockCases,
       });
-      expect(result[0].docketNumber).toBe('102-19');
-      expect(result[1].docketNumber).toBe('101-18');
+      expect(result[0].docketNumber).toBe('101-18');
+      expect(result[1].docketNumber).toBe('102-19');
     });
   });
 

--- a/shared/src/business/utilities/getFormattedTrialSessionDetails.js
+++ b/shared/src/business/utilities/getFormattedTrialSessionDetails.js
@@ -1,4 +1,4 @@
-const { compact, isEmpty, isEqual } = require('lodash');
+const { compact, isEmpty, isEqual, partition } = require('lodash');
 
 exports.formatCase = ({ applicationContext, caseItem }) => {
   caseItem.docketNumberWithSuffix = `${caseItem.docketNumber}${
@@ -73,10 +73,8 @@ exports.formattedTrialSessionDetails = ({
     .map(caseItem => exports.formatCase({ applicationContext, caseItem }))
     .sort(exports.compareCasesByDocketNumber);
 
-  trialSession.openCases = trialSession.allCases.filter(
-    item => item.removedFromTrial !== true,
-  );
-  trialSession.inactiveCases = trialSession.allCases.filter(
+  [trialSession.inactiveCases, trialSession.openCases] = partition(
+    trialSession.allCases,
     item => item.removedFromTrial === true,
   );
 

--- a/web-client/src/presenter/actions/setMessageDetailViewerDocumentToDisplayAction.js
+++ b/web-client/src/presenter/actions/setMessageDetailViewerDocumentToDisplayAction.js
@@ -68,10 +68,8 @@ export const setMessageDetailViewerDocumentToDisplayAction = async ({
   store.set(state.viewerDocumentToDisplay, viewerDocumentToDisplay);
 
   if (
-    viewerDocumentToDisplay &&
-    viewerDocumentToDisplay.documentId &&
-    mostRecentMessage.attachments &&
-    mostRecentMessage.attachments.length
+    viewerDocumentToDisplay?.documentId &&
+    mostRecentMessage.attachments?.length
   ) {
     const formattedAttachment = setAttachmentToDisplay(
       applicationContext,


### PR DESCRIPTION
Refactored to permit separate testing of case filtering and sorting;
Changed persistence to immediately fetch all case info before composing the result rather than awaiting each call.