### PR TITLE
8976: add debugging to help catch a reoccurrence of 8976

### DIFF
--- a/shared/src/business/useCases/courtIssuedDocument/serveCourtIssuedDocumentInteractor.js
+++ b/shared/src/business/useCases/courtIssuedDocument/serveCourtIssuedDocumentInteractor.js
@@ -255,6 +255,10 @@ exports.serveCourtIssuedDocumentInteractor = async (
         status: false,
       });
 
+    applicationContext.logger.error(
+      'Error attempting to serve a Court Issued Document',
+      { err: e },
+    );
     throw e;
   }
 };

--- a/shared/src/business/useCases/courtIssuedDocument/serveCourtIssuedDocumentInteractor.test.js
+++ b/shared/src/business/useCases/courtIssuedDocument/serveCourtIssuedDocumentInteractor.test.js
@@ -163,6 +163,8 @@ describe('serveCourtIssuedDocumentInteractor', () => {
       .getPersistenceGateway()
       .updateCase.mockImplementation(caseToUpdate => caseToUpdate);
 
+    applicationContext.logger.error.mockImplementation(() => {});
+
     applicationContext
       .getUseCaseHelpers()
       .countPagesInDocument.mockResolvedValue(1);
@@ -534,5 +536,12 @@ describe('serveCourtIssuedDocumentInteractor', () => {
       docketNumber: mockCases[0].docketNumber,
       status: false,
     });
+
+    expect(applicationContext.logger.error).toHaveBeenCalledWith(
+      'Error attempting to serve a Court Issued Document',
+      {
+        err: new Error('whoops, that is an error!'),
+      },
+    );
   });
 });


### PR DESCRIPTION
We were unable to replicate or find solid evidence in the logs to explain how https://github.com/flexion/ef-cms/issues/8976 happened. Somehow the docket entry got tagged with the `isPendingService` flag, but service did not complete. We couldn't find any information in the logs about the previous attempt. 

The last trace of the attempt was that the Work Item `work-item|9faa7809-6540-40d7-bc36-063830760f38` was created at `2021-09-23T13:20:51.336Z`, moments before the failures started. Cannot find any evidence in the logs as to what failed, so we are introducing this logger entry to help report failures whenever they happen. 

It's still curious why the flag wasn't unset in the catch block.