### PR TITLE
Hide status from public case

### DIFF
--- a/docs/api/v1.yaml
+++ b/docs/api/v1.yaml
@@ -164,9 +164,6 @@ components:
         sortableDocketNumber:
           type: integer
           example: 20000384
-        status:
-          type: string
-          example: New
         trialLocation:
           type: string
     Contact:

--- a/docs/api/v2.yaml
+++ b/docs/api/v2.yaml
@@ -198,9 +198,6 @@ components:
         sortableDocketNumber:
           type: integer
           example: 20000384
-        status:
-          type: string
-          example: New
         trialDate:
           type: string
           format: date-time

--- a/shared/src/business/entities/cases/Case.js
+++ b/shared/src/business/entities/cases/Case.js
@@ -2277,9 +2277,13 @@ const caseHasServedDocketEntries = rawCase => {
  */
 
 const canAllowDocumentServiceForCase = rawCase => {
-  const isOpen = ![CASE_STATUS_TYPES.closed, CASE_STATUS_TYPES.new].includes(
-    rawCase.status,
-  );
+  const isOpen =
+    rawCase.isStatusNew === false || // PublicCase does not expose status
+    (!rawCase.isStatusNew &&
+      ![CASE_STATUS_TYPES.closed, CASE_STATUS_TYPES.new].includes(
+        rawCase.status,
+      ));
+
   const MAX_CLOSED_DATE = calculateISODate({
     howMuch: -6,
     units: 'months',

--- a/shared/src/business/entities/cases/Case.js
+++ b/shared/src/business/entities/cases/Case.js
@@ -2279,17 +2279,21 @@ const caseHasServedDocketEntries = rawCase => {
 const canAllowDocumentServiceForCase = rawCase => {
   const isOpen =
     rawCase.showPrintableDocketRecord === true || // PublicCase does not expose status
-    ![CASE_STATUS_TYPES.closed, CASE_STATUS_TYPES.new].includes(rawCase.status);
+    (rawCase.status &&
+      ![CASE_STATUS_TYPES.closed, CASE_STATUS_TYPES.new].includes(
+        rawCase.status,
+      ));
 
   const MAX_CLOSED_DATE = calculateISODate({
     howMuch: -6,
     units: 'months',
   });
-  const isRecent =
+  const isRecentlyClosed =
+    rawCase.status === CASE_STATUS_TYPES.closed &&
     rawCase.closedDate &&
     dateStringsCompared(rawCase.closedDate, MAX_CLOSED_DATE) >= 0;
 
-  return Boolean(isOpen || isRecent);
+  return Boolean(isOpen || isRecentlyClosed);
 };
 
 module.exports = {

--- a/shared/src/business/entities/cases/Case.js
+++ b/shared/src/business/entities/cases/Case.js
@@ -2278,11 +2278,8 @@ const caseHasServedDocketEntries = rawCase => {
 
 const canAllowDocumentServiceForCase = rawCase => {
   const isOpen =
-    rawCase.isStatusNew === false || // PublicCase does not expose status
-    (!rawCase.isStatusNew &&
-      ![CASE_STATUS_TYPES.closed, CASE_STATUS_TYPES.new].includes(
-        rawCase.status,
-      ));
+    rawCase.showPrintableDocketRecord === true || // PublicCase does not expose status
+    ![CASE_STATUS_TYPES.closed, CASE_STATUS_TYPES.new].includes(rawCase.status);
 
   const MAX_CLOSED_DATE = calculateISODate({
     howMuch: -6,

--- a/shared/src/business/entities/cases/PublicCase.js
+++ b/shared/src/business/entities/cases/PublicCase.js
@@ -48,7 +48,7 @@ PublicCase.prototype.init = function init(rawCase, { applicationContext }) {
   this._score = rawCase['_score'];
 
   this.isSealed = isSealedCase(rawCase);
-  this.isStatusNew = rawCase.status === CASE_STATUS_TYPES.new;
+  this.showPrintableDocketRecord = rawCase.status !== CASE_STATUS_TYPES.new;
 
   const currentUser = applicationContext.getCurrentUser();
 
@@ -98,18 +98,12 @@ const publicCaseSchema = {
   hasIrsPractitioner: joi.boolean().required(),
   isPaper: joi.boolean().optional(),
   isSealed: joi.boolean(),
-  isStatusNew: joi.boolean(),
   partyType: JoiValidationConstants.STRING.valid(...Object.values(PARTY_TYPES))
     .required()
     .description('Party type of the case petitioner.'),
   petitioners: joi.array().items(PublicContact.VALIDATION_RULES).required(),
   receivedAt: JoiValidationConstants.ISO_DATE.optional(),
-  status: JoiValidationConstants.STRING.valid(
-    ...Object.values(CASE_STATUS_TYPES),
-  )
-    .optional()
-    .meta({ tags: ['Restricted'] })
-    .description('Status of the case.'),
+  showPrintableDocketRecord: joi.boolean(),
 };
 
 const sealedCaseSchemaRestricted = {

--- a/shared/src/business/entities/cases/PublicCase.js
+++ b/shared/src/business/entities/cases/PublicCase.js
@@ -44,7 +44,6 @@ PublicCase.prototype.init = function init(rawCase, { applicationContext }) {
     !!rawCase.irsPractitioners && rawCase.irsPractitioners.length > 0;
   this.isPaper = rawCase.isPaper;
   this.partyType = rawCase.partyType;
-  this.status = rawCase.status;
   this.receivedAt = rawCase.receivedAt;
   this._score = rawCase['_score'];
 

--- a/shared/src/business/entities/cases/PublicCase.test.js
+++ b/shared/src/business/entities/cases/PublicCase.test.js
@@ -128,7 +128,7 @@ describe('PublicCase', () => {
         },
       ],
       receivedAt: 'testing',
-      showPrintableDocketRecord: true,
+      showPrintableDocketRecord: false,
     });
   });
 
@@ -173,7 +173,7 @@ describe('PublicCase', () => {
         },
       ],
       receivedAt: 'testing',
-      showPrintableDocketRecord: false,
+      showPrintableDocketRecord: true,
     });
   });
 

--- a/shared/src/business/entities/cases/PublicCase.test.js
+++ b/shared/src/business/entities/cases/PublicCase.test.js
@@ -129,7 +129,6 @@ describe('PublicCase', () => {
         },
       ],
       receivedAt: 'testing',
-      status: CASE_STATUS_TYPES.new,
     });
   });
 
@@ -175,7 +174,6 @@ describe('PublicCase', () => {
         },
       ],
       receivedAt: 'testing',
-      status: CASE_STATUS_TYPES.calendared,
     });
   });
 

