### PR TITLE
Add Architecture Decision Records for Terraform, Serverless, and monolambda decisions.

### DIFF
--- a/docs/architecture/decisions/0003-use-terraform-to-automate-infrastructure-provisioning.md
+++ b/docs/architecture/decisions/0003-use-terraform-to-automate-infrastructure-provisioning.md
@@ -14,7 +14,7 @@ As specified in the Court’s [Deliverables and Performance Standards](https://g
 
 Terraform and Serverless were initially selected to configure AWS. This issue is documented in retrospect, and Serverless was moved away from (which will be documented in a further decision record) — so this issue will focus on Terraform exclusively.
 
-Terraform is a popular and [recommended](https://engineering.18f.gov/language-selection/) framework for automating infrastructure and storing configuration in code.
+Terraform was deemed the most popular and [recommended](https://engineering.18f.gov/language-selection/) framework for automating infrastructure and storing configuration in code.
 
 ## Decision
 
@@ -26,7 +26,7 @@ We’ll automate provisioning and configuring infrastructure components using Te
 
 > What becomes easier or more difficult to do and any risks introduced by the change that will need to be mitigated.
 
-- Creating new environments is easier because it’s done by executing an automated command instead of a set of steps which must be done manually.
+- Creating new environments is easier because it’s done by executing an automated command instead of a set of steps which must be done manually. Could not imagine delivering the project manually.
 - The risk of misconfiguration of an environment decreases.
 - Management of Terraform state adds complexity to configuration, but is an acceptable level of complexity due to the automation benefits. Terraform state is version-specific, so upgrading versions of Terraform can be complex to execute.
   - This complexity is mitigated by automatically running Terraform on each deploy, decreasing the chance of Terraform state falling more than one version update behind.

--- a/docs/architecture/decisions/0003-use-terraform-to-automate-infrastructure-provisioning.md
+++ b/docs/architecture/decisions/0003-use-terraform-to-automate-infrastructure-provisioning.md
@@ -1,0 +1,32 @@
+# 3. Use Terraform to automate infrastructure provisioning
+
+Date: 2021-07-13
+
+## Status
+
+Accepted
+
+## Context
+
+> The issue motivating this decision, and any context that influences or constrains the decision. **This issue was documented in retrospect.**
+
+As specified in the Court’s [Deliverables and Performance Standards](https://github.com/ustaxcourt/case-management-rfq/blob/master/02_SOW.md#deliverables-and-performance-standards), the project must be deployed, where acceptable quality is defined as deployed with a single command. As interpreted by the team, this requires some form of automation of infrastructure provisioning.
+
+Terraform and Serverless were initially selected to configure AWS. This issue is documented in retrospect, and Serverless was moved away from (which will be documented in a further decision record) — so this issue will focus on Terraform exclusively.
+
+Terraform is a popular and [recommended](https://engineering.18f.gov/language-selection/) framework for automating infrastructure and storing configuration in code.
+
+## Decision
+
+> The change that we're proposing or have agreed to implement.
+
+We’ll automate provisioning and configuring infrastructure components using Terraform. If any manual steps are needed to upgrade environments from the main code branch to the next version, they will be documented in the pull request proposing the change.
+
+## Consequences
+
+> What becomes easier or more difficult to do and any risks introduced by the change that will need to be mitigated.
+
+- Creating new environments is easier because it’s done by executing an automated command instead of a set of steps which must be done manually.
+- The risk of misconfiguration of an environment decreases.
+- Management of Terraform state adds complexity to configuration, but is an acceptable level of complexity due to the automation benefits. Terraform state is version-specific, so upgrading versions of Terraform can be complex to execute.
+  - This complexity is mitigated by automatically running Terraform on each deploy, decreasing the chance of Terraform state falling more than one version update behind.

--- a/docs/architecture/decisions/0004-deploy-lambda-code-using-terraform-instead-of-serverless.md
+++ b/docs/architecture/decisions/0004-deploy-lambda-code-using-terraform-instead-of-serverless.md
@@ -12,9 +12,11 @@ Accepted
 
 Prior to this decision, the Serverless Framework was used to package and deploy Lambda code to AWS. Any additional infrastructure needed (like S3 buckets) were configured using Terraform before running `serverless deploy`.
 
+Serverless uses the [Cloud Formation resource specification](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html). This was finalized in 2011, and much as changed since then rendering it somewhat obsolete.
+
 When running deployments, Serverless Framework uses AWS CloudFormation. CloudFormation has a 200 resource limit for a single CloudFormation run, which caused us to [split our deployment into multiple Serverless configuration sets](https://github.com/flexion/ef-cms/pull/2276).
 
-Additionally, CloudFormation stacks can get into a locked state when using Serverless, and to unlock the stack to get it deployable again the stack has to be destroyed and re-created. This is a routine and regular issue that we have experienced.
+Additionally, CloudFormation stacks can get into a locked state when using Serverless, and to unlock the stack to get it deployable again the stack has to be destroyed and re-created. This is a routine and regular issue that we have experienced. It was also painfully time-consuming to remove them and then recreate.
 
 ## Decision
 

--- a/docs/architecture/decisions/0004-deploy-lambda-code-using-terraform-instead-of-serverless.md
+++ b/docs/architecture/decisions/0004-deploy-lambda-code-using-terraform-instead-of-serverless.md
@@ -1,0 +1,31 @@
+# 4. Deploy lambda code using Terraform instead of Serverless
+
+Date: 2021-07-13
+
+## Status
+
+Accepted
+
+## Context
+
+> The issue motivating this decision, and any context that influences or constrains the decision. **This issue was documented in retrospect.**
+
+Prior to this decision, the Serverless Framework was used to package and deploy Lambda code to AWS. Any additional infrastructure needed (like S3 buckets) were configured using Terraform before running `serverless deploy`.
+
+When running deployments, Serverless Framework uses AWS CloudFormation. CloudFormation has a 200 resource limit for a single CloudFormation run, which caused us to [split our deployment into multiple Serverless configuration sets](https://github.com/flexion/ef-cms/pull/2276).
+
+Additionally, CloudFormation stacks can get into a locked state when using Serverless, and to unlock the stack to get it deployable again the stack has to be destroyed and re-created. This is a routine and regular issue that we have experienced.
+
+## Decision
+
+> The change that we're proposing or have agreed to implement.
+
+We will remove the Serverless Framework and deploy all infrastructure including Lambda code through Terraform.
+
+## Consequences
+
+> What becomes easier or more difficult to do and any risks introduced by the change that will need to be mitigated.
+
+- We currently use Serverless to run the API locally in development. We may be able to continue to user Serverless Framework for local development and use sls package to generate a package which can be deployed using Terraform, or we will need to find a new solution to run locally. Running serverless locally takes significant memory resources (gigabytes) for unknown reasons, which can cause issues when running in Docker.
+- We can unify our deployment scripts into fewer steps because we will no longer have a 200 resource limit imposed on our configuration by CloudFormation (as we will no longer be using CloudFormation).
+- Unifying our deployment steps will likely decrease deployment times. Our current deployments take about 30 minutes, and initial prototypes of Terraform-only deployments run in about 3 minutes.

--- a/docs/architecture/decisions/0005-use-one-lambda-with-an-integrated-router-instead-of-one-lambda-per-route.md
+++ b/docs/architecture/decisions/0005-use-one-lambda-with-an-integrated-router-instead-of-one-lambda-per-route.md
@@ -1,0 +1,34 @@
+# 5. Use one lambda with an integrated router instead of one lambda per route
+
+Date: 2021-07-13
+
+## Status
+
+Accepted
+
+## Context
+
+> The issue motivating this decision, and any context that influences or constrains the decision. **This issue was documented in retrospect.**
+
+Before this decision, we had been using one Lambda per HTTP route and relying on API Gateway to perform routing. Serverless Framework lead us into this pattern, however, it caused:
+
+- A significant amount of infrastructure configuration (leading to longer deploy times)
+- A slower in-app experience (when navigating around the application, less-often used routes, especially routes that were only accessible to a subset of users, would need to cold-start)
+- A complex local development experience (each route was booted as a separate script as they are in Lambda, leading to large memory footprints)
+
+## Decision
+
+> The change that we're proposing or have agreed to implement.
+
+We’ll send all HTTP requests to a single Lambda, which will perform internal routing.
+
+## Consequences
+
+> What becomes easier or more difficult to do and any risks introduced by the change that will need to be mitigated.
+
+As documented in the [pull request at the time](https://github.com/ustaxcourt/ef-cms/pull/280), the benefits to having a single Lambda hosting all of our code include:
+
+- Faster deploys
+- Limited amount of cold starts
+- Less infrastructure overhead (single file having all our routes vs 15 serverless files)
+- A single express service to run locally when doing development


### PR DESCRIPTION
As a part of #1223, this pull request introduces documentation around three related decisions — the decisions to use Terraform, to no longer use Serverless, and to use a single lambda function over one-per-route. The purpose of this documentation is to:

- Create a pattern of documentation for major architectural choices, to help remind future team members (Future Us, or others) of the context and thoughts around how major choices were made, the mitigations we took for risks, and make revisiting or changing the decision explicit and intentional.
- Assist in onboarding new technical employees, like the DevSecOps Engineer (current open for candidates), to reduce churn on questions like "why did we do this?" which may be easily misunderstood or misinterpreted as a change proposal instead of information gathering.

To be clear, the intention is not to revisit these choices or perform analysis or postmortem reviews. 

This is my best take at recovering what is available to me — it will likely benefit from some folks who were in the room taking a look at it and filling in any missing information. 