### PR TITLE
8536 fallback dynamodb region from staging

### DIFF
--- a/shared/src/utilities/getDynamoEndpoints.js
+++ b/shared/src/utilities/getDynamoEndpoints.js
@@ -2,12 +2,17 @@ const AWS = require('aws-sdk');
 const { DynamoDB } = AWS;
 
 /**
- * deleteByGsi
+ * getDynamoEndpoints
  *
  * @param {object} providers the providers object
- * @param {object} providers.applicationContext the application context
- * @param {object} providers.gsi the gsi to search and delete
- * @returns {Promise} the promise of the call to persistence
+ * @param {object} providers.fallbackRegion the region to fallback to
+ * @param {object} providers.fallbackRegionEndpoint the endpoint of the fallback region
+ * @param {object} providers.mainRegion the main region in use
+ * @param {object} providers.mainRegionEndpoint the main region endpoint in use
+ * @param {object} providers.masterDynamoDbEndpoint the master dynamo db endpoint in use
+ * @param {object} providers.masterRegion the master region
+ * @param {object} providers.useMasterRegion the flag indicating whether or not to use the master region
+ * @returns {Object} the main region database and the fallback region database values
  */
 exports.getDynamoEndpoints = ({
   fallbackRegion,

--- a/shared/src/utilities/getDynamoEndpoints.js
+++ b/shared/src/utilities/getDynamoEndpoints.js
@@ -1,0 +1,32 @@
+const AWS = require('aws-sdk');
+const { DynamoDB } = AWS;
+
+/**
+ * deleteByGsi
+ *
+ * @param {object} providers the providers object
+ * @param {object} providers.applicationContext the application context
+ * @param {object} providers.gsi the gsi to search and delete
+ * @returns {Promise} the promise of the call to persistence
+ */
+exports.getDynamoEndpoints = ({
+  fallbackRegion,
+  fallbackRegionEndpoint,
+  mainRegion,
+  mainRegionEndpoint,
+  masterDynamoDbEndpoint,
+  masterRegion,
+  useMasterRegion,
+}) => {
+  const mainRegionDB = new DynamoDB.DocumentClient({
+    endpoint: useMasterRegion ? masterDynamoDbEndpoint : mainRegionEndpoint,
+    region: useMasterRegion ? masterRegion : mainRegion,
+  });
+
+  const fallbackRegionDB = new DynamoDB.DocumentClient({
+    endpoint: useMasterRegion ? fallbackRegionEndpoint : masterDynamoDbEndpoint,
+    region: useMasterRegion ? fallbackRegion : masterRegion,
+  });
+
+  return { fallbackRegionDB, mainRegionDB };
+};

--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -1187,6 +1187,7 @@ const getDocumentClient = ({ useMasterRegion = false } = {}) => {
     dynamoClientCache[type] = {
       batchGet: fallbackHandler({ key: 'batchGet', ...config }),
       batchWrite: fallbackHandler({ key: 'batchWrite', ...config }),
+      delete: fallbackHandler({ key: 'delete', ...config }),
       get: fallbackHandler({ key: 'get', ...config }),
       put: fallbackHandler({ key: 'put', ...config }),
       query: fallbackHandler({ key: 'query', ...config }),

--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -1182,21 +1182,23 @@ const getDocumentClient = ({ useMasterRegion = false } = {}) => {
     });
 
     const fallbackHandler = key => params => {
-      return new Promise((resolve, reject) => {
-        mainRegionDB[key](params)
-          .promise()
-          .catch(err => {
-            if (
-              err.code === 'ResourceNotFoundException' ||
-              err.statusCode === 503
-            ) {
-              return fallbackRegionDB[key](params).promise();
-            }
-            throw err;
-          })
-          .then(resolve)
-          .catch(reject);
-      });
+      return {
+        promise: new Promise((resolve, reject) => {
+          mainRegionDB[key](params)
+            .promise()
+            .catch(err => {
+              if (
+                err.code === 'ResourceNotFoundException' ||
+                err.statusCode === 503
+              ) {
+                return fallbackRegionDB[key](params).promise();
+              }
+              throw err;
+            })
+            .then(resolve)
+            .catch(reject);
+        }),
+      };
     };
 
     dynamoClientCache[type] = {

--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -494,9 +494,6 @@ const {
   getDownloadPolicyUrlInteractor,
 } = require('../../shared/src/business/useCases/getDownloadPolicyUrlInteractor');
 const {
-  getDynamoEndpoint,
-} = require('../../shared/src/persistence/dynamo/helpers/getDynamoEndpoint');
-const {
   getEligibleCasesForTrialCity,
 } = require('../../shared/src/persistence/dynamo/trialSessions/getEligibleCasesForTrialCity');
 const {
@@ -1289,7 +1286,6 @@ const gatewayMethods = {
     createTrialSessionWorkingCopy,
     createUser,
     fetchPendingItems,
-    getDynamoEndpoint,
     getSesStatus,
     incrementCounter,
     markMessageThreadRepliedTo,

--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -494,6 +494,9 @@ const {
   getDownloadPolicyUrlInteractor,
 } = require('../../shared/src/business/useCases/getDownloadPolicyUrlInteractor');
 const {
+  getDynamoEndpoint,
+} = require('../../shared/src/persistence/dynamo/helpers/getDynamoEndpoint');
+const {
   getEligibleCasesForTrialCity,
 } = require('../../shared/src/persistence/dynamo/trialSessions/getEligibleCasesForTrialCity');
 const {
@@ -1286,6 +1289,7 @@ const gatewayMethods = {
     createTrialSessionWorkingCopy,
     createUser,
     fetchPendingItems,
+    getDynamoEndpoint,
     getSesStatus,
     incrementCounter,
     markMessageThreadRepliedTo,

--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -1203,12 +1203,17 @@ const fallbackHandler = ({
 
 const getDocumentClient = ({ useMasterRegion = false } = {}) => {
   const type = useMasterRegion ? 'master' : 'region';
-
   const mainRegion = environment.region;
   const fallbackRegion =
     environment.region === 'us-west-1' ? 'us-east-1' : 'us-west-1';
-  const mainRegionEndpoint = `dynamodb.${mainRegion}.amazonaws.com`;
-  const fallbackRegionEndpoint = `dynamodb.${fallbackRegion}.amazonaws.com`;
+  const mainRegionEndpoint = environment.dynamoDbEndpoint.includes('localhost')
+    ? 'http://localhost:8000'
+    : `dynamodb.${mainRegion}.amazonaws.com`;
+  const fallbackRegionEndpoint = environment.dynamoDbEndpoint.includes(
+    'localhost',
+  )
+    ? 'http://localhost:8000'
+    : `dynamodb.${fallbackRegion}.amazonaws.com`;
   const config = {
     fallbackRegion,
     fallbackRegionEndpoint,

--- a/web-api/src/fallbackHandler.js
+++ b/web-api/src/fallbackHandler.js
@@ -1,0 +1,46 @@
+const AWS = require('aws-sdk');
+const { DynamoDB } = AWS;
+
+const fallbackHandler = ({
+  fallbackRegion,
+  fallbackRegionEndpoint,
+  key,
+  mainRegion,
+  mainRegionEndpoint,
+  masterDynamoDbEndpoint,
+  masterRegion,
+  useMasterRegion,
+}) => {
+  const mainRegionDB = new DynamoDB.DocumentClient({
+    endpoint: useMasterRegion ? masterDynamoDbEndpoint : mainRegionEndpoint,
+    region: useMasterRegion ? masterRegion : mainRegion,
+  });
+
+  const fallbackRegionDB = new DynamoDB.DocumentClient({
+    endpoint: useMasterRegion ? fallbackRegionEndpoint : masterDynamoDbEndpoint,
+    region: useMasterRegion ? fallbackRegion : masterRegion,
+  });
+
+  return params => {
+    return {
+      promise: () =>
+        new Promise((resolve, reject) => {
+          mainRegionDB[key](params)
+            .promise()
+            .catch(err => {
+              if (
+                err.code === 'ResourceNotFoundException' ||
+                err.statusCode === 503
+              ) {
+                return fallbackRegionDB[key](params).promise();
+              }
+              throw err;
+            })
+            .then(resolve)
+            .catch(reject);
+        }),
+    };
+  };
+};
+
+module.exports.fallbackHandler = fallbackHandler;

--- a/web-api/src/fallbackHandler.js
+++ b/web-api/src/fallbackHandler.js
@@ -1,5 +1,6 @@
-const AWS = require('aws-sdk');
-const { DynamoDB } = AWS;
+const {
+  getDynamoEndpoints,
+} = require('../../shared/src/utilities/getDynamoEndpoints');
 
 const fallbackHandler = ({
   fallbackRegion,
@@ -11,14 +12,15 @@ const fallbackHandler = ({
   masterRegion,
   useMasterRegion,
 }) => {
-  const mainRegionDB = new DynamoDB.DocumentClient({
-    endpoint: useMasterRegion ? masterDynamoDbEndpoint : mainRegionEndpoint,
-    region: useMasterRegion ? masterRegion : mainRegion,
-  });
-
-  const fallbackRegionDB = new DynamoDB.DocumentClient({
-    endpoint: useMasterRegion ? fallbackRegionEndpoint : masterDynamoDbEndpoint,
-    region: useMasterRegion ? fallbackRegion : masterRegion,
+  const { fallbackRegionDB, mainRegionDB } = getDynamoEndpoints({
+    fallbackRegion,
+    fallbackRegionEndpoint,
+    key,
+    mainRegion,
+    mainRegionEndpoint,
+    masterDynamoDbEndpoint,
+    masterRegion,
+    useMasterRegion,
   });
 
   return params => {

--- a/web-api/src/fallbackHandler.test.js
+++ b/web-api/src/fallbackHandler.test.js
@@ -1,0 +1,83 @@
+const { fallbackHandler } = require('./fallbackhandler');
+
+const mockGet = jest.fn();
+
+jest.mock('aws-sdk', () => {
+  return {
+    DynamoDB: {
+      DocumentClient: jest.fn(() => ({
+        get: mockGet,
+      })),
+    },
+  };
+});
+
+describe('fallbackHandler', () => {
+  it('should not fallback if the first request was successful', async () => {
+    mockGet.mockImplementationOnce(() => ({
+      promise: () =>
+        Promise.resolve({
+          Item: {
+            text: 'success',
+          },
+        }),
+    }));
+
+    await fallbackHandler({
+      key: 'get',
+    })({
+      TableName: 'testing',
+    }).promise();
+    expect(mockGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fallback if the main dynamodb region is down', async () => {
+    mockGet.mockImplementationOnce(() => ({
+      promise: () =>
+        Promise.reject({
+          code: 'ResourceNotFoundException',
+        }),
+    }));
+
+    mockGet.mockImplementationOnce(() => ({
+      promise: () =>
+        Promise.resolve({
+          Item: {
+            text: 'success',
+          },
+        }),
+    }));
+
+    await fallbackHandler({
+      key: 'get',
+    })({
+      TableName: 'testing',
+    }).promise();
+    expect(mockGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('should fallback if the main dynamodb region is throwing 503 errors', async () => {
+    mockGet.mockImplementationOnce(() => ({
+      promise: () =>
+        Promise.reject({
+          statusCode: 503,
+        }),
+    }));
+
+    mockGet.mockImplementationOnce(() => ({
+      promise: () =>
+        Promise.resolve({
+          Item: {
+            text: 'success',
+          },
+        }),
+    }));
+
+    await fallbackHandler({
+      key: 'get',
+    })({
+      TableName: 'testing',
+    }).promise();
+    expect(mockGet).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web-api/src/fallbackHandler.test.js
+++ b/web-api/src/fallbackHandler.test.js
@@ -80,4 +80,25 @@ describe('fallbackHandler', () => {
     }).promise();
     expect(mockGet).toHaveBeenCalledTimes(2);
   });
+
+  it('should throw an error if the main dynamodb region is throwing other types of errors', async () => {
+    mockGet.mockImplementationOnce(() => ({
+      promise: () =>
+        Promise.reject({
+          statusCode: 500,
+        }),
+    }));
+
+    mockGet.mockImplementationOnce(() => ({
+      promise: () => Promise.reject({}),
+    }));
+
+    await expect(
+      fallbackHandler({
+        key: 'get',
+      })({
+        TableName: 'testing',
+      }).promise(),
+    ).rejects.toEqual({ statusCode: 500 });
+  });
 });

--- a/web-api/src/fallbackHandler.test.js
+++ b/web-api/src/fallbackHandler.test.js
@@ -1,4 +1,4 @@
-const { fallbackHandler } = require('./fallbackhandler');
+const { fallbackHandler } = require('./fallbackHandler');
 
 const mockGet = jest.fn();
 

--- a/web-api/src/lambdaWrapper.test.js
+++ b/web-api/src/lambdaWrapper.test.js
@@ -81,6 +81,19 @@ describe('lambdaWrapper', () => {
     expect(res.send).toHaveBeenCalled();
   });
 
+  it('calls res.send with when there is no res.body and when header is application/json', async () => {
+    await lambdaWrapper(() => {
+      return {
+        body: undefined,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      };
+    })(req, res);
+    expect(JSON.parse).toHaveBeenCalled();
+    expect(res.send).toHaveBeenCalledWith(undefined);
+  });
+
   it('calls res.redirect if header Location is set', async () => {
     await lambdaWrapper(() => {
       return {

--- a/web-api/src/logger.test.js
+++ b/web-api/src/logger.test.js
@@ -70,6 +70,40 @@ describe('logger', () => {
     );
   });
 
+  it('sets logger.defaultMeta.environment color stage to from the environment variables', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.CURRENT_COLOR = 'blue';
+    process.env.STAGE = 'someEnv';
+
+    await subject(req, res);
+    const instance = req.locals.logger;
+
+    instance.info = jest.fn();
+
+    res.end();
+    expect(instance.defaultMeta.environment).toEqual({
+      color: 'blue',
+      stage: 'someEnv',
+    });
+  });
+
+  it('sets logger.defaultMeta.environment color to green and stage to local when those environment variables are undefined', async () => {
+    delete process.env.CURRENT_COLOR;
+    delete process.env.STAGE;
+    process.env.NODE_ENV = 'production';
+
+    await subject(req, res);
+    const instance = req.locals.logger;
+
+    instance.info = jest.fn();
+
+    res.end();
+    expect(instance.defaultMeta.environment).toEqual({
+      color: 'green',
+      stage: 'local',
+    });
+  });
+
   it('passes request IDs to event if set in production', async () => {
     process.env.NODE_ENV = 'production';
 


### PR DESCRIPTION
Adding fallback logic which wraps our getDocumentClient call which is used anywhere in our application we attempt to fetch or store data into dynamodb.  This will try to make a request to the main region the API is deployed on, but fall back if the Resource does not exist (we manually deleted the table) or if AWS returns a 503 error (which we think only happens if their service is having issues).