### PR TITLE
Fix CSP violation for Dynamsoft

### DIFF
--- a/web-client/terraform/common/cloudfront-edge/header-security-lambda.js
+++ b/web-client/terraform/common/cloudfront-edge/header-security-lambda.js
@@ -46,7 +46,7 @@ exports.handler = (awsEvent, handlerContext, callback) => {
     `form-action ${applicationUrl} ${subdomainsUrl}`,
     `object-src ${subdomainsUrl} ${applicationUrl} ${s3Url}`,
     `script-src 'self' 'unsafe-inline' ${dynamsoftUrlProd} ${dynamsoftUrlStaging} ${statuspageUrl} resource://pdf.js`,
-    'worker-src blob:',
+    'worker-src blob: data:',
     `style-src 'self' 'unsafe-inline' ${dynamsoftUrlProd} ${dynamsoftUrlStaging}`,
     `img-src ${applicationUrl} ${subdomainsUrl} blob: data:`,
     `font-src ${applicationUrl} ${subdomainsUrl}`,


### PR DESCRIPTION
Observed this error when reproducing the issue users were complaining about:

```
Refused to create a worker from 'data:text/javascript;base64,...s=' because it violates the following Content Security Policy directive: "worker-src blob:".
```