### PR TITLE
ustc-1830: toggle evaluate_target_health to true for API domains

### DIFF
--- a/web-api/terraform/api/api-public.tf
+++ b/web-api/terraform/api/api-public.tf
@@ -223,7 +223,7 @@ resource "aws_route53_record" "api_public_route53_regional_record" {
   alias {
     name                   = aws_api_gateway_domain_name.api_public_custom.regional_domain_name
     zone_id                = aws_api_gateway_domain_name.api_public_custom.regional_zone_id
-    evaluate_target_health = false
+    evaluate_target_health = true
   }
 
   latency_routing_policy {

--- a/web-api/terraform/api/api.tf
+++ b/web-api/terraform/api/api.tf
@@ -349,7 +349,7 @@ resource "aws_route53_record" "api_route53_regional_record" {
   alias {
     name                   = aws_api_gateway_domain_name.api_custom.regional_domain_name
     zone_id                = aws_api_gateway_domain_name.api_custom.regional_zone_id
-    evaluate_target_health = false
+    evaluate_target_health = true
   }
 
   latency_routing_policy {

--- a/web-api/terraform/api/websockets.tf
+++ b/web-api/terraform/api/websockets.tf
@@ -235,7 +235,7 @@ resource "aws_route53_record" "websocket_regional_record" {
   alias {
     name                   = aws_apigatewayv2_domain_name.websockets_domain.domain_name_configuration.0.target_domain_name
     zone_id                = aws_apigatewayv2_domain_name.websockets_domain.domain_name_configuration.0.hosted_zone_id
-    evaluate_target_health = false
+    evaluate_target_health = true
   }
 
   latency_routing_policy {

--- a/web-api/terraform/template/main-east.tf
+++ b/web-api/terraform/template/main-east.tf
@@ -382,7 +382,7 @@ resource "aws_route53_record" "api_route53_main_east_regional_record" {
   alias {
     name                   = aws_api_gateway_domain_name.api_custom_main_east.regional_domain_name
     zone_id                = aws_api_gateway_domain_name.api_custom_main_east.regional_zone_id
-    evaluate_target_health = false
+    evaluate_target_health = true
   }
 
   latency_routing_policy {
@@ -399,7 +399,7 @@ resource "aws_route53_record" "public_api_route53_main_east_regional_record" {
   alias {
     name                   = aws_api_gateway_domain_name.public_api_custom_main_east.regional_domain_name
     zone_id                = aws_api_gateway_domain_name.public_api_custom_main_east.regional_zone_id
-    evaluate_target_health = false
+    evaluate_target_health = true
   }
 
   latency_routing_policy {

--- a/web-api/terraform/template/main-west.tf
+++ b/web-api/terraform/template/main-west.tf
@@ -234,7 +234,7 @@ resource "aws_route53_record" "api_route53_main_west_regional_record" {
   alias {
     name                   = aws_api_gateway_domain_name.api_custom_main_west.regional_domain_name
     zone_id                = aws_api_gateway_domain_name.api_custom_main_west.regional_zone_id
-    evaluate_target_health = false
+    evaluate_target_health = true
   }
 
   latency_routing_policy {
@@ -253,7 +253,7 @@ resource "aws_route53_record" "public_api_route53_main_west_regional_record" {
   alias {
     name                   = aws_api_gateway_domain_name.public_api_custom_main_west.regional_domain_name
     zone_id                = aws_api_gateway_domain_name.public_api_custom_main_west.regional_zone_id
-    evaluate_target_health = false
+    evaluate_target_health = true
   }
 
   latency_routing_policy {


### PR DESCRIPTION
This toggles on the evaluate target health option for the public and private apis. This way if a region is experiencing network issues and the API endpoint is deemed unhealthy by AWS, then it will not receive API requests, and the application will failover to another healthy record with the same domain name in another availability zone.

This should cover the following subdomains:

* `api-blue.{EFCMS_DOMAIN}`
* `api-green.{EFCMS_DOMAIN}`
* `public-api-blue.{EFCMS_DOMAIN}`
* `public-api-green.{EFCMS_DOMAIN}`
* `api.{EFCMS_DOMAIN}`
* `public-api.{EFCMS_DOMAIN}`

Solves: #1830 

![Screen Shot 2021-12-16 at 2 39 22 PM](https://user-images.githubusercontent.com/5023502/146437610-36999d5c-4251-46ea-9c69-a4b28673a7fa.png)
