### PR TITLE
8522 - Require user to provide 4 dig year on filing date

### DIFF
--- a/web-client/src/presenter/actions/EditDocketRecordEntry/validateDocumentAction.js
+++ b/web-client/src/presenter/actions/EditDocketRecordEntry/validateDocumentAction.js
@@ -20,6 +20,14 @@ export const validateDocumentAction = ({ applicationContext, get, path }) => {
       document: formMetadata,
     });
 
+  if (formMetadata.filingDateYear && formMetadata.filingDateYear.length !== 4) {
+    if (!errors) {
+      errors = {};
+    }
+
+    errors.filingDate = errors.filingDate || 'Enter a four-digit year';
+  }
+
   let errorDisplayOrder = ['description', 'eventCode', 'filingDate', 'index'];
 
   if (editType === 'Document') {

--- a/web-client/src/presenter/actions/EditDocketRecordEntry/validateDocumentAction.test.js
+++ b/web-client/src/presenter/actions/EditDocketRecordEntry/validateDocumentAction.test.js
@@ -195,4 +195,54 @@ describe('validateDocumentAction', () => {
       applicationContext.getUseCases().validateDocumentInteractor,
     ).toHaveBeenCalled();
   });
+
+  describe('filingDate', () => {
+    it('returns an error message if the user enters a two-digit year', async () => {
+      await runAction(validateDocumentAction, {
+        modules: {
+          presenter,
+        },
+        state: {
+          form: {
+            ...mockDocument,
+            filingDateYear: '20',
+          },
+          screenMetadata: {
+            editType: 'CourtIssued',
+          },
+        },
+      });
+
+      expect(errorStub.mock.calls[0][0].errors.filingDate).toEqual(
+        'Enter a four-digit year',
+      );
+    });
+
+    it('does not overwrite errors returned from the validateDocumentInteractor if the user enters a two-digit year', async () => {
+      applicationContext
+        .getUseCases()
+        .validateDocumentInteractor.mockReturnValue({
+          filingDate: 'The date was invalid',
+        });
+
+      await runAction(validateDocumentAction, {
+        modules: {
+          presenter,
+        },
+        state: {
+          form: {
+            ...mockDocument,
+            filingDateYear: '20',
+          },
+          screenMetadata: {
+            editType: 'CourtIssued',
+          },
+        },
+      });
+
+      expect(errorStub.mock.calls[0][0].errors.filingDate).toEqual(
+        'The date was invalid',
+      );
+    });
+  });
 });


### PR DESCRIPTION
This prevents a user from entering a 2-digit year when updating docket entry meta data.

<img width="612" alt="Screen Shot 2021-07-05 at 12 11 49 PM" src="https://user-images.githubusercontent.com/1891789/124507189-8ade9380-dd8a-11eb-90c3-bb9978dc3473.png">
