### PR TITLE
7518 - Bug - Keep draft selected while on case

### DIFF
--- a/web-client/integration-tests/petitionsClerkViewsDraftDocuments.test.js
+++ b/web-client/integration-tests/petitionsClerkViewsDraftDocuments.test.js
@@ -1,0 +1,107 @@
+import { fakeFile, loginAs, setupTest, viewCaseDetail } from './helpers';
+import { formattedCaseDetail as formattedCaseDetailComputed } from '../src/presenter/computeds/formattedCaseDetail';
+import { petitionsClerkAddsOrderToCase } from './journey/petitionsClerkAddsOrderToCase';
+import { petitionsClerkCreatesNewCase } from './journey/petitionsClerkCreatesNewCase';
+import { petitionsClerkViewsDraftDocuments } from './journey/petitionsClerkViewsDraftDocuments';
+import { runCompute } from 'cerebral/test';
+import { withAppContextDecorator } from '../src/withAppContext';
+
+const formattedCaseDetail = withAppContextDecorator(
+  formattedCaseDetailComputed,
+);
+
+const test = setupTest();
+
+describe('Petitions Clerk Views Draft Documents', () => {
+  beforeAll(() => {
+    jest.setTimeout(30000);
+  });
+
+  afterAll(() => {
+    test.closeSocket();
+  });
+
+  loginAs(test, 'petitionsclerk@example.com');
+  petitionsClerkCreatesNewCase(test, fakeFile, 'Lubbock, Texas');
+
+  it('views case detail', async () => {
+    await viewCaseDetail({ docketNumber: test.docketNumber, test });
+  });
+
+  petitionsClerkAddsOrderToCase(test);
+  petitionsClerkAddsOrderToCase(test);
+  petitionsClerkViewsDraftDocuments(test, 2);
+
+  it('views the second document in the draft documents list', async () => {
+    // reset the draft documents view meta
+    test.setState('draftDocumentViewerDocketEntryId', null);
+
+    await test.runSequence('gotoCaseDetailSequence', {
+      docketNumber: test.docketNumber,
+      primaryTab: 'drafts',
+    });
+
+    expect(
+      test.getState(
+        'currentViewMetadata.caseDetail.caseDetailInternalTabs.drafts',
+      ),
+    ).toEqual(true);
+
+    // this gets fired when the component is mounted, so it is being explicitly called here
+    await test.runSequence('loadDefaultDraftViewerDocumentToDisplaySequence');
+
+    let formattedCase = runCompute(formattedCaseDetail, {
+      state: test.getState(),
+    });
+
+    let { draftDocuments } = formattedCase;
+
+    const viewerDraftDocumentIdToDisplay = test.getState(
+      'viewerDraftDocumentToDisplay.docketEntryId',
+    );
+    expect(viewerDraftDocumentIdToDisplay).toEqual(
+      draftDocuments[0].docketEntryId,
+    );
+
+    // select the second document in the list
+    await test.runSequence('setViewerDraftDocumentToDisplaySequence', {
+      viewerDraftDocumentToDisplay: draftDocuments[1],
+    });
+
+    expect(
+      test.getState('screenMetadata.draftDocumentViewerDocketEntryId'),
+    ).toEqual(draftDocuments[1].docketEntryId);
+
+    // change tabs and come back to draft documents
+
+    test.setState('currentViewMetadata.caseDetail.primaryTab', 'docketRecord');
+    await test.runSequence('setCaseDetailPrimaryTabSequence');
+
+    test.setState('currentViewMetadata.caseDetail.primaryTab', 'drafts');
+    await test.runSequence('setCaseDetailPrimaryTabSequence');
+
+    expect(
+      test.getState('screenMetadata.draftDocumentViewerDocketEntryId'),
+    ).toEqual(draftDocuments[1].docketEntryId);
+
+    //leave case and come back
+    await test.runSequence('gotoDashboardSequence');
+
+    await test.runSequence('gotoCaseDetailSequence', {
+      docketNumber: test.docketNumber,
+      primaryTab: 'drafts',
+    });
+
+    // this gets fired when the component is mounted, so it is being explicitly called here
+    await test.runSequence('loadDefaultDraftViewerDocumentToDisplaySequence');
+
+    formattedCase = runCompute(formattedCaseDetail, {
+      state: test.getState(),
+    });
+
+    // resets back to first document
+    expect(test.getState('viewerDraftDocumentToDisplay.docketEntryId')).toEqual(
+      formattedCase.draftDocuments[0].docketEntryId,
+    );
+  });
+});

