### PR TITLE
V2 api add firm name

### DIFF
--- a/docs/api/v2.yaml
+++ b/docs/api/v2.yaml
@@ -271,6 +271,7 @@ components:
           example: privatePractitioner1@example.com
         firmName:
           type: string
+          example: Some Firm
         name:
           type: string
           example: Test private practitioner1

--- a/docs/api/v2.yaml
+++ b/docs/api/v2.yaml
@@ -269,6 +269,8 @@ components:
         email:
           type: string
           example: privatePractitioner1@example.com
+        firmName:
+          type: string
         name:
           type: string
           example: Test private practitioner1

--- a/web-api/src/v2/getCaseLambda.test.js
+++ b/web-api/src/v2/getCaseLambda.test.js
@@ -247,6 +247,7 @@ describe('getCaseLambda (which fails if version increase is needed, DO NOT CHANG
             state: 'IL',
           },
           email: 'ab@example.com',
+          firmName: 'GW Law Offices',
           name: 'Test Attorney',
           serviceIndicator: 'Paper',
         },

--- a/web-api/src/v2/marshallers/marshallPractitioner.js
+++ b/web-api/src/v2/marshallers/marshallPractitioner.js
@@ -14,6 +14,7 @@ exports.marshallPractitioner = practitionerObject => {
       ? marshallContact(practitionerObject.contact)
       : undefined,
     email: practitionerObject.email,
+    firmName: practitionerObject.firmName,
     name: practitionerObject.name,
     serviceIndicator: practitionerObject.serviceIndicator,
   };

--- a/web-api/src/v2/marshallers/marshallPractitioner.js
+++ b/web-api/src/v2/marshallers/marshallPractitioner.js
@@ -14,7 +14,7 @@ exports.marshallPractitioner = practitionerObject => {
       ? marshallContact(practitionerObject.contact)
       : undefined,
     email: practitionerObject.email,
-    firmName: practitionerObject.firmName,
+    firmName: practitionerObject.firmName || '',
     name: practitionerObject.name,
     serviceIndicator: practitionerObject.serviceIndicator,
   };

--- a/web-api/src/v2/marshallers/marshallPractitioner.test.js
+++ b/web-api/src/v2/marshallers/marshallPractitioner.test.js
@@ -15,13 +15,21 @@ describe('marshallPractitioner', () => {
   it('returns a practitioner object with the expected properties', () => {
     expect(
       Object.keys(marshallPractitioner(MOCK_PRACTITIONER)).sort(),
-    ).toEqual(['barNumber', 'contact', 'email', 'name', 'serviceIndicator']);
+    ).toEqual([
+      'barNumber',
+      'contact',
+      'email',
+      'firmName',
+      'name',
+      'serviceIndicator',
+    ]);
   });
 
   it('marshalls from the current practitioner format', () => {
     const mock = Object.assign({}, MOCK_PRACTITIONER, {
       contact: MOCK_CONTACT,
       email: MOCK_CONTACT.email,
+      firmName: 'A Firm Example',
       serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
     });
 
@@ -29,6 +37,7 @@ describe('marshallPractitioner', () => {
     expect(mock.contact).toBeDefined();
     expect(mock.email).toBeDefined();
     expect(mock.name).toBeDefined();
+    expect(mock.firmName).toBeDefined();
     expect(mock.serviceIndicator).toBeDefined();
 
     const marshalled = marshallPractitioner(mock);
@@ -36,6 +45,7 @@ describe('marshallPractitioner', () => {
     expect(marshalled.barNumber).toEqual(mock.barNumber);
     expect(marshalled.email).toEqual(mock.email);
     expect(marshalled.name).toEqual(mock.name);
+    expect(marshalled.firmName).toBeDefined();
     expect(marshalled.serviceIndicator).toEqual(mock.serviceIndicator);
 
     // Exact format asserted in other tests.


### PR DESCRIPTION
In order to include more information about a case, we have received a request to include `firmName` for a Practitioner in the Cases endpoint in the V2 API. This code adds Firm Name to the Practitioner Schema. The information was already readily available. This also updates the tests for the getCaseLambda as the firmName was specified in the mock data.

docs/api/v2.yaml is also updated to reflect the addition.

