### PR TITLE
USTC-1675: Fix printable docket record for Unauthenticated users and Users' own cases

### DIFF
--- a/shared/src/business/entities/cases/Case.js
+++ b/shared/src/business/entities/cases/Case.js
@@ -473,6 +473,8 @@ Case.VALIDATION_RULES = {
       then: joi.required(),
     })
     .meta({ tags: ['Restricted'] }),
+  canAllowDocumentService: joi.boolean().optional(),
+  canAllowPrintableDocketRecord: joi.boolean().optional(),
   caseCaption: JoiValidationConstants.CASE_CAPTION.required().description(
     'The name of the party bringing the case, e.g. "Carol Williams, Petitioner," "Mark Taylor, Incompetent, Debra Thomas, Next Friend, Petitioner," or "Estate of Test Taxpayer, Deceased, Petitioner." This is the first half of the case title.',
   ),

--- a/shared/src/business/useCases/public/getPublicCaseInteractor.js
+++ b/shared/src/business/useCases/public/getPublicCaseInteractor.js
@@ -3,6 +3,7 @@ const {
   caseSealedFormatter,
 } = require('../../utilities/caseFilter');
 const { Case, isSealedCase } = require('../../entities/cases/Case');
+const { decorateForCaseStatus } = require('../getCaseInteractor');
 const { NotFoundError } = require('../../../errors/errors');
 const { PublicCase } = require('../../entities/cases/PublicCase');
 
@@ -36,6 +37,7 @@ exports.getPublicCaseInteractor = async (
   }
 
   rawCaseRecord = caseContactAddressSealedFormatter(rawCaseRecord, {});
+  rawCaseRecord = decorateForCaseStatus(rawCaseRecord);
 
   const publicCaseDetail = new PublicCase(rawCaseRecord, {
     applicationContext,


### PR DESCRIPTION
This ensures that the `canAllowPrintableDocketRecord` is properly introduced for parties associated with a case as well as Public Cases to users who are not logged in.