### PR TITLE
Bug 8154: remove no-wrap from trial session working copy table headers

### DIFF
--- a/web-client/src/views/TrialSessionWorkingCopy/WorkingCopySessionList.jsx
+++ b/web-client/src/views/TrialSessionWorkingCopy/WorkingCopySessionList.jsx
@@ -80,8 +80,8 @@ export const WorkingCopySessionList = connect(
                 </Button>
               </th>
               <th aria-label="manually added indicator"></th>
-              <th className="no-wrap">Case Title</th>
-              <th className="no-wrap">
+              <th>Case Title</th>
+              <th>
                 <Button
                   link
                   className="sortable-header-button margin-right-0"
@@ -112,10 +112,8 @@ export const WorkingCopySessionList = connect(
                   )}
                 </Button>
               </th>
-              <th className="no-wrap">Respondent Counsel</th>
-              <th className="no-wrap" colSpan="2">
-                Trial Status
-              </th>
+              <th>Respondent Counsel</th>
+              <th colSpan="2">Trial Status</th>
             </tr>
           </thead>
           {trialSessionWorkingCopyHelper.formattedCases.map(item => {


### PR DESCRIPTION
This isn't really a true fix, but it does make this table look better down to a 940px wide screen resolution, whereas before the table started looking bad at screen sizes around 1120px wide. There isn't much we can do about this without designing this table to be a responsive layout, which we can do, but we don't typically design internal screens for mobile or tablets. We can also reduce some padding within the table so that it will fit better on smaller screens, but this didn't seem worth the tradeoff of being inconsistent with other tables on the site. 

Here's how it looks at 940px wide now:
<img width="945" alt="Screen Shot 2021-06-08 at 1 18 55 PM" src="https://user-images.githubusercontent.com/43251054/121252582-0701bc00-c85d-11eb-9f1f-dce29f4798bd.png">


And at a larger width, the removal of `no-wrap` doesn't seem to have any effect:
<img width="1342" alt="Screen Shot 2021-06-08 at 1 26 25 PM" src="https://user-images.githubusercontent.com/43251054/121252720-31537980-c85d-11eb-9544-e141acdbf54f.png">
