### PR TITLE
Decide to document architecture decision records.

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/architecture/decisions

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,8 @@ Table of contents:
 | Testing | See [testing overview](./testing.md).
 | Email | The [email documentation](./architecture/email.md) includes sending domains and information about SPF, DKIM, and DMARC records.
 
+See the [architecture decision records folder](./architecture/decisions/) for more insight into how the application’s architecture came to be.
+
 ## Developing EF-CMS on a local developer machine
 
 | Item | Description

--- a/docs/architecture/decisions/0001-record-architecture-decisions.md
+++ b/docs/architecture/decisions/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2021-05-27
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).


### PR DESCRIPTION
Related to #1223, this pull request adds the first decision record — the decision to use decision records. 

The `.adr-dir` file tells [`adr-tools`](https://github.com/npryce/adr-tools) where the decision records folder is — but decision records can also be added manually. 