### PR TITLE
8685 - Cloning the passed Metadata to prevent objects title from changing

### DIFF
--- a/shared/src/business/useCases/externalDocument/generateDocumentTitleInteractor.js
+++ b/shared/src/business/useCases/externalDocument/generateDocumentTitleInteractor.js
@@ -1,6 +1,7 @@
 const {
   ExternalDocumentFactory,
 } = require('../../entities/externalDocument/ExternalDocumentFactory');
+const { cloneDeep } = require('lodash');
 
 /**
  * generateDocumentTitleInteractor
@@ -14,6 +15,8 @@ exports.generateDocumentTitleInteractor = (
   applicationContext,
   { documentMetadata },
 ) => {
+  documentMetadata = cloneDeep(documentMetadata);
+
   if (documentMetadata.previousDocument) {
     documentMetadata.previousDocument.documentTitle = applicationContext
       .getUtilities()

--- a/shared/src/business/useCases/externalDocument/generateDocumentTitleInteractor.test.js
+++ b/shared/src/business/useCases/externalDocument/generateDocumentTitleInteractor.test.js
@@ -38,4 +38,31 @@ describe('generateDocumentTitleInteractor', () => {
     ).toHaveBeenCalled();
     expect(title).toBe('abc Title Cool');
   });
+
+  it('should not overwrite the origrinal metadata previousDocument title passed as an argument', async () => {
+    const metadata = {
+      documentMetadata: {
+        documentTitle: 'abc [pizza]',
+        previousDocument: {
+          addToCoversheet: true,
+          additionalInfo: 'Cool',
+          documentTitle: 'Title',
+        },
+        scenario: 'nonstandard a',
+      },
+    };
+
+    const title = await generateDocumentTitleInteractor(
+      applicationContext,
+      metadata,
+    );
+
+    expect(
+      applicationContext.getUtilities().getDocumentTitleWithAdditionalInfo,
+    ).toHaveBeenCalled();
+    expect(title).toBe('abc Title Cool');
+    expect(metadata.documentMetadata.previousDocument.documentTitle).toBe(
+      'Title',
+    );
+  });
 });

--- a/shared/src/business/useCases/externalDocument/generateDocumentTitleInteractor.test.js
+++ b/shared/src/business/useCases/externalDocument/generateDocumentTitleInteractor.test.js
@@ -20,10 +20,22 @@ describe('generateDocumentTitleInteractor', () => {
     expect(title).toEqual('abc');
   });
 
+  it('generates a document title if previous document is undefined', async () => {
+    const title = await generateDocumentTitleInteractor(applicationContext, {
+      documentMetadata: {
+        documentTitle: 'abc',
+        previousDocument: undefined,
+        scenario: 'nonstandard a',
+      },
+    });
+
+    expect(title).toEqual('abc');
+  });
+
   it('generate the full document title for the previousDocument when documentMetadata.previousDocument exists', async () => {
     const title = await generateDocumentTitleInteractor(applicationContext, {
       documentMetadata: {
-        documentTitle: 'abc [pizza]',
+        documentTitle: 'abc [Document Name]',
         previousDocument: {
           addToCoversheet: true,
           additionalInfo: 'Cool',
@@ -42,7 +54,7 @@ describe('generateDocumentTitleInteractor', () => {
   it('should not overwrite the origrinal metadata previousDocument title passed as an argument', async () => {
     const metadata = {
       documentMetadata: {
-        documentTitle: 'abc [pizza]',
+        documentTitle: 'abc [Document Name]',
         previousDocument: {
           addToCoversheet: true,
           additionalInfo: 'Cool',


### PR DESCRIPTION
We had a function which we were passing an object as an argument, and that function was modifying the title of that object.  This was causing the title of the Exhibit(s) in the dropdown to continuously be modified when clicking the document title.


https://user-images.githubusercontent.com/1868782/129267402-8a78870e-6066-477c-a36e-3f6aabd12c06.mp4

