### PR TITLE
Flexion-9019: Allow text-wrapping for calendar notes

### DIFF
--- a/web-client/src/views/TrialSessionWorkingCopy/WorkingCopySessionList.jsx
+++ b/web-client/src/views/TrialSessionWorkingCopy/WorkingCopySessionList.jsx
@@ -187,7 +187,7 @@ export const WorkingCopySessionList = connect(
                   <tr className="notes-row">
                     <td></td>
                     <td></td>
-                    <td className="font-body-2xs no-wrap" colSpan="4">
+                    <td className="font-body-2xs" colSpan="4">
                       <span className="text-bold margin-right-1">
                         Calendar notes:
                       </span>


### PR DESCRIPTION
Fixes text-wrapping issue for calendar notes: <img width="1461" alt="Screen Shot 2021-10-13 at 1 30 53 PM" src="https://user-images.githubusercontent.com/66225176/137192690-7d1eb729-7cb0-4138-8eec-f3fd9a38c19e.png">

Tested on Windows 10 VM w/Edge
