### PR TITLE
USTC-1695: Fix button for editing Petitioner Info for Cases closed longer than 6 months

### DIFF
--- a/shared/src/business/useCases/updatePetitionerInformationInteractor.js
+++ b/shared/src/business/useCases/updatePetitionerInformationInteractor.js
@@ -2,6 +2,7 @@ const {
   aggregatePartiesForService,
 } = require('../utilities/aggregatePartiesForService');
 const {
+  canAllowDocumentServiceForCase,
   Case,
   getPetitionerById,
   getPractitionersRepresenting,
@@ -304,7 +305,11 @@ const updatePetitionerInformationInteractor = async (
     updatedPetitionerData.contactId,
   );
 
-  if (petitionerInfoChange && !updatedCaseContact.isAddressSealed) {
+  if (
+    petitionerInfoChange &&
+    !updatedCaseContact.isAddressSealed &&
+    canAllowDocumentServiceForCase(caseEntity)
+  ) {
     const partyWithPaperService = caseEntity.hasPartyWithServiceType(
       SERVICE_INDICATOR_TYPES.SI_PAPER,
     );

--- a/web-client/src/presenter/computeds/partiesInformationHelper.js
+++ b/web-client/src/presenter/computeds/partiesInformationHelper.js
@@ -1,3 +1,4 @@
+import { CASE_STATUS_TYPES } from '../../../../shared/src/business/entities/EntityConstants';
 import { capitalize } from 'lodash';
 import { state } from 'cerebral';
 
@@ -110,14 +111,10 @@ export const partiesInformationHelper = (get, applicationContext) => {
         practitioner.representing.includes(petitioner.contactId),
     );
 
-    const canAllowDocumentServiceForCase = !!applicationContext
-      .getUtilities()
-      .canAllowDocumentServiceForCase(caseDetail);
-
     const canEditPetitioner = getCanEditPetitioner({
       applicationContext,
       permissions,
-      petitionIsServed: canAllowDocumentServiceForCase,
+      petitionIsServed: caseDetail.status !== CASE_STATUS_TYPES.new,
       petitioner,
       user,
       userAssociatedWithCase,


### PR DESCRIPTION
Solves: https://github.com/ustaxcourt/ef-cms/issues/1695

Docket clerks reported that you could no longer edit the Petitioner contact for a Case that had been closed longer than 6 months. It appears that work for https://github.com/flexion/ef-cms/issues/8952 broke this as we became reliant on whether or not you could perform service on a closed case via https://github.com/ustaxcourt/ef-cms/pull/1668

However, once we made the button available, it also exposed a bug that we were still performing service on cases that were closed greater than six months. This logic needed to be performed at the Lambda level and not in the client.
