### PR TITLE
Allow dynamodb:GetItem for migrations policy

### DIFF
--- a/iam/terraform/environment-specific/main/migration.tf
+++ b/iam/terraform/environment-specific/main/migration.tf
@@ -43,9 +43,9 @@ resource "aws_iam_role_policy" "migration_policy" {
             "Action": [
                 "dynamodb:BatchWriteItem",
                 "dynamodb:DescribeStream",
-                "dynamodb:GetItem",
                 "dynamodb:GetRecords",
                 "dynamodb:GetShardIterator",
+                "dynamodb:ListShards",
                 "dynamodb:ListStreams",
                 "dynamodb:Query",
                 "dynamodb:PutItem",

--- a/iam/terraform/environment-specific/main/migration.tf
+++ b/iam/terraform/environment-specific/main/migration.tf
@@ -43,6 +43,7 @@ resource "aws_iam_role_policy" "migration_policy" {
             "Action": [
                 "dynamodb:BatchWriteItem",
                 "dynamodb:DescribeStream",
+                "dynamodb:GetItem",
                 "dynamodb:GetRecords",
                 "dynamodb:GetShardIterator",
                 "dynamodb:ListShards",

--- a/iam/terraform/environment-specific/main/migration.tf
+++ b/iam/terraform/environment-specific/main/migration.tf
@@ -43,9 +43,9 @@ resource "aws_iam_role_policy" "migration_policy" {
             "Action": [
                 "dynamodb:BatchWriteItem",
                 "dynamodb:DescribeStream",
+                "dynamodb:GetItem",
                 "dynamodb:GetRecords",
                 "dynamodb:GetShardIterator",
-                "dynamodb:ListShards",
                 "dynamodb:ListStreams",
                 "dynamodb:Query",
                 "dynamodb:PutItem",


### PR DESCRIPTION
As observed in a recent migration that failed, we are now making use
of GetItem. This permission needed to be added to the policy so that
the migration could succeed. This means we need to run the environment-
specific terraform before attempting a deploy.

Also observed this error in the console while manually adjusting the policy.

```
Invalid Action: The action dynamodb:ListShards does not exist. Learn more 
```

However, after reviewing [AWS Documentation](https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html), we are keeping it.

