### PR TITLE
remove verbose logging

### DIFF
--- a/web-api/src/notifications/connectLambda.js
+++ b/web-api/src/notifications/connectLambda.js
@@ -19,7 +19,7 @@ exports.connectLambda = event =>
           endpoint,
         });
 
-      applicationContext.logger.info('Websocket connected', {
+      applicationContext.logger.debug('Websocket connected', {
         requestId: {
           connection: event.requestContext.connectionId,
         },

--- a/web-api/src/notifications/disconnectLambda.js
+++ b/web-api/src/notifications/disconnectLambda.js
@@ -16,7 +16,7 @@ exports.disconnectLambda = event =>
           connectionId: event.requestContext.connectionId,
         });
 
-      applicationContext.logger.info('Websocket disconnected', {
+      applicationContext.logger.debug('Websocket disconnected', {
         requestId: {
           connection: event.requestContext.connectionId,
         },


### PR DESCRIPTION
The chatter on the websocket logs have become very noisy since the previous update that helped debug our websocket issues. We're lowering the level to `.debug` this logging as they're not proving helpful at the moment.