### PR TITLE
8392 - BUG -  Update Trial Eligibility Mapping Records with Case Type

### DIFF
--- a/shared/src/business/entities/cases/Case.js
+++ b/shared/src/business/entities/cases/Case.js
@@ -2049,7 +2049,7 @@ Case.prototype.deleteStatistic = function (statisticId) {
  * @returns {Boolean} true if at least one party on the case has the provided serviceIndicator type, false otherwise.
  */
 // NOTE: This method will have to be changed to account for all petitioners on the case
-// (instead of just primary and secondary) once the User Management Batch 1 stories have been mered.
+// (instead of just primary and secondary) once the User Management Batch 1 stories have been merged.
 const hasPartyWithServiceType = function (rawCase, serviceType) {
   const contactPrimary = getContactPrimary(rawCase);
   const contactSecondary = getContactSecondary(rawCase);
@@ -2073,6 +2073,21 @@ const hasPartyWithServiceType = function (rawCase, serviceType) {
  */
 Case.prototype.hasPartyWithServiceType = function (serviceType) {
   return hasPartyWithServiceType(this, serviceType);
+};
+
+/**
+ * Returns true if the case should be displayed as eligible for trial sessions
+ *
+ * @returns {Boolean} true if the case is eligible
+ */
+Case.prototype.getShouldHaveTrialSortMappingRecords = function () {
+  return !!(
+    (this.highPriority ||
+      this.status === CASE_STATUS_TYPES.generalDocketReadyForTrial) &&
+    this.preferredTrialCity &&
+    !this.blocked &&
+    (!this.automaticBlocked || (this.automaticBlocked && this.highPriority))
+  );
 };
 
 const isSealedCase = rawCase => {

--- a/shared/src/business/entities/cases/Case.test.js
+++ b/shared/src/business/entities/cases/Case.test.js
@@ -5002,4 +5002,98 @@ describe('Case entity', () => {
       ).toEqual(false);
     });
   });
+
+  describe('getShouldHaveTrialSortMappingRecords', () => {
+    it('returns true if the case is high priority, has a preferred trial city, and is not blocked', () => {
+      const caseEntity = new Case(
+        {
+          ...MOCK_CASE,
+          blocked: false,
+          highPriority: true,
+          preferredTrialCity: 'Somecity',
+          status: CASE_STATUS_TYPES.generalDocket,
+        },
+        { applicationContext },
+      );
+
+      expect(caseEntity.getShouldHaveTrialSortMappingRecords()).toEqual(true);
+    });
+
+    it('returns true if the case is high priority, has a preferred trial city, is not blocked, and has automatic block', () => {
+      const caseEntity = new Case(
+        {
+          ...MOCK_CASE,
+          automaticBlocked: true,
+          blocked: false,
+          highPriority: true,
+          preferredTrialCity: 'Somecity',
+          status: CASE_STATUS_TYPES.generalDocket,
+        },
+        { applicationContext },
+      );
+
+      expect(caseEntity.getShouldHaveTrialSortMappingRecords()).toEqual(true);
+    });
+
+    it('returns true if the case status is ready for trial, has a preferred trial city, is not blocked, and has NO automatic block', () => {
+      const caseEntity = new Case(
+        {
+          ...MOCK_CASE,
+          blocked: false,
+          highPriority: false,
+          preferredTrialCity: 'Somecity',
+          status: CASE_STATUS_TYPES.generalDocketReadyForTrial,
+        },
+        { applicationContext },
+      );
+
+      expect(caseEntity.getShouldHaveTrialSortMappingRecords()).toEqual(true);
+    });
+
+    it('returns false if the case is blocked', () => {
+      const caseEntity = new Case(
+        {
+          ...MOCK_CASE,
+          blocked: true,
+          highPriority: false,
+          preferredTrialCity: 'Somecity',
+          status: CASE_STATUS_TYPES.generalDocketReadyForTrial,
+        },
+        { applicationContext },
+      );
+
+      expect(caseEntity.getShouldHaveTrialSortMappingRecords()).toEqual(false);
+    });
+
+    it('returns false if the case does not have a prefered trial city', () => {
+      const caseEntity = new Case(
+        {
+          ...MOCK_CASE,
+          blocked: false,
+          highPriority: false,
+          preferredTrialCity: undefined,
+          status: CASE_STATUS_TYPES.generalDocketReadyForTrial,
+        },
+        { applicationContext },
+      );
+
+      expect(caseEntity.getShouldHaveTrialSortMappingRecords()).toEqual(false);
+    });
+
+    it('returns false if the case status is ready for trial, has a preferred trial city, is not blocked, and has automatic block', () => {
+      const caseEntity = new Case(
+        {
+          ...MOCK_CASE,
+          automaticBlocked: true,
+          blocked: true,
+          highPriority: false,
+          preferredTrialCity: 'Somecity',
+          status: CASE_STATUS_TYPES.generalDocketReadyForTrial,
+        },
+        { applicationContext },
+      );
+
+      expect(caseEntity.getShouldHaveTrialSortMappingRecords()).toEqual(false);
+    });
+  });
 });

--- a/shared/src/business/useCases/updatePetitionDetailsInteractor.js
+++ b/shared/src/business/useCases/updatePetitionDetailsInteractor.js
@@ -1,26 +1,14 @@
 const {
-  CASE_STATUS_TYPES,
-  MINUTE_ENTRIES_MAP,
-  PAYMENT_STATUS,
-} = require('../entities/EntityConstants');
-const {
   isAuthorized,
   ROLE_PERMISSIONS,
 } = require('../../authorization/authorizationClientService');
