### PR TITLE
BUG: Orders that are 2 or more pages in Length have two different font types #8935

### DIFF
--- a/shared/src/business/utilities/pdfGenerator/components/PageMetaHeaderDocket.jsx
+++ b/shared/src/business/utilities/pdfGenerator/components/PageMetaHeaderDocket.jsx
@@ -4,12 +4,22 @@ export const PageMetaHeaderDocket = ({ docketNumber }) => {
   return (
     <div style={{ position: 'relative', top: '-20px' }}>
       <div
-        style={{ float: 'left', fontSize: '12px', transform: 'scale(0.75)' }}
+        style={{
+          float: 'left',
+          fontFamily: 'Times New Roman',
+          fontSize: '12px',
+          transform: 'scale(0.75)',
+        }}
       >
         Docket No.: {docketNumber}
       </div>
       <div
-        style={{ float: 'right', fontSize: '12px', transform: 'scale(0.75)' }}
+        style={{
+          float: 'right',
+          fontFamily: 'Times New Roman',
+          fontSize: '12px',
+          transform: 'scale(0.75)',
+        }}
       >
         Page <span className="pageNumber"></span> of{' '}
         <span className="totalPages"></span>


### PR DESCRIPTION
Original font from bug report:
![image](https://user-images.githubusercontent.com/20514925/147364399-ac834094-d8e9-4597-9e73-4ddefb71a3a0.png)


Updated font:
![image](https://user-images.githubusercontent.com/20514925/147364414-693ce41d-59ab-4fc6-9ef1-9e325646a4cd.png)
