### PR TITLE
Bug 8477: View Full PDF not working on mobile/iPad

### DIFF
--- a/web-client/integration-tests/helpers.js
+++ b/web-client/integration-tests/helpers.js
@@ -515,6 +515,13 @@ export const setupTest = ({ useCases = {} } = {}) => {
     location: { replace: jest.fn() },
     open: url => {
       test.setState('openedUrl', url);
+      return {
+        close: jest.fn(),
+        document: {
+          write: jest.fn(),
+        },
+        location: '',
+      };
     },
     pdfjsObj: {
       getData: () => Promise.resolve(getFakeFile(true)),

--- a/web-client/src/presenter/actions/openCaseDocumentDownloadUrlAction.js
+++ b/web-client/src/presenter/actions/openCaseDocumentDownloadUrlAction.js
@@ -20,10 +20,10 @@ export const openCaseDocumentDownloadUrlAction = async ({
     useSameTab,
   } = props;
 
-  let pdfWindow;
+  let openedPdfWindow;
   if (!isForIFrame && !useSameTab) {
-    pdfWindow = window.open();
-    pdfWindow.document.write('Loading your document...');
+    openedPdfWindow = window.open();
+    openedPdfWindow.document.write('Loading your document...');
   }
 
   try {
@@ -40,10 +40,10 @@ export const openCaseDocumentDownloadUrlAction = async ({
     } else if (useSameTab) {
       window.location.href = url;
     } else {
-      pdfWindow.location.href = url;
+      openedPdfWindow.location.href = url;
     }
   } catch (e) {
-    if (pdfWindow) pdfWindow.close();
-    throw new Error(e);
+    if (openedPdfWindow) openedPdfWindow.close();
+    throw new Error(`Unable to get document download url. ${e.message}`);
   }
 };

--- a/web-client/src/presenter/actions/openCaseDocumentDownloadUrlAction.js
+++ b/web-client/src/presenter/actions/openCaseDocumentDownloadUrlAction.js
@@ -43,7 +43,8 @@ export const openCaseDocumentDownloadUrlAction = async ({
       openedPdfWindow.location.href = url;
     }
   } catch (e) {
-    if (openedPdfWindow) openedPdfWindow.close();
+    openedPdfWindow?.close();
+
     throw new Error(`Unable to get document download url. ${e.message}`);
   }
 };

--- a/web-client/src/presenter/actions/openCaseDocumentDownloadUrlAction.js
+++ b/web-client/src/presenter/actions/openCaseDocumentDownloadUrlAction.js
@@ -5,13 +5,11 @@ import { state } from 'cerebral';
  *
  * @param {object} providers the providers object
  * @param {object} providers.props the cerebral props object
- * @param {object} providers.router the router object
  * @param {object} providers.store the cerebral store object used for clearing alertError, alertSuccess
  */
 export const openCaseDocumentDownloadUrlAction = async ({
   applicationContext,
   props,
-  router,
   store,
 }) => {
   const {
@@ -22,19 +20,30 @@ export const openCaseDocumentDownloadUrlAction = async ({
     useSameTab,
   } = props;
 
-  const { url } = await applicationContext
-    .getUseCases()
-    .getDocumentDownloadUrlInteractor(applicationContext, {
-      docketNumber,
-      isPublic,
-      key: docketEntryId,
-    });
+  let pdfWindow;
+  if (!isForIFrame && !useSameTab) {
+    pdfWindow = window.open();
+    pdfWindow.document.write('Loading your document...');
+  }
 
-  if (isForIFrame) {
-    store.set(state.iframeSrc, url);
-  } else if (useSameTab) {
-    window.location.href = url;
-  } else {
-    router.openInNewTab(url);
+  try {
+    const { url } = await applicationContext
+      .getUseCases()
+      .getDocumentDownloadUrlInteractor(applicationContext, {
+        docketNumber,
+        isPublic,
+        key: docketEntryId,
+      });
+
+    if (isForIFrame) {
+      store.set(state.iframeSrc, url);
+    } else if (useSameTab) {
+      window.location.href = url;
+    } else {
+      pdfWindow.location.href = url;
+    }
+  } catch (e) {
+    if (pdfWindow) pdfWindow.close();
+    throw new Error(e);
   }
 };

--- a/web-client/src/presenter/actions/openCaseDocumentDownloadUrlAction.test.js
+++ b/web-client/src/presenter/actions/openCaseDocumentDownloadUrlAction.test.js
@@ -7,7 +7,7 @@ describe('openCaseDocumentDownloadUrlAction', () => {
   const closeSpy = jest.fn();
   const writeSpy = jest.fn();
 
-  beforeAll(() => {
+  beforeEach(() => {
     window.open = jest.fn().mockReturnValue({
       close: closeSpy,
       document: {
@@ -111,5 +111,28 @@ describe('openCaseDocumentDownloadUrlAction', () => {
     ).rejects.toThrow();
 
     expect(closeSpy).toHaveBeenCalled();
+    expect(window.open().close).toHaveBeenCalled();
+  });
+
+  it('should not try to close openedPdfWindow if it does not exist when getDocumentDownloadUrlInteractor fails', async () => {
+    window.open = jest.fn().mockReturnValue(null);
+
+    applicationContext
+      .getUseCases()
+      .getDocumentDownloadUrlInteractor.mockRejectedValue(new Error());
+
+    await expect(
+      runAction(openCaseDocumentDownloadUrlAction, {
+        modules: { presenter },
+        props: {
+          docketEntryId: 'docket-entry-id-123',
+          docketNumber: '123-20',
+          isForIFrame: false,
+          useSameTab: false,
+        },
+      }),
+    ).rejects.toThrow();
+
+    expect(closeSpy).not.toHaveBeenCalled();
   });
 });

--- a/web-client/src/presenter/actions/openCaseDocumentDownloadUrlAction.test.js
+++ b/web-client/src/presenter/actions/openCaseDocumentDownloadUrlAction.test.js
@@ -4,12 +4,20 @@ import { presenter } from '../presenter-mock';
 import { runAction } from 'cerebral/test';
 
 describe('openCaseDocumentDownloadUrlAction', () => {
+  const closeSpy = jest.fn();
+  const writeSpy = jest.fn();
+
   beforeAll(() => {
     window.open = jest.fn().mockReturnValue({
+      close: closeSpy,
+      document: {
+        write: writeSpy,
+      },
       location: { href: '' },
     });
     delete window.location;
     window.location = { href: '' };
+    window.document.write = jest.fn(); //remove?
 
     presenter.providers.applicationContext = applicationContext;
 
@@ -63,18 +71,6 @@ describe('openCaseDocumentDownloadUrlAction', () => {
   });
 
   it('should open in a new tab when props.useSameTab and props.isForIFrame are false', async () => {
-    const writeSpy = jest.fn();
-    window.open = jest.fn().mockReturnValue({
-      close: jest.fn(),
-      document: {
-        write: writeSpy,
-      },
-      location: {
-        href: 'something original',
-      },
-    });
-    window.document.write = jest.fn();
-
     await runAction(openCaseDocumentDownloadUrlAction, {
       modules: { presenter },
       props: {
@@ -102,20 +98,6 @@ describe('openCaseDocumentDownloadUrlAction', () => {
     applicationContext
       .getUseCases()
       .getDocumentDownloadUrlInteractor.mockRejectedValue(new Error());
-
-    const closeSpy = jest.fn();
-    const writeSpy = jest.fn();
-
-    window.open = jest.fn().mockReturnValue({
-      close: closeSpy,
-      document: {
-        write: writeSpy,
-      },
-      location: {
-        href: 'something original',
-      },
-    });
-    window.document.write = jest.fn();
 
     await expect(
       runAction(openCaseDocumentDownloadUrlAction, {

--- a/web-client/src/presenter/actions/openCaseDocumentDownloadUrlAction.test.js
+++ b/web-client/src/presenter/actions/openCaseDocumentDownloadUrlAction.test.js
@@ -4,8 +4,6 @@ import { presenter } from '../presenter-mock';
 import { runAction } from 'cerebral/test';
 
 describe('openCaseDocumentDownloadUrlAction', () => {
-  const openInNewTab = jest.fn();
-
   beforeAll(() => {
     window.open = jest.fn().mockReturnValue({
       location: { href: '' },
@@ -14,7 +12,6 @@ describe('openCaseDocumentDownloadUrlAction', () => {
     window.location = { href: '' };
 
     presenter.providers.applicationContext = applicationContext;
-    presenter.providers.router = { openInNewTab };
 
     applicationContext
       .getUseCases()
@@ -65,15 +62,31 @@ describe('openCaseDocumentDownloadUrlAction', () => {
     expect(window.location.href).toEqual('http://example.com');
   });
 
-  it('should open in a new tab when props.useSameTab and props.isForIFrame is false', async () => {
+  it('should open in a new tab when props.useSameTab and props.isForIFrame are false', async () => {
+    const writeSpy = jest.fn();
+    window.open = jest.fn().mockReturnValue({
+      close: jest.fn(),
+      document: {
+        write: writeSpy,
+      },
+      location: {
+        href: 'something original',
+      },
+    });
+    window.document.write = jest.fn();
+
     await runAction(openCaseDocumentDownloadUrlAction, {
       modules: { presenter },
       props: {
         docketEntryId: 'docket-entry-id-123',
         docketNumber: '123-20',
+        isForIFrame: false,
         useSameTab: false,
       },
     });
+
+    expect(window.open).toHaveBeenCalled();
+    expect(writeSpy).toHaveBeenCalled();
 
     expect(
       applicationContext.getUseCases().getDocumentDownloadUrlInteractor.mock
@@ -82,6 +95,40 @@ describe('openCaseDocumentDownloadUrlAction', () => {
       docketNumber: '123-20',
       key: 'docket-entry-id-123',
     });
-    expect(openInNewTab).toHaveBeenCalledWith('http://example.com');
+    expect(window.open().location.href).toEqual('http://example.com');
+  });
+
+  it('should throw an error when getDocumentDownloadUrlInteractor fails', async () => {
+    applicationContext
+      .getUseCases()
+      .getDocumentDownloadUrlInteractor.mockRejectedValue(new Error());
+
+    const closeSpy = jest.fn();
+    const writeSpy = jest.fn();
+
+    window.open = jest.fn().mockReturnValue({
+      close: closeSpy,
+      document: {
+        write: writeSpy,
+      },
+      location: {
+        href: 'something original',
+      },
+    });
+    window.document.write = jest.fn();
+
+    await expect(
+      runAction(openCaseDocumentDownloadUrlAction, {
+        modules: { presenter },
+        props: {
+          docketEntryId: 'docket-entry-id-123',
+          docketNumber: '123-20',
+          isForIFrame: false,
+          useSameTab: false,
+        },
+      }),
+    ).rejects.toThrow();
+
+    expect(closeSpy).toHaveBeenCalled();
   });
 });

--- a/web-client/src/presenter/actions/openCaseDocumentDownloadUrlAction.test.js
+++ b/web-client/src/presenter/actions/openCaseDocumentDownloadUrlAction.test.js
@@ -17,7 +17,6 @@ describe('openCaseDocumentDownloadUrlAction', () => {
     });
     delete window.location;
     window.location = { href: '' };
-    window.document.write = jest.fn(); //remove?
 
     presenter.providers.applicationContext = applicationContext;
 


### PR DESCRIPTION
- instead of calling openInNewTab, immediately open a window within the action so that Safari doesn't consider this to be a pop-up to be blocked