### PR TITLE
BUG 8581: search for quoted judge name phrase

### DIFF
--- a/shared/src/persistence/elasticsearch/advancedDocumentSearch.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearch.js
@@ -135,23 +135,20 @@ exports.advancedDocumentSearch = async ({
     });
   }
 
-  if (startDate) {
-    docketEntryQueryParams.push({
-      range: {
-        'filingDate.S': {
-          format: 'strict_date_time', // ISO-8601 time stamp
-          gte: startDate,
-        },
-      },
-    });
-  }
-
   if (endDate && startDate) {
     docketEntryQueryParams.push({
       range: {
         'filingDate.S': {
-          format: 'strict_date_time', // ISO-8601 time stamp
-          lte: endDate,
+          gte: `${startDate}||/h`,
+          lte: `${endDate}||/h`,
+        },
+      },
+    });
+  } else if (startDate) {
+    docketEntryQueryParams.push({
+      range: {
+        'filingDate.S': {
+          gte: `${startDate}||/h`,
         },
       },
     });

--- a/shared/src/persistence/elasticsearch/advancedDocumentSearch.test.js
+++ b/shared/src/persistence/elasticsearch/advancedDocumentSearch.test.js
@@ -333,8 +333,7 @@ describe('advancedDocumentSearch', () => {
       {
         range: {
           'filingDate.S': {
-            format: 'strict_date_time',
-            gte: '2020-02-20T05:00:00.000Z',
+            gte: '2020-02-20T05:00:00.000Z||/h',
           },
         },
       },
@@ -357,16 +356,8 @@ describe('advancedDocumentSearch', () => {
       {
         range: {
           'filingDate.S': {
-            format: 'strict_date_time',
-            gte: '2020-02-20T05:00:00.000Z',
-          },
-        },
-      },
-      {
-        range: {
-          'filingDate.S': {
-            format: 'strict_date_time',
-            lte: '2020-02-21T04:59:59.999Z',
+            gte: '2020-02-20T05:00:00.000Z||/h',
+            lte: '2020-02-21T04:59:59.999Z||/h',
           },
         },
       },

--- a/shared/src/persistence/elasticsearch/caseDeadlines/getCaseDeadlinesByDateRange.js
+++ b/shared/src/persistence/elasticsearch/caseDeadlines/getCaseDeadlinesByDateRange.js
@@ -21,9 +21,8 @@ exports.getCaseDeadlinesByDateRange = async ({
     {
       range: {
         'deadlineDate.S': {
-          format: 'strict_date_time', // ISO-8601 time stamp
-          gte: startDate,
-          lte: endDate,
+          gte: `${startDate}||/h`,
+          lte: `${endDate}||/h`,
         },
       },
     },
@@ -31,8 +30,10 @@ exports.getCaseDeadlinesByDateRange = async ({
 
   if (judge) {
     queryArray.push({
-      match: {
-        'associatedJudge.S': { query: judge },
+      simple_query_string: {
+        default_operator: 'and',
+        fields: ['associatedJudge.S'],
+        query: `"${judge}"`,
       },
     });
   }

--- a/shared/src/persistence/elasticsearch/caseDeadlines/getCaseDeadlinesByDateRange.js
+++ b/shared/src/persistence/elasticsearch/caseDeadlines/getCaseDeadlinesByDateRange.js
@@ -16,19 +16,13 @@ exports.getCaseDeadlinesByDateRange = async ({
       ? pageSize
       : DEADLINE_REPORT_PAGE_SIZE;
 
-  const queryArray = [
+  const queryArray = [];
+  const filterArray = [
     {
       range: {
         'deadlineDate.S': {
           format: 'strict_date_time', // ISO-8601 time stamp
           gte: startDate,
-        },
-      },
-    },
-    {
-      range: {
-        'deadlineDate.S': {
-          format: 'strict_date_time', // ISO-8601 time stamp
           lte: endDate,
         },
       },
@@ -38,7 +32,7 @@ exports.getCaseDeadlinesByDateRange = async ({
   if (judge) {
     queryArray.push({
       match: {
-        'associatedJudge.S': { operator: 'and', query: judge },
+        'associatedJudge.S': { query: judge },
       },
     });
   }
@@ -48,6 +42,7 @@ exports.getCaseDeadlinesByDateRange = async ({
       from,
       query: {
         bool: {
+          filter: filterArray,
           must: queryArray,
         },
       },

--- a/shared/src/persistence/elasticsearch/caseDeadlines/getCaseDeadlinesByDateRange.test.js
+++ b/shared/src/persistence/elasticsearch/caseDeadlines/getCaseDeadlinesByDateRange.test.js
@@ -33,15 +33,15 @@ describe('getCaseDeadlinesByDateRange', () => {
     );
     expect(search.mock.calls[0][0].searchParameters.body.from).toEqual(0);
     expect(
-      search.mock.calls[0][0].searchParameters.body.query.bool.must[0].range[
+      search.mock.calls[0][0].searchParameters.body.query.bool.filter[0].range[
         'deadlineDate.S'
       ].gte,
-    ).toEqual(START_DATE);
+    ).toEqual(`${START_DATE}||/h`);
     expect(
-      search.mock.calls[0][0].searchParameters.body.query.bool.must[1].range[
+      search.mock.calls[0][0].searchParameters.body.query.bool.filter[0].range[
         'deadlineDate.S'
       ].lte,
-    ).toEqual(END_DATE);
+    ).toEqual(`${END_DATE}||/h`);
   });
 
   it('returns results from the search client using pageSize that is passed in if it is less than DEADLINE_REPORT_PAGE_SIZE', async () => {
@@ -82,10 +82,12 @@ describe('getCaseDeadlinesByDateRange', () => {
     });
 
     expect(
-      search.mock.calls[0][0].searchParameters.body.query.bool.must[2],
+      search.mock.calls[0][0].searchParameters.body.query.bool.must[0],
     ).toEqual({
-      match: {
-        'associatedJudge.S': { operator: 'and', query: 'Buch' },
+      simple_query_string: {
+        default_operator: 'and',
+        fields: ['associatedJudge.S'],
+        query: '"Buch"',
       },
     });
   });

--- a/web-client/src/views/CaseDeadlines/CaseDeadlines.jsx
+++ b/web-client/src/views/CaseDeadlines/CaseDeadlines.jsx
@@ -130,7 +130,7 @@ export const CaseDeadlines = connect(
                   </thead>
                   <tbody>
                     {caseDeadlineReportHelper.caseDeadlines.map(item => (
-                      <tr key={item.docketNumber}>
+                      <tr key={item.caseDeadlineId}>
                         <td className="smaller-column semi-bold">
                           {item.formattedDeadline}
                         </td>


### PR DESCRIPTION
Also, refine date range searches to be more efficient, rounding to the hour, place within a single range query if both start and end are present.  The date range syntax change also should give us more efficiency per
https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#date-math
Where date ranges are placed in filters, rounded up/down (depending on whether range is 'gte' or 'lte') to the nearest hour.  Those filtered results are aggregated and more quickly available to subsequent searches.  Queries for "today" ought to become slightly more performant.

edit: also fixed a react for-loop key that was producing "duplicate" warnings.