### PR TITLE
8178 - Revert preserveWhitespace option in quill to test

### DIFF
--- a/web-client/src/views/CreateOrder/TextEditor.jsx
+++ b/web-client/src/views/CreateOrder/TextEditor.jsx
@@ -77,7 +77,6 @@ export const TextEditor = ({
               ],
             ],
           }}
-          preserveWhitespace={true}
           tabIndex={0}
           onChange={(content, delta, source, editor) => {
             const fullDelta = editor.getContents();


### PR DESCRIPTION
This reverts a fix to another bug (https://github.com/flexion/ef-cms/issues/8033) in an effort to identify if its the source of some odd behavior when pasting from Word documents.

The preserveWhitespace option adds `<pre>` tags around the block to try and preserve formatting. We've tried various ways to identify _what_ formatting is coming in from Word to make things look off, but were unsuccessful. Also, this is not reproducible when opening the Word document on a Mac in Pages or OpenOffice.