### PR TITLE
Irs api change prevention

### DIFF
--- a/web-api/src/v1/getCaseLambda.test.js
+++ b/web-api/src/v1/getCaseLambda.test.js
@@ -31,7 +31,7 @@ const createSilentAppContext = user => {
   return applicationContext;
 };
 
-describe('getCaseLambda', () => {
+describe('getCaseLambda (which fails if version increase is needed, DO NOT CHANGE TESTS)', () => {
   let CI;
   // disable logging by mimicking CI for this test
   beforeAll(() => {

--- a/web-api/src/v1/marshallers/marshallCase.test.js
+++ b/web-api/src/v1/marshallers/marshallCase.test.js
@@ -7,7 +7,7 @@ const {
 const { marshallCase } = require('./marshallCase');
 const { MOCK_CASE } = require('../../../../shared/src/test/mockCase');
 
-describe('marshallCase', () => {
+describe('marshallCase (which fails if version increase is needed, DO NOT CHANGE TESTS)', () => {
   it('returns a case object with the expected properties', () => {
     expect(Object.keys(marshallCase(MOCK_CASE)).sort()).toEqual([
       'caseCaption',

--- a/web-api/src/v2/getCaseLambda.test.js
+++ b/web-api/src/v2/getCaseLambda.test.js
@@ -66,7 +66,7 @@ const createSilentAppContext = user => {
   return applicationContext;
 };
 
-describe('getCaseLambda', () => {
+describe('getCaseLambda (which fails if version increase is needed, DO NOT CHANGE TESTS)', () => {
   let CI;
   // disable logging by mimicking CI for this test
   beforeAll(() => {

--- a/web-api/src/v2/marshallers/marshallCase.test.js
+++ b/web-api/src/v2/marshallers/marshallCase.test.js
@@ -7,7 +7,7 @@ const {
 const { marshallCase } = require('./marshallCase');
 const { MOCK_CASE } = require('../../../../shared/src/test/mockCase');
 
-describe('marshallCase', () => {
+describe('marshallCase (which fails if version increase is needed, DO NOT CHANGE TESTS)', () => {
   it('returns a case object with the expected properties', () => {
     expect(Object.keys(marshallCase(MOCK_CASE)).sort()).toEqual([
       'caseCaption',


### PR DESCRIPTION
- added comment to test describe so if they fail, we know not to change the tests if the entity is changed => increase the version instead