--- a/shared/src/business/entities/cases/PublicCase.test.js
+++ b/shared/src/business/entities/cases/PublicCase.test.js
@@ -112,7 +112,6 @@ describe('PublicCase', () => {
       hasIrsPractitioner: false,
       isPaper: true,
       isSealed: false,
-      isStatusNew: true,
       partyType: PARTY_TYPES.petitioner,
       petitioners: [
         {
@@ -129,6 +128,7 @@ describe('PublicCase', () => {
         },
       ],
       receivedAt: 'testing',
+      showPrintableDocketRecord: true,
     });
   });
 
@@ -164,7 +164,6 @@ describe('PublicCase', () => {
       entityName: 'PublicCase',
       hasIrsPractitioner: false,
       isSealed: false,
-      isStatusNew: false,
       partyType: PARTY_TYPES.petitioner,
       petitioners: [
         {
@@ -174,6 +173,7 @@ describe('PublicCase', () => {
         },
       ],
       receivedAt: 'testing',
+      showPrintableDocketRecord: false,
     });
   });
 

--- a/shared/src/business/useCases/getCaseInteractor.test.js
+++ b/shared/src/business/useCases/getCaseInteractor.test.js
@@ -290,10 +290,9 @@ describe('getCaseInteractor', () => {
         entityName: 'PublicCase',
         hasIrsPractitioner: false,
         isSealed: true,
-        isStatusNew: true,
         partyType: undefined,
         receivedAt: undefined,
-        status: MOCK_CASE.status,
+        showPrintableDocketRecord: true,
       });
     });
 

--- a/shared/src/business/useCases/public/casePublicSearchInteractor.test.js
+++ b/shared/src/business/useCases/public/casePublicSearchInteractor.test.js
@@ -42,6 +42,7 @@ describe('casePublicSearchInteractor', () => {
           partyType: PARTY_TYPES.petitioner,
           petitioners: [getContactPrimary(MOCK_CASE)],
           receivedAt: '2019-03-01T21:40:46.415Z',
+          status: 'Calendared',
         },
       ]);
 
