### PR TITLE
Improve documentation for glue jobs

### DIFF
--- a/docs/operations/production-like-data-sets.md
+++ b/docs/operations/production-like-data-sets.md
@@ -4,12 +4,16 @@ From time to time the team feels that it makes sense to perform a glue job to re
 
 In order to do this, you need to have an empty DDB table in the environment to which you are sending the Glue Job. You may need to delete a table (east & west) and then re-deploy in order to get an empty DDB table to send information. I usually delete the table that is not the current source or destination table in the `efcms-deploy-{ENV}` table so that the environment can continue to function on the current table. Deleting a table in one region causes a replication event to happen to the other, so if you have trouble deleting the second regional table, wait a few minutes and try again.
 
-1. Once the table is ready, perform the steps documented in [the Glue Job documentation](../../shared/admin-tools/glue/GLUE_JOBS.md). Expect the glue job to complete in about 6 – 7 hours.
-
-2. After the glue job is completed, synchronize the us-east-1 S3 buckets containing documents to the target environment (the us-west-1 buckets will automatically replicate):
+1. Once the table is ready, perform the steps documented in [the Glue Job documentation](../../shared/admin-tools/glue/GLUE_JOBS.md). Expect the glue job to complete in about 2 – 3 hours.
+2. As the glue job runs, synchronize the us-east-1 S3 buckets containing documents to the target environment (the us-west-1 buckets will automatically replicate):
 
     ```bash
     aws s3 sync s3://dawson.ustaxcourt.gov-documents-prod-us-east-1 s3://test.ef-cms.ustaxcourt.gov-documents-test-us-east-1
     ```
 
-3. Finally, you will need to do a [blue/green migration](../blue-green-migration.md) or run your deploy that may have a blue/green migration to index this information and get it working with the environment. During this deployment, the environment will be offline.
+3. Next you will need to do a [blue/green migration](../blue-green-migration.md) or run your deploy that may have a blue/green migration to index this information and get it working with the environment. During this deployment, the environment will be offline.
+4. After the blue/green migration completes, you will need to recreate the test users for that environment as they are not included in the production data.
+
+    ```bash
+    node shared/admin-tools/users/setup-test-users.js
+    ```


### PR DESCRIPTION
We keep forgetting the important step of recreating the test users in an environment after it receives a glue job. This makes it unusable as there is no way to login. This documentation improvement shows how to create those test users.