### PR TITLE
8952 - Decorate Case Status

### DIFF
--- a/shared/src/business/entities/cases/Case.canAllowDocumentServiceForCase.test.js
+++ b/shared/src/business/entities/cases/Case.canAllowDocumentServiceForCase.test.js
@@ -4,13 +4,31 @@ const { CASE_STATUS_TYPES } = require('../EntityConstants');
 const { MOCK_CASE } = require('../../../test/mockCase');
 
 describe('canAllowDocumentServiceForCase', () => {
+  it('returns true if the rawCase.canAllowDocumentService value is defined and true', () => {
+    expect(
+      canAllowDocumentServiceForCase({
+        ...MOCK_CASE,
+        canAllowDocumentService: true,
+      }),
+    ).toEqual(true);
+  });
+
+  it('returns false if the rawCase.canAllowDocumentService value is defined and false', () => {
+    expect(
+      canAllowDocumentServiceForCase({
+        ...MOCK_CASE,
+        canAllowDocumentService: false,
+      }),
+    ).toEqual(false);
+  });
+
   it('returns true if the case is not in NEW status', () => {
     expect(
       canAllowDocumentServiceForCase({
         ...MOCK_CASE,
         status: CASE_STATUS_TYPES.generalDocket,
       }),
-    ).toBeTruthy();
+    ).toEqual(true);
   });
 
   it('returns false if the case is in NEW status', () => {
@@ -19,7 +37,7 @@ describe('canAllowDocumentServiceForCase', () => {
         ...MOCK_CASE,
         status: CASE_STATUS_TYPES.new,
       }),
-    ).toBeFalsy();
+    ).toEqual(false);
   });
 
   it('returns false if the case is closed more than six months ago', () => {
@@ -29,7 +47,7 @@ describe('canAllowDocumentServiceForCase', () => {
         closedDate: '2019-03-01T21:40:48.000Z',
         status: CASE_STATUS_TYPES.closed,
       }),
-    ).toBeFalsy();
+    ).toEqual(false);
   });
 
   it('returns true if the case is closed within the last six months', () => {
@@ -42,6 +60,6 @@ describe('canAllowDocumentServiceForCase', () => {
         }),
         status: CASE_STATUS_TYPES.closed,
       }),
-    ).toBeTruthy();
+    ).toEqual(true);
   });
 });

