### PR TITLE
Bug 7925: use serif font for print service address label page

### DIFF
--- a/shared/src/business/utilities/htmlGenerator/index.scss
+++ b/shared/src/business/utilities/htmlGenerator/index.scss
@@ -543,7 +543,7 @@ th {
 }
 
 #address-label-cover-sheet {
-  font-family: sans-serif;
+  font-family: 'nimbus_roman', serif;
   font-size: 12px;
 
   .docket {


### PR DESCRIPTION
<img width="927" alt="Screen Shot 2021-05-27 at 12 23 58 PM" src="https://user-images.githubusercontent.com/43251054/119885601-e5ace180-bee6-11eb-9a17-173dd1db5085.png">
