### PR TITLE
De-dupe the eligible case docket numbers...

### DIFF
--- a/shared/src/persistence/dynamo/trialSessions/getEligibleCasesForTrialSession.js
+++ b/shared/src/persistence/dynamo/trialSessions/getEligibleCasesForTrialSession.js
@@ -19,7 +19,9 @@ exports.getEligibleCasesForTrialSession = async ({
     applicationContext,
   });
 
-  const docketNumbers = mappings.map(metadata => metadata.docketNumber);
+  const docketNumbers = [
+    ...new Set(mappings.map(metadata => metadata.docketNumber)),
+  ];
 
   const results = await client.batchGet({
     applicationContext,

--- a/shared/src/persistence/dynamo/trialSessions/getEligibleCasesForTrialSession.test.js
+++ b/shared/src/persistence/dynamo/trialSessions/getEligibleCasesForTrialSession.test.js
@@ -47,4 +47,32 @@ describe('getEligibleCasesForTrialSession', () => {
       },
     ]);
   });
+
+  it('should remove any duplicate cases it receives the list of cases it receives from the mapping records query', async () => {
+    client.query = jest.fn().mockReturnValue([
+      {
+        docketNumber: MOCK_CASE.docketNumber,
+        pk: 'eligible-for-trial-case-catalog',
+        sk: 'WashingtonDistrictofColumbia-R-D-20181212654321-101-18',
+      },
+      {
+        docketNumber: MOCK_CASE.docketNumber,
+        pk: 'eligible-for-trial-case-catalog',
+        sk: 'WashingtonDistrictofColumbia-R-D-20181212000000-101-18',
+      },
+    ]);
+
+    await getEligibleCasesForTrialSession({
+      applicationContext,
+    });
+    expect(client.batchGet).toHaveBeenCalledWith({
+      applicationContext,
+      keys: [
+        {
+          pk: `case|${MOCK_CASE.docketNumber}`,
+          sk: `case|${MOCK_CASE.docketNumber}`,
+        },
+      ],
+    });
+  });
 });

--- a/shared/src/persistence/dynamo/trialSessions/getEligibleCasesForTrialSession.test.js
+++ b/shared/src/persistence/dynamo/trialSessions/getEligibleCasesForTrialSession.test.js
@@ -48,7 +48,7 @@ describe('getEligibleCasesForTrialSession', () => {
     ]);
   });
 
-  it('should remove any duplicate cases it receives the list of cases it receives from the mapping records query', async () => {
+  it('should remove duplicate docketNumbers returned by the eligible-for-trial-case-catalog query', async () => {
     client.query = jest.fn().mockReturnValue([
       {
         docketNumber: MOCK_CASE.docketNumber,


### PR DESCRIPTION
This removes any duplicate docket numbers that we receive from the query of mapping records for the given Trial Location
prefix. An underlying data issue underlying causes this problem, and we are working to fix it with [this bug report](https://github.com/ustaxcourt/ef-cms/tree/diagnose-trial-session-bug). 

We have encountered this bug numerous times before, and we have resorted to fixing the data in production. For reference, here are the previous bug reports:

* https://github.com/flexion/ef-cms/issues/8186
* https://github.com/flexion/ef-cms/issues/8594
* https://github.com/flexion/ef-cms/issues/8384

