### PR TITLE
Refactor: check to see if we have anything to delete...

### DIFF
--- a/shared/src/persistence/dynamo/notifications/deleteUserConnection.js
+++ b/shared/src/persistence/dynamo/notifications/deleteUserConnection.js
@@ -17,6 +17,13 @@ exports.deleteUserConnection = async ({ applicationContext, connectionId }) => {
     applicationContext,
   });
 
+  if (!connection) {
+    // it must have expired
+    return;
+  }
+
+  const toDelete = [connection];
+
   const userConnection = await client.get({
     Key: {
       pk: `user|${connection.userId}`,
@@ -25,8 +32,12 @@ exports.deleteUserConnection = async ({ applicationContext, connectionId }) => {
     applicationContext,
   });
 
+  if (userConnection) {
+    toDelete.push(userConnection);
+  }
+
   await client.batchDelete({
     applicationContext,
-    items: [userConnection, connection],
+    items: toDelete,
   });
 };

--- a/shared/src/persistence/dynamo/notifications/deleteUserConnection.js
+++ b/shared/src/persistence/dynamo/notifications/deleteUserConnection.js
@@ -18,7 +18,6 @@ exports.deleteUserConnection = async ({ applicationContext, connectionId }) => {
   });
 
   if (!connection) {
-    // it must have expired
     return;
   }
 

--- a/shared/src/persistence/dynamo/notifications/deleteUserConnection.test.js
+++ b/shared/src/persistence/dynamo/notifications/deleteUserConnection.test.js
@@ -35,15 +35,69 @@ describe('deleteUserConnection', () => {
       applicationContext.getDocumentClient().batchWrite,
     ).toHaveBeenCalledWith({
       RequestItems: {
-        'efcms-local': [
-          {
+        'efcms-local': expect.arrayContaining([
+          expect.objectContaining({
             DeleteRequest: {
               Key: {
                 pk: 'user|abc',
                 sk: 'connection|123',
               },
             },
+          }),
+          expect.objectContaining({
+            DeleteRequest: {
+              Key: {
+                pk: 'connection|123',
+                sk: 'connection|123',
+              },
+            },
+          }),
+        ]),
+      },
+    });
+  });
+
+  it('if no connection is found given the connectionId, nothing else happens', async () => {
+    applicationContext.getDocumentClient().get.mockReturnValueOnce({
+      promise: () => Promise.resolve({}),
+    });
+
+    await deleteUserConnection({
+      applicationContext,
+      connectionId: '123',
+    });
+
+    expect(
+      applicationContext.getDocumentClient().batchWrite,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('if no user connection is found given the connectionId, it only deletes the connection', async () => {
+    applicationContext.getDocumentClient().get.mockReturnValueOnce({
+      promise: () =>
+        Promise.resolve({
+          Item: {
+            connectionId: '123',
+            pk: 'connection|123',
+            sk: 'connection|123',
+            userId: 'abc',
           },
+        }),
+    });
+    applicationContext.getDocumentClient().get.mockReturnValueOnce({
+      promise: () => Promise.resolve({}),
+    });
+
+    await deleteUserConnection({
+      applicationContext,
+      connectionId: '123',
+    });
+
+    expect(
+      applicationContext.getDocumentClient().batchWrite,
+    ).toHaveBeenCalledWith({
+      RequestItems: {
+        'efcms-local': [
           {
             DeleteRequest: {
               Key: {

--- a/shared/src/persistence/dynamo/notifications/deleteUserConnection.test.js
+++ b/shared/src/persistence/dynamo/notifications/deleteUserConnection.test.js
@@ -58,6 +58,7 @@ describe('deleteUserConnection', () => {
   });
 
   it('if no connection is found given the connectionId, nothing else happens', async () => {
+    // the connection must have expired via ttl
     applicationContext.getDocumentClient().get.mockReturnValueOnce({
       promise: () => Promise.resolve({}),
     });
@@ -84,6 +85,7 @@ describe('deleteUserConnection', () => {
           },
         }),
     });
+    // the user connection must have expired via ttl
     applicationContext.getDocumentClient().get.mockReturnValueOnce({
       promise: () => Promise.resolve({}),
     });


### PR DESCRIPTION
before deleting them. 

Previously, if one of the `.get` calls couldn't find an item, we still proceeded forward trying to access properties of an object that was undefined. 

This refactor simply checks to see if we have anything to delete.