### PR TITLE
Clearing Keyword field on opinion search so retries will work.

### DIFF
--- a/cypress-smoketests/support/pages/advanced-search.js
+++ b/cypress-smoketests/support/pages/advanced-search.js
@@ -52,8 +52,7 @@ exports.searchOrderByKeyword = keyword => {
 };
 
 exports.searchOpinionByKeyword = keyword => {
-  cy.get('input#keyword-search').clear();
-  cy.get('input#keyword-search').type(keyword);
+  cy.get('input#keyword-search').clear().type(keyword);
   cy.get('button#advanced-search-button').click();
   cy.get('table.search-results').should('exist');
 };

--- a/cypress-smoketests/support/pages/advanced-search.js
+++ b/cypress-smoketests/support/pages/advanced-search.js
@@ -52,6 +52,7 @@ exports.searchOrderByKeyword = keyword => {
 };
 
 exports.searchOpinionByKeyword = keyword => {
+  cy.get('input#keyword-search').clear();
   cy.get('input#keyword-search').type(keyword);
   cy.get('button#advanced-search-button').click();
   cy.get('table.search-results').should('exist');


### PR DESCRIPTION
A search smoketest fails repeatedly when we were trying to test the re-migration of the 0003 migration on the Court's test environment.  This should make the test more resilient to a slow OpenSearch processing.