### PR TITLE
Add `dynamodb:DeleteItem` to migration policy

### DIFF
--- a/iam/terraform/environment-specific/main/migration.tf
+++ b/iam/terraform/environment-specific/main/migration.tf
@@ -42,6 +42,7 @@ resource "aws_iam_role_policy" "migration_policy" {
         {
             "Action": [
                 "dynamodb:BatchWriteItem",
+                "dynamodb:DeleteItem",
                 "dynamodb:DescribeStream",
                 "dynamodb:GetItem",
                 "dynamodb:GetRecords",


### PR DESCRIPTION
A new migration uses `deleteItem` in order to remove erroneous records.
We need to introduce this permission to the policy used by the lambda
for migrations.