### PR TITLE
ustc-1731: change instance types for elasticsearch cluster nodes

### DIFF
--- a/scripts/get-es-instance-type.sh
+++ b/scripts/get-es-instance-type.sh
@@ -29,15 +29,15 @@ elif [[ $BRANCH == 'irs' ]] ; then
 elif [[ $BRANCH == 'staging' ]] ; then
   echo "t2.medium.elasticsearch"
 elif [[ $BRANCH == 'test' ]] ; then
-  echo "m5.large.elasticsearch"
+  echo "r5.xlarge.elasticsearch"
 elif [[ $BRANCH == 'migration' ]] ; then
-  echo "m5.large.elasticsearch"
+  echo "r5.xlarge.elasticsearch"
 elif [[ $BRANCH == 'master' ]] ; then
   echo "m5.large.elasticsearch"
 elif [[ $BRANCH == 'dawson' ]] ; then
   echo "t2.small.elasticsearch"
 elif [[ $BRANCH == 'prod' ]] ; then
-  echo "m5.xlarge.elasticsearch"
+  echo "r5.xlarge.elasticsearch"
 else
   exit 1;
 fi


### PR DESCRIPTION
Completes: https://github.com/ustaxcourt/ef-cms/issues/1731

Following some recent production activity where the JVM Memory Pressure became too high, we adjusted the instance type in the console to `r5.xlarge`, which is optimized for memory. They have been holding up very well so far, and so we are committing this change. 

Additionally, we're increasing the resources for `test` and `migration` so we can conduct some realistic performance tests with the updated configuration.