### PR TITLE
8842 - omit filers from validation when validating document type

### DIFF
--- a/web-client/src/presenter/actions/EditDocketRecordEntry/validateDocumentAction.js
+++ b/web-client/src/presenter/actions/EditDocketRecordEntry/validateDocumentAction.js
@@ -43,7 +43,7 @@ export const validateDocumentAction = ({ applicationContext, get, path }) => {
             entryMetadata: formMetadata,
           }),
       },
-      ['dateReceived'],
+      ['dateReceived', 'filers'],
     );
 
     errorDisplayOrder = [

--- a/web-client/src/presenter/actions/EditDocketRecordEntry/validateDocumentAction.test.js
+++ b/web-client/src/presenter/actions/EditDocketRecordEntry/validateDocumentAction.test.js
@@ -107,6 +107,31 @@ describe('validateDocumentAction', () => {
     expect(errorStub).toHaveBeenCalled();
   });
 
+  it('should not cause an error if filers is empty with document tuype', async () => {
+    applicationContext
+      .getUseCases()
+      .validateDocumentInteractor.mockReturnValue(null);
+    applicationContext
+      .getUseCases()
+      .validateDocketEntryInteractor.mockReturnValue({
+        filers: 'error',
+      });
+
+    await runAction(validateDocumentAction, {
+      modules: {
+        presenter,
+      },
+      state: {
+        form: mockDocument,
+        screenMetadata: {
+          editType: 'Document',
+        },
+      },
+    });
+
+    expect(errorStub).not.toHaveBeenCalled();
+  });
+
   it('should call the success path when no errors are found with a document', async () => {
     applicationContext
       .getUseCases()

--- a/web-client/src/presenter/actions/EditDocketRecordEntry/validateDocumentAction.test.js
+++ b/web-client/src/presenter/actions/EditDocketRecordEntry/validateDocumentAction.test.js
@@ -107,7 +107,7 @@ describe('validateDocumentAction', () => {
     expect(errorStub).toHaveBeenCalled();
   });
 
-  it('should not cause an error if filers is empty with document tuype', async () => {
+  it('should not cause an error if filers is empty with document type', async () => {
     applicationContext
       .getUseCases()
       .validateDocumentInteractor.mockReturnValue(null);


### PR DESCRIPTION
It seems that legacy docket entries have a blank filers array which means the docket entry fails validation since we expect at least 1 filer to exist, but I don't think we have a way to figure out the userId of who filed the document when we migrated these legacy docket entries.  When editing a docket entry, we don't display the filers checkboxes, so there shouldn't be a reason why we validate them on the UI.