### PR TITLE
8828 - prevent updating receivedAt for electronically filed case

### DIFF
--- a/shared/src/business/useCases/saveCaseDetailInternalEditInteractor.js
+++ b/shared/src/business/useCases/saveCaseDetailInternalEditInteractor.js
@@ -76,6 +76,10 @@ exports.saveCaseDetailInternalEditInteractor = async (
     statistics: caseToUpdate.statistics,
   };
 
+  if (!originalCaseEntity.isPaper) {
+    editableFields.receivedAt = originalCaseEntity.receivedAt;
+  }
+
   const caseWithFormEdits = {
     ...caseRecord,
     ...editableFields,

--- a/shared/src/business/useCases/saveCaseDetailInternalEditInteractor.test.js
+++ b/shared/src/business/useCases/saveCaseDetailInternalEditInteractor.test.js
@@ -324,4 +324,29 @@ describe('updateCase', () => {
       mockCase.petitioners[0].contactId,
     ]);
   });
+
+  it('should not allow the recevedAt field to be updated if it is an electronic filing', async () => {
+    const currentCaseDetail = {
+      ...mockCase,
+      isPaper: false,
+      receivedAt: '2021-01-01T16:00:00.000Z',
+    };
+    applicationContext
+      .getPersistenceGateway()
+      .getCaseByDocketNumber.mockReturnValue({ ...currentCaseDetail });
+
+    const result = await saveCaseDetailInternalEditInteractor(
+      applicationContext,
+      {
+        caseToUpdate: {
+          ...mockCase,
+          contactPrimary: getContactPrimary(mockCase),
+          receivedAt: '2021-08-08T16:00:00.000Z', // a new receivedAt
+        },
+        docketNumber: mockCase.docketNumber,
+      },
+    );
+
+    expect(result.receivedAt).toEqual(currentCaseDetail.receivedAt);
+  });
 });


### PR DESCRIPTION
You can't edit the receivedAt date for an electronically-filed case, however QCing the case passes an updated value to the interactor and it gets updated. This prevents the interactor from overwriting the `case.receiveedAt`field.

Note: There is a migration to fix the old data coming in a separate PR.