### PR TITLE
Enable search for prod

### DIFF
--- a/shared/src/business/utilities/getIsFeatureEnabled.js
+++ b/shared/src/business/utilities/getIsFeatureEnabled.js
@@ -8,13 +8,13 @@ const { User } = require('../entities/User');
  * @returns {boolean} whether the feature is enabled
  */
 
+// eslint-disable-next-line no-unused-vars
 const getIsFeatureEnabled = (featureName, user, env) => {
   const features = {
     advanced_document_search: (() => {
-      const isProduction = env === 'prod';
       const isInternalUser = User.isInternalUser(user.role);
 
-      return !isProduction && isInternalUser;
+      return isInternalUser;
     })(),
   };
 

--- a/shared/src/business/utilities/getIsFeatureEnabled.test.js
+++ b/shared/src/business/utilities/getIsFeatureEnabled.test.js
@@ -33,7 +33,7 @@ describe('getIsFeatureEnabled', () => {
       expect(isEnabled).toEqual(false);
     });
 
-    it('returns false if the user is an internal user and the current environment is prod', () => {
+    it('returns true if the user is an internal user and the current environment is prod', () => {
       const user = {
         role: ROLES.judge,
       };
@@ -45,7 +45,7 @@ describe('getIsFeatureEnabled', () => {
         env,
       );
 
-      expect(isEnabled).toEqual(false);
+      expect(isEnabled).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
Looks like we left a hardcoded measure to prevent prod from permitting search. Let's disable that since https://github.com/flexion/ef-cms/issues/8544 was intended to enable it. 