### PR TITLE
7341 - bug - only use last name for judge opinion search

### DIFF
--- a/shared/src/business/utilities/getIsFeatureEnabled.test.js
+++ b/shared/src/business/utilities/getIsFeatureEnabled.test.js
@@ -63,6 +63,4 @@ describe('getIsFeatureEnabled', () => {
 
     expect(isEnabled).toEqual(false);
   });
-
-
 });

--- a/web-client/src/views/AdvancedSearch/AdvancedDocumentSearch.jsx
+++ b/web-client/src/views/AdvancedSearch/AdvancedDocumentSearch.jsx
@@ -115,10 +115,7 @@ export const AdvancedDocumentSearch = connect(
                 >
                   <option value="">- Select -</option>
                   {judges.map(judge => (
-                    <option
-                      key={judge.judgeFullName}
-                      value={judge.judgeFullName}
-                    >
+                    <option key={judge.judgeFullName} value={judge.name}>
                       {judge.name}
                     </option>
                   ))}


### PR DESCRIPTION
This is a temporary fix preventing middle initials which are shared between judges from returning mixed results when a judge is given in opinion search.

This _could_ still produce unexpected results in the case of judges with the same last name (or a first name that matches the last name being queried). PO intends to work on stories that will create a more unique way of identifying / associating judges with documents in the system.