### PR TITLE
Bug 7257: show 'Not Served' message for unserved docket entries on mobile 

### DIFF
--- a/web-client/src/views/DocketRecord/DocketRecordOverlay.jsx
+++ b/web-client/src/views/DocketRecord/DocketRecordOverlay.jsx
@@ -137,7 +137,10 @@ export const DocketRecordOverlay = connect(
               <p className="margin-top-0">{entry.action}</p>
               <p className="semi-bold label margin-top-3">Served</p>
               <p className="margin-top-0">
-                {entry.isStatusServed && <span>{entry.servedAtFormatted}</span>}
+                {entry.showNotServed && (
+                  <span className="text-semibold not-served">Not served</span>
+                )}
+                {entry.showServed && <span>{entry.servedAtFormatted}</span>}
               </p>
               <p className="semi-bold label margin-top-3">Parties</p>
               <p className="margin-top-0">{entry.servedPartiesCode}</p>


### PR DESCRIPTION
<img width="454" alt="Screen Shot 2021-05-26 at 2 49 03 PM" src="https://user-images.githubusercontent.com/43251054/119735812-bc7e4980-be31-11eb-910a-60c733416da2.png">
<img width="446" alt="Screen Shot 2021-05-26 at 2 48 46 PM" src="https://user-images.githubusercontent.com/43251054/119735817-bdaf7680-be31-11eb-921a-1bbb58b19a78.png">
