### PR TITLE
8786: (BUG) do not populate filers array with strings

### DIFF
--- a/web-client/src/presenter/actions/setFilersFromFilersMapAction.js
+++ b/web-client/src/presenter/actions/setFilersFromFilersMapAction.js
@@ -1,8 +1,7 @@
-import { isEmpty } from 'lodash';
 import { state } from 'cerebral';
 
 /**
- * sets the filers from the filersMap or filedBy on the form
+ * sets the filers from the filersMap on the form
  *
  * @param {object} providers the providers object
  * @param {object} providers.store the cerebral store object
@@ -14,10 +13,6 @@ export const setFilersFromFilersMapAction = ({ get, store }) => {
   filers = Object.keys(form.filersMap)
     .map(contactId => (form.filersMap[contactId] ? contactId : null))
     .filter(Boolean);
-
-  if (isEmpty(form.filersMap) && form.filedBy) {
-    filers = [form.filedBy];
-  }
 
   store.set(state.form.filers, filers);
 };

--- a/web-client/src/presenter/actions/setFilersFromFilersMapAction.test.js
+++ b/web-client/src/presenter/actions/setFilersFromFilersMapAction.test.js
@@ -19,7 +19,7 @@ describe('setFilersFromFilersMapAction', () => {
     ]);
   });
 
-  it('sets state.form.filedBy to the filers array when state.form.filersMap is empty', async () => {
+  it('sets state.form.filers to an empty array when state.form.filersMap is empty', async () => {
     const result = await runAction(setFilersFromFilersMapAction, {
       state: {
         form: {
@@ -29,6 +29,6 @@ describe('setFilersFromFilersMapAction', () => {
       },
     });
 
-    expect(result.state.form.filers).toEqual(['A legacy user']);
+    expect(result.state.form.filers).toEqual([]);
   });
 });


### PR DESCRIPTION
Bugfix addresses #8786 by rolling back changes made to fix bug #8554, whose tests still pass.
Code will need to be deployed to a production-like environment to be able to verify that both bug workflows are fixed.

More context: the `filers` array is validated against rules which expect it to contain _only_ UUIDs.  However, this code was pushing non-UUID strings into that array which caused validation, and is unclear whether the original "fix" was simply an alternative approach to creating slightly more complex validation conditionals.