### PR TITLE
8576: BUG remove unneeded async decorators

### DIFF
--- a/web-client/src/presenter/actions/setCaseOnFormAction.js
+++ b/web-client/src/presenter/actions/setCaseOnFormAction.js
@@ -8,7 +8,7 @@ import { state } from 'cerebral';
  * @param {object} providers.props the cerebral props object
  * @param {object} providers.store the cerebral store
  */
-export const setCaseOnFormAction = async ({ props, store }) => {
+export const setCaseOnFormAction = ({ props, store }) => {
   const caseDetail = cloneDeep(props.caseDetail);
   store.set(state.form, caseDetail);
 };

--- a/web-client/src/presenter/actions/setCaseOnFormUsingStateAction.js
+++ b/web-client/src/presenter/actions/setCaseOnFormUsingStateAction.js
@@ -9,10 +9,8 @@ import { state } from 'cerebral';
  * @param {object} providers.store the cerebral store
  * @returns {object} caseDetail onto the props stream
  */
-export const setCaseOnFormUsingStateAction = async ({ get, store }) => {
+export const setCaseOnFormUsingStateAction = ({ get, store }) => {
   const caseDetail = cloneDeep(get(state.caseDetail));
-
   store.set(state.form, caseDetail);
-
   return { caseDetail };
 };

--- a/web-client/src/presenter/actions/setContactsOnFormAction.js
+++ b/web-client/src/presenter/actions/setContactsOnFormAction.js
@@ -9,7 +9,7 @@ import { state } from 'cerebral';
  * @param {object} providers.props the cerebral props object
  * @param {object} providers.store the cerebral store
  */
-export const setContactsOnFormAction = async ({
+export const setContactsOnFormAction = ({
   applicationContext,
   props,
   store,

--- a/web-client/src/presenter/sequences/gotoReviewSavedPetitionSequence.js
+++ b/web-client/src/presenter/sequences/gotoReviewSavedPetitionSequence.js
@@ -10,13 +10,13 @@ import { showProgressSequenceDecorator } from '../utilities/sequenceHelpers';
 export const gotoReviewSavedPetitionSequence = [
   shouldLoadCaseAction,
   {
-    ignore: [setCaseOnFormUsingStateAction, setContactsOnFormAction],
+    ignore: [setCaseOnFormUsingStateAction],
     load: showProgressSequenceDecorator([
       getCaseAction,
       setCaseAction,
       setCaseOnFormAction,
-      setContactsOnFormAction,
     ]),
   },
+  setContactsOnFormAction,
   setCurrentPageAction('ReviewSavedPetition'),
 ];


### PR DESCRIPTION
action had 'async' decoration.  Removed it, and suddenly sequence worked correctly.

tried a variety of things, but if the leading action in the 'ignore' path returned a promise, the second action (which had also been async) would not fire and the jsx would throw an error.