### PR TITLE
9278: Inactive Judges are Selectible in Order Search

### DIFF
--- a/cypress-integration/integration/public/advanced-search.spec.js
+++ b/cypress-integration/integration/public/advanced-search.spec.js
@@ -53,11 +53,24 @@ describe('Advanced search', () => {
 
   describe('order', () => {
     it('should be able to search for an order by legacy judge', () => {
+      const judgeNameColumnIndex = 5;
+      const wantedLegacyJudge = 'Fieri';
+
       navigateToDashboard();
       clickOnSearchTab('order');
-      searchForOrderByJudge('Fieri');
+      searchForOrderByJudge(wantedLegacyJudge);
       searchForDocuments();
+
       expect(searchResultsTable()).to.exist;
+
+      //assert that every judge in the search result list is the wanted legacy judge
+      cy.get('tr.search-result').each(element => {
+        cy.wrap(element).within(() => {
+          cy.get('td')
+            .eq(judgeNameColumnIndex)
+            .should('have.text', wantedLegacyJudge);
+        });
+      });
     });
   });
 });

--- a/cypress-integration/integration/public/advanced-search.spec.js
+++ b/cypress-integration/integration/public/advanced-search.spec.js
@@ -10,6 +10,7 @@ const {
   searchForCaseByDocketNumber,
   searchForCaseByPetitionerInformation,
   searchForDocuments,
+  searchForOrderByJudge,
   searchResultsTable,
 } = require('../../support/pages/public/advanced-search');
 
@@ -45,6 +46,16 @@ describe('Advanced search', () => {
       enterDocumentKeywordForOpinionSearch('opinion');
       enterStartDateForOpinionSearch('08/03/1995');
       enterDocumentDocketNumber('124-20L');
+      searchForDocuments();
+      expect(searchResultsTable()).to.exist;
+    });
+  });
+
+  describe('order', () => {
+    it('should be able to search for an order by legacy judge', () => {
+      navigateToDashboard();
+      clickOnSearchTab('order');
+      searchForOrderByJudge('Fieri');
       searchForDocuments();
       expect(searchResultsTable()).to.exist;
     });

--- a/cypress-integration/support/pages/public/advanced-search.js
+++ b/cypress-integration/support/pages/public/advanced-search.js
@@ -46,3 +46,7 @@ exports.searchResultsTable = () => {
 exports.docketRecordTable = () => {
   return cy.get('table#docket-record-table');
 };
+
+exports.searchForOrderByJudge = judge => {
+  return cy.get('#order-judge').select(judge);
+};

--- a/shared/src/business/entities/PublicUser.js
+++ b/shared/src/business/entities/PublicUser.js
@@ -22,7 +22,7 @@ PublicUser.prototype.init = function init(rawUser) {
 const userDecorator = (obj, rawObj) => {
   obj.name = rawObj.name;
   obj.role = rawObj.role;
-  if (obj.role === ROLES.judge) {
+  if (obj.role === ROLES.judge || obj.role === ROLES.legacyJudge) {
     obj.judgeFullName = rawObj.judgeFullName;
     obj.judgeTitle = rawObj.judgeTitle;
   }


### PR DESCRIPTION
We now return the same data for an inactive judge as we do for current judge from the public API.  We also added a new Cypress integration test for this.