### PR TITLE
Adjust max filename size

### DIFF
--- a/shared/src/business/useCases/trialSessions/batchDownloadTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/batchDownloadTrialSessionInteractor.js
@@ -246,17 +246,17 @@ const batchDownloadTrialSessionInteractor = async (
 };
 
 exports.generateValidDocketEntryFilename = ({
-  eventCode,
+  documentTitle,
   filingDate,
   index,
 }) => {
-  const MAX_OVERALL_FILE_LENGTH = 26;
+  const MAX_OVERALL_FILE_LENGTH = 64;
   const EXTENSION = '.pdf';
   const VALID_FILE_NAME_MAX_LENGTH = MAX_OVERALL_FILE_LENGTH - EXTENSION.length;
 
   const docDate = formatDateString(filingDate, 'YYYY-MM-DD');
   const docNum = padStart(`${index}`, 4, '0');
-  let fileName = sanitize(`${docDate}_${docNum}_${eventCode}`);
+  let fileName = sanitize(`${docDate}_${docNum}_${documentTitle}`);
   if (fileName.length > VALID_FILE_NAME_MAX_LENGTH) {
     fileName = fileName.substring(0, VALID_FILE_NAME_MAX_LENGTH);
   }

--- a/shared/src/business/useCases/trialSessions/batchDownloadTrialSessionInteractor.test.js
+++ b/shared/src/business/useCases/trialSessions/batchDownloadTrialSessionInteractor.test.js
@@ -84,31 +84,31 @@ describe('batchDownloadTrialSessionInteractor', () => {
   });
 
   describe('file name generation', () => {
-    it('truncates filenames if long eventCode causes them to exceed 26 characters', () => {
+    it('truncates filenames if long document title causes them to exceed 64 characters', () => {
       const docketEntry = {
         documentTitle:
           'Harrell slipped the cool bulk of the thought-helmet over his head and signalled to the scientist, who pulled the actuator switch. Harrell shuddered as psionic current surged through him; he stiffened, wriggled, and felt himself glide out of his body, hover incorporeally in the air between his now soulless shell and the alien bound opposite.',
-        eventCode: 'ABCDEFGHIJKLMNOPQRSTUVWZYZ',
+        eventCode: 'MISC',
         filingDate: '2020-06-20T15:43:12.000Z',
         index: '7',
       };
-      const expectedName = '2020-06-20_0007_ABCDEF.pdf';
+      const expectedName =
+        '2020-06-20_0007_Harrell slipped the cool bulk of the thought.pdf';
       const filename = generateValidDocketEntryFilename(docketEntry);
-      expect(filename.length).toBe(26);
+      expect(filename.length).toBe(64);
       expect(filename).toBe(expectedName);
     });
-    it('generates a filename without any truncation when overall length is 26 characters or less', () => {
+    it('generates a filename without any truncation when overall length is 64 characters or less', () => {
       const docketEntry = {
-        documentTitle:
-          "Harrell met the downcrashing blow of the alien's broad-sword fully; the shock of impact sent numbing shivers up his arm as far as his shoulder but he held on and turned aside the b",
+        documentTitle: 'Harrell met the downcrashing blow',
         eventCode: 'MISC',
         filingDate: '2020-06-20T15:43:12.000Z',
         index: '7',
       };
 
-      const expectedName = '2020-06-20_0007_MISC.pdf';
+      const expectedName =
+        '2020-06-20_0007_Harrell met the downcrashing blow.pdf';
       const filename = generateValidDocketEntryFilename(docketEntry);
-      expect(filename.length).toBe(24);
       expect(filename).toBe(expectedName);
     });
   });


### PR DESCRIPTION
- switch back to using `documentTitle`
- reduce cap to 64 characters