### PR TITLE
7913: progress indicator for private practitioners

### DIFF
--- a/shared/src/business/useCases/users/generateChangeOfAddress.js
+++ b/shared/src/business/useCases/users/generateChangeOfAddress.js
@@ -53,15 +53,17 @@ exports.generateChangeOfAddress = async ({
     });
 
   let completedCases = 0;
-  await applicationContext.getNotificationGateway().sendNotificationToUser({
-    applicationContext,
-    message: {
-      action: `${websocketMessagePrefix}_contact_update_progress`,
-      completedCases,
-      totalCases: docketNumbers.length,
-    },
-    userId: requestUserId || user.userId,
-  });
+  if (docketNumbers.length > 0) {
+    await applicationContext.getNotificationGateway().sendNotificationToUser({
+      applicationContext,
+      message: {
+        action: `${websocketMessagePrefix}_contact_update_progress`,
+        completedCases,
+        totalCases: docketNumbers.length,
+      },
+      userId: requestUserId || user.userId,
+    });
+  }
 
   const updatedCases = [];
 

--- a/shared/src/business/useCases/users/generateChangeOfAddress.js
+++ b/shared/src/business/useCases/users/generateChangeOfAddress.js
@@ -52,18 +52,20 @@ exports.generateChangeOfAddress = async ({
       userId: user.userId,
     });
 
-  let completedCases = 0;
-  if (docketNumbers.length > 0) {
-    await applicationContext.getNotificationGateway().sendNotificationToUser({
-      applicationContext,
-      message: {
-        action: `${websocketMessagePrefix}_contact_update_progress`,
-        completedCases,
-        totalCases: docketNumbers.length,
-      },
-      userId: requestUserId || user.userId,
-    });
+  if (docketNumbers.length === 0) {
+    return [];
   }
+
+  let completedCases = 0;
+  await applicationContext.getNotificationGateway().sendNotificationToUser({
+    applicationContext,
+    message: {
+      action: `${websocketMessagePrefix}_contact_update_progress`,
+      completedCases,
+      totalCases: docketNumbers.length,
+    },
+    userId: requestUserId || user.userId,
+  });
 
   const updatedCases = [];
 

--- a/shared/src/business/useCases/users/generateChangeOfAddress.test.js
+++ b/shared/src/business/useCases/users/generateChangeOfAddress.test.js
@@ -170,6 +170,25 @@ describe('generateChangeOfAddress', () => {
     });
   });
 
+  it('should NOT send a notification to the user if they have no associated cases', async () => {
+    applicationContext
+      .getPersistenceGateway()
+      .getCasesByUserId.mockReturnValueOnce([]);
+
+    await generateChangeOfAddress({
+      applicationContext,
+      contactInfo: {
+        ...mockIrsPractitioner.contact,
+        address1: '234 Main St',
+      },
+      user: {},
+    });
+
+    expect(
+      applicationContext.getNotificationGateway().sendNotificationToUser,
+    ).not.toHaveBeenCalled();
+  });
+
   it('should calculate the number of pages in the generated change of address pdf', async () => {
     const mockNumberOfPages = 999;
     applicationContext

--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -1493,12 +1493,6 @@ module.exports = (appContextUser, logger = createLogger()) => {
         httpOptions: {
           timeout: 900000, // 15 minutes
         },
-        options: {
-          maxRetries: 3,
-          retryDelayOptions: {
-            base: 100,
-          },
-        },
       });
     },
     getNotificationGateway: () => ({

--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -1493,6 +1493,12 @@ module.exports = (appContextUser, logger = createLogger()) => {
         httpOptions: {
           timeout: 900000, // 15 minutes
         },
+        options: {
+          maxRetries: 3,
+          retryDelayOptions: {
+            base: 100,
+          },
+        },
       });
     },
     getNotificationGateway: () => ({

--- a/web-client/src/presenter/computeds/userContactEditProgressHelper.js
+++ b/web-client/src/presenter/computeds/userContactEditProgressHelper.js
@@ -3,10 +3,14 @@ import { state } from 'cerebral';
 export const userContactEditProgressHelper = get => {
   const completedCases = get(state.userContactEditProgress.completedCases) || 0;
   const totalCases = get(state.userContactEditProgress.totalCases) || 0;
+  const percentComplete =
+    completedCases && totalCases
+      ? Math.floor((completedCases * 100) / totalCases)
+      : 0;
 
   return {
     completedCases,
-    percentComplete: Math.floor((completedCases * 100) / totalCases),
+    percentComplete,
     totalCases,
   };
 };

--- a/web-client/src/presenter/computeds/userContactEditProgressHelper.test.js
+++ b/web-client/src/presenter/computeds/userContactEditProgressHelper.test.js
@@ -26,7 +26,33 @@ describe('userContactEditProgressHelper', () => {
     });
     expect(result).toMatchObject({
       completedCases: 0,
-      percentComplete: NaN,
+      percentComplete: 0,
+      totalCases: 0,
+    });
+  });
+
+  it('returns zero percent if completed cases are zero', () => {
+    const result = runCompute(userContactEditProgressHelper, {
+      state: {
+        userContactEditProgress: { completedCases: 0 },
+      },
+    });
+    expect(result).toMatchObject({
+      completedCases: 0,
+      percentComplete: 0,
+      totalCases: 0,
+    });
+  });
+
+  it('returns zero percent if total cases are zero', () => {
+    const result = runCompute(userContactEditProgressHelper, {
+      state: {
+        userContactEditProgress: { totalCases: 0 },
+      },
+    });
+    expect(result).toMatchObject({
+      completedCases: 0,
+      percentComplete: 0,
       totalCases: 0,
     });
   });

