### PR TITLE
8670 - remove records result in empty objects trying to be processed

### DIFF
--- a/iam/terraform/environment-specific/main/migration.tf
+++ b/iam/terraform/environment-specific/main/migration.tf
@@ -50,7 +50,8 @@ resource "aws_iam_role_policy" "migration_policy" {
                 "dynamodb:ListStreams",
                 "dynamodb:Query",
                 "dynamodb:PutItem",
-                "dynamodb:Scan"
+                "dynamodb:Scan",
+                "dynamodb:DeleteItem"
             ],
             "Resource": [
                 "arn:aws:dynamodb:us-east-1:${data.aws_caller_identity.current.account_id}:table/*",

--- a/web-api/migration-terraform/main/lambdas/migration.js
+++ b/web-api/migration-terraform/main/lambdas/migration.js
@@ -37,6 +37,13 @@ const getFilteredGlobalEvents = event => {
   );
 };
 
+const getRemoveEvents = event => {
+  const { Records } = event;
+  return Records.filter(item => item.eventName === 'REMOVE').map(item =>
+    AWS.DynamoDB.Converter.unmarshall(item.dynamodb.OldImage),
+  );
+};
+
 exports.getFilteredGlobalEvents = getFilteredGlobalEvents;
 exports.processItems = processItems;
 exports.handler = async event => {
@@ -46,4 +53,19 @@ exports.handler = async event => {
     items,
     migrateRecords: migrations,
   });
+
+  const removeEvents = getRemoveEvents(event);
+  await Promise.all(
+    removeEvents.map(item =>
+      docClient
+        .delete({
+          Key: {
+            pk: item.pk,
+            sk: item.sk,
+          },
+          TableName: process.env.DESTINATION_TABLE,
+        })
+        .promise(),
+    ),
+  );
 };

--- a/web-api/migration-terraform/main/lambdas/migration.js
+++ b/web-api/migration-terraform/main/lambdas/migration.js
@@ -32,7 +32,7 @@ const processItems = async ({ documentClient, items, migrateRecords }) => {
 
 const getFilteredGlobalEvents = event => {
   const { Records } = event;
-  return Records.map(item =>
+  return Records.filter(item => item.eventName !== 'REMOVE').map(item =>
     AWS.DynamoDB.Converter.unmarshall(item.dynamodb.NewImage),
   );
 };

--- a/web-api/migration-terraform/main/lambdas/migration.test.js
+++ b/web-api/migration-terraform/main/lambdas/migration.test.js
@@ -29,8 +29,8 @@ describe('migration', () => {
   });
 
   describe('getFilteredGlobalEvents', () => {
-    it('should return everything', async () => {
-      const items = await getFilteredGlobalEvents({
+    it('should return everything', () => {
+      const items = getFilteredGlobalEvents({
         Records: [
           {
             dynamodb: {
@@ -49,6 +49,100 @@ describe('migration', () => {
         ],
       });
       expect(items.length).toBe(1);
+    });
+
+    it('should not attempt to process REMOVE events', () => {
+      const items = getFilteredGlobalEvents({
+        Records: [
+          {
+            awsRegion: 'us-east-1',
+            dynamodb: {
+              Keys: {
+                Id: {
+                  N: '101',
+                },
+              },
+              NewImage: {
+                Id: {
+                  N: '101',
+                },
+                Message: {
+                  S: 'New item!',
+                },
+              },
+              SequenceNumber: '111',
+              SizeBytes: 26,
+              StreamViewType: 'NEW_AND_OLD_IMAGES',
+            },
+            eventID: '1',
+            eventName: 'INSERT',
+            eventSource: 'aws:dynamodb',
+            eventSourceARN: 'stream-ARN',
+            eventVersion: '1.0',
+          },
+          {
+            awsRegion: 'us-east-1',
+            dynamodb: {
+              Keys: {
+                Id: {
+                  N: '101',
+                },
+              },
+              NewImage: {
+                Id: {
+                  N: '101',
+                },
+                Message: {
+                  S: 'This item has changed',
+                },
+              },
+              OldImage: {
+                Id: {
+                  N: '101',
+                },
+                Message: {
+                  S: 'New item!',
+                },
+              },
+              SequenceNumber: '222',
+              SizeBytes: 59,
+              StreamViewType: 'NEW_AND_OLD_IMAGES',
+            },
+            eventID: '2',
+            eventName: 'MODIFY',
+            eventSource: 'aws:dynamodb',
+            eventSourceARN: 'stream-ARN',
+            eventVersion: '1.0',
+          },
+          {
+            awsRegion: 'us-east-1',
+            dynamodb: {
+              Keys: {
+                Id: {
+                  N: '101',
+                },
+              },
+              OldImage: {
+                Id: {
+                  N: '101',
+                },
+                Message: {
+                  S: 'This item has changed',
+                },
+              },
+              SequenceNumber: '333',
+              SizeBytes: 38,
+              StreamViewType: 'NEW_AND_OLD_IMAGES',
+            },
+            eventID: '3',
+            eventName: 'REMOVE',
+            eventSource: 'aws:dynamodb',
+            eventSourceARN: 'stream-ARN',
+            eventVersion: '1.0',
+          },
+        ],
+      });
+      expect(items.length).toEqual(2);
     });
   });
 });


### PR DESCRIPTION
There is an issue with live migrations failing on REMOVE events on the dynamodb stream.  This issue was created due to an earlier refactoring where we upgraded to dynamodb 2019.  The current code was taking an empty object {} and trying to run it through the migrations scripts which would cause it to fail with `item.pk of undefined`.