+const {
+  MINUTE_ENTRIES_MAP,
+  PAYMENT_STATUS,
+} = require('../entities/EntityConstants');
 const { Case } = require('../entities/cases/Case');
 const { DocketEntry } = require('../entities/DocketEntry');
 const { UnauthorizedError } = require('../../errors/errors');
-
-const getShouldHaveTrialSortMappingRecords = caseDetail => {
-  return (
-    (caseDetail.highPriority ||
-      caseDetail.status === CASE_STATUS_TYPES.generalDocketReadyForTrial) &&
-    caseDetail.preferredTrialCity &&
-    !caseDetail.blocked &&
-    (!caseDetail.automaticBlocked ||
-      (caseDetail.automaticBlocked && caseDetail.highPriority))
-  );
-};
 
 /**
  * updatePetitionDetailsInteractor
@@ -115,7 +103,7 @@ exports.updatePetitionDetailsInteractor = async (
     }
   }
 
-  if (getShouldHaveTrialSortMappingRecords(newCaseEntity)) {
+  if (newCaseEntity.getShouldHaveTrialSortMappingRecords()) {
     const oldCaseEntity = new Case(oldCase, { applicationContext });
     const oldTrialSortTag = oldCaseEntity.generateTrialSortTags();
     const newTrialSortTag = newCaseEntity.generateTrialSortTags();

--- a/shared/src/business/useCases/updatePetitionDetailsInteractor.test.js
+++ b/shared/src/business/useCases/updatePetitionDetailsInteractor.test.js
@@ -1,5 +1,6 @@
 const {
   CASE_STATUS_TYPES,
+  CASE_TYPES_MAP,
   MINUTE_ENTRIES_MAP,
   PAYMENT_STATUS,
 } = require('../entities/EntityConstants');
@@ -239,6 +240,50 @@ describe('updatePetitionDetailsInteractor', () => {
         highPriority: true,
         preferredTrialCity: 'Cheyenne, Wyoming',
         status: CASE_STATUS_TYPES.rule155,
+      },
+    });
+
+    expect(
+      applicationContext.getPersistenceGateway()
+        .createCaseTrialSortMappingRecords,
+    ).toHaveBeenCalled();
+  });
+
+  it('should call createCaseTrialSortMappingRecords if the case type is changed', async () => {
+    applicationContext
+      .getPersistenceGateway()
+      .getCaseByDocketNumber.mockReturnValue({
+        ...generalDocketReadyForTrialCase,
+        caseType: CASE_TYPES_MAP.cdp,
+      });
+
+    await updatePetitionDetailsInteractor(applicationContext, {
+      docketNumber: generalDocketReadyForTrialCase.docketNumber,
+      petitionDetails: {
+        ...generalDocketReadyForTrialCase,
+        caseType: CASE_TYPES_MAP.deficiency,
+      },
+    });
+
+    expect(
+      applicationContext.getPersistenceGateway()
+        .createCaseTrialSortMappingRecords,
+    ).toHaveBeenCalled();
+  });
+
+  it('should call createCaseTrialSortMappingRecords if the case procedure type is changed', async () => {
+    applicationContext
+      .getPersistenceGateway()
+      .getCaseByDocketNumber.mockReturnValue({
+        ...generalDocketReadyForTrialCase,
+        procedureType: 'Regular',
+      });
+
+    await updatePetitionDetailsInteractor(applicationContext, {
+      docketNumber: generalDocketReadyForTrialCase.docketNumber,
+      petitionDetails: {
+        ...generalDocketReadyForTrialCase,
+        procedureType: 'Small',
       },
     });
 

--- a/shared/src/business/useCases/updatePetitionDetailsInteractor.test.js
+++ b/shared/src/business/useCases/updatePetitionDetailsInteractor.test.js
@@ -293,6 +293,27 @@ describe('updatePetitionDetailsInteractor', () => {
     ).toHaveBeenCalled();
   });
 
+  it('should NOT call createCaseTrialSortMappingRecords if there are no changes that would alter the trial sort tags', async () => {
+    applicationContext
+      .getPersistenceGateway()
+      .getCaseByDocketNumber.mockReturnValue({
+        ...generalDocketReadyForTrialCase,
+        procedureType: 'Regular',
+      });
+
+    await updatePetitionDetailsInteractor(applicationContext, {
+      docketNumber: generalDocketReadyForTrialCase.docketNumber,
+      petitionDetails: {
+        ...generalDocketReadyForTrialCase,
+      },
+    });
+
+    expect(
+      applicationContext.getPersistenceGateway()
+        .createCaseTrialSortMappingRecords,
+    ).not.toHaveBeenCalled();
+  });
+
   it('does not allow fields that do not exist on the editableFields list to be updated on the case', async () => {
     applicationContext
       .getPersistenceGateway()


### PR DESCRIPTION
When changing the case type on a case, we weren't updating these mapping records, though there is a specific designation in the `eligible-for-trial-case-catalog` mapping record for certain case types. While looking at this, I noticed this was also not being done for the procedure type.

I refactored the logic a little, adding a method on the Case entity to determine if it was eligible to have these mapping records, and then removed logic for specific fields that might have changed in favor calling the method to generate the tags on both the old and new tags to see if there's a change. This way we don't have to track those fields in two places. Lastly I'm specifically comparing the `nonHybrid` sort keys because they account for the `procedureType` where the `hybrid` one does not. 