--- a/shared/src/business/entities/cases/Case.js
+++ b/shared/src/business/entities/cases/Case.js
@@ -2277,6 +2277,10 @@ const caseHasServedDocketEntries = rawCase => {
  */
 
 const canAllowDocumentServiceForCase = rawCase => {
+  if (typeof rawCase.canAllowDocumentService !== 'undefined') {
+    return rawCase.canAllowDocumentService;
+  }
+
   const isOpen = ![CASE_STATUS_TYPES.closed, CASE_STATUS_TYPES.new].includes(
     rawCase.status,
   );

--- a/shared/src/business/entities/cases/PublicCase.js
+++ b/shared/src/business/entities/cases/PublicCase.js
@@ -34,6 +34,7 @@ const { PublicDocketEntry } = require('./PublicDocketEntry');
 function PublicCase() {}
 PublicCase.prototype.init = function init(rawCase, { applicationContext }) {
   this.entityName = 'PublicCase';
+  this.canAllowDocumentService = rawCase.canAllowDocumentService;
   this.caseCaption = rawCase.caseCaption;
   this.docketNumber = rawCase.docketNumber;
   this.docketNumberSuffix = rawCase.docketNumberSuffix;
@@ -44,7 +45,6 @@ PublicCase.prototype.init = function init(rawCase, { applicationContext }) {
     !!rawCase.irsPractitioners && rawCase.irsPractitioners.length > 0;
   this.isPaper = rawCase.isPaper;
   this.partyType = rawCase.partyType;
-  this.status = rawCase.status;
   this.receivedAt = rawCase.receivedAt;
   this._score = rawCase['_score'];
 
@@ -80,6 +80,7 @@ PublicCase.prototype.init = function init(rawCase, { applicationContext }) {
 };
 
 const publicCaseSchema = {
+  canAllowDocumentService: joi.boolean().optional(),
   caseCaption: JoiValidationConstants.CASE_CAPTION.optional(),
   createdAt: JoiValidationConstants.ISO_DATE.optional(),
   docketEntries: joi
@@ -105,12 +106,6 @@ const publicCaseSchema = {
     .description('Party type of the case petitioner.'),
   petitioners: joi.array().items(PublicContact.VALIDATION_RULES).required(),
   receivedAt: JoiValidationConstants.ISO_DATE.optional(),
-  status: JoiValidationConstants.STRING.valid(
-    ...Object.values(CASE_STATUS_TYPES),
-  )
-    .optional()
-    .meta({ tags: ['Restricted'] })
-    .description('Status of the case.'),
 };
 
 const sealedCaseSchemaRestricted = {

--- a/shared/src/business/entities/cases/PublicCase.test.js
+++ b/shared/src/business/entities/cases/PublicCase.test.js
@@ -76,6 +76,7 @@ describe('PublicCase', () => {
   it('should only have expected fields', () => {
     const entity = new PublicCase(
       {
+        canAllowDocumentService: true,
         caseCaption: 'testing',
         createdAt: 'testing',
         docketEntries: [],
@@ -103,6 +104,7 @@ describe('PublicCase', () => {
     );
 
     expect(entity.toRawObject()).toEqual({
+      canAllowDocumentService: true,
       caseCaption: 'testing',
       docketEntries: [],
       docketNumber: 'testing',
@@ -129,7 +131,6 @@ describe('PublicCase', () => {
         },
       ],
       receivedAt: 'testing',
-      status: CASE_STATUS_TYPES.new,
     });
   });
 
@@ -175,7 +176,6 @@ describe('PublicCase', () => {
         },
       ],
       receivedAt: 'testing',
-      status: CASE_STATUS_TYPES.calendared,
     });
   });
 

--- a/shared/src/business/useCases/getCaseInteractor.js
+++ b/shared/src/business/useCases/getCaseInteractor.js
@@ -73,7 +73,7 @@ const getCaseForExternalUser = ({
   }
 };
 
-export const decorateForCaseStatus = caseRecord => {
+const decorateForCaseStatus = caseRecord => {
   // allow document service
   caseRecord.canAllowDocumentService =
     canAllowDocumentServiceForCase(caseRecord);
@@ -82,6 +82,8 @@ export const decorateForCaseStatus = caseRecord => {
 
   return caseRecord;
 };
+
+exports.decorateForCaseStatus = decorateForCaseStatus;
 
 /**
  * getCaseInteractor

--- a/shared/src/business/useCases/getCaseInteractor.js
+++ b/shared/src/business/useCases/getCaseInteractor.js
@@ -1,4 +1,5 @@
 const {
+  canAllowDocumentServiceForCase,
   Case,
   getPetitionerById,
   isAssociatedUser,
@@ -72,6 +73,16 @@ const getCaseForExternalUser = ({
   }
 };
 
+export const decorateForCaseStatus = caseRecord => {
+  // allow document service
+  caseRecord.canAllowDocumentService =
+    canAllowDocumentServiceForCase(caseRecord);
+
+  // TODO: allow printable docket record
+
+  return caseRecord;
+};
+
 /**
  * getCaseInteractor
  *
@@ -81,12 +92,14 @@ const getCaseForExternalUser = ({
  * @returns {object} the case data
  */
 exports.getCaseInteractor = async (applicationContext, { docketNumber }) => {
-  const caseRecord = await applicationContext
-    .getPersistenceGateway()
-    .getCaseByDocketNumber({
+  const caseRecord = decorateForCaseStatus(
+    await applicationContext.getPersistenceGateway().getCaseByDocketNumber({
       applicationContext,
       docketNumber: Case.formatDocketNumber(docketNumber),
-    });
+    }),
+  );
+
+  //caseRecord = decorateForCaseStatus(caseRecord);
 
   if (!caseRecord.docketNumber && !caseRecord.entityName) {
     const error = new NotFoundError(`Case ${docketNumber} was not found.`);

--- a/shared/src/business/useCases/getCaseInteractor.test.js
+++ b/shared/src/business/useCases/getCaseInteractor.test.js
@@ -5,28 +5,37 @@ const {
   ROLES,
 } = require('../entities/EntityConstants');
 const {
+  decorateForCaseStatus,
+  getCaseInteractor,
+} = require('./getCaseInteractor');
+const {
   MOCK_CASE,
   MOCK_CASE_WITH_SECONDARY_OTHERS,
 } = require('../../test/mockCase');
 const { applicationContext } = require('../test/createTestApplicationContext');
-const { getCaseInteractor } = require('./getCaseInteractor');
 const { getOtherFilers } = require('../entities/cases/Case');
 const { docketEntries } = MOCK_CASE;
 const { cloneDeep } = require('lodash');
 
 describe('getCaseInteractor', () => {
+  let testCase;
+  let mockCaseContactPrimary;
+
+  beforeEach(() => {
+    testCase = { ...MOCK_CASE };
+    mockCaseContactPrimary = testCase.petitioners[0];
+  });
+
   const petitionsclerkId = '23c4d382-1136-492f-b1f4-45e893c34771';
   const docketClerkId = '44c4d382-1136-492f-b1f4-45e893c34771';
   const irsPractitionerId = '6cf19fba-18c6-467a-9ea6-7a14e42add2f';
   const practitionerId = '295c3640-7ff9-40bb-b2f1-8117bba084ea';
   const practitioner2Id = '42614976-4228-49aa-a4c3-597dae1c7220';
 
-  const mockCaseContactPrimary = MOCK_CASE.petitioners[0];
-
   it('should format the given docket number, removing leading zeroes and suffix', async () => {
     applicationContext
       .getPersistenceGateway()
-      .getCaseByDocketNumber.mockReturnValue(MOCK_CASE);
+      .getCaseByDocketNumber.mockReturnValue(testCase);
 
     await getCaseInteractor(applicationContext, {
       docketNumber: '000123-19S',
@@ -77,7 +86,7 @@ describe('getCaseInteractor', () => {
       role: ROLES.petitionsClerk,
       userId: petitionsclerkId,
     });
-    const mockInvalidCase = { ...MOCK_CASE, caseCaption: undefined };
+    const mockInvalidCase = { ...testCase, caseCaption: undefined };
     applicationContext
       .getPersistenceGateway()
       .getCaseByDocketNumber.mockReturnValue(mockInvalidCase);
@@ -99,7 +108,7 @@ describe('getCaseInteractor', () => {
     applicationContext
       .getPersistenceGateway()
       .getCaseByDocketNumber.mockResolvedValue({
-        ...MOCK_CASE,
+        ...testCase,
         docketNumber: '101-00',
         petitioners: [
           {
@@ -125,7 +134,7 @@ describe('getCaseInteractor', () => {
       .getPersistenceGateway()
       .getCaseByDocketNumber.mockReturnValue(
         Promise.resolve({
-          ...MOCK_CASE,
+          ...testCase,
           docketNumber: '101-00',
           petitioners: [
             {
@@ -153,7 +162,7 @@ describe('getCaseInteractor', () => {
     applicationContext
       .getPersistenceGateway()
       .getCaseByDocketNumber.mockResolvedValue({
-        ...MOCK_CASE,
+        ...testCase,
         docketNumber: '101-00',
         partyType: PARTY_TYPES.petitionerSpouse,
         petitioners: [
@@ -241,7 +250,7 @@ describe('getCaseInteractor', () => {
         .getPersistenceGateway()
         .getCaseByDocketNumber.mockReturnValue(
           Promise.resolve({
-            ...MOCK_CASE,
+            ...testCase,
             caseCaption: 'a case caption',
             caseType: CASE_TYPES_MAP.other,
             createdAt: applicationContext.getUtilities().createISODateString(),
@@ -290,10 +299,9 @@ describe('getCaseInteractor', () => {
         entityName: 'PublicCase',
         hasIrsPractitioner: false,
         isSealed: true,
-        isStatusNew: true,
+        isStatusNew: false,
         partyType: undefined,
         receivedAt: undefined,
-        status: MOCK_CASE.status,
       });
     });
 
@@ -336,7 +344,7 @@ describe('getCaseInteractor', () => {
         .getPersistenceGateway()
         .getCaseByDocketNumber.mockReturnValue(
           Promise.resolve({
-            ...MOCK_CASE,
+            ...testCase,
             privatePractitioners: [
               {
                 barNumber: 'BN1234',
@@ -379,6 +387,7 @@ describe('getCaseInteractor', () => {
       const contactPrimary = result.petitioners[0];
       expect(contactPrimary.address1).toBeUndefined();
       expect(contactPrimary.phone).toBeUndefined();
+      expect(result.canAllowDocumentService).toEqual(false);
     });
 
     it('should return a Case entity when the current user is associated with the case', async () => {
@@ -395,6 +404,15 @@ describe('getCaseInteractor', () => {
       const contactPrimary = result.petitioners[0];
       expect(contactPrimary.address1).toBeDefined();
       expect(contactPrimary.phone).toBeDefined();
+    });
+  });
+
+  describe('decorateForCaseStatus', () => {
+    it('sets the canAllowDocumentService on the given case record', () => {
+      expect(MOCK_CASE.canAllowDocumentService).not.toBeDefined();
+      expect(
+        decorateForCaseStatus(MOCK_CASE).canAllowDocumentService,
+      ).toBeDefined();
     });
   });
 });

--- a/shared/src/business/utilities/caseFilter.js
+++ b/shared/src/business/utilities/caseFilter.js
@@ -10,7 +10,6 @@ const CASE_ATTRIBUTE_WHITELIST = [
   'isPaper',
   'isSealed',
   'sealedDate',
-  'status',
 ];
 
 const CASE_CONTACT_ATTRIBUTE_WHITELIST = [

--- a/web-api/src/v1/getCaseLambda.test.js
+++ b/web-api/src/v1/getCaseLambda.test.js
@@ -96,14 +96,16 @@ describe('getCaseLambda (which fails if version increase is needed, DO NOT CHANG
 
     expect(response.statusCode).toBe('200');
     expect(response.headers['Content-Type']).toBe('application/json');
-    const parsedResponse = JSON.parse(response.body);
-    expect(parsedResponse).toHaveProperty('caseCaption', expect.any(String));
-    expect(parsedResponse.assignedJudge).toBeUndefined();
-    expect(parsedResponse.noticeOfTrialDate).toBeUndefined();
-    expect(parsedResponse.trialLocation).toBeUndefined();
-    expect(parsedResponse.userId).toBeUndefined();
-    expect(parsedResponse.contactPrimary).toBeDefined();
-    expect(parsedResponse.status).toBeDefined();
+    expect(JSON.parse(response.body)).toHaveProperty(
+      'caseCaption',
+      expect.any(String),
+    );
+    expect(JSON.parse(response.body).assignedJudge).toBeUndefined();
+    expect(JSON.parse(response.body).contactPrimary).toBeUndefined();
+    expect(JSON.parse(response.body).noticeOfTrialDate).toBeUndefined();
+    expect(JSON.parse(response.body).status).toBeUndefined();
+    expect(JSON.parse(response.body).trialLocation).toBeUndefined();
+    expect(JSON.parse(response.body).userId).toBeUndefined();
   });
 
   it('returns 404 when the docket number isn’t found', async () => {

--- a/web-api/src/v2/getCaseLambda.test.js
+++ b/web-api/src/v2/getCaseLambda.test.js
@@ -119,14 +119,16 @@ describe('getCaseLambda (which fails if version increase is needed, DO NOT CHANG
 
     expect(response.statusCode).toBe('200');
     expect(response.headers['Content-Type']).toBe('application/json');
-    const parsedResponse = JSON.parse(response.body);
-    expect(parsedResponse).toHaveProperty('caseCaption', expect.any(String));
-    expect(parsedResponse.assignedJudge).toBeUndefined();
-    expect(parsedResponse.contactPrimary).toBeDefined();
-    expect(parsedResponse.status).toBeDefined();
-    expect(parsedResponse.trialDate).toBeUndefined();
-    expect(parsedResponse.trialLocation).toBeUndefined();
-    expect(parsedResponse.userId).toBeUndefined();
+    expect(JSON.parse(response.body)).toHaveProperty(
+      'caseCaption',
+      expect.any(String),
+    );
+    expect(JSON.parse(response.body).assignedJudge).toBeUndefined();
+    expect(JSON.parse(response.body).contactPrimary).toBeUndefined();
+    expect(JSON.parse(response.body).status).toBeUndefined();
+    expect(JSON.parse(response.body).trialDate).toBeUndefined();
+    expect(JSON.parse(response.body).trialLocation).toBeUndefined();
+    expect(JSON.parse(response.body).userId).toBeUndefined();
   });
 
   it('returns 404 when the docket number isn’t found', async () => {


### PR DESCRIPTION
This adds a little function in getCaseInteractor to compute the canAllowDocumentService field without sending case status information over the network for PublicCase objects.

As a side note, we will make use of this decorator for other fields / future stories.