@@ -61,7 +62,6 @@ describe('casePublicSearchInteractor', () => {
         entityName: 'PublicCase',
         hasIrsPractitioner: false,
         isSealed: false,
-        isStatusNew: false,
         partyType: PARTY_TYPES.petitioner,
         petitioners: [
           {
@@ -73,6 +73,7 @@ describe('casePublicSearchInteractor', () => {
           },
         ],
         receivedAt: '2019-03-01T21:40:46.415Z',
+        showPrintableDocketRecord: true,
       },
     ]);
   });

--- a/web-api/src/v1/getCaseLambda.test.js
+++ b/web-api/src/v1/getCaseLambda.test.js
@@ -102,8 +102,8 @@ describe('getCaseLambda (which fails if version increase is needed, DO NOT CHANG
     expect(parsedResponse.noticeOfTrialDate).toBeUndefined();
     expect(parsedResponse.trialLocation).toBeUndefined();
     expect(parsedResponse.userId).toBeUndefined();
-    expect(parsedResponse.contactPrimary).toBeDefined();
-    expect(parsedResponse.status).toBeDefined();
+    expect(parsedResponse.contactPrimary).toBeUndefined();
+    expect(parsedResponse.status).toBeUndefined();
   });
 
   it('returns 404 when the docket number isn’t found', async () => {
@@ -200,7 +200,6 @@ describe('getCaseLambda (which fails if version increase is needed, DO NOT CHANG
       preferredTrialCity: 'Washington, District of Columbia',
       respondents: [],
       sortableDocketNumber: 18000101,
-      status: 'Calendared',
     });
   });
 });

--- a/web-api/src/v1/marshallers/marshallCase.js
+++ b/web-api/src/v1/marshallers/marshallCase.js
@@ -38,7 +38,6 @@ exports.marshallCase = caseObject => {
     preferredTrialCity: caseObject.preferredTrialCity,
     respondents: (caseObject.irsPractitioners || []).map(marshallPractitioner),
     sortableDocketNumber: caseObject.sortableDocketNumber,
-    status: caseObject.status,
     trialLocation: caseObject.trialLocation,
   };
 };

--- a/web-api/src/v1/marshallers/marshallCase.test.js
+++ b/web-api/src/v1/marshallers/marshallCase.test.js
@@ -69,7 +69,6 @@ describe('marshallCase (which fails if version increase is needed, DO NOT CHANGE
       'preferredTrialCity',
       'respondents',
       'sortableDocketNumber',
-      'status',
       'trialLocation',
     ]);
   });
@@ -106,8 +105,10 @@ describe('marshallCase (which fails if version increase is needed, DO NOT CHANGE
     expect(marshalled.partyType).toEqual(mock.partyType);
     expect(marshalled.preferredTrialCity).toEqual(mock.preferredTrialCity);
     expect(marshalled.sortableDocketNumber).toEqual(mock.sortableDocketNumber);
-    expect(marshalled.status).toEqual(mock.status);
     expect(marshalled.trialLocation).toEqual(mock.trialLocation);
+
+    // We intentionally not include status
+    expect(marshalled.status).toBeUndefined();
 
     // Exact format asserted in other tests.
     expect(marshalled.contactPrimary).toBeDefined();

--- a/web-api/src/v2/getCaseLambda.test.js
+++ b/web-api/src/v2/getCaseLambda.test.js
@@ -122,8 +122,8 @@ describe('getCaseLambda (which fails if version increase is needed, DO NOT CHANG
     const parsedResponse = JSON.parse(response.body);
     expect(parsedResponse).toHaveProperty('caseCaption', expect.any(String));
     expect(parsedResponse.assignedJudge).toBeUndefined();
-    expect(parsedResponse.contactPrimary).toBeDefined();
-    expect(parsedResponse.status).toBeDefined();
+    expect(parsedResponse.contactPrimary).toBeUndefined();
+    expect(parsedResponse.status).toBeUndefined();
     expect(parsedResponse.trialDate).toBeUndefined();
     expect(parsedResponse.trialLocation).toBeUndefined();
     expect(parsedResponse.userId).toBeUndefined();
@@ -259,7 +259,6 @@ describe('getCaseLambda (which fails if version increase is needed, DO NOT CHANG
         },
       ],
       sortableDocketNumber: 18000101,
-      status: 'Calendared',
       trialDate: '2020-03-01T00:00:00.000Z',
       trialLocation: 'Washington, District of Columbia',
     });

