### PR TITLE
ustc-1817: use paginated query for getting docket numbers for a given user

### DIFF
--- a/shared/src/persistence/dynamo/cases/getDocketNumbersByUser.js
+++ b/shared/src/persistence/dynamo/cases/getDocketNumbersByUser.js
@@ -9,7 +9,7 @@ exports.getDocketNumbersByUser = async ({ applicationContext, userId }) => {
 };
 
 exports.getCasesAssociatedWithUser = ({ applicationContext, userId }) =>
-  client.query({
+  client.queryFull({
     ExpressionAttributeNames: {
       '#pk': 'pk',
       '#sk': 'sk',

--- a/shared/src/persistence/dynamo/cases/getDocketNumbersByUser.test.js
+++ b/shared/src/persistence/dynamo/cases/getDocketNumbersByUser.test.js
@@ -12,7 +12,7 @@ describe('getDocketNumbersByUser', () => {
   };
 
   beforeEach(() => {
-    client.query = jest.fn().mockReturnValueOnce([
+    client.queryFull = jest.fn().mockReturnValueOnce([
       {
         pk: 'user|455de2eb-77b2-4815-aa2b-99475b2f68bb',
         sk: 'case|123-20',


### PR DESCRIPTION
Some practitioners are on thousands of cases, and all of this information cannot be returned in one DDB query.