--- a/web-client/src/providers/socket.js
+++ b/web-client/src/providers/socket.js
@@ -42,10 +42,9 @@ export const socketProvider = ({ socketRouter }) => {
           if (applicationContext) {
             applicationContext.logger.error(
               'Failed to establish WebSocket connection',
-              e,
+              { e },
             );
           }
-          console.error(e);
           reject();
         }
       });

--- a/web-client/src/providers/socket.js
+++ b/web-client/src/providers/socket.js
@@ -22,37 +22,34 @@ export const socketProvider = ({ socketRouter }) => {
 
   const start = () => {
     const token = app.getState('token');
+    if (!socket) {
+      return new Promise((resolve, reject) => {
+        try {
+          socket = createWebSocketClient(token);
+          socket.onmessage = socketRouter(app);
+          socket.onerror = error => {
+            applicationContext.logger.error('Websocket error detected', error);
+            return reject(error);
+          };
 
-    if (socket && socket.close) {
-      stopSocket();
-    }
-
-    return new Promise((resolve, reject) => {
-      try {
-        socket = createWebSocketClient(token);
-        socket.onmessage = socketRouter(app);
-        socket.onerror = error => {
-          applicationContext.logger.error('Websocket error detected', error);
-          return reject(error);
-        };
-
-        socket.onopen = () => {
-          // the socket needs to be open for a short period or it could miss the first message
-          setTimeout(() => {
-            resolve();
-          }, 300);
-        };
-      } catch (e) {
-        if (applicationContext) {
-          applicationContext.logger.error(
-            'Failed to establish WebSocket connection',
-            e,
-          );
+          socket.onopen = () => {
+            // the socket needs to be open for a short period or it could miss the first message
+            setTimeout(() => {
+              resolve();
+            }, 300);
+          };
+        } catch (e) {
+          if (applicationContext) {
+            applicationContext.logger.error(
+              'Failed to establish WebSocket connection',
+              e,
+            );
+          }
+          console.error(e);
+          reject();
         }
-        console.error(e);
-        reject();
-      }
-    });
+      });
+    }
   };
 
   const initialize = (_app, _applicationContext) => {

--- a/web-client/src/providers/socket.js
+++ b/web-client/src/providers/socket.js
@@ -31,7 +31,10 @@ export const socketProvider = ({ socketRouter }) => {
       try {
         socket = createWebSocketClient(token);
         socket.onmessage = socketRouter(app);
-        socket.onerror = reject;
+        socket.onerror = error => {
+          applicationContext.logger.error('Websocket error detected', error);
+          return reject(error);
+        };
 
         socket.onopen = () => {
           // the socket needs to be open for a short period or it could miss the first message

--- a/web-client/src/providers/socket.test.js
+++ b/web-client/src/providers/socket.test.js
@@ -54,4 +54,12 @@ describe('socket', () => {
     expect(webSocketStub).toHaveBeenCalled();
     expect(webSocketCloseStub).toHaveBeenCalled();
   });
+
+  it('calling start twice returns the original socket rather than a second one', () => {
+    startSocket();
+    startSocket();
+
+    expect(webSocketStub).toBeCalledTimes(1);
+    expect(webSocketCloseStub).not.toHaveBeenCalled();
+  });
 });

--- a/web-client/src/providers/socketRouter.js
+++ b/web-client/src/providers/socketRouter.js
@@ -69,8 +69,6 @@ export const socketRouter = (app, onMessageCallbackFn) => {
           ...message,
         });
         break;
-      default:
-        console.info('unroutable socket action', action);
     }
 
     (onMessageCallbackFn || noop)(message);

--- a/web-client/src/providers/socketRouter.js
+++ b/web-client/src/providers/socketRouter.js
@@ -69,6 +69,8 @@ export const socketRouter = (app, onMessageCallbackFn) => {
           ...message,
         });
         break;
+      default:
+        console.info('unroutable socket action', action);
     }
 
     (onMessageCallbackFn || noop)(message);


### PR DESCRIPTION
prevent progress bar from showing if practitioner is updating *only* their firm name.
prevent "NaN%" from being displayed due to division-by-zero, instead show "0%" if this should ever be calculated.
Do not close & reopen sockets, which is one possible cause of socket messages being dropped and not processed by the application.