### PR TITLE
BUG: servedParties code not displaying on docket record

### DIFF
--- a/web-api/migration-terraform/main/lambdas/migration-segments.js
+++ b/web-api/migration-terraform/main/lambdas/migration-segments.js
@@ -6,6 +6,9 @@ const {
   migrateItems: bugMigration0035,
 } = require('./migrations/bug-0035-private-practitioner-representing');
 const {
+  migrateItems: bugMigration0036,
+} = require('./migrations/bug-0036-public-served-parties-code');
+const {
   migrateItems: migration0036,
 } = require('./migrations/0036-phone-number-format');
 const {
@@ -31,9 +34,11 @@ const sqs = new AWS.SQS({ region: 'us-east-1' });
 
 // eslint-disable-next-line no-unused-vars
 const migrateRecords = async ({ documentClient, items }) => {
-
   applicationContext.logger.info('about to run bug migration 0035');
   items = await bugMigration0035(items, documentClient);
+
+  applicationContext.logger.info('about to run bug migration 0036');
+  items = await bugMigration0036(items, documentClient);
 
   applicationContext.logger.debug('about to run migration 0036');
   items = await migration0036(items);

--- a/web-api/migration-terraform/main/lambdas/migrations/bug-0036-public-served-parties-code.js
+++ b/web-api/migration-terraform/main/lambdas/migrations/bug-0036-public-served-parties-code.js
@@ -1,0 +1,40 @@
+const createApplicationContext = require('../../../../src/applicationContext');
+const {
+  DocketEntry,
+} = require('../../../../../shared/src/business/entities/DocketEntry');
+const {
+  getServedPartiesCode,
+} = require('../../../../../shared/src/business/entities/DocketEntry');
+
+const applicationContext = createApplicationContext({});
+
+const migrateItems = async items => {
+  const itemsAfter = [];
+  for (const item of items) {
+    if (
+      item.pk.startsWith('case|') &&
+      item.sk.startsWith('docket-entry|') &&
+      item.servedAt &&
+      item.servedParties &&
+      !item.servedPartiesCode
+    ) {
+      item.servedPartiesCode = getServedPartiesCode(item.servedParties);
+      new DocketEntry(item, { applicationContext }).validateForMigration();
+
+      applicationContext.logger.info(
+        'Adding served parties code for docket entry',
+        {
+          pk: item.pk,
+          sk: item.sk,
+        },
+      );
+
+      itemsAfter.push(item);
+    } else {
+      itemsAfter.push(item);
+    }
+  }
+  return itemsAfter;
+};
+
+exports.migrateItems = migrateItems;

--- a/web-api/migration-terraform/main/lambdas/migrations/bug-0036-public-served-parties-code.test.js
+++ b/web-api/migration-terraform/main/lambdas/migrations/bug-0036-public-served-parties-code.test.js
@@ -1,0 +1,99 @@
+const {
+  MOCK_DOCUMENTS,
+} = require('../../../../../shared/src/test/mockDocuments');
+const {
+  SERVED_PARTIES_CODES,
+} = require('../../../../../shared/src/business/entities/EntityConstants');
+const { migrateItems } = require('./bug-0036-public-served-parties-code');
+
+describe('migrateItems', () => {
+  let mockDocketEntryItem;
+
+  beforeEach(() => {
+    mockDocketEntryItem = {
+      ...MOCK_DOCUMENTS[2],
+      pk: 'case|999-99',
+      sk: 'docket-entry|d3989b49-dea9-4c1a-88fd-379b972032d8',
+    };
+  });
+
+  it('should return and not modify records that are NOT docket entry records', async () => {
+    const items = [
+      {
+        pk: 'case|101-21',
+        sk: 'user|6d74eadc-0181-4ff5-826c-305200e8733d',
+      },
+      {
+        pk: 'case|101-21',
+        sk: 'docket-entry|101-21',
+      },
+    ];
+    const results = await migrateItems(items);
+
+    expect(results).toEqual([
+      {
+        pk: 'case|101-21',
+        sk: 'user|6d74eadc-0181-4ff5-826c-305200e8733d',
+      },
+      {
+        pk: 'case|101-21',
+        sk: 'docket-entry|101-21',
+      },
+    ]);
+  });
+
+  it('should not modify docket entries that do not have a servedParties array', async () => {
+    const items = [
+      {
+        ...mockDocketEntryItem,
+        servedAt: '',
+        servedParties: undefined,
+        servedPartiesCode: undefined,
+      },
+    ];
+
+    const results = await migrateItems(items);
+
+    expect(results[0].servedPartiesCode).toBeUndefined();
+  });
+
+  it('should not modify docket entries that do not have servedAt', async () => {
+    const items = [
+      {
+        ...mockDocketEntryItem,
+        servedAt: undefined,
+        servedPartiesCode: undefined,
+      },
+    ];
+
+    const results = await migrateItems(items);
+
+    expect(results[0].servedPartiesCode).toBeUndefined();
+  });
+
+  it('should not modify docket entries that have a servedPartiesCode', async () => {
+    const items = [
+      {
+        ...mockDocketEntryItem,
+        servedPartiesCode: SERVED_PARTIES_CODES.BOTH,
+      },
+    ];
+
+    const results = await migrateItems(items);
+
+    expect(results[0].servedPartiesCode).toEqual(SERVED_PARTIES_CODES.BOTH);
+  });
+
+  it('should modify docket entries that do not have a servedPartiesCode', async () => {
+    const items = [
+      {
+        ...mockDocketEntryItem,
+        servedPartiesCode: undefined,
+      },
+    ];
+
+    const results = await migrateItems(items);
+
+    expect(results[0].servedPartiesCode).toBeDefined();
+  });
+});


### PR DESCRIPTION
added a migration to set servedPartiesCode on served docket entries when it is undefined.