### PR TITLE
Fix User Guide links from Blackstone to DAWSON

### DIFF
--- a/web-client/src/views/FileDocument/BeforeYouFileADocument.jsx
+++ b/web-client/src/views/FileDocument/BeforeYouFileADocument.jsx
@@ -77,7 +77,7 @@ export const BeforeYouFileADocument = connect(
                       format. For more information on mailing exhibits, see the{' '}
                       <a
                         className="usa-link--external"
-                        href="https://www.ustaxcourt.gov/resources/eaccess/Petitioners_Guide_to_eAccess_and_eFiling.pdf"
+                        href="https://ustaxcourt.gov/resources/dawson/DAWSON_Petitioner_Training_Guide.pdf"
                         rel="noopener noreferrer"
                         target="_blank"
                       >

--- a/web-client/src/views/FileDocument/WhatCanIIncludeModalOverlay.jsx
+++ b/web-client/src/views/FileDocument/WhatCanIIncludeModalOverlay.jsx
@@ -28,7 +28,7 @@ export const WhatCanIIncludeModalOverlay = connect(
               For more information on mailing attachments, see the{' '}
               <a
                 className="usa-link--external"
-                href="https://www.ustaxcourt.gov/resources/eaccess/Petitioners_Guide_to_eAccess_and_eFiling.pdf"
+                href="https://ustaxcourt.gov/resources/dawson/DAWSON_Petitioner_Training_Guide.pdf"
                 rel="noopener noreferrer"
                 target="_blank"
               >


### PR DESCRIPTION
Looks like we still had a few outdated links to eAaccess User Guides. When we removed those from our web site's S3 bucket, they began to 404. This PR updates the URLs to their proper locations.