### PR TITLE
7512: set focus on header after initial application load

### DIFF
--- a/web-client/src/views/AppComponent.jsx
+++ b/web-client/src/views/AppComponent.jsx
@@ -165,6 +165,8 @@ const pages = {
   WorkQueue,
 };
 
+let initialPageLoaded = false;
+
 /**
  * Root application component
  */
@@ -190,7 +192,12 @@ export const AppComponent = connect(
     };
 
     useEffect(() => {
-      focusMain();
+      if (initialPageLoaded) {
+        focusMain();
+      }
+      if (currentPage !== 'Interstitial') {
+        initialPageLoaded = true;
+      }
     }, [currentPage]);
 
     const CurrentPage = pages[currentPage];

--- a/web-client/src/views/AppComponentPublic.jsx
+++ b/web-client/src/views/AppComponentPublic.jsx
@@ -34,6 +34,8 @@ const pages = {
   TodaysOrders,
 };
 
+let initialPageLoaded = false;
+
 /**
  * Root application component for the public site
  */
@@ -50,7 +52,12 @@ export const AppComponentPublic = connect(
     };
 
     useEffect(() => {
-      focusMain();
+      if (initialPageLoaded) {
+        focusMain();
+      }
+      if (currentPage !== 'Interstitial') {
+        initialPageLoaded = true;
+      }
     });
 
     if (!process.env.CI) {


### PR DESCRIPTION
When the application is loading for the very first time, the first value for `currentPage` is `Interstitial`, and the second value is the view which represents the user's dashboard.
This code will prevent us from programatically setting the keyboard / voiceover focus on the main content's header until at least the second "main view change".  Thus on initial load, voiceover and keyboard users will still step into the application by first encountering the skip-navigation link at the beginning of the page.  Thereafter, they will be directed to the content headers.