--- a/web-api/src/v2/marshallers/marshallCase.js
+++ b/web-api/src/v2/marshallers/marshallCase.js
@@ -37,7 +37,6 @@ exports.marshallCase = caseObject => {
     preferredTrialCity: caseObject.preferredTrialCity,
     respondents: (caseObject.irsPractitioners || []).map(marshallPractitioner),
     sortableDocketNumber: caseObject.sortableDocketNumber,
-    status: caseObject.status,
     trialDate: caseObject.trialDate,
     trialLocation: caseObject.trialLocation,
   };

--- a/web-api/src/v2/marshallers/marshallCase.test.js
+++ b/web-api/src/v2/marshallers/marshallCase.test.js
@@ -67,7 +67,6 @@ describe('marshallCase (which fails if version increase is needed, DO NOT CHANGE
       'preferredTrialCity',
       'respondents',
       'sortableDocketNumber',
-      'status',
       'trialDate',
       'trialLocation',
     ]);
@@ -104,9 +103,11 @@ describe('marshallCase (which fails if version increase is needed, DO NOT CHANGE
     expect(marshalled.partyType).toEqual(mock.partyType);
     expect(marshalled.preferredTrialCity).toEqual(mock.preferredTrialCity);
     expect(marshalled.sortableDocketNumber).toEqual(mock.sortableDocketNumber);
-    expect(marshalled.status).toEqual(mock.status);
     expect(marshalled.trialDate).toEqual(mock.trialDate);
     expect(marshalled.trialLocation).toEqual(mock.trialLocation);
+
+    // We intentionally not include status
+    expect(marshalled.status).toBeUndefined();
 
     // Exact format asserted in other tests.
     expect(marshalled.contactPrimary).toBeDefined();

--- a/web-client/src/presenter/actions/getCaseAssociationAction.test.js
+++ b/web-client/src/presenter/actions/getCaseAssociationAction.test.js
@@ -287,7 +287,7 @@ describe('getCaseAssociation', () => {
       state: {
         caseDetail: {
           docketEntries: [{ documentType: 'Petition' }],
-          status: CASE_STATUS_TYPES.new,
+          showPrintableDocketRecord: false,
         },
       },
     });

--- a/web-client/src/presenter/computeds/Public/publicCaseDetailHelper.js
+++ b/web-client/src/presenter/computeds/Public/publicCaseDetailHelper.js
@@ -74,7 +74,8 @@ export const publicCaseDetailHelper = (get, applicationContext) => {
 
   const formattedCaseDetail = formatCaseDetail(publicCase);
 
-  const showPrintableDocketRecord = !formattedCaseDetail.isStatusNew;
+  const showPrintableDocketRecord =
+    !!formattedCaseDetail.showPrintableDocketRecord;
 
   return {
     formattedCaseDetail,

--- a/web-client/src/presenter/computeds/Public/publicCaseDetailHelper.test.js
+++ b/web-client/src/presenter/computeds/Public/publicCaseDetailHelper.test.js
@@ -47,7 +47,7 @@ describe('publicCaseDetailHelper', () => {
         state: {
           caseDetail: {
             docketEntries: [],
-            isStatusNew: false,
+            showPrintableDocketRecord: true,
           },
         },
       });
@@ -59,7 +59,7 @@ describe('publicCaseDetailHelper', () => {
         state: {
           caseDetail: {
             docketEntries: [],
-            isStatusNew: true,
+            showPrintableDocketRecord: false,
           },
         },
       });

--- a/web-client/src/presenter/computeds/caseDetailHeaderHelper.test.js
+++ b/web-client/src/presenter/computeds/caseDetailHeaderHelper.test.js
@@ -51,7 +51,7 @@ describe('caseDetailHeaderHelper', () => {
         ...getBaseState(petitionerUser),
         caseDetail: {
           docketEntries: [],
-          status: CASE_STATUS_TYPES.new,
+          isStatusNew: true,
         },
       },
     });
@@ -66,7 +66,7 @@ describe('caseDetailHeaderHelper', () => {
           docketEntries: [
             { documentType: 'Petition', servedAt: '2019-03-01T21:40:46.415Z' },
           ],
-          status: CASE_STATUS_TYPES.generalDocket,
+          isStatusNew: false,
         },
       },
     });

--- a/web-client/src/presenter/computeds/caseDetailHeaderHelper.test.js
+++ b/web-client/src/presenter/computeds/caseDetailHeaderHelper.test.js
@@ -51,7 +51,7 @@ describe('caseDetailHeaderHelper', () => {
         ...getBaseState(petitionerUser),
         caseDetail: {
           docketEntries: [],
-          isStatusNew: true,
+          showPrintableDocketRecord: false,
         },
       },
     });
@@ -66,7 +66,7 @@ describe('caseDetailHeaderHelper', () => {
           docketEntries: [
             { documentType: 'Petition', servedAt: '2019-03-01T21:40:46.415Z' },
           ],
-          isStatusNew: false,
+          showPrintableDocketRecord: true,
         },
       },
     });

--- a/web-client/src/presenter/computeds/caseDetailHelper.js
+++ b/web-client/src/presenter/computeds/caseDetailHelper.js
@@ -49,11 +49,6 @@ export const caseDetailHelper = (get, applicationContext) => {
 
   const hasConsolidatedCases = !isEmpty(caseDetail.consolidatedCases);
 
-  console.log({
-    caseDetail,
-    hi: 'yes',
-  });
-
   const canAllowDocumentServiceForCase = applicationContext
     .getUtilities()
     .canAllowDocumentServiceForCase(caseDetail);

--- a/web-client/src/presenter/computeds/caseDetailHelper.js
+++ b/web-client/src/presenter/computeds/caseDetailHelper.js
@@ -49,6 +49,11 @@ export const caseDetailHelper = (get, applicationContext) => {
 
   const hasConsolidatedCases = !isEmpty(caseDetail.consolidatedCases);
 
+  console.log({
+    caseDetail,
+    hi: 'yes',
+  });
+
   const canAllowDocumentServiceForCase = applicationContext
     .getUtilities()
     .canAllowDocumentServiceForCase(caseDetail);

--- a/web-client/src/presenter/computeds/caseDetailHelper.test.js
+++ b/web-client/src/presenter/computeds/caseDetailHelper.test.js
@@ -442,7 +442,7 @@ describe('case detail computed', () => {
               servedAt: '2019-03-01T21:40:46.415Z',
             },
           ],
-          isStatusNew: false,
+          showPrintableDocketRecord: true,
         },
       },
     });
@@ -457,7 +457,7 @@ describe('case detail computed', () => {
         ...getBaseState(user),
         caseDetail: {
           docketEntries: [{ documentType: 'Petition' }],
-          isStatusNew: true,
+          showPrintableDocketRecord: false,
         },
       },
     });

--- a/web-client/src/presenter/computeds/caseDetailHelper.test.js
+++ b/web-client/src/presenter/computeds/caseDetailHelper.test.js
@@ -1,7 +1,4 @@
-import {
-  CASE_STATUS_TYPES,
-  ROLES,
-} from '../../../../shared/src/business/entities/EntityConstants';
+import { ROLES } from '../../../../shared/src/business/entities/EntityConstants';
 import { applicationContextForClient as applicationContext } from '../../../../shared/src/business/test/createTestApplicationContext';
 import { caseDetailHelper as caseDetailHelperComputed } from './caseDetailHelper';
 import {
@@ -440,9 +437,12 @@ describe('case detail computed', () => {
         ...getBaseState(user),
         caseDetail: {
           docketEntries: [
-            { documentType: 'Petition', servedAt: '2019-03-01T21:40:46.415Z' },
+            {
+              documentType: 'Petition',
+              servedAt: '2019-03-01T21:40:46.415Z',
+            },
           ],
-          status: CASE_STATUS_TYPES.generalDocket,
+          isStatusNew: false,
         },
       },
     });
@@ -457,7 +457,7 @@ describe('case detail computed', () => {
         ...getBaseState(user),
         caseDetail: {
           docketEntries: [{ documentType: 'Petition' }],
-          status: CASE_STATUS_TYPES.new,
+          isStatusNew: true,
         },
       },
     });


### PR DESCRIPTION
In order to keep information secure as per Court requirements, we are keeping `status` hidden from Public endpoints. Additionally, we are removing it from the v1 and v2 APIs as this information is internal and should only be conveyed to Court users.