### PR TITLE
remove erroneous .logger calls in client

### DIFF
--- a/web-client/src/providers/socket.js
+++ b/web-client/src/providers/socket.js
@@ -28,7 +28,7 @@ export const socketProvider = ({ socketRouter }) => {
           socket = createWebSocketClient(token);
           socket.onmessage = socketRouter(app);
           socket.onerror = error => {
-            applicationContext.logger.error('Websocket error detected', error);
+            console.error(error);
             return reject(error);
           };
 
@@ -40,10 +40,7 @@ export const socketProvider = ({ socketRouter }) => {
           };
         } catch (e) {
           if (applicationContext) {
-            applicationContext.logger.error(
-              'Failed to establish WebSocket connection',
-              { e },
-            );
+            console.error(e);
           }
           reject();
         }


### PR DESCRIPTION
This fixes an issue introduced by https://github.com/ustaxcourt/ef-cms/pull/1219 where IRS Practitioners were unable to login to DAWSON. They were encountering an unhandled JavaScript error because `applicationContext.logger` is not defined in the client.

Related issue: https://github.com/flexion/ef-cms/issues/7913