### PR TITLE
BUG 8693: Checkboxes on Section QC Page are not working

### DIFF
--- a/web-client/src/views/FileDocument/SupportingDocumentInclusionsForm.jsx
+++ b/web-client/src/views/FileDocument/SupportingDocumentInclusionsForm.jsx
@@ -92,7 +92,7 @@ export const SupportingDocumentInclusionsForm = connect(
                 }}
               />
               <label
-                className="usa-checkbox__label inline-block supporting-document-certificate-of-service"
+                className="inline-block supporting-document-certificate-of-service usa-checkbox__label"
                 htmlFor={`${type}-certificateOfService`}
               >
                 Certificate Of Service

--- a/web-client/src/views/WorkQueue/SectionWorkQueueInProgress.jsx
+++ b/web-client/src/views/WorkQueue/SectionWorkQueueInProgress.jsx
@@ -33,7 +33,7 @@ const SectionWorkQueueInProgressRow = React.memo(
                   }}
                 />
                 <label
-                  className="usa-checkbox__label padding-top-05"
+                  className="padding-top-05 usa-checkbox__label"
                   htmlFor={item.workItemId}
                   id={`label-${item.workItemId}`}
                 />

--- a/web-client/src/views/WorkQueue/SectionWorkQueueInbox.jsx
+++ b/web-client/src/views/WorkQueue/SectionWorkQueueInbox.jsx
@@ -88,7 +88,7 @@ SectionWorkQueueTable.Row = React.memo(
                   }}
                 />
                 <label
-                  className="usa-checkbox__label padding-top-05"
+                  className="padding-top-05 usa-checkbox__label"
                   htmlFor={item.workItemId}
                   id={`label-${item.workItemId}`}
                 />


### PR DESCRIPTION
This is happening due to a bug in USWDS.
Awaiting a release from them which will include a fix for this 🎉 (so we don't have to ensure that the classes `usa-radio__label` and `usa-checkbox__label` are always last in class name lists)

![image](https://user-images.githubusercontent.com/16403861/127715224-c90234c2-cf10-4216-b3b8-7bddaf5933f6.png)
![image](https://user-images.githubusercontent.com/16403861/127715283-ee2cb9f3-612f-4585-87ae-d59631b5fbe7.png)
