### PR TITLE
8485 - Upgrade Dynamo Global Version

### DIFF
--- a/iam/terraform/account-specific/main/circle-ci.tf
+++ b/iam/terraform/account-specific/main/circle-ci.tf
@@ -193,7 +193,8 @@ resource "aws_iam_policy" "circle_ci_policy" {
         "dynamodb:GetRecords",
         "dynamodb:GetShardIterator",
         "dynamodb:ListStreams",
-        "dynamodb:UpdateGlobalTable"
+        "dynamodb:UpdateGlobalTable",
+        "dynamodb:CreateTableReplica"
       ],
       "Resource": [
         "arn:aws:dynamodb::${data.aws_caller_identity.current.account_id}:global-table/efcms-*",

--- a/iam/terraform/account-specific/main/circle-ci.tf
+++ b/iam/terraform/account-specific/main/circle-ci.tf
@@ -192,6 +192,7 @@ resource "aws_iam_policy" "circle_ci_policy" {
         "dynamodb:DescribeStream",
         "dynamodb:GetRecords",
         "dynamodb:GetShardIterator",
+        "dynamodb:UpdateItem",
         "dynamodb:ListStreams",
         "dynamodb:UpdateGlobalTable",
         "dynamodb:CreateTableReplica"

--- a/shared/src/business/useCases/processStreamRecordsInteractor.js
+++ b/shared/src/business/useCases/processStreamRecordsInteractor.js
@@ -1,5 +1,4 @@
 const {
-  filterRecords,
   partitionRecords,
   processCaseEntries,
   processDocketEntries,
@@ -44,8 +43,6 @@ exports.processStreamRecordsInteractor = async (
   applicationContext,
   { recordsToProcess },
 ) => {
-  recordsToProcess = recordsToProcess.filter(filterRecords);
-
   const {
     caseEntityRecords,
     docketEntryRecords,

--- a/shared/src/business/useCases/processStreamRecordsInteractor.test.js
+++ b/shared/src/business/useCases/processStreamRecordsInteractor.test.js
@@ -1,6 +1,5 @@
 jest.mock('./processStreamUtilities');
 const {
-  filterRecords,
   partitionRecords,
   processCaseEntries,
   processDocketEntries,
@@ -24,7 +23,6 @@ describe('processStreamRecordsInteractor', () => {
     processMessageEntries.mockResolvedValue([]);
     processOtherEntries.mockResolvedValue([]);
 
-    filterRecords.mockReturnValue(true);
     partitionRecords.mockReturnValue({
       caseEntityRecords: [],
       docketEntryRecords: [],
@@ -39,7 +37,6 @@ describe('processStreamRecordsInteractor', () => {
       recordsToProcess: [{ my: 'record' }],
     });
 
-    expect(filterRecords).toHaveBeenCalled();
     expect(partitionRecords).toHaveBeenCalled();
 
     expect(processRemoveEntries).toHaveBeenCalled();

--- a/shared/src/business/useCases/processStreamUtilities.js
+++ b/shared/src/business/useCases/processStreamUtilities.js
@@ -1,28 +1,10 @@
 const AWS = require('aws-sdk');
-const { compact, flattenDeep, get, omit, partition } = require('lodash');
+const { compact, flattenDeep, omit, partition } = require('lodash');
 
 const {
   OPINION_EVENT_CODES_WITH_BENCH_OPINION,
   ORDER_EVENT_CODES,
 } = require('../entities/EntityConstants');
-
-const filterRecords = record => {
-  // to prevent global tables writing extra data
-  const NEW_TIME_KEY = 'dynamodb.NewImage.aws:rep:updatetime.N';
-  const OLD_TIME_KEY = 'dynamodb.OldImage.aws:rep:updatetime.N';
-  const IS_DELETING_KEY = 'dynamodb.NewImage.aws:rep:deleting.BOOL';
-
-  const newTime = get(record, NEW_TIME_KEY);
-  const oldTime = get(record, OLD_TIME_KEY);
-  const isDeleting = get(record, IS_DELETING_KEY);
-
-  return (
-    (process.env.NODE_ENV !== 'production' ||
-      (newTime && newTime !== oldTime) ||
-      record.eventName === 'REMOVE') &&
-    !isDeleting
-  );
-};
 
 const partitionRecords = records => {
   const [removeRecords, insertModifyRecords] = partition(
@@ -359,7 +341,6 @@ const processRemoveEntries = async ({ applicationContext, removeRecords }) => {
   }
 };
 
-exports.filterRecords = filterRecords;
 exports.partitionRecords = partitionRecords;
 exports.processCaseEntries = processCaseEntries;
 exports.processDocketEntries = processDocketEntries;

--- a/shared/src/business/useCases/processStreamUtilities.test.js
+++ b/shared/src/business/useCases/processStreamUtilities.test.js
@@ -1,5 +1,4 @@
 const {
-  filterRecords,
   partitionRecords,
   processCaseEntries,
   processDocketEntries,
@@ -19,101 +18,6 @@ describe('processStreamUtilities', () => {
     applicationContext
       .getPersistenceGateway()
       .bulkIndexRecords.mockReturnValue({ failedRecords: [] });
-  });
-
-  describe('filterRecords', () => {
-    const getMockRecord = ({
-      deleting = false,
-      id = null,
-      newTime = 'newTime',
-      oldTime = 'oldTime',
-      removeRecord = false,
-    }) => {
-      const mockRecord = {
-        dynamodb: {
-          NewImage: {
-            'aws:rep:deleting': {
-              BOOL: deleting,
-            },
-            'aws:rep:updatetime': {
-              N: newTime,
-            },
-          },
-          OldImage: {
-            'aws:rep:deleting': {
-              BOOL: false,
-            },
-            'aws:rep:updatetime': {
-              N: oldTime,
-            },
-          },
-        },
-        eventName: removeRecord ? 'REMOVE' : 'MODIFY',
-        id, // this is just an identifier for the test output and not actually on these records
-      };
-
-      if (removeRecord) {
-        delete mockRecord.dynamodb.NewImage; // remove events do not have a NewImage
-      }
-
-      return mockRecord;
-    };
-
-    beforeEach(() => {
-      process.env.NODE_ENV = 'production'; // necessary to evaluate other conditionals
-    });
-
-    afterEach(() => {
-      process.env.NODE_ENV = undefined; // resetting back after each test
-    });
-
-    it('filters out records with a deleting value of true', () => {
-      const record1 = getMockRecord({ deleting: true, id: '1' }); // should be filtered out
-      const record2 = getMockRecord({ id: '2' }); // should pass filter
-      const recordsToProcess = [record1, record2];
-
-      const result = recordsToProcess.filter(filterRecords);
-
-      expect(result).toMatchObject([record2]);
-    });
-
-    it('filters out records with where the updatetime did not change', () => {
-      const record1 = getMockRecord({
-        id: '1',
-        newTime: 'sameTime',
-        oldTime: 'sameTime',
-      }); // should be filtered out
-      const record2 = getMockRecord({
-        id: '2',
-        newTime: 'someTime',
-        oldTime: 'anotherTime',
-      }); // should pass filter
-      const recordsToProcess = [record1, record2];
-
-      const result = recordsToProcess.filter(filterRecords);
-
-      expect(result).toMatchObject([record2]);
-    });
-
-    it('returns records with a REMOVE event', () => {
-      const record1 = getMockRecord({
-        id: '1',
-        newTime: 'sameTime',
-        oldTime: 'sameTime',
-        removeRecord: false,
-      }); // should be filtered out
-      const record2 = getMockRecord({
-        id: '2',
-        newTime: 'sameTime',
-        oldTime: 'sameTime',
-        removeRecord: true,
-      }); // should pass filter
-      const recordsToProcess = [record1, record2];
-
-      const result = recordsToProcess.filter(filterRecords);
-
-      expect(result).toMatchObject([record2]);
-    });
   });
 
   describe('partitionRecords', () => {

--- a/web-api/migration-terraform/main/lambdas/migration.js
+++ b/web-api/migration-terraform/main/lambdas/migration.js
@@ -1,5 +1,4 @@
 const AWS = require('aws-sdk');
-const { get } = require('lodash');
 const { migrateRecords: migrations } = require('./migration-segments');
 
 const dynamodb = new AWS.DynamoDB({
@@ -33,14 +32,9 @@ const processItems = async ({ documentClient, items, migrateRecords }) => {
 
 const getFilteredGlobalEvents = event => {
   const { Records } = event;
-  return Records.filter(record => {
-    // to prevent global tables writing extra data
-    const NEW_TIME_KEY = 'dynamodb.NewImage.aws:rep:updatetime.N';
-    const OLD_TIME_KEY = 'dynamodb.OldImage.aws:rep:updatetime.N';
-    const newTime = get(record, NEW_TIME_KEY);
-    const oldTime = get(record, OLD_TIME_KEY);
-    return newTime && newTime !== oldTime;
-  }).map(item => AWS.DynamoDB.Converter.unmarshall(item.dynamodb.NewImage));
+  return Records.map(item =>
+    AWS.DynamoDB.Converter.unmarshall(item.dynamodb.NewImage),
+  );
 };
 
 exports.getFilteredGlobalEvents = getFilteredGlobalEvents;

--- a/web-api/migration-terraform/main/lambdas/migration.test.js
+++ b/web-api/migration-terraform/main/lambdas/migration.test.js
@@ -29,29 +29,7 @@ describe('migration', () => {
   });
 
   describe('getFilteredGlobalEvents', () => {
-    it('should not try to migrate global table dynamo events', async () => {
-      const items = await getFilteredGlobalEvents({
-        Records: [
-          {
-            dynamodb: {
-              NewImage: {
-                'aws:rep:updatetime': {
-                  N: 10,
-                },
-              },
-              OldImage: {
-                'aws:rep:updatetime': {
-                  N: 10,
-                },
-              },
-            },
-          },
-        ],
-      });
-      expect(items.length).toBe(0);
-    });
-
-    it('should return non global table dynamo events', async () => {
+    it('should return everything', async () => {
       const items = await getFilteredGlobalEvents({
         Records: [
           {

--- a/web-api/src/streams/processStreamRecordsLambda.test.js
+++ b/web-api/src/streams/processStreamRecordsLambda.test.js
@@ -4,7 +4,7 @@ describe('processStreamRecordsLambda', () => {
   it('should throw an exception if the interactor throws an exception', async () => {
     let error;
     try {
-      await processStreamRecordsLambda({});
+      await processStreamRecordsLambda(null);
     } catch (err) {
       error = err;
     }

--- a/web-api/terraform/template/dynamo-table/dynamo-migration.tf
+++ b/web-api/terraform/template/dynamo-table/dynamo-migration.tf
@@ -58,68 +58,6 @@ resource "aws_dynamodb_table" "efcms-table-east" {
     attribute_name = "ttl"
     enabled        = true
   }
-}
-
-resource "aws_dynamodb_table" "efcms-table-west" {
-  provider     = aws.us-west-1
-  name         = var.table_name
-  billing_mode = "PAY_PER_REQUEST"
-
-  hash_key  = "pk"
-  range_key = "sk"
-
-  attribute {
-    name = "pk"
-    type = "S"
-  }
-
-  attribute {
-    name = "sk"
-    type = "S"
-  }
-
-  attribute {
-    name = "gsi1pk"
-    type = "S"
-  }
-
-  point_in_time_recovery {
-    enabled = true
-  }
-
-  global_secondary_index {
-    name            = "gsi1"
-    hash_key        = "gsi1pk"
-    range_key       = "pk"
-    projection_type = "ALL"
-  }
-
-  stream_enabled   = true
-  stream_view_type = "NEW_AND_OLD_IMAGES"
-
-  tags = {
-    Name        = var.table_name
-    Environment = var.environment
-  }
-
-  ttl {
-    attribute_name = "ttl"
-    enabled        = true
-  }
-}
-
-resource "aws_dynamodb_global_table" "efcms-table-global" {
-  depends_on = [
-    aws_dynamodb_table.efcms-table-east,
-    aws_dynamodb_table.efcms-table-west,
-  ]
-
-  name = var.table_name
-
-  replica {
-    region_name = "us-east-1"
-  }
-
   replica {
     region_name = "us-west-1"
   }


### PR DESCRIPTION
This updates the dynamodb global table version to `2019.11.21` which will remove the `aws:rep:` attributes from the events which we think the filterRecords logic may be skipping over some records then dynamo decides to not send an event for some changes.

To get this deployed, you will need to:
- run account specific terraform to update your circle-ci policy permissions `npm run deploy:account-specific`
- delete the dynamodb tables (efcms-test-alpha, efcms-test-beta) on the US-WEST-1 ONLY

This deploy would result in downtime for any west coast users until the new replicas are created. (maybe 10-20 minutes until terraform finishes?)