### PR TITLE
8506 - refresh migrate flag after running setup blue green if needed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -379,6 +379,9 @@ jobs:
               -e "ENV=${ENV}" \
               --rm efcms /bin/sh -c "./setup-for-blue-green-migration.sh"
       - run:
+          name: Setup Migrate Flag
+          command: echo "export MIGRATE_FLAG=$(./scripts/get-migrate-flag.sh $ENV)" >> $BASH_ENV
+      - run:
           no_output_timeout: 20m
           name: 'Deploy - Web API - Terraform'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,6 +382,9 @@ jobs:
           name: Setup Migrate Flag
           command: echo "export MIGRATE_FLAG=$(./scripts/get-migrate-flag.sh $ENV)" >> $BASH_ENV
       - run:
+          name: Setup Destination Table
+          command: echo "export DESTINATION_TABLE=$(./scripts/get-destination-table.sh $ENV)" >> $BASH_ENV
+      - run:
           no_output_timeout: 20m
           name: 'Deploy - Web API - Terraform'
           command: |


### PR DESCRIPTION
We added automation to turn on the migrate true flag, but circle was keeping a reference to an old cache value which was causing the terraform API to run thinking the migrate flag was false even though the script prior turned it on.


same issue with destination table