### PR TITLE
Bug 7571: correctly format certificate of service date on Receipt of Filing

### DIFF
--- a/shared/src/business/useCases/generatePrintableFilingReceiptInteractor.js
+++ b/shared/src/business/useCases/generatePrintableFilingReceiptInteractor.js
@@ -10,10 +10,12 @@ const getDocumentInfo = ({ applicationContext, documentData }) => {
   return {
     attachments: doc.attachments,
     certificateOfService: doc.certificateOfService,
-    certificateOfServiceDate: doc.certificateOfServiceDate,
     documentTitle: doc.documentTitle,
     filedBy: doc.filedBy,
     filingDate: doc.filingDate,
+    formattedCertificateOfServiceDate: applicationContext
+      .getUtilities()
+      .formatDateString(doc.certificateOfServiceDate, 'MMDDYY'),
     objections: doc.objections,
     receivedAt: doc.receivedAt,
   };

--- a/shared/src/business/useCases/generatePrintableFilingReceiptInteractor.test.js
+++ b/shared/src/business/useCases/generatePrintableFilingReceiptInteractor.test.js
@@ -93,4 +93,21 @@ describe('generatePrintableFilingReceiptInteractor', () => {
     expect(receiptMockCall.secondarySupportingDocuments.length).toBe(2);
     expect(receiptMockCall.secondaryDocument).toBeDefined();
   });
+
+  it('formats certificateOfServiceDate', async () => {
+    await generatePrintableFilingReceiptInteractor(applicationContext, {
+      docketNumber: MOCK_CASE.docketNumber,
+      documentsFiled: {
+        certificateOfService: true,
+        certificateOfServiceDate: '2019-08-25T05:00:00.000Z',
+        primaryDocumentId: mockPrimaryDocketEntryId,
+      },
+    });
+
+    const receiptMockCall = applicationContext.getDocumentGenerators()
+      .receiptOfFiling.mock.calls[0][0].data;
+    expect(receiptMockCall.document.formattedCertificateOfServiceDate).toEqual(
+      '08/25/19',
+    );
+  });
 });

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/ReceiptOfFiling.jsx
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/ReceiptOfFiling.jsx
@@ -22,7 +22,8 @@ const DocumentRow = ({ document }) => {
             {hasAttachments && <p className="included">Attachment(s)</p>}
             {hasCertificateOfService && (
               <p className="included">
-                Certificate of Service {document.certificateOfServiceDate}
+                Certificate of Service{' '}
+                {document.formattedCertificateOfServiceDate}
               </p>
             )}
           </>

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/ReceiptOfFiling.test.js
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/ReceiptOfFiling.test.js
@@ -200,9 +200,9 @@ describe('ReceiptOfFiling', () => {
     expect(wrapper.find('p.included').text()).toEqual('Attachment(s)');
   });
 
-  it('displays the certificate of service date if the document has a certificate of service', () => {
+  it('displays the formatted certificate of service date if the document has a certificate of service', () => {
     document.certificateOfService = true;
-    document.certificateOfServiceDate = '02/02/20';
+    document.formattedCertificateOfServiceDate = '02/02/20';
 
     const wrapper = mount(
       <ReceiptOfFiling
@@ -216,7 +216,7 @@ describe('ReceiptOfFiling', () => {
     wrapper.find('.receipt-filed-document').at(0);
 
     expect(wrapper.find('p.included').text()).toEqual(
-      `Certificate of Service ${document.certificateOfServiceDate}`,
+      `Certificate of Service ${document.formattedCertificateOfServiceDate}`,
     );
   });
 


### PR DESCRIPTION
With Certificate of Service:
<img width="897" alt="Screen Shot 2021-05-27 at 11 16 51 AM" src="https://user-images.githubusercontent.com/43251054/119878349-de81d580-bede-11eb-89aa-89288c93e3dd.png">


Without Certificate of Service:
<img width="835" alt="Screen Shot 2021-05-27 at 11 17 06 AM" src="https://user-images.githubusercontent.com/43251054/119878368-e3468980-bede-11eb-9202-2dee9b393140.png">
