### PR TITLE
ustc: Reintroduce smoke tests into migration environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -822,14 +822,12 @@ build-and-deploy-defaults: &build-and-deploy-defaults
       ignore:
         - develop # run the related develop workflow below
         - prod # run with context workflow below
-        - migration # run without smoketests workflow
 
 build-and-deploy-without-smoketests-defaults:
   &build-and-deploy-without-smoketests-defaults
   filters:
     branches:
       only:
-        - migration
 
 build-and-deploy-with-context-defaults: &build-and-deploy-with-context-defaults
   context: efcms-<< pipeline.git.branch >>
@@ -910,6 +908,7 @@ workflows:
                 - experimental4
                 - experimental5
                 - dawson
+                - migration
       - migrate:
           requires:
             - deploy
@@ -924,6 +923,7 @@ workflows:
                 - experimental3
                 - experimental4
                 - experimental5
+                - migration
       - smoketests:
           requires:
             - migrate
@@ -938,6 +938,7 @@ workflows:
                 - experimental3
                 - experimental4
                 - experimental5
+                - migration
       - smoketests-readonly:
           requires:
             - smoketests
@@ -952,6 +953,7 @@ workflows:
                 - experimental3
                 - experimental4
                 - experimental5
+                - migration
       - switch-colors:
           requires:
             - smoketests-readonly
@@ -968,6 +970,7 @@ workflows:
                 - experimental4
                 - experimental5
                 - dawson
+                - migration
   build-and-deploy-without-smoketests:
     jobs:
       - build-client-integration:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -823,12 +823,6 @@ build-and-deploy-defaults: &build-and-deploy-defaults
         - develop # run the related develop workflow below
         - prod # run with context workflow below
 
-build-and-deploy-without-smoketests-defaults:
-  &build-and-deploy-without-smoketests-defaults
-  filters:
-    branches:
-      only:
-
 build-and-deploy-with-context-defaults: &build-and-deploy-with-context-defaults
   context: efcms-<< pipeline.git.branch >>
   filters:
@@ -971,38 +965,6 @@ workflows:
                 - experimental5
                 - dawson
                 - migration
-  build-and-deploy-without-smoketests:
-    jobs:
-      - build-client-integration:
-          <<: *build-and-deploy-without-smoketests-defaults
-      - e2e-pa11y:
-          <<: *build-and-deploy-without-smoketests-defaults
-      - e2e-pa11y-public:
-          <<: *build-and-deploy-without-smoketests-defaults
-      - e2e-cypress:
-          <<: *build-and-deploy-without-smoketests-defaults
-      - e2e-cypress-smoketests-local:
-          <<: *build-and-deploy-without-smoketests-defaults
-      - e2e-cypress-public:
-          <<: *build-and-deploy-without-smoketests-defaults
-      - deploy:
-          <<: *build-and-deploy-without-smoketests-defaults
-          requires:
-            - build-client-integration
-            - e2e-pa11y
-            - e2e-pa11y-public
-            - e2e-cypress
-            - e2e-cypress-smoketests-local
-            - e2e-cypress-public
-      - migrate:
-          <<: *build-and-deploy-without-smoketests-defaults
-          requires:
-            - deploy
-      - switch-colors:
-          <<: *build-and-deploy-without-smoketests-defaults
-          requires:
-            - migrate
-
   build-and-deploy-with-context:
     jobs:
       - build-client-integration:


### PR DESCRIPTION
When we stood up the `migration` environment, we had no way for the `smoketests` to make use of the strong password in place for the test users. Now we've been able to encapsulate the strong password in an environment-specific environment var `DEFAULT_ACCOUNT_PASS_MIG`. 