### PR TITLE
8769 - Bug - Trial Clerk Permission to download Trial Session

### DIFF
--- a/shared/src/authorization/authorizationClientService.js
+++ b/shared/src/authorization/authorizationClientService.js
@@ -225,6 +225,7 @@ const AUTHORIZATION_MAP = {
   reportersOffice: allInternalUserPermissions,
   trialclerk: [
     ...allInternalUserPermissions,
+    ROLE_PERMISSIONS.BATCH_DOWNLOAD_TRIAL_SESSION,
     ROLE_PERMISSIONS.TRIAL_SESSION_WORKING_COPY,
   ],
 };

--- a/shared/src/business/useCases/trialSessions/batchDownloadTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/batchDownloadTrialSessionInteractor.js
@@ -283,8 +283,9 @@ exports.batchDownloadTrialSessionInteractor = async (
   } catch (error) {
     const { userId } = applicationContext.getCurrentUser();
 
+    const erMsg = error.message || 'unknown error';
     applicationContext.logger.error(
-      `Error when batch downloading trial session with id ${trialSessionId}`,
+      `Error when batch downloading trial session with id ${trialSessionId} - ${erMsg}`,
       { error },
     );
     await applicationContext.getNotificationGateway().sendNotificationToUser({

--- a/shared/src/business/useCases/trialSessions/batchDownloadTrialSessionInteractor.test.js
+++ b/shared/src/business/useCases/trialSessions/batchDownloadTrialSessionInteractor.test.js
@@ -222,7 +222,35 @@ describe('batchDownloadTrialSessionInteractor', () => {
       trialSessionId: '123',
     });
 
-    expect(applicationContext.logger.error).toHaveBeenCalled();
+    expect(applicationContext.logger.error).toHaveBeenCalledWith(
+      'Error when batch downloading trial session with id 123 - Unauthorized',
+      expect.anything(),
+    );
+    expect(
+      applicationContext.getNotificationGateway().sendNotificationToUser,
+    ).toHaveBeenCalledWith({
+      applicationContext: expect.anything(),
+      message: {
+        action: 'batch_download_error',
+        error: expect.anything(),
+      },
+      userId: 'abc-123',
+    });
+  });
+
+  it('throws an unknown error if an error is thrown without a message', async () => {
+    applicationContext
+      .getPersistenceGateway()
+      .getCalendaredCasesForTrialSession.mockRejectedValueOnce(new Error());
+
+    await batchDownloadTrialSessionInteractor(applicationContext, {
+      trialSessionId: '123',
+    });
+
+    expect(applicationContext.logger.error).toHaveBeenCalledWith(
+      'Error when batch downloading trial session with id 123 - unknown error',
+      expect.anything(),
+    );
     expect(
       applicationContext.getNotificationGateway().sendNotificationToUser,
     ).toHaveBeenCalledWith({


### PR DESCRIPTION
This adds the permission to allow a trialClerk to batch download a trial session. Additionally, errors caught in the try/catch will include the error message in the logs to make issues a little easier to identify.