### PR TITLE
7585: document titles restricted length

### DIFF
--- a/web-client/src/presenter/computeds/selectDocumentTypeHelper.js
+++ b/web-client/src/presenter/computeds/selectDocumentTypeHelper.js
@@ -123,24 +123,29 @@ export const getOptionsForCategory = ({
   return options;
 };
 
+export const MAX_TITLE_LENGTH = 100;
+
 export const getPreviouslyFiledDocuments = (
   applicationContext,
   caseDetail,
   selectedDocketEntryId,
 ) => {
   const { INITIAL_DOCUMENT_TYPES } = applicationContext.getConstants();
+  const withDocumentTitle = doc => {
+    let documentTitle = applicationContext
+      .getUtilities()
+      .getDocumentTitleWithAdditionalInfo({ docketEntry: doc });
+    if (documentTitle && documentTitle.length > MAX_TITLE_LENGTH) {
+      documentTitle = documentTitle.substring(0, MAX_TITLE_LENGTH - 1) + '…';
+    }
+    return { ...doc, documentTitle };
+  };
+
   return caseDetail.docketEntries
     .filter(
       doc =>
         doc.documentType !== INITIAL_DOCUMENT_TYPES.stin.documentType &&
         doc.docketEntryId !== selectedDocketEntryId,
     )
-    .map(doc => {
-      return {
-        ...doc,
-        documentTitle: applicationContext
-          .getUtilities()
-          .getDocumentTitleWithAdditionalInfo({ docketEntry: doc }),
-      };
-    });
+    .map(withDocumentTitle);
 };

--- a/web-client/src/presenter/computeds/selectDocumentTypeHelper.test.js
+++ b/web-client/src/presenter/computeds/selectDocumentTypeHelper.test.js
@@ -1,10 +1,11 @@
 import { INITIAL_DOCUMENT_TYPES } from '../../../../shared/src/business/entities/EntityConstants';
-import { MOCK_CASE } from '../../../../shared/src/test/mockCase';
-import { applicationContext } from '../../../../shared/src/business/test/createTestApplicationContext';
 import {
+  MAX_TITLE_LENGTH,
   getOptionsForCategory,
   getPreviouslyFiledDocuments,
 } from './selectDocumentTypeHelper';
+import { MOCK_CASE } from '../../../../shared/src/test/mockCase';
+import { applicationContext } from '../../../../shared/src/business/test/createTestApplicationContext';
 
 describe('selectDocumentTypeHelper', () => {
   describe('getOptionsForCategory', () => {
@@ -352,6 +353,87 @@ describe('selectDocumentTypeHelper', () => {
           .mock.calls[0][0],
       ).toEqual({ docketEntry: mockExhibit });
       expect(result[0].documentTitle).toEqual('Exhibit(s) First');
+    });
+
+    it('should return documentTitle truncated to MAX_TITLE_LENGTH', () => {
+      applicationContext
+        .getUtilities()
+        .getDocumentTitleWithAdditionalInfo.mockReturnValueOnce(
+          "MOTION FOR PROTECTIVE ORDER PURSUANT TO RULE 103 REGARDING RESPONDING TO RESP'S INTERROGATORIES & REQUEST FOR PRODUCTION OF DOCUMENTS. by Petrs. Michael R. Bridges & Casie L. Bridges; Marvin R. Allen & Susan A. Allen; & Michael R. Bridges & Casie L. Bridges (EXHIBIT)",
+        );
+      const mockSelectedDocketEntryId = 'f9fbccfb-88cb-4bf6-a90d-174b6f4130d0';
+      const mockExhibit = {
+        addToCoversheet: true,
+        additionalInfo: 'First',
+        docketEntryId: '3913f8a9-891a-4c9c-827e-1a02b403fa63',
+        documentTitle: 'Exhibit(s)',
+        documentType: 'Exhibit(s)',
+      };
+
+      const mockCaseDetail = {
+        docketEntries: [
+          mockExhibit,
+          {
+            docketEntryId: mockSelectedDocketEntryId,
+          },
+        ],
+      };
+
+      const result = getPreviouslyFiledDocuments(
+        applicationContext,
+        mockCaseDetail,
+        mockSelectedDocketEntryId,
+      );
+
+      expect(
+        applicationContext.getUtilities().getDocumentTitleWithAdditionalInfo,
+      ).toHaveBeenCalled();
+      expect(
+        applicationContext.getUtilities().getDocumentTitleWithAdditionalInfo
+          .mock.calls[0][0],
+      ).toEqual({ docketEntry: mockExhibit });
+      expect(result[0].documentTitle.length).toBe(MAX_TITLE_LENGTH);
+      expect(result[0].documentTitle).toEqual(
+        "MOTION FOR PROTECTIVE ORDER PURSUANT TO RULE 103 REGARDING RESPONDING TO RESP'S INTERROGATORIES & R…",
+      );
+    });
+
+    it('should return documentTitle undefined if utility function returns undefined', () => {
+      applicationContext
+        .getUtilities()
+        .getDocumentTitleWithAdditionalInfo.mockReturnValueOnce(undefined);
+      const mockSelectedDocketEntryId = 'f9fbccfb-88cb-4bf6-a90d-174b6f4130d0';
+      const mockExhibit = {
+        addToCoversheet: true,
+        additionalInfo: 'First',
+        docketEntryId: '3913f8a9-891a-4c9c-827e-1a02b403fa63',
+        documentTitle: 'Exhibit(s)',
+        documentType: 'Exhibit(s)',
+      };
+
+      const mockCaseDetail = {
+        docketEntries: [
+          mockExhibit,
+          {
+            docketEntryId: mockSelectedDocketEntryId,
+          },
+        ],
+      };
+
+      const result = getPreviouslyFiledDocuments(
+        applicationContext,
+        mockCaseDetail,
+        mockSelectedDocketEntryId,
+      );
+
+      expect(
+        applicationContext.getUtilities().getDocumentTitleWithAdditionalInfo,
+      ).toHaveBeenCalled();
+      expect(
+        applicationContext.getUtilities().getDocumentTitleWithAdditionalInfo
+          .mock.calls[0][0],
+      ).toEqual({ docketEntry: mockExhibit });
+      expect(result[0].documentTitle).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
when shown in a select menu, document titles will be truncated to 100 characters if necessary.  Addresses undesirable behavior in Windows 10 + Edge in which select menu width exceeds width of viewport and obscures the select menu scrollbar.

![Screen Shot 2021-05-27 at 10 01 36 AM](https://user-images.githubusercontent.com/2445917/119851888-6dd5bb80-bed4-11eb-8980-be64a636499e.png)
