### PR TITLE
USTC-1675: assign decorated fields for Case

### DIFF
--- a/shared/src/business/entities/cases/Case.js
+++ b/shared/src/business/entities/cases/Case.js
@@ -267,6 +267,9 @@ const assignFieldsForAllUsers = ({ obj, rawCase }) => {
 
   obj.docketNumberWithSuffix =
     obj.docketNumber + (obj.docketNumberSuffix || '');
+
+  obj.canAllowDocumentService = rawCase.canAllowDocumentService;
+  obj.canAllowPrintableDocketRecord = rawCase.canAllowPrintableDocketRecord;
 };
 
 const assignDocketEntries = ({


### PR DESCRIPTION
Use decorator that assigns fields for all users for our decorators so that they're available to Internal users and Practitioner users.