### PR TITLE
ustc-1695: fix logic for serving a notice of change of address on closed cases

### DIFF
--- a/shared/src/business/useCases/updatePetitionerInformationInteractor.js
+++ b/shared/src/business/useCases/updatePetitionerInformationInteractor.js
@@ -2,6 +2,7 @@ const {
   aggregatePartiesForService,
 } = require('../utilities/aggregatePartiesForService');
 const {
+  canAllowDocumentServiceForCase,
   Case,
   getPetitionerById,
   getPractitionersRepresenting,
@@ -304,7 +305,11 @@ const updatePetitionerInformationInteractor = async (
     updatedPetitionerData.contactId,
   );
 
-  if (petitionerInfoChange && !updatedCaseContact.isAddressSealed) {
+  if (
+    petitionerInfoChange &&
+    !updatedCaseContact.isAddressSealed &&
+    canAllowDocumentServiceForCase(caseEntity)
+  ) {
     const partyWithPaperService = caseEntity.hasPartyWithServiceType(
       SERVICE_INDICATOR_TYPES.SI_PAPER,
     );


### PR DESCRIPTION
Once we made the button available, there was no logic in place to prevent docket entries from being created and served for change address on cases that have been closed for more than 6 months.