### PR TITLE
USTC-1767: fix reindex complete check...

### DIFF
--- a/shared/admin-tools/elasticsearch/check-reindex-complete.test.js
+++ b/shared/admin-tools/elasticsearch/check-reindex-complete.test.js
@@ -6,8 +6,9 @@ jest.mock('../../../web-api/elasticsearch/client', () => ({
 
 describe('isReindexComplete', () => {
   const mockEnvName = 'experimental100';
+  const count = jest.fn();
   const stats = jest.fn();
-  const mockIndices = { indices: { stats } };
+  const mockIndices = { count, indices: { stats } };
   console.log = () => null;
 
   beforeEach(() => {
@@ -15,56 +16,13 @@ describe('isReindexComplete', () => {
   });
 
   it('should call getClient with the correct environment and table versions when destination table is alpha', async () => {
-    stats.mockReturnValueOnce({
-      indices: {
-        'efcms-case': {
-          total: {
-            docs: {
-              count: 3,
-            },
-          },
-        },
-        'efcms-docket-entry': {
-          total: {
-            docs: {
-              count: 3,
-            },
-          },
-        },
-        'efcms-user': {
-          total: {
-            docs: {
-              count: 3,
-            },
-          },
-        },
-      },
-    });
-    stats.mockReturnValueOnce({
-      indices: {
-        'efcms-case': {
-          total: {
-            docs: {
-              count: 9,
-            },
-          },
-        },
-        'efcms-docket-entry': {
-          total: {
-            docs: {
-              count: 8,
-            },
-          },
-        },
-        'efcms-user': {
-          total: {
-            docs: {
-              count: 5,
-            },
-          },
-        },
-      },
-    });
+    count.mockReturnValueOnce({ count: 3 });
+    count.mockReturnValueOnce({ count: 3 });
+    count.mockReturnValueOnce({ count: 3 });
+
+    count.mockReturnValueOnce({ count: 9 });
+    count.mockReturnValueOnce({ count: 8 });
+    count.mockReturnValueOnce({ count: 5 });
 
     process.env.DESTINATION_TABLE = 'efcms-exp100-alpha';
     await isReindexComplete(mockEnvName);
@@ -74,56 +32,13 @@ describe('isReindexComplete', () => {
   });
 
   it('should call getClient with the correct environment and table versions when destination table is beta', async () => {
-    stats.mockReturnValueOnce({
-      indices: {
-        'efcms-case': {
-          total: {
-            docs: {
-              count: 3,
-            },
-          },
-        },
-        'efcms-docket-entry': {
-          total: {
-            docs: {
-              count: 3,
-            },
-          },
-        },
-        'efcms-user': {
-          total: {
-            docs: {
-              count: 3,
-            },
-          },
-        },
-      },
-    });
-    stats.mockReturnValueOnce({
-      indices: {
-        'efcms-case': {
-          total: {
-            docs: {
-              count: 9,
-            },
-          },
-        },
-        'efcms-docket-entry': {
-          total: {
-            docs: {
-              count: 8,
-            },
-          },
-        },
-        'efcms-user': {
-          total: {
-            docs: {
-              count: 5,
-            },
-          },
-        },
-      },
-    });
+    count.mockReturnValueOnce({ count: 3 });
+    count.mockReturnValueOnce({ count: 3 });
+    count.mockReturnValueOnce({ count: 3 });
+
+    count.mockReturnValueOnce({ count: 9 });
+    count.mockReturnValueOnce({ count: 8 });
+    count.mockReturnValueOnce({ count: 5 });
 
     process.env.DESTINATION_TABLE = 'efcms-exp100-beta';
     await isReindexComplete(mockEnvName);
@@ -133,56 +48,13 @@ describe('isReindexComplete', () => {
   });
 
   it('should return false when there is a difference in the current and destination index count', async () => {
-    stats.mockReturnValueOnce({
-      indices: {
-        'efcms-case': {
-          total: {
-            docs: {
-              count: 3,
-            },
-          },
-        },
-        'efcms-docket-entry': {
-          total: {
-            docs: {
-              count: 3,
-            },
-          },
-        },
-        'efcms-user': {
-          total: {
-            docs: {
-              count: 3,
-            },
-          },
-        },
-      },
-    });
-    stats.mockReturnValueOnce({
-      indices: {
-        'efcms-case': {
-          total: {
-            docs: {
-              count: 9,
-            },
-          },
-        },
-        'efcms-docket-entry': {
-          total: {
-            docs: {
-              count: 8,
-            },
-          },
-        },
-        'efcms-user': {
-          total: {
-            docs: {
-              count: 5,
-            },
-          },
-        },
-      },
-    });
+    count.mockReturnValueOnce({ count: 3 });
+    count.mockReturnValueOnce({ count: 3 });
+    count.mockReturnValueOnce({ count: 3 });
+
+    count.mockReturnValueOnce({ count: 9 });
+    count.mockReturnValueOnce({ count: 8 });
+    count.mockReturnValueOnce({ count: 5 });
 
     const result = await isReindexComplete(mockEnvName);
 
@@ -190,6 +62,14 @@ describe('isReindexComplete', () => {
   });
 
   it('should return false when there is no difference in the current and destination index count and elasticsearch is still reindexing', async () => {
+    count.mockReturnValueOnce({ count: 3 });
+    count.mockReturnValueOnce({ count: 3 });
+    count.mockReturnValueOnce({ count: 3 });
+
+    count.mockReturnValueOnce({ count: 3 });
+    count.mockReturnValueOnce({ count: 3 });
+    count.mockReturnValueOnce({ count: 3 });
+
     stats
       .mockReturnValueOnce({
         indices: {
@@ -269,6 +149,14 @@ describe('isReindexComplete', () => {
   });
 
   it('should return true when there is no difference in the current and destination index count and elasticsearch is finished reindexing', async () => {
+    count.mockReturnValueOnce({ count: 3 });
+    count.mockReturnValueOnce({ count: 3 });
+    count.mockReturnValueOnce({ count: 3 });
+
+    count.mockReturnValueOnce({ count: 3 });
+    count.mockReturnValueOnce({ count: 3 });
+    count.mockReturnValueOnce({ count: 3 });
+
     stats
       .mockReturnValueOnce({
         indices: {

--- a/shared/admin-tools/elasticsearch/health-migration.js
+++ b/shared/admin-tools/elasticsearch/health-migration.js
@@ -20,9 +20,13 @@ console.log(environmentName);
 
 const getCounts = async ({ indexName, version }) => {
   const esClient = await getClient({ environmentName, version });
-  const info = await esClient.indices.stats({ index: indexName });
+  const info = await esClient.count({
+    index: indexName,
+  });
 
-  return info['_all'].total.docs.count;
+  console.log(info);
+
+  return info.count;
 };
 
 (async () => {


### PR DESCRIPTION
Solves: https://github.com/ustaxcourt/ef-cms/issues/1767

Looks like the addition of a replica caused our counts to be off with the existing script. We are switching to using the `count` api to ensure the critical indexes match and continuing to use the stats api to check to see if indexing is still happening. 