--- a/web-client/src/presenter/actions/getDefaultDraftViewerDocumentToDisplayAction.js
+++ b/web-client/src/presenter/actions/getDefaultDraftViewerDocumentToDisplayAction.js
@@ -14,7 +14,10 @@ export const getDefaultDraftViewerDocumentToDisplayAction = ({
   applicationContext,
   get,
 }) => {
-  const draftDocketEntryId = get(state.draftDocumentViewerDocketEntryId);
+  const draftDocketEntryId =
+    get(state.draftDocumentViewerDocketEntryId) ||
+    get(state.screenMetadata.draftDocumentViewerDocketEntryId);
+
   const caseDetail = get(state.caseDetail);
   const { draftDocuments } = applicationContext
     .getUtilities()

--- a/web-client/src/presenter/actions/getDefaultDraftViewerDocumentToDisplayAction.test.js
+++ b/web-client/src/presenter/actions/getDefaultDraftViewerDocumentToDisplayAction.test.js
@@ -8,7 +8,7 @@ describe('getDefaultDraftViewerDocumentToDisplayAction', () => {
     presenter.providers.applicationContext = applicationContext;
   });
 
-  it('returns the first draft document as the default', async () => {
+  it('returns the first draft document as the default if state.screenMetadata.draftDocumentViewerDocketEntryId is not set', async () => {
     const result = await runAction(
       getDefaultDraftViewerDocumentToDisplayAction,
       {
@@ -91,6 +91,79 @@ describe('getDefaultDraftViewerDocumentToDisplayAction', () => {
             ],
           },
           draftDocumentViewerDocketEntryId: '345',
+        },
+      },
+    );
+    expect(result.output).toMatchObject({
+      viewerDraftDocumentToDisplay: { docketEntryId: '345' },
+    });
+  });
+
+  it('returns the correct document when state.draftDocumentViewerDocketEntryId is not set but state.screenMetadata.draftDocumentViewerDocketEntryId is', async () => {
+    const result = await runAction(
+      getDefaultDraftViewerDocumentToDisplayAction,
+      {
+        modules: {
+          presenter,
+        },
+        state: {
+          caseDetail: {
+            docketEntries: [
+              {
+                docketEntryId: '123',
+                documentType: 'Petition',
+              },
+              {
+                docketEntryId: '234',
+                documentType: 'Order',
+              },
+              {
+                docketEntryId: '345',
+                documentType: 'Notice',
+                isDraft: true,
+              },
+            ],
+          },
+          screenMetadata: {
+            draftDocumentViewerDocketEntryId: '345',
+          },
+        },
+      },
+    );
+    expect(result.output).toMatchObject({
+      viewerDraftDocumentToDisplay: { docketEntryId: '345' },
+    });
+  });
+
+  it('returns the correct document when state.draftDocumentViewerDocketEntryId is set along with state.screenMetadata.draftDocumentViewerDocketEntryId', async () => {
+    const result = await runAction(
+      getDefaultDraftViewerDocumentToDisplayAction,
+      {
+        modules: {
+          presenter,
+        },
+        state: {
+          caseDetail: {
+            docketEntries: [
+              {
+                docketEntryId: '123',
+                documentType: 'Petition',
+              },
+              {
+                docketEntryId: '234',
+                documentType: 'Order',
+              },
+              {
+                docketEntryId: '345',
+                documentType: 'Notice',
+                isDraft: true,
+              },
+            ],
+          },
+          draftDocumentViewerDocketEntryId: '345',
+          screenMetadata: {
+            draftDocumentViewerDocketEntryId: 'nope',
+          },
         },
       },
     );

--- a/web-client/src/presenter/actions/setViewerDraftDocumentToDisplayAction.js
+++ b/web-client/src/presenter/actions/setViewerDraftDocumentToDisplayAction.js
@@ -19,7 +19,13 @@ export const setViewerDraftDocumentToDisplayAction = async ({
   const docketNumber = get(state.caseDetail.docketNumber);
 
   store.set(state.viewerDraftDocumentToDisplay, viewerDraftDocumentToDisplay);
+
   if (viewerDraftDocumentToDisplay) {
+    store.set(
+      state.screenMetadata.draftDocumentViewerDocketEntryId,
+      viewerDraftDocumentToDisplay.docketEntryId,
+    );
+
     const {
       url,
     } = await applicationContext

--- a/web-client/src/presenter/actions/setViewerDraftDocumentToDisplayAction.test.js
+++ b/web-client/src/presenter/actions/setViewerDraftDocumentToDisplayAction.test.js
@@ -34,7 +34,27 @@ describe('setViewerDraftDocumentToDisplayAction', () => {
     expect(result.state.iframeSrc).toEqual('www.example.com');
   });
 
-  it('does not set iframeSrc if props.viewerDraftDocumentToDisplay is null', async () => {
+  it('sets the state.screenMetadata.draftDocumentViewerDocketEntryId from props on state from viewerDraftDocumentToDisplay if set', async () => {
+    const result = await runAction(setViewerDraftDocumentToDisplayAction, {
+      modules: {
+        presenter,
+      },
+      props: {
+        viewerDraftDocumentToDisplay: { docketEntryId: '1234' },
+      },
+      state: {
+        caseDetail: {
+          docketNumber: '123-45',
+        },
+        viewerDraftDocumentToDisplay: null,
+      },
+    });
+    expect(
+      result.state.screenMetadata.draftDocumentViewerDocketEntryId,
+    ).toEqual('1234');
+  });
+
+  it('does not set state.screenMetadata.draftDocumentViewerDocketEntryId or iframeSrc if props.viewerDraftDocumentToDisplay is null', async () => {
     const result = await runAction(setViewerDraftDocumentToDisplayAction, {
       modules: {
         presenter,
@@ -46,9 +66,13 @@ describe('setViewerDraftDocumentToDisplayAction', () => {
         caseDetail: {
           docketNumber: '123-45',
         },
+        screenMetadata: {},
         viewerDraftDocumentToDisplay: null,
       },
     });
     expect(result.state.iframeSrc).toBeUndefined();
+    expect(
+      result.state.screenMetadata.draftDocumentViewerDocketEntryId,
+    ).toBeUndefined();
   });
 });


### PR DESCRIPTION
When navigating within a case, this will keep the last selected draft document the default when returning to the Drafts tab. When leaving the case and coming back, it will default to the first document in the list.