### PR TITLE
7450: remove event listener

### DIFF
--- a/web-client/src/ustc-ui/Modal/BaseModal.jsx
+++ b/web-client/src/ustc-ui/Modal/BaseModal.jsx
@@ -45,21 +45,11 @@ export const BaseModal = connect(
     };
 
     useEffect(() => {
-      const touchmoveTriggered = event => {
-        return event.preventDefault();
-      };
-
       const toggleNoScroll = scrollingOn => {
         if (scrollingOn) {
           window.document.body.classList.add('no-scroll');
-          window.document.addEventListener('touchmove', touchmoveTriggered, {
-            passive: false,
-          });
         } else {
           window.document.body.classList.remove('no-scroll');
-          window.document.removeEventListener('touchmove', touchmoveTriggered, {
-            passive: false,
-          });
         }
       };
 


### PR DESCRIPTION
a listener was preventing touchmove scrolling on ipad (possibly others).  Original intent was to prevent the background from scrolling, but this is currently deemed a harmless price to pay so that these "tall" modals can scroll as desired for ipad users.

