### PR TITLE
ustc-1695: fix missing edit petitioner button

### DIFF
--- a/web-client/src/presenter/computeds/partiesInformationHelper.js
+++ b/web-client/src/presenter/computeds/partiesInformationHelper.js
@@ -1,3 +1,4 @@
+import { CASE_STATUS_TYPES } from '../../../../shared/src/business/entities/EntityConstants';
 import { capitalize } from 'lodash';
 import { state } from 'cerebral';
 
@@ -110,14 +111,10 @@ export const partiesInformationHelper = (get, applicationContext) => {
         practitioner.representing.includes(petitioner.contactId),
     );
 
-    const canAllowDocumentServiceForCase = !!applicationContext
-      .getUtilities()
-      .canAllowDocumentServiceForCase(caseDetail);
-
     const canEditPetitioner = getCanEditPetitioner({
       applicationContext,
       permissions,
-      petitionIsServed: canAllowDocumentServiceForCase,
+      petitionIsServed: caseDetail.status !== CASE_STATUS_TYPES.new,
       petitioner,
       user,
       userAssociatedWithCase,


### PR DESCRIPTION
Attempting to fix https://github.com/ustaxcourt/ef-cms/issues/1695

We are using the wrong helper for determining whether or not we can edit a petitioner's information. It really depends whether or not the status is not New