### PR TITLE
ustc-1675: fix printable docket record button for public case for external users

### DIFF
--- a/shared/src/persistence/dynamo/trialSessions/getEligibleCasesForTrialSession.js
+++ b/shared/src/persistence/dynamo/trialSessions/getEligibleCasesForTrialSession.js
@@ -19,7 +19,9 @@ exports.getEligibleCasesForTrialSession = async ({
     applicationContext,
   });
 
-  const docketNumbers = mappings.map(metadata => metadata.docketNumber);
+  const docketNumbers = [
+    ...new Set(mappings.map(metadata => metadata.docketNumber)),
+  ];
 
   const results = await client.batchGet({
     applicationContext,

--- a/shared/src/persistence/dynamo/trialSessions/getEligibleCasesForTrialSession.test.js
+++ b/shared/src/persistence/dynamo/trialSessions/getEligibleCasesForTrialSession.test.js
@@ -47,4 +47,32 @@ describe('getEligibleCasesForTrialSession', () => {
       },
     ]);
   });
+
+  it('should remove any duplicate cases it receives the list of cases it receives from the mapping records query', async () => {
+    client.query = jest.fn().mockReturnValue([
+      {
+        docketNumber: MOCK_CASE.docketNumber,
+        pk: 'eligible-for-trial-case-catalog',
+        sk: 'WashingtonDistrictofColumbia-R-D-20181212654321-101-18',
+      },
+      {
+        docketNumber: MOCK_CASE.docketNumber,
+        pk: 'eligible-for-trial-case-catalog',
+        sk: 'WashingtonDistrictofColumbia-R-D-20181212000000-101-18',
+      },
+    ]);
+
+    await getEligibleCasesForTrialSession({
+      applicationContext,
+    });
+    expect(client.batchGet).toHaveBeenCalledWith({
+      applicationContext,
+      keys: [
+        {
+          pk: `case|${MOCK_CASE.docketNumber}`,
+          sk: `case|${MOCK_CASE.docketNumber}`,
+        },
+      ],
+    });
+  });
 });

--- a/shared/src/persistence/dynamo/trialSessions/getEligibleCasesForTrialSession.test.js
+++ b/shared/src/persistence/dynamo/trialSessions/getEligibleCasesForTrialSession.test.js
@@ -48,7 +48,7 @@ describe('getEligibleCasesForTrialSession', () => {
     ]);
   });
 
-  it('should remove any duplicate cases it receives the list of cases it receives from the mapping records query', async () => {
+  it('should remove duplicate docketNumbers returned by the eligible-for-trial-case-catalog query', async () => {
     client.query = jest.fn().mockReturnValue([
       {
         docketNumber: MOCK_CASE.docketNumber,

--- a/web-client/src/presenter/computeds/docketRecordHelper.js
+++ b/web-client/src/presenter/computeds/docketRecordHelper.js
@@ -2,7 +2,7 @@ import { state } from 'cerebral';
 
 export const docketRecordHelper = get => {
   const permissions = get(state.permissions);
-  const showPrintableDocketRecord = get(state.caseDetail.isStatusNew);
+  const showPrintableDocketRecord = get(state.caseDetail.isStatusNew) === false;
 
   return {
     showEditDocketRecordEntry: permissions.EDIT_DOCKET_ENTRY,

--- a/web-client/src/presenter/computeds/docketRecordHelper.js
+++ b/web-client/src/presenter/computeds/docketRecordHelper.js
@@ -1,10 +1,8 @@
-import { CASE_STATUS_TYPES } from '../../../../shared/src/business/entities/EntityConstants';
 import { state } from 'cerebral';
 
 export const docketRecordHelper = get => {
   const permissions = get(state.permissions);
-  const showPrintableDocketRecord =
-    get(state.caseDetail.status) !== CASE_STATUS_TYPES.new;
+  const showPrintableDocketRecord = get(state.caseDetail.isStatusNew);
 
   return {
     showEditDocketRecordEntry: permissions.EDIT_DOCKET_ENTRY,

--- a/web-client/src/presenter/computeds/docketRecordHelper.test.js
+++ b/web-client/src/presenter/computeds/docketRecordHelper.test.js
@@ -1,4 +1,3 @@
-import { CASE_STATUS_TYPES } from '../../../../shared/src/business/entities/EntityConstants';
 import { docketRecordHelper } from './docketRecordHelper';
 import { runCompute } from 'cerebral/test';
 
@@ -6,34 +5,38 @@ describe('docket record helper', () => {
   it('should show links for editing docket entries if user does have EDIT_DOCKET_ENTRY permission', () => {
     const result = runCompute(docketRecordHelper, {
       state: {
-        caseDetail: {},
+        caseDetail: {
+          isStatusNew: false,
+        },
         form: {},
         permissions: {
           EDIT_DOCKET_ENTRY: true,
         },
       },
     });
-    expect(result.showEditDocketRecordEntry).toBeTruthy();
+    expect(result.showEditDocketRecordEntry).toBe(true);
   });
 
   it('should not show links for editing docket entries if user does not have EDIT_DOCKET_ENTRY permission', () => {
     const result = runCompute(docketRecordHelper, {
       state: {
-        caseDetail: {},
+        caseDetail: {
+          isStatusNew: false,
+        },
         form: {},
         permissions: {
           EDIT_DOCKET_ENTRY: false,
         },
       },
     });
-    expect(result.showEditDocketRecordEntry).toBeFalsy();
+    expect(result.showEditDocketRecordEntry).toBe(false);
   });
 
   it('should show printable docket record button if the case status is not new', () => {
     const result = runCompute(docketRecordHelper, {
       state: {
         caseDetail: {
-          status: CASE_STATUS_TYPES.calendared,
+          isStatusNew: false,
         },
         form: {},
         permissions: {
@@ -41,14 +44,14 @@ describe('docket record helper', () => {
         },
       },
     });
-    expect(result.showPrintableDocketRecord).toBeTruthy();
+    expect(result.showPrintableDocketRecord).toBe(true);
   });
 
   it('should not show printable docket record button if the case status is new', () => {
     const result = runCompute(docketRecordHelper, {
       state: {
         caseDetail: {
-          status: CASE_STATUS_TYPES.new,
+          isStatusNew: true,
         },
         form: {},
         permissions: {
@@ -56,6 +59,6 @@ describe('docket record helper', () => {
         },
       },
     });
-    expect(result.showPrintableDocketRecord).toBeFalsy();
+    expect(result.showPrintableDocketRecord).toBe(false);
   });
 });


### PR DESCRIPTION
Working to solve https://github.com/ustaxcourt/ef-cms/issues/1675

It appears that https://github.com/flexion/ef-cms/issues/8280 introduced a bug that the Printable Docket Record button still shows up for External Users even though the case status is New. This is because the Case Status is not exposed in a Public Case.

We are using `isStatusNew`, which was introduced in 8280.