### PR TITLE
8828 - Bug - receivedAt migration

### DIFF
--- a/web-api/migration-terraform/main/lambdas/migration-segments.js
+++ b/web-api/migration-terraform/main/lambdas/migration-segments.js
@@ -18,6 +18,9 @@ const {
   migrateItems: migration0038,
 } = require('./migrations/0038-parse-generated-orders');
 const {
+  migrateItems: migration0040,
+} = require('./migrations/bug-0040-case-received-at');
+const {
   migrateItems: validationMigration,
 } = require('./migrations/0000-validate-all-items');
 const { chunk } = require('lodash');
@@ -67,6 +70,11 @@ const migrateRecords = async ({
   if (!ranMigrations['0038-parse-generated-orders.js']) {
     applicationContext.logger.debug('about to run migration 0038');
     items = await migration0038(items);
+  }
+
+  if (!ranMigrations['bug-0040-case-received-at.js']) {
+    applicationContext.logger.debug('about to run migration 0040');
+    items = await migration0040(items, documentClient);
   }
 
   applicationContext.logger.debug('about to run validation migration');
@@ -174,6 +182,7 @@ exports.handler = async event => {
     ...(await hasMigrationRan('0036-phone-number-format.js')),
     ...(await hasMigrationRan('devex-0037-combine-work-items.js')),
     ...(await hasMigrationRan('0038-parse-generated-orders.js')),
+    ...(await hasMigrationRan('bug-0040-case-received-at.js')),
   };
 
   await scanTableSegment(segment, totalSegments, ranMigrations);

--- a/web-api/migration-terraform/main/lambdas/migrations/bug-0040-case-received-at.js
+++ b/web-api/migration-terraform/main/lambdas/migrations/bug-0040-case-received-at.js
@@ -1,0 +1,64 @@
+const createApplicationContext = require('../../../../src/applicationContext');
+const {
+  aggregateCaseItems,
+} = require('../../../../../shared/src/persistence/dynamo/helpers/aggregateCaseItems');
+const {
+  Case,
+} = require('../../../../../shared/src/business/entities/cases/Case');
+const {
+  INITIAL_DOCUMENT_TYPES,
+} = require('../../../../../shared/src/business/entities/EntityConstants');
+const applicationContext = createApplicationContext({});
+
+const migrateItems = async (items, documentClient) => {
+  const itemsAfter = [];
+
+  for (const item of items) {
+    if (item.pk.startsWith('case|') && item.sk.startsWith('case|')) {
+      const fullCase = await documentClient
+        .query({
+          ExpressionAttributeNames: {
+            '#pk': 'pk',
+          },
+          ExpressionAttributeValues: {
+            ':pk': `case|${item.docketNumber}`,
+          },
+          KeyConditionExpression: '#pk = :pk',
+          TableName: process.env.SOURCE_TABLE,
+        })
+        .promise()
+        .then(res => {
+          return res.Items;
+        });
+
+      const caseRecord = aggregateCaseItems(fullCase);
+
+      const petitionItem = caseRecord.docketEntries.find(
+        entry => entry.eventCode === INITIAL_DOCUMENT_TYPES.petition.eventCode,
+      );
+
+      if (!item.isPaper && item.receivedAt !== petitionItem.receivedAt) {
+        // an electronic filing where the received at was changed from that of the petition
+
+        applicationContext.logger.info(
+          `Updating case.receivedAt from ${item.receivedAt} to ${petitionItem.receivedAt} to match petition.`,
+          {
+            pk: item.pk,
+            sk: item.sk,
+          },
+        );
+
+        item.receivedAt = petitionItem.receivedAt;
+      }
+
+      new Case(item, { applicationContext }).validateWithLogging(
+        applicationContext,
+      );
+    }
+
+    itemsAfter.push(item);
+  }
+  return itemsAfter;
+};
+
+exports.migrateItems = migrateItems;

--- a/web-api/migration-terraform/main/lambdas/migrations/bug-0040-case-received-at.test.js
+++ b/web-api/migration-terraform/main/lambdas/migrations/bug-0040-case-received-at.test.js
@@ -1,0 +1,118 @@
+const {
+  INITIAL_DOCUMENT_TYPES,
+} = require('../../../../../shared/src/business/entities/EntityConstants');
+const { migrateItems } = require('./bug-0040-case-received-at');
+const { MOCK_CASE } = require('../../../../../shared/src/test/mockCase');
+
+describe('migrateItems', () => {
+  let mockCaseItem;
+  let documentClient;
+  let mockPetitionItem;
+
+  beforeEach(() => {
+    mockCaseItem = {
+      ...MOCK_CASE,
+      pk: `case|${MOCK_CASE.docketNumber}`,
+      sk: `case|${MOCK_CASE.docketNumber}`,
+    };
+
+    mockPetitionItem = {
+      archived: false,
+      docketEntryId: '83b77e98-4cf6-4fb4-b8c0-f5f90fd68f3c',
+      documentType: INITIAL_DOCUMENT_TYPES.petition.documentType,
+      eventCode: INITIAL_DOCUMENT_TYPES.petition.eventCode,
+      filedBy: 'Test Petitioner',
+      pk: `case|${MOCK_CASE.docketNumber}`,
+      sk: 'docket-entry|83b77e98-4cf6-4fb4-b8c0-f5f90fd68f3c',
+      userId: '8bbfcd5a-b02b-4983-8e9c-6cc50d3d566c',
+    };
+
+    documentClient = {
+      query: jest.fn().mockImplementation(() => ({
+        promise: async () => ({
+          Items: [mockCaseItem, mockPetitionItem],
+        }),
+      })),
+    };
+  });
+
+  it('should return and not modify records that are NOT case records', async () => {
+    const items = [
+      {
+        noticeOfTrialDate: '2025-04-10T04:00:00.000Z',
+        pk: `case|${MOCK_CASE.docketNumber}`,
+        sk: 'user|6d74eadc-0181-4ff5-826c-305200e8733d',
+      },
+      {
+        noticeOfTrialDate: '2025-04-10T04:00:00.000Z',
+        pk: `case|${MOCK_CASE.docketNumber}`,
+        sk: 'docket-entry|83b77e98-4cf6-4fb4-b8c0-f5f90fd68f3c',
+      },
+    ];
+    const results = await migrateItems(items, documentClient);
+
+    expect(results).toEqual([
+      {
+        noticeOfTrialDate: '2025-04-10T04:00:00.000Z', // field doesn't belong here, but proving it is unmodified
+        pk: `case|${MOCK_CASE.docketNumber}`,
+        sk: 'user|6d74eadc-0181-4ff5-826c-305200e8733d',
+      },
+      {
+        noticeOfTrialDate: '2025-04-10T04:00:00.000Z', // field doesn't belong here, but proving it is unmodified
+        pk: `case|${MOCK_CASE.docketNumber}`,
+        sk: 'docket-entry|83b77e98-4cf6-4fb4-b8c0-f5f90fd68f3c',
+      },
+    ]);
+
+    expect(documentClient.query).not.toHaveBeenCalled();
+  });
+
+  it('should update the case.receivedAt field to match the petition recievedAt if they do not match and the case is electronic', async () => {
+    mockPetitionItem.receivedAt = '2020-01-01T16:00:00.000Z';
+
+    const items = [
+      {
+        ...mockCaseItem,
+        isPaper: false,
+        receivedAt: '2021-06-06T16:00:00.000Z', // a newer (incorrect) date
+      },
+    ];
+
+    const results = await migrateItems(items, documentClient);
+
+    expect(results[0].receivedAt).toEqual('2020-01-01T16:00:00.000Z'); // the petition date
+  });
+
+  it('should NOT update the case.receivedAt field to match the petition recievedAt if they match and the case is electronic', async () => {
+    mockPetitionItem.receivedAt = '2021-06-06T16:00:00.000Z';
+
+    const items = [
+      {
+        ...mockCaseItem,
+        isPaper: false,
+        receivedAt: '2021-06-06T16:00:00.000Z',
+      },
+    ];
+
+    const results = await migrateItems(items, documentClient);
+
+    expect(results[0].receivedAt).toEqual('2021-06-06T16:00:00.000Z');
+  });
+
+  it('should NOT update the case.receivedAt field to match the petition recievedAt if the case is paper', async () => {
+    mockPetitionItem.receivedAt = '2020-01-01T16:00:00.000Z';
+
+    const items = [
+      {
+        ...mockCaseItem,
+        isPaper: true,
+        mailingDate: '2020-06-01T16:00:00.000Z',
+        receivedAt: '2021-06-06T16:00:00.000Z',
+      },
+    ];
+
+    const results = await migrateItems(items, documentClient);
+
+    expect(results[0].receivedAt).toEqual('2021-06-06T16:00:00.000Z');
+  });
+});

--- a/web-api/migration-terraform/main/lambdas/utilities.js
+++ b/web-api/migration-terraform/main/lambdas/utilities.js
@@ -1,0 +1,33 @@
+const queryFullCase = async (documentClient, docketNumber) => {
+  let hasMoreResults = true;
+  let lastKey = null;
+  let allResults = [];
+  while (hasMoreResults) {
+    hasMoreResults = false;
+
+    const subsetResults = await documentClient
+      .query({
+        ExclusiveStartKey: lastKey,
+        ExpressionAttributeNames: {
+          '#pk': 'pk',
+        },
+        ExpressionAttributeValues: {
+          ':pk': `case|${docketNumber}`,
+        },
+        KeyConditionExpression: '#pk = :pk',
+        TableName: process.env.SOURCE_TABLE,
+      })
+      .promise();
+
+    hasMoreResults = !!subsetResults.LastEvaluatedKey;
+    lastKey = subsetResults.LastEvaluatedKey;
+
+    allResults = [...allResults, ...subsetResults.Items];
+  }
+
+  return allResults;
+};
+
+module.exports = {
+  queryFullCase,
+};

--- a/web-api/migration-terraform/main/lambdas/utilities.test.js
+++ b/web-api/migration-terraform/main/lambdas/utilities.test.js
@@ -1,0 +1,44 @@
+const { queryFullCase } = require('./utilities');
+
+describe('queryFullCase', () => {
+  let documentClient;
+  const item1 = { item: 'one' };
+  const item2 = { item: 'two' };
+
+  beforeEach(() => {
+    documentClient = {
+      query: jest
+        .fn()
+        .mockReturnValueOnce({
+          promise: () => ({
+            Items: [item1],
+            LastEvaluatedKey: '1',
+          }),
+        })
+        .mockReturnValueOnce({
+          promise: () => ({
+            Items: [item2],
+            LastEvaluatedKey: null,
+          }),
+        }),
+    };
+  });
+
+  it('calls the documentClient query method to fetch case items for the given docket number', async () => {
+    await queryFullCase(documentClient, '101-21');
+
+    expect(documentClient.query).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ExpressionAttributeValues: {
+          ':pk': 'case|101-21',
+        },
+      }),
+    );
+  });
+
+  it('returns all aggregated results from the query', async () => {
+    const results = await queryFullCase(documentClient, '101-21');
+
+    expect(results).toEqual([item1, item2]);
+  });
+});

--- a/web-api/src/applicationContext.js
+++ b/web-api/src/applicationContext.js
@@ -79,6 +79,7 @@ const {
   bulkIndexRecords,
 } = require('../../shared/src/persistence/elasticsearch/bulkIndexRecords');
 const {
+  calculateDifferenceInDays,
   calculateISODate,
   createISODateString,
   formatDateString,
@@ -1921,6 +1922,7 @@ module.exports = (appContextUser, logger = createLogger()) => {
     },
     getUtilities: () => {
       return {
+        calculateDifferenceInDays,
         calculateISODate,
         compareCasesByDocketNumber,
         compareISODateStrings,


### PR DESCRIPTION
This verifies the recievedAt for a case hasn't been updated from that of the petition for electronic cases due to a bug that was introduced that allowed this to happen during the QC process.

NOTE: This is going to updated case records that may have a few ms difference in time. Should we account for that? An example from a test run:
`Updating case.receivedAt from 2020-06-25T20:58:55.411Z to 2020-06-25T20:58:55.414Z to match petition.`