### PR TITLE
BUG 9323: private practitioners can be petitioners

### DIFF
--- a/shared/src/business/entities/cases/PublicCase.test.js
+++ b/shared/src/business/entities/cases/PublicCase.test.js
@@ -7,7 +7,6 @@ const {
   COUNTRY_TYPES,
   DOCKET_NUMBER_SUFFIXES,
   PARTY_TYPES,
-  ROLES,
   TRANSCRIPT_EVENT_CODE,
   UNIQUE_OTHER_FILER_TYPE,
 } = require('../EntityConstants');
@@ -384,12 +383,6 @@ describe('PublicCase', () => {
     });
 
     it('should show all contact and practitioner information if user has IRS Practitioner role', () => {
-      //TODO: FIX THIS too- this mock is also not doing anything
-
-      // applicationContext.getCurrentUser.mockReturnValueOnce({
-      //   role: ROLES.irsPractitioner,
-      // });
-
       const rawContactPrimary = {
         address1: '907 West Rocky Cowley Parkway',
         address2: '104 West 120th Street',
@@ -498,10 +491,6 @@ describe('PublicCase', () => {
     });
 
     it('should not show practitioner and other filer information if user has IRS Practitioner role and the case is sealed', () => {
-      applicationContext.getCurrentUser.mockReturnValueOnce({
-        role: ROLES.irsPractitioner,
-      });
-
       const rawCase = {
         ...MOCK_CASE,
         irsPractitioners: [

--- a/shared/src/business/entities/cases/PublicCase.test.js
+++ b/shared/src/business/entities/cases/PublicCase.test.js
@@ -384,9 +384,11 @@ describe('PublicCase', () => {
     });
 
     it('should show all contact and practitioner information if user has IRS Practitioner role', () => {
-      applicationContext.getCurrentUser.mockReturnValueOnce({
-        role: ROLES.irsPractitioner,
-      });
+      //TODO: FIX THIS too- this mock is also not doing anything
+
+      // applicationContext.getCurrentUser.mockReturnValueOnce({
+      //   role: ROLES.irsPractitioner,
+      // });
 
       const rawContactPrimary = {
         address1: '907 West Rocky Cowley Parkway',

--- a/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.js
+++ b/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.js
@@ -28,6 +28,9 @@ exports.associatePrivatePractitionerToCase = async ({
       docketNumber,
     });
 
+  const isPrivatePractitionerAssociated = caseToUpdate.privatePractitioners?.includes(
+    practitioner => practitioner.userId === user.userId);
+
   const isAssociated = await applicationContext
     .getPersistenceGateway()
     .verifyCaseForUser({

--- a/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.js
+++ b/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.js
@@ -42,7 +42,7 @@ exports.associatePrivatePractitionerToCase = async ({
 
   if (isPrivatePractitionerOnCase) {
     throw new Error(
-      'The Private Practitioner is already associated with the case.',
+      `The Private Practitioner is already associated with case ${docketNumber}.`,
     );
   }
 

--- a/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.js
+++ b/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.js
@@ -55,6 +55,10 @@ exports.associatePrivatePractitionerToCase = async ({
       userCase: userCaseEntity.validate().toRawObject(),
       userId: user.userId,
     });
+  } else {
+    applicationContext.logger.info(
+      `BUG 9323: Private Practitioner with userId: ${user.userId} was already associated with case ${docketNumber} but did not appear in the privatePractitioners array.`,
+    );
   }
 
   const caseEntity = new Case(caseToUpdate, { applicationContext });

--- a/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.js
+++ b/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.js
@@ -36,10 +36,9 @@ exports.associatePrivatePractitionerToCase = async ({
       docketNumber,
     });
 
-  const isPrivatePractitionerOnCase =
-    caseToUpdate.privatePractitioners?.includes(
-      practitioner => practitioner.userId === user.userId,
-    );
+  const isPrivatePractitionerOnCase = caseToUpdate.privatePractitioners?.some(
+    practitioner => practitioner.userId === user.userId,
+  );
 
   if (isPrivatePractitionerOnCase) {
     throw new Error(

--- a/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.js
+++ b/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.js
@@ -21,6 +21,13 @@ exports.associatePrivatePractitionerToCase = async ({
   serviceIndicator,
   user,
 }) => {
+  const caseToUpdate = await applicationContext
+    .getPersistenceGateway()
+    .getCaseByDocketNumber({
+      applicationContext,
+      docketNumber,
+    });
+
   const isAssociated = await applicationContext
     .getPersistenceGateway()
     .verifyCaseForUser({
@@ -30,13 +37,6 @@ exports.associatePrivatePractitionerToCase = async ({
     });
 
   if (!isAssociated) {
-    const caseToUpdate = await applicationContext
-      .getPersistenceGateway()
-      .getCaseByDocketNumber({
-        applicationContext,
-        docketNumber,
-      });
-
     const userCaseEntity = new UserCase(caseToUpdate);
 
     await applicationContext.getPersistenceGateway().associateUserWithCase({

--- a/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.test.js
+++ b/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.test.js
@@ -20,7 +20,6 @@ const { MOCK_USERS } = require('../../../test/mockUsers');
 
 describe('associatePrivatePractitionerToCase', () => {
   let caseRecord;
-
   const practitionerUser = {
     barNumber: 'BN1234',
     name: 'Emmett Lathrop "Doc" Brown, Ph.D.',
@@ -116,6 +115,30 @@ describe('associatePrivatePractitionerToCase', () => {
     expect(
       applicationContext.getPersistenceGateway().associateUserWithCase,
     ).not.toHaveBeenCalled();
+  });
+
+  it('should not add case|privatePractitioner record if user is already practitioner on case', async () => {
+    const freshDocketNumber = '1234-56';
+
+    applicationContext
+      .getPersistenceGateway()
+      .getCaseByDocketNumber.mockResolvedValueOnce({
+        ...caseRecord,
+        docketNumber: freshDocketNumber,
+        privatePractitioners: [practitionerUser],
+      });
+
+    await expect(
+      associatePrivatePractitionerToCase({
+        applicationContext,
+        docketNumber: freshDocketNumber,
+        representing: [],
+        user: practitionerUser,
+      }),
+    ).rejects.toThrow(
+      'The Private Practitioner is already associated with the case.',
+    );
+
     expect(
       applicationContext.getUseCaseHelpers().updateCaseAndAssociations,
     ).not.toHaveBeenCalled();

--- a/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.test.js
+++ b/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.test.js
@@ -162,8 +162,11 @@ describe('associatePrivatePractitionerToCase', () => {
     });
 
     expect(
-      applicationContext.getUseCaseHelpers().updateCaseAndAssociations,
-    ).not.toHaveBeenCalled();
+      applicationContext.getUseCaseHelpers().updateCaseAndAssociations.mock
+        .calls[0][0].caseToUpdate.privatePractitioners,
+    ).toEqual(
+      expect.arrayContaining([expect.objectContaining(practitionerUser)]),
+    );
   });
 
   it('should add mapping for a practitioner', async () => {

--- a/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.test.js
+++ b/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.test.js
@@ -142,6 +142,30 @@ describe('associatePrivatePractitionerToCase', () => {
     ).not.toHaveBeenCalled();
   });
 
+  it('BUG 9323: should add case|privatePractitioner record if user is already associated (probably a petitioner) but not a practitioner on case', async () => {
+    applicationContext
+      .getPersistenceGateway()
+      .getCaseByDocketNumber.mockResolvedValueOnce({
+        ...caseRecord,
+        privatePractitioners: [],
+      });
+
+    applicationContext
+      .getPersistenceGateway()
+      .verifyCaseForUser.mockResolvedValueOnce(true);
+
+    await associatePrivatePractitionerToCase({
+      applicationContext,
+      docketNumber: caseRecord.docketNumber,
+      representing: [],
+      user: practitionerUser,
+    });
+
+    expect(
+      applicationContext.getUseCaseHelpers().updateCaseAndAssociations,
+    ).not.toHaveBeenCalled();
+  });
+
   it('should add mapping for a practitioner', async () => {
     applicationContext
       .getPersistenceGateway()

--- a/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.test.js
+++ b/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.test.js
@@ -134,7 +134,7 @@ describe('associatePrivatePractitionerToCase', () => {
         user: practitionerUser,
       }),
     ).rejects.toThrow(
-      'The Private Practitioner is already associated with the case.',
+      `The Private Practitioner is already associated with case ${caseRecord.docketNumber}.`,
     );
 
     expect(
@@ -142,7 +142,35 @@ describe('associatePrivatePractitionerToCase', () => {
     ).not.toHaveBeenCalled();
   });
 
-  it('BUG 9323: should add case|privatePractitioner record if user is already associated (probably a petitioner) but not a practitioner on case', async () => {
+  it('should add user mapping AND case|privatePractitioner association for a practitioner who is not already associated with the case', async () => {
+    applicationContext
+      .getPersistenceGateway()
+      .verifyCaseForUser.mockReturnValue(false);
+
+    await associatePrivatePractitionerToCase({
+      applicationContext,
+      docketNumber: caseRecord.docketNumber,
+      representing: [caseRecord.petitioners[0].contactId],
+      user: practitionerUser,
+    });
+
+    expect(
+      applicationContext.getPersistenceGateway().associateUserWithCase,
+    ).toHaveBeenCalled();
+
+    expect(
+      applicationContext.getUseCaseHelpers().updateCaseAndAssociations.mock
+        .calls[0][0].caseToUpdate.privatePractitioners,
+    ).toEqual(
+      expect.arrayContaining([expect.objectContaining(practitionerUser)]),
+    );
+
+    expect(
+      applicationContext.getUseCaseHelpers().updateCaseAndAssociations,
+    ).toHaveBeenCalled();
+  });
+
+  it('BUG 9323: should add case|privatePractitioner record if user is already associated (probably as a petitioner) but not a practitioner on case', async () => {
     applicationContext
       .getPersistenceGateway()
       .getCaseByDocketNumber.mockResolvedValueOnce({
@@ -162,31 +190,20 @@ describe('associatePrivatePractitionerToCase', () => {
     });
 
     expect(
+      applicationContext.getPersistenceGateway().associateUserWithCase,
+    ).not.toHaveBeenCalled();
+
+    expect(applicationContext.logger.info).toHaveBeenCalled();
+    expect(applicationContext.logger.info.mock.calls[0][0]).toEqual(
+      `BUG 9323: Private Practitioner with userId: ${practitionerUser.userId} was already associated with case ${caseRecord.docketNumber} but did not appear in the privatePractitioners array.`,
+    );
+
+    expect(
       applicationContext.getUseCaseHelpers().updateCaseAndAssociations.mock
         .calls[0][0].caseToUpdate.privatePractitioners,
     ).toEqual(
       expect.arrayContaining([expect.objectContaining(practitionerUser)]),
     );
-  });
-
-  it('should add mapping for a practitioner', async () => {
-    applicationContext
-      .getPersistenceGateway()
-      .verifyCaseForUser.mockReturnValue(false);
-
-    await associatePrivatePractitionerToCase({
-      applicationContext,
-      docketNumber: caseRecord.docketNumber,
-      representing: [caseRecord.petitioners[0].contactId],
-      user: practitionerUser,
-    });
-
-    expect(
-      applicationContext.getPersistenceGateway().associateUserWithCase,
-    ).toHaveBeenCalled();
-    expect(
-      applicationContext.getUseCaseHelpers().updateCaseAndAssociations,
-    ).toHaveBeenCalled();
   });
 
   it('should set petitioners to receive no service if the practitioner is representing them', async () => {

--- a/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.test.js
+++ b/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.test.js
@@ -118,20 +118,18 @@ describe('associatePrivatePractitionerToCase', () => {
   });
 
   it('should not add case|privatePractitioner record if user is already practitioner on case', async () => {
-    const freshDocketNumber = '1234-56';
-
     applicationContext
       .getPersistenceGateway()
       .getCaseByDocketNumber.mockResolvedValueOnce({
         ...caseRecord,
-        docketNumber: freshDocketNumber,
+
         privatePractitioners: [practitionerUser],
       });
 
     await expect(
       associatePrivatePractitionerToCase({
         applicationContext,
-        docketNumber: freshDocketNumber,
+        docketNumber: caseRecord.docketNumber,
         representing: [],
         user: practitionerUser,
       }),

--- a/shared/src/business/useCaseHelper/caseAssociation/removeCounselFromRemovedPetitioner.js
+++ b/shared/src/business/useCaseHelper/caseAssociation/removeCounselFromRemovedPetitioner.js
@@ -32,45 +32,20 @@ exports.removeCounselFromRemovedPetitioner = async ({
 
   for (const practitioner of practitioners) {
     const practitionerIsAlsoAPetitionerOnCase = caseEntity.petitioners.some(
-      petitioner => petitioner.petitionerContactId === practitioner.userId,
+      petitioner => petitioner.contactId === practitioner.userId,
     );
-
-    const doesPetitionerRepresentThemselves = practitioner.representing.some(
-      petitionerId => petitionerId === petitionerContactId,
-    );
-
-    // const doesPractitionerRepresentOtherPetitioner =
-    //   practitioner.representing.some(
-    //     petitionerId => petitionerId !== petitionerContactId,
-    //   );
-
-    // fore practitioner
-    // do they represent somebody else?
-    // if they represent another petitioner on the case we don't remove them from the case
-    // else removeRepresentingFromPractitioners
-    // if that practitioner who represents someone else on the case is also a petitioner on the case
-    // then only remove them from the representing array do not delete the representing array
-    //
 
     if (practitioner.representing.length === 1) {
       caseEntity.removePrivatePractitioner(practitioner);
 
-      if (practitionerIsAlsoAPetitionerOnCase) {
-        if (doesPetitionerRepresentThemselves) {
-          await applicationContext.getPersistenceGateway().deleteUserFromCase({
-            applicationContext,
-            docketNumber: caseEntity.docketNumber,
-            userId: practitioner.userId,
-          });
-        }
+      // if practitioner is a self-representing petitioner, their user|case record has already been removed
+      if (!practitionerIsAlsoAPetitionerOnCase) {
+        await applicationContext.getPersistenceGateway().deleteUserFromCase({
+          applicationContext,
+          docketNumber: caseEntity.docketNumber,
+          userId: practitioner.userId,
+        });
       }
-      // if (!practitionerIsAlsoAPetitionerOnCase) {
-      //   await applicationContext.getPersistenceGateway().deleteUserFromCase({
-      //     applicationContext,
-      //     docketNumber: caseEntity.docketNumber,
-      //     userId: practitioner.userId,
-      //   });
-      // }
     } else {
       caseEntity.removeRepresentingFromPractitioners(petitionerContactId);
     }

--- a/shared/src/business/useCaseHelper/caseAssociation/removeCounselFromRemovedPetitioner.js
+++ b/shared/src/business/useCaseHelper/caseAssociation/removeCounselFromRemovedPetitioner.js
@@ -31,14 +31,46 @@ exports.removeCounselFromRemovedPetitioner = async ({
     caseEntity.getPractitionersRepresenting(petitionerContactId);
 
   for (const practitioner of practitioners) {
+    const practitionerIsAlsoAPetitionerOnCase = caseEntity.petitioners.some(
+      petitioner => petitioner.petitionerContactId === practitioner.userId,
+    );
+
+    const doesPetitionerRepresentThemselves = practitioner.representing.some(
+      petitionerId => petitionerId === petitionerContactId,
+    );
+
+    // const doesPractitionerRepresentOtherPetitioner =
+    //   practitioner.representing.some(
+    //     petitionerId => petitionerId !== petitionerContactId,
+    //   );
+
+    // fore practitioner
+    // do they represent somebody else?
+    // if they represent another petitioner on the case we don't remove them from the case
+    // else removeRepresentingFromPractitioners
+    // if that practitioner who represents someone else on the case is also a petitioner on the case
+    // then only remove them from the representing array do not delete the representing array
+    //
+
     if (practitioner.representing.length === 1) {
       caseEntity.removePrivatePractitioner(practitioner);
 
-      await applicationContext.getPersistenceGateway().deleteUserFromCase({
-        applicationContext,
-        docketNumber: caseEntity.docketNumber,
-        userId: practitioner.userId,
-      });
+      if (practitionerIsAlsoAPetitionerOnCase) {
+        if (doesPetitionerRepresentThemselves) {
+          await applicationContext.getPersistenceGateway().deleteUserFromCase({
+            applicationContext,
+            docketNumber: caseEntity.docketNumber,
+            userId: practitioner.userId,
+          });
+        }
+      }
+      // if (!practitionerIsAlsoAPetitionerOnCase) {
+      //   await applicationContext.getPersistenceGateway().deleteUserFromCase({
+      //     applicationContext,
+      //     docketNumber: caseEntity.docketNumber,
+      //     userId: practitioner.userId,
+      //   });
+      // }
     } else {
       caseEntity.removeRepresentingFromPractitioners(petitionerContactId);
     }
@@ -46,3 +78,15 @@ exports.removeCounselFromRemovedPetitioner = async ({
 
   return caseEntity.validate();
 };
+
+// if (practitioner.representing.length === 1) {
+//   caseEntity.removePrivatePractitioner(practitioner);
+
+//   await applicationContext.getPersistenceGateway().deleteUserFromCase({
+//     applicationContext,
+//     docketNumber: caseEntity.docketNumber,
+//     userId: practitioner.userId,
+//   });
+// } else {
+//   caseEntity.removeRepresentingFromPractitioners(petitionerContactId);
+// }

--- a/shared/src/business/useCaseHelper/caseAssociation/removeCounselFromRemovedPetitioner.js
+++ b/shared/src/business/useCaseHelper/caseAssociation/removeCounselFromRemovedPetitioner.js
@@ -53,15 +53,3 @@ exports.removeCounselFromRemovedPetitioner = async ({
 
   return caseEntity.validate();
 };
-
-// if (practitioner.representing.length === 1) {
-//   caseEntity.removePrivatePractitioner(practitioner);
-
-//   await applicationContext.getPersistenceGateway().deleteUserFromCase({
-//     applicationContext,
-//     docketNumber: caseEntity.docketNumber,
-//     userId: practitioner.userId,
-//   });
-// } else {
-//   caseEntity.removeRepresentingFromPractitioners(petitionerContactId);
-// }

--- a/shared/src/business/useCases/caseAssociation/deleteCounselFromCaseInteractor.js
+++ b/shared/src/business/useCases/caseAssociation/deleteCounselFromCaseInteractor.js
@@ -56,11 +56,15 @@ exports.deleteCounselFromCaseInteractor = async (
 
   aggregatePartiesForService(caseEntity);
 
-  await applicationContext.getPersistenceGateway().deleteUserFromCase({
-    applicationContext,
-    docketNumber,
-    userId,
-  });
+  if (
+    !caseEntity.petitioners.includes(petitioner => petitioner.userId === userId)
+  ) {
+    await applicationContext.getPersistenceGateway().deleteUserFromCase({
+      applicationContext,
+      docketNumber,
+      userId,
+    });
+  }
 
   const updatedCase = await applicationContext
     .getUseCaseHelpers()

--- a/shared/src/business/useCases/caseAssociation/deleteCounselFromCaseInteractor.js
+++ b/shared/src/business/useCases/caseAssociation/deleteCounselFromCaseInteractor.js
@@ -57,7 +57,7 @@ exports.deleteCounselFromCaseInteractor = async (
   aggregatePartiesForService(caseEntity);
 
   if (
-    !caseEntity.petitioners.includes(petitioner => petitioner.userId === userId)
+    !caseEntity.petitioners.some(petitioner => petitioner.contactId === userId)
   ) {
     await applicationContext.getPersistenceGateway().deleteUserFromCase({
       applicationContext,

--- a/shared/src/business/useCases/caseAssociationRequest/submitCaseAssociationRequestInteractor.test.js
+++ b/shared/src/business/useCases/caseAssociationRequest/submitCaseAssociationRequestInteractor.test.js
@@ -36,7 +36,6 @@ describe('submitCaseAssociationRequest', () => {
     await expect(
       submitCaseAssociationRequestInteractor(applicationContext, {
         docketNumber: MOCK_CASE.docketNumber,
-        userId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
       }),
     ).rejects.toThrow('Unauthorized');
   });
@@ -70,12 +69,11 @@ describe('submitCaseAssociationRequest', () => {
 
     await submitCaseAssociationRequestInteractor(applicationContext, {
       docketNumber: MOCK_CASE.docketNumber,
-      representing: [mockContactId],
-      userId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+      filers: [mockContactId],
     });
 
     expect(
-      applicationContext.getUseCaseHelpers().updateCaseAndAssociations,
+      applicationContext.getPersistenceGateway().associateUserWithCase,
     ).not.toBeCalled();
   });
 
@@ -103,7 +101,6 @@ describe('submitCaseAssociationRequest', () => {
     await submitCaseAssociationRequestInteractor(applicationContext, {
       docketNumber: MOCK_CASE.docketNumber,
       filers: [mockContactId],
-      userId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
     });
 
     expect(
@@ -143,7 +140,6 @@ describe('submitCaseAssociationRequest', () => {
 
     await submitCaseAssociationRequestInteractor(applicationContext, {
       docketNumber: MOCK_CASE.docketNumber,
-      userId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
     });
 
     expect(

--- a/shared/src/business/useCases/caseAssociationRequest/submitPendingCaseAssociationRequestInteractor.js
+++ b/shared/src/business/useCases/caseAssociationRequest/submitPendingCaseAssociationRequestInteractor.js
@@ -33,8 +33,6 @@ exports.submitPendingCaseAssociationRequestInteractor = async (
     practitioner => practitioner.userId === user.userId,
   );
 
-  console.log('isPrivatePractitionerOnCase*** ', isPrivatePractitionerOnCase);
-
   if (isPrivatePractitionerOnCase) {
     throw new Error(
       `The Private Practitioner is already associated with case ${docketNumber}.`,

--- a/shared/src/business/useCases/caseAssociationRequest/submitPendingCaseAssociationRequestInteractor.js
+++ b/shared/src/business/useCases/caseAssociationRequest/submitPendingCaseAssociationRequestInteractor.js
@@ -16,17 +16,11 @@ exports.submitPendingCaseAssociationRequestInteractor = async (
   applicationContext,
   { docketNumber },
 ) => {
-  const authorizedUser = applicationContext.getCurrentUser();
+  const user = applicationContext.getCurrentUser();
 
-  if (
-    !isAuthorized(authorizedUser, ROLE_PERMISSIONS.ASSOCIATE_SELF_WITH_CASE)
-  ) {
+  if (!isAuthorized(user, ROLE_PERMISSIONS.ASSOCIATE_SELF_WITH_CASE)) {
     throw new UnauthorizedError('Unauthorized');
   }
-
-  const user = await applicationContext
-    .getPersistenceGateway()
-    .getUserById({ applicationContext, userId: authorizedUser.userId });
 
   const caseDetail = await applicationContext
     .getPersistenceGateway()
@@ -38,6 +32,8 @@ exports.submitPendingCaseAssociationRequestInteractor = async (
   const isPrivatePractitionerOnCase = caseDetail.privatePractitioners?.some(
     practitioner => practitioner.userId === user.userId,
   );
+
+  console.log('isPrivatePractitionerOnCase*** ', isPrivatePractitionerOnCase);
 
   if (isPrivatePractitionerOnCase) {
     throw new Error(

--- a/shared/src/business/useCases/caseAssociationRequest/submitPendingCaseAssociationRequestInteractor.test.js
+++ b/shared/src/business/useCases/caseAssociationRequest/submitPendingCaseAssociationRequestInteractor.test.js
@@ -26,36 +26,72 @@ describe('submitPendingCaseAssociationRequest', () => {
     ).rejects.toThrow('Unauthorized');
   });
 
-  it('should not add mapping if already associated', async () => {
+  it('should not add mapping if practitioner is already on case', async () => {
     applicationContext.getCurrentUser.mockReturnValue({
       name: 'Emmett Lathrop "Doc" Brown, Ph.D.',
       role: ROLES.privatePractitioner,
       userId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
     });
-    applicationContext.getPersistenceGateway().getUserById.mockReturnValue({
-      name: 'Emmett Lathrop "Doc" Brown, Ph.D.',
-      role: ROLES.privatePractitioner,
-      userId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
-    });
+
+    const caseDetail = {
+      privatePractitioners: [
+        { userId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb' },
+      ],
+    };
+
     applicationContext
       .getPersistenceGateway()
-      .verifyCaseForUser.mockReturnValue(true);
+      .getCaseByDocketNumber.mockResolvedValue(caseDetail);
+    // applicationContext.getPersistenceGateway().getUserById.mockReturnValue({
+    //   name: 'Emmett Lathrop "Doc" Brown, Ph.D.',
+    //   role: ROLES.privatePractitioner,
+    //   userId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+    // });
+    // applicationContext
+    //   .getPersistenceGateway()
+    //   .verifyCaseForUser.mockReturnValue(true);
 
-    await submitPendingCaseAssociationRequestInteractor(applicationContext, {
-      docketNumber: caseRecord.docketNumber,
-      userId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
-    });
+    const results = submitPendingCaseAssociationRequestInteractor(
+      applicationContext,
+      {
+        docketNumber: caseRecord.docketNumber,
+      },
+    );
+
+    await expect(results).rejects.toThrow(
+      `The Private Practitioner is already associated with case ${caseRecord.docketNumber}.`,
+    );
 
     expect(
       applicationContext.getPersistenceGateway().associateUserWithCasePending,
     ).not.toBeCalled();
   });
 
-  it('should not add mapping if these is already a pending association', async () => {
-    await submitPendingCaseAssociationRequestInteractor(applicationContext, {
-      docketNumber: caseRecord.docketNumber,
+  it('should not add mapping if there is already a pending association', async () => {
+    applicationContext.getCurrentUser.mockReturnValue({
+      name: 'Emmett Lathrop "Doc" Brown, Ph.D.',
+      role: ROLES.privatePractitioner,
       userId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
     });
+
+    const caseDetail = {
+      privatePractitioners: [],
+    };
+
+    applicationContext
+      .getPersistenceGateway()
+      .getCaseByDocketNumber.mockResolvedValue(caseDetail);
+
+    applicationContext
+      .getPersistenceGateway()
+      .verifyPendingCaseForUser.mockReturnValue(true);
+
+    await expect(
+      submitPendingCaseAssociationRequestInteractor(applicationContext, {
+        docketNumber: caseRecord.docketNumber,
+        userId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+      }),
+    ).resolves.not.toThrow();
 
     expect(
       applicationContext.getPersistenceGateway().associateUserWithCasePending,
@@ -63,9 +99,14 @@ describe('submitPendingCaseAssociationRequest', () => {
   });
 
   it('should add mapping', async () => {
+    const caseDetail = {
+      privatePractitioners: [],
+    };
+
     applicationContext
       .getPersistenceGateway()
-      .verifyCaseForUser.mockReturnValue(false);
+      .getCaseByDocketNumber.mockResolvedValue(caseDetail);
+
     applicationContext
       .getPersistenceGateway()
       .verifyPendingCaseForUser.mockReturnValue(false);

--- a/shared/src/business/useCases/caseAssociationRequest/submitPendingCaseAssociationRequestInteractor.test.js
+++ b/shared/src/business/useCases/caseAssociationRequest/submitPendingCaseAssociationRequestInteractor.test.js
@@ -34,15 +34,13 @@ describe('submitPendingCaseAssociationRequest', () => {
     await expect(
       submitPendingCaseAssociationRequestInteractor(applicationContext, {
         docketNumber: caseRecord.docketNumber,
-        userId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+        userId: mockCurrentUser.userId,
       }),
     ).rejects.toThrow('Unauthorized');
   });
 
   it('should not add mapping if practitioner is already on case', async () => {
-    caseDetail.privatePractitioners = [
-      { userId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb' },
-    ];
+    caseDetail.privatePractitioners = [{ userId: mockCurrentUser.userId }];
 
     const results = submitPendingCaseAssociationRequestInteractor(
       applicationContext,
@@ -68,7 +66,7 @@ describe('submitPendingCaseAssociationRequest', () => {
     await expect(
       submitPendingCaseAssociationRequestInteractor(applicationContext, {
         docketNumber: caseRecord.docketNumber,
-        userId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+        userId: mockCurrentUser.userId,
       }),
     ).resolves.not.toThrow();
 
@@ -84,7 +82,7 @@ describe('submitPendingCaseAssociationRequest', () => {
 
     await submitPendingCaseAssociationRequestInteractor(applicationContext, {
       docketNumber: caseRecord.docketNumber,
-      userId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+      userId: mockCurrentUser.userId,
     });
 
     expect(

--- a/shared/src/business/useCases/removePetitionerAndUpdateCaptionInteractor.js
+++ b/shared/src/business/useCases/removePetitionerAndUpdateCaptionInteractor.js
@@ -2,6 +2,9 @@ const {
   isAuthorized,
   ROLE_PERMISSIONS,
 } = require('../../authorization/authorizationClientService');
+const {
+  removeCounselFromRemovedPetitioner,
+} = require('../useCaseHelper/caseAssociation/removeCounselFromRemovedPetitioner');
 const { Case } = require('../entities/cases/Case');
 const { CASE_STATUS_TYPES } = require('../entities/EntityConstants');
 const { UnauthorizedError } = require('../../errors/errors');
@@ -72,35 +75,40 @@ exports.removePetitionerAndUpdateCaptionInteractor = async (
     if (!isPetitionerRepresented) {
       // do nothing
     } else {
-      const practitioners =
-        caseEntity.getPractitionersRepresenting(petitionerContactId);
-      console.log('Practitioners ', practitioners);
+      removeCounselFromRemovedPetitioner({
+        applicationContext,
+        caseEntity,
+        petitionerContactId,
+      });
+      // const practitioners =
+      //   caseEntity.getPractitionersRepresenting(petitionerContactId);
+      // console.log('Practitioners ', practitioners);
 
-      const practitionerModificationPromises = practitioners.map(
-        async practitioner => {
-          caseEntity.removeRepresentingFromPractitioners(petitionerContactId);
+      // const practitionerModificationPromises = practitioners.map(
+      //   async practitioner => {
+      //     caseEntity.removeRepresentingFromPractitioners(petitionerContactId);
 
-          if (practitioner.representing.length === 0) {
-            caseEntity.removePrivatePractitioner(practitioner);
+      //     if (practitioner.representing.length === 0) {
+      //       caseEntity.removePrivatePractitioner(practitioner);
 
-            if (
-              caseEntity.petitioners.some(petitioner => {
-                petitioner.contactId !== practitioner.userId;
-              })
-            ) {
-              await applicationContext
-                .getPersistenceGateway()
-                .deleteUserFromCase({
-                  applicationContext,
-                  docketNumber: caseEntity.docketNumber,
-                  userId: practitioner.userId,
-                });
-            }
-          }
-        },
-      );
+      //       if (
+      //         caseEntity.petitioners.some(petitioner => {
+      //           petitioner.contactId !== practitioner.userId;
+      //         })
+      //       ) {
+      //         await applicationContext
+      //           .getPersistenceGateway()
+      //           .deleteUserFromCase({
+      //             applicationContext,
+      //             docketNumber: caseEntity.docketNumber,
+      //             userId: practitioner.userId,
+      //           });
+      //       }
+      //     }
+      //   },
+      // );
 
-      await Promise.all(practitionerModificationPromises);
+      // await Promise.all(practitionerModificationPromises);
     }
   } else {
     //yes

--- a/shared/src/business/useCases/removePetitionerAndUpdateCaptionInteractor.js
+++ b/shared/src/business/useCases/removePetitionerAndUpdateCaptionInteractor.js
@@ -70,16 +70,15 @@ exports.removePetitionerAndUpdateCaptionInteractor = async (
       practitioner => practitioner.representing.includes(petitionerContactId),
     );
 
-    console.log('isPetitionerRepresented ', isPetitionerRepresented);
-
     if (!isPetitionerRepresented) {
       // do nothing
     } else {
-      removeCounselFromRemovedPetitioner({
+      caseEntity = await removeCounselFromRemovedPetitioner({
         applicationContext,
         caseEntity,
         petitionerContactId,
       });
+
       // const practitioners =
       //   caseEntity.getPractitionersRepresenting(petitionerContactId);
       // console.log('Practitioners ', practitioners);
@@ -112,35 +111,41 @@ exports.removePetitionerAndUpdateCaptionInteractor = async (
     }
   } else {
     //yes
-    const practitionerInQuestion = caseEntity.privatePractitioners.find(
-      privatePractitioner => privatePractitioner.userId === petitionerContactId,
-    );
-    const doesPetitionerRepresentThemselves =
-      practitionerInQuestion.representing.some(
-        petitionerId => petitionerId === petitionerContactId,
-      );
+    // const practitionerInQuestion = caseEntity.privatePractitioners.find(
+    //   privatePractitioner => privatePractitioner.userId === petitionerContactId,
+    // );
+    // const doesPetitionerRepresentThemselves =
+    //   practitionerInQuestion.representing.some(
+    //     petitionerId => petitionerId === petitionerContactId,
+    //   );
 
-    if (!doesPetitionerRepresentThemselves) {
-      //no
-      //do nothing actually
-    } else {
-      //yes
-      const doesPetitionerRepresentOtherPetitioner =
-        practitionerInQuestion.representing.some(
-          petitionerId => petitionerId !== petitionerContactId,
-        );
+    // if (!doesPetitionerRepresentThemselves) {
+    //   //no
+    //   //do nothing actually
+    // } else {
+    //   //yes
+    //   const doesPetitionerRepresentOtherPetitioner =
+    //     practitionerInQuestion.representing.some(
+    //       petitionerId => petitionerId !== petitionerContactId,
+    //     );
 
-      if (!doesPetitionerRepresentOtherPetitioner) {
-        caseEntity.removePrivatePractitioner(practitionerInQuestion);
-        await applicationContext.getPersistenceGateway().deleteUserFromCase({
-          applicationContext,
-          docketNumber,
-          userId: petitionerContactId,
-        });
-      } else {
-        caseEntity.removeRepresentingFromPractitioners(petitionerContactId);
-      }
-    }
+    //   if (!doesPetitionerRepresentOtherPetitioner) {
+    //     caseEntity.removePrivatePractitioner(practitionerInQuestion);
+    //     await applicationContext.getPersistenceGateway().deleteUserFromCase({
+    //       applicationContext,
+    //       docketNumber,
+    //       userId: petitionerContactId,
+    //     });
+    //   } else {
+    //     caseEntity.removeRepresentingFromPractitioners(petitionerContactId);
+    //   }
+    // }
+
+    caseEntity = await removeCounselFromRemovedPetitioner({
+      applicationContext,
+      caseEntity,
+      petitionerContactId,
+    });
   }
 
   //Old stuff below

--- a/shared/src/business/useCases/removePetitionerAndUpdateCaptionInteractor.js
+++ b/shared/src/business/useCases/removePetitionerAndUpdateCaptionInteractor.js
@@ -59,96 +59,18 @@ exports.removePetitionerAndUpdateCaptionInteractor = async (
     );
 
   if (!deletedPetitionerIsAlsoPractitionerOnCase) {
-    //no
     await applicationContext.getPersistenceGateway().deleteUserFromCase({
       applicationContext,
       docketNumber,
       userId: petitionerContactId,
     });
-
-    const isPetitionerRepresented = caseEntity.privatePractitioners.some(
-      practitioner => practitioner.representing.includes(petitionerContactId),
-    );
-
-    if (!isPetitionerRepresented) {
-      // do nothing
-    } else {
-      caseEntity = await removeCounselFromRemovedPetitioner({
-        applicationContext,
-        caseEntity,
-        petitionerContactId,
-      });
-
-      // const practitioners =
-      //   caseEntity.getPractitionersRepresenting(petitionerContactId);
-      // console.log('Practitioners ', practitioners);
-
-      // const practitionerModificationPromises = practitioners.map(
-      //   async practitioner => {
-      //     caseEntity.removeRepresentingFromPractitioners(petitionerContactId);
-
-      //     if (practitioner.representing.length === 0) {
-      //       caseEntity.removePrivatePractitioner(practitioner);
-
-      //       if (
-      //         caseEntity.petitioners.some(petitioner => {
-      //           petitioner.contactId !== practitioner.userId;
-      //         })
-      //       ) {
-      //         await applicationContext
-      //           .getPersistenceGateway()
-      //           .deleteUserFromCase({
-      //             applicationContext,
-      //             docketNumber: caseEntity.docketNumber,
-      //             userId: practitioner.userId,
-      //           });
-      //       }
-      //     }
-      //   },
-      // );
-
-      // await Promise.all(practitionerModificationPromises);
-    }
-  } else {
-    //yes
-    // const practitionerInQuestion = caseEntity.privatePractitioners.find(
-    //   privatePractitioner => privatePractitioner.userId === petitionerContactId,
-    // );
-    // const doesPetitionerRepresentThemselves =
-    //   practitionerInQuestion.representing.some(
-    //     petitionerId => petitionerId === petitionerContactId,
-    //   );
-
-    // if (!doesPetitionerRepresentThemselves) {
-    //   //no
-    //   //do nothing actually
-    // } else {
-    //   //yes
-    //   const doesPetitionerRepresentOtherPetitioner =
-    //     practitionerInQuestion.representing.some(
-    //       petitionerId => petitionerId !== petitionerContactId,
-    //     );
-
-    //   if (!doesPetitionerRepresentOtherPetitioner) {
-    //     caseEntity.removePrivatePractitioner(practitionerInQuestion);
-    //     await applicationContext.getPersistenceGateway().deleteUserFromCase({
-    //       applicationContext,
-    //       docketNumber,
-    //       userId: petitionerContactId,
-    //     });
-    //   } else {
-    //     caseEntity.removeRepresentingFromPractitioners(petitionerContactId);
-    //   }
-    // }
-
-    caseEntity = await removeCounselFromRemovedPetitioner({
-      applicationContext,
-      caseEntity,
-      petitionerContactId,
-    });
   }
 
-  //Old stuff below
+  caseEntity = await removeCounselFromRemovedPetitioner({
+    applicationContext,
+    caseEntity,
+    petitionerContactId,
+  });
 
   caseEntity.caseCaption = caseCaption;
 

--- a/shared/src/business/useCases/removePetitionerAndUpdateCaptionInteractor.js
+++ b/shared/src/business/useCases/removePetitionerAndUpdateCaptionInteractor.js
@@ -65,10 +65,21 @@ exports.removePetitionerAndUpdateCaptionInteractor = async (
       //do nothing actually
     } else {
       //yes
-      // const doesPetitionerRepresentOtherPetitioner =
-      //   practitionerInQuestion.representing.some(
-      //     petitionerId => petitionerId !== petitionerContactId,
-      //   );
+      const doesPetitionerRepresentOtherPetitioner =
+        practitionerInQuestion.representing.some(
+          petitionerId => petitionerId !== petitionerContactId,
+        );
+
+      if (!doesPetitionerRepresentOtherPetitioner) {
+        caseEntity.removePrivatePractitioner(practitionerInQuestion);
+        await applicationContext.getPersistenceGateway().deleteUserFromCase({
+          applicationContext,
+          docketNumber,
+          userId: petitionerContactId,
+        });
+      } else {
+        caseEntity.removeRepresentingFromPractitioners(petitionerContactId);
+      }
     }
   }
 

--- a/shared/src/business/useCases/removePetitionerAndUpdateCaptionInteractor.js
+++ b/shared/src/business/useCases/removePetitionerAndUpdateCaptionInteractor.js
@@ -2,9 +2,6 @@ const {
   isAuthorized,
   ROLE_PERMISSIONS,
 } = require('../../authorization/authorizationClientService');
-const {
-  removeCounselFromRemovedPetitioner,
-} = require('../useCaseHelper/caseAssociation/removeCounselFromRemovedPetitioner');
 const { Case } = require('../entities/cases/Case');
 const { CASE_STATUS_TYPES } = require('../entities/EntityConstants');
 const { UnauthorizedError } = require('../../errors/errors');
@@ -66,11 +63,13 @@ exports.removePetitionerAndUpdateCaptionInteractor = async (
     });
   }
 
-  caseEntity = await removeCounselFromRemovedPetitioner({
-    applicationContext,
-    caseEntity,
-    petitionerContactId,
-  });
+  caseEntity = await applicationContext
+    .getUseCaseHelpers()
+    .removeCounselFromRemovedPetitioner({
+      applicationContext,
+      caseEntity,
+      petitionerContactId,
+    });
 
   caseEntity.caseCaption = caseCaption;
 

--- a/shared/src/business/useCases/removePetitionerAndUpdateCaptionInteractor.js
+++ b/shared/src/business/useCases/removePetitionerAndUpdateCaptionInteractor.js
@@ -42,14 +42,11 @@ exports.removePetitionerAndUpdateCaptionInteractor = async (
     );
 
   const privatePractitionerRepresentsOtherPetitionerOnCase =
-    caseDetail.privatePractitioners.find(privatePractitioner => {
-      privatePractitioner.representing.some(userId => {
-        userId !== petitionerContactId;
+    caseEntity.privatePractitioners.find(privatePractitioner => {
+      privatePractitioner.representing.some(
+        userId => userId !== petitionerContactId,
+      );
     });
-
-  petitionerThatRepresentsThemselves?.representing.some(
-    userId => userId !== petitionerContactId,
-  );
 
   if (caseToUpdate.status === CASE_STATUS_TYPES.new) {
     throw new Error(
@@ -65,12 +62,12 @@ exports.removePetitionerAndUpdateCaptionInteractor = async (
 
   if (!isSelfRepresentingPrivatePractitioner) {
     caseEntity = await applicationContext
-    .getUseCaseHelpers()
-    .removeCounselFromRemovedPetitioner({
-      applicationContext,
-      caseEntity,
-      petitionerContactId,
-    });
+      .getUseCaseHelpers()
+      .removeCounselFromRemovedPetitioner({
+        applicationContext,
+        caseEntity,
+        petitionerContactId,
+      });
   } else if (!privatePractitionerRepresentsOtherPetitionerOnCase) {
     caseEntity = await applicationContext
       .getUseCaseHelpers()

--- a/shared/src/business/useCases/removePetitionerAndUpdateCaptionInteractor.test.js
+++ b/shared/src/business/useCases/removePetitionerAndUpdateCaptionInteractor.test.js
@@ -17,6 +17,7 @@ describe('removePetitionerAndUpdateCaptionInteractor', () => {
   let mockCase;
   let petitionerToRemove;
   const SECONDARY_CONTACT_ID = '56387318-0092-49a3-8cc1-921b0432bd16';
+  const PRIMARY_CONTACT_ID = '76d23e2c-80a4-4280-9b44-eefaadfd48dc';
   beforeEach(() => {
     petitionerToRemove = {
       address1: '2729 Chicken St',
@@ -99,7 +100,22 @@ describe('removePetitionerAndUpdateCaptionInteractor', () => {
     );
   });
 
-  it('should remove the specified petitioner form the case petitioners array', async () => {
+  it('should update the case caption', async () => {
+    const mockUpdatedCaption = 'An updated caption';
+
+    await removePetitionerAndUpdateCaptionInteractor(applicationContext, {
+      caseCaption: mockUpdatedCaption,
+      contactId: MOCK_CASE.petitioners[0].contactId,
+      docketNumber: mockCase.docketNumber,
+    });
+
+    expect(
+      applicationContext.getPersistenceGateway().updateCase.mock.calls[0][0]
+        .caseToUpdate.caseCaption,
+    ).toEqual(mockUpdatedCaption);
+  });
+
+  it('should remove the specified petitioner from the case petitioners array', async () => {
     await removePetitionerAndUpdateCaptionInteractor(applicationContext, {
       caseCaption: MOCK_CASE.caseCaption,
       contactId: petitionerToRemove.contactId,
@@ -145,31 +161,17 @@ describe('removePetitionerAndUpdateCaptionInteractor', () => {
     expect(
       applicationContext.getPersistenceGateway().deleteUserFromCase.mock
         .calls[0][0].userId,
-    ).toEqual(mockPrivatePractitioner.userId);
+    ).toEqual(petitionerToRemove.contactId);
+
     expect(
       applicationContext.getPersistenceGateway().deleteUserFromCase.mock
         .calls[1][0].userId,
-    ).toEqual(petitionerToRemove.contactId);
+    ).toEqual(mockPrivatePractitioner.userId);
 
     expect(caseToUpdate.privatePractitioners.length).toEqual(0);
   });
 
-  it('should update the case caption', async () => {
-    const mockUpdatedCaption = 'An updated caption';
-
-    await removePetitionerAndUpdateCaptionInteractor(applicationContext, {
-      caseCaption: mockUpdatedCaption,
-      contactId: MOCK_CASE.petitioners[0].contactId,
-      docketNumber: mockCase.docketNumber,
-    });
-
-    expect(
-      applicationContext.getPersistenceGateway().updateCase.mock.calls[0][0]
-        .caseToUpdate.caseCaption,
-    ).toEqual(mockUpdatedCaption);
-  });
-
-  it('should remove the petitioner from the representing id of the privatePractitioner', async () => {
+  it('should remove practitioner from case when they represent the only removed petitioner', async () => {
     const otherPetitioner = petitionerToRemove;
 
     mockCase.privatePractitioners = [
@@ -209,5 +211,138 @@ describe('removePetitionerAndUpdateCaptionInteractor', () => {
       applicationContext.getPersistenceGateway().updateCase.mock.calls[0][0]
         .caseToUpdate.privatePractitioners[0].representing,
     ).toEqual([otherPetitioner.contactId]);
+  });
+
+  it("BUG-9323: should not remove practitioner's user from case when they represent only the removed petitioner, but are also themselves a petitioner", async () => {
+    const mockPrivatePractitioner = {
+      barNumber: 'b1234',
+      name: 'Test Practitioner',
+      representing: [petitionerToRemove.contactId],
+      role: ROLES.privatePractitioner,
+      userId: '5b7e10a2-f9df-4ee8-bbb0-c01a698fdd32',
+    };
+    mockCase = {
+      ...mockCase,
+      petitioners: [
+        petitionerToRemove,
+        {
+          ...MOCK_CASE.petitioners[0],
+          contactId: mockPrivatePractitioner.userId,
+        },
+      ],
+      privatePractitioners: [mockPrivatePractitioner],
+    };
+
+    await removePetitionerAndUpdateCaptionInteractor(applicationContext, {
+      caseCaption: mockCase.caseCaption,
+      contactId: petitionerToRemove.contactId,
+      docketNumber: mockCase.docketNumber,
+    });
+
+    const { caseToUpdate } =
+      applicationContext.getUseCaseHelpers().updateCaseAndAssociations.mock
+        .calls[0][0];
+
+    expect(
+      applicationContext.getPersistenceGateway().deleteUserFromCase.mock
+        .calls[0][0].userId,
+    ).toEqual(petitionerToRemove.contactId);
+
+    expect(
+      applicationContext.getPersistenceGateway().deleteUserFromCase,
+    ).toHaveBeenCalledTimes(1);
+
+    expect(
+      getPetitionerById(caseToUpdate, petitionerToRemove.contactId),
+    ).toBeUndefined();
+
+    expect(caseToUpdate.privatePractitioners.length).toEqual(0);
+  });
+
+  it("BUG-9323: should remove petitioner's user from case ONCE when they are also a (self respresenting) practitioner on the case", async () => {
+    const mockPrivatePractitioner = {
+      barNumber: 'b1234',
+      name: 'Test Practitioner',
+      representing: [petitionerToRemove.contactId],
+      role: ROLES.privatePractitioner,
+      userId: petitionerToRemove.contactId,
+    };
+    mockCase = {
+      ...mockCase,
+      petitioners: [
+        petitionerToRemove,
+        {
+          ...MOCK_CASE.petitioners[0],
+          contactId: mockPrivatePractitioner.userId,
+        },
+      ],
+      privatePractitioners: [mockPrivatePractitioner],
+    };
+
+    await removePetitionerAndUpdateCaptionInteractor(applicationContext, {
+      caseCaption: mockCase.caseCaption,
+      contactId: petitionerToRemove.contactId,
+      docketNumber: mockCase.docketNumber,
+    });
+
+    const { caseToUpdate } =
+      applicationContext.getUseCaseHelpers().updateCaseAndAssociations.mock
+        .calls[0][0];
+
+    expect(
+      applicationContext.getPersistenceGateway().deleteUserFromCase.mock
+        .calls[0][0].userId,
+    ).toEqual(petitionerToRemove.contactId);
+
+    expect(
+      applicationContext.getPersistenceGateway().deleteUserFromCase,
+    ).toHaveBeenCalledTimes(1);
+
+    expect(
+      getPetitionerById(caseToUpdate, petitionerToRemove.contactId),
+    ).toBeUndefined();
+
+    expect(caseToUpdate.privatePractitioners.length).toEqual(0);
+  });
+
+  it("BUG-9323: should NOT remove petitioner's user from case when they are also a practitioner on the case (not self-representing)", async () => {
+    const mockPrivatePractitioner = {
+      barNumber: 'b1234',
+      name: 'Test Practitioner',
+      representing: [PRIMARY_CONTACT_ID],
+      role: ROLES.privatePractitioner,
+      userId: petitionerToRemove.contactId,
+    };
+    mockCase = {
+      ...mockCase,
+      petitioners: [
+        petitionerToRemove,
+        {
+          ...MOCK_CASE.petitioners[0],
+          contactId: PRIMARY_CONTACT_ID,
+        },
+      ],
+      privatePractitioners: [mockPrivatePractitioner],
+    };
+
+    await removePetitionerAndUpdateCaptionInteractor(applicationContext, {
+      caseCaption: mockCase.caseCaption,
+      contactId: petitionerToRemove.contactId,
+      docketNumber: mockCase.docketNumber,
+    });
+
+    const { caseToUpdate } =
+      applicationContext.getUseCaseHelpers().updateCaseAndAssociations.mock
+        .calls[0][0];
+
+    expect(
+      applicationContext.getPersistenceGateway().deleteUserFromCase,
+    ).not.toHaveBeenCalled();
+
+    expect(
+      getPetitionerById(caseToUpdate, petitionerToRemove.contactId),
+    ).toBeUndefined();
+
+    expect(caseToUpdate.privatePractitioners.length).toEqual(1);
   });
 });

--- a/shared/src/business/useCases/updatePetitionerInformationInteractor.test.js
+++ b/shared/src/business/useCases/updatePetitionerInformationInteractor.test.js
@@ -90,12 +90,14 @@ describe('updatePetitionerInformationInteractor', () => {
   it('should throw an error when the user making the request is a private practitioner not associated with the case', async () => {
     mockUser = { ...mockUser, role: ROLES.privatePractitioner };
 
-    applicationContext
-      .getPersistenceGateway()
-      .getCaseByDocketNumber.mockReturnValueOnce({
-        ...mockCase,
-        privatePractitioners: [{ representing: [], userId: '7' }],
-      });
+    // TODO: FIX THIS (This mock does nothing, why is this test written this way?)
+
+    // applicationContext
+    //   .getPersistenceGateway()
+    //   .getCaseByDocketNumber.mockReturnValueOnce({
+    //     ...mockCase,
+    //     privatePractitioners: [{ representing: [], userId: '7' }],
+    //   });
 
     await expect(
       updatePetitionerInformationInteractor(applicationContext, {

--- a/shared/src/business/useCases/updatePetitionerInformationInteractor.test.js
+++ b/shared/src/business/useCases/updatePetitionerInformationInteractor.test.js
@@ -90,14 +90,12 @@ describe('updatePetitionerInformationInteractor', () => {
   it('should throw an error when the user making the request is a private practitioner not associated with the case', async () => {
     mockUser = { ...mockUser, role: ROLES.privatePractitioner };
 
-    // TODO: FIX THIS (This mock does nothing, why is this test written this way?)
-
-    // applicationContext
-    //   .getPersistenceGateway()
-    //   .getCaseByDocketNumber.mockReturnValueOnce({
-    //     ...mockCase,
-    //     privatePractitioners: [{ representing: [], userId: '7' }],
-    //   });
+    applicationContext
+      .getPersistenceGateway()
+      .getCaseByDocketNumber.mockReturnValueOnce({
+        ...mockCase,
+        privatePractitioners: [{ representing: [], userId: '7' }],
+      });
 
     await expect(
       updatePetitionerInformationInteractor(applicationContext, {

--- a/web-client/integration-tests/admissionsClerkAddsEmailToPetitionerWithEFiledPetitions.test.js
+++ b/web-client/integration-tests/admissionsClerkAddsEmailToPetitionerWithEFiledPetitions.test.js
@@ -1,9 +1,9 @@
+import { admissionsClerkEditsPetitionerEmail } from './journey/admissionsClerkEditsPetitionerEmail';
 import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
 import {
   contactPrimaryFromState,
   fakeFile,
   loginAs,
-  refreshElasticsearchIndex,
   setupTest,
   uploadPetition,
 } from './helpers';
@@ -43,62 +43,7 @@ describe('admissions clerk adds an email to a petitioner who already exists in t
   petitionsClerkCreatesNewCase(cerebralTest, fakeFile);
 
   loginAs(cerebralTest, 'admissionsclerk@example.com');
-  it('admissions clerk adds petitioner email with existing cognito account to case', async () => {
-    await refreshElasticsearchIndex();
-
-    let contactPrimary = contactPrimaryFromState(cerebralTest);
-
-    await cerebralTest.runSequence(
-      'gotoEditPetitionerInformationInternalSequence',
-      {
-        contactId: contactPrimary.contactId,
-        docketNumber: cerebralTest.docketNumber,
-      },
-    );
-
-    expect(cerebralTest.getState('currentPage')).toEqual(
-      'EditPetitionerInformationInternal',
-    );
-    expect(cerebralTest.getState('form.updatedEmail')).toBeUndefined();
-    expect(cerebralTest.getState('form.confirmEmail')).toBeUndefined();
-
-    await cerebralTest.runSequence('updateFormValueSequence', {
-      key: 'contact.updatedEmail',
-      value: EMAIL_TO_ADD,
-    });
-
-    await cerebralTest.runSequence('updateFormValueSequence', {
-      key: 'contact.confirmEmail',
-      value: EMAIL_TO_ADD,
-    });
-
-    await cerebralTest.runSequence('submitEditPetitionerSequence');
-
-    expect(cerebralTest.getState('validationErrors')).toEqual({});
-
-    expect(cerebralTest.getState('modal.showModal')).toBe(
-      'MatchingEmailFoundModal',
-    );
-    expect(cerebralTest.getState('currentPage')).toEqual(
-      'EditPetitionerInformationInternal',
-    );
-
-    await cerebralTest.runSequence(
-      'submitUpdatePetitionerInformationFromModalSequence',
-    );
-
-    expect(cerebralTest.getState('modal.showModal')).toBeUndefined();
-    expect(cerebralTest.getState('currentPage')).toEqual('CaseDetailInternal');
-
-    contactPrimary = contactPrimaryFromState(cerebralTest);
-
-    expect(contactPrimary.email).toEqual(EMAIL_TO_ADD);
-    expect(contactPrimary.serviceIndicator).toEqual(
-      SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
-    );
-
-    await refreshElasticsearchIndex();
-  });
+  admissionsClerkEditsPetitionerEmail(cerebralTest, EMAIL_TO_ADD);
 
   it('admissions clerk verifies NOCE is not generated on the original case e-filed by the petitioner', async () => {
     await cerebralTest.runSequence('gotoCaseDetailSequence', {

--- a/web-client/integration-tests/admissionsClerkAddsPetitionerWithExistingAccountToCase.test.js
+++ b/web-client/integration-tests/admissionsClerkAddsPetitionerWithExistingAccountToCase.test.js
@@ -1,3 +1,4 @@
+import { admissionsClerkEditsPetitionerEmail } from './journey/admissionsClerkEditsPetitionerEmail';
 import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
 import {
   contactPrimaryFromState,
@@ -29,62 +30,7 @@ describe('admissions clerk adds petitioner with existing cognito account to case
   petitionsClerkAddsPractitionersToCase(cerebralTest, true);
 
   loginAs(cerebralTest, 'admissionsclerk@example.com');
-  it('admissions clerk adds petitioner email with existing cognito account to case', async () => {
-    await refreshElasticsearchIndex();
-
-    let contactPrimary = contactPrimaryFromState(cerebralTest);
-
-    await cerebralTest.runSequence(
-      'gotoEditPetitionerInformationInternalSequence',
-      {
-        contactId: contactPrimary.contactId,
-        docketNumber: cerebralTest.docketNumber,
-      },
-    );
-
-    expect(cerebralTest.getState('currentPage')).toEqual(
-      'EditPetitionerInformationInternal',
-    );
-    expect(cerebralTest.getState('form.updatedEmail')).toBeUndefined();
-    expect(cerebralTest.getState('form.confirmEmail')).toBeUndefined();
-
-    await cerebralTest.runSequence('updateFormValueSequence', {
-      key: 'contact.updatedEmail',
-      value: EMAIL_TO_ADD,
-    });
-
-    await cerebralTest.runSequence('updateFormValueSequence', {
-      key: 'contact.confirmEmail',
-      value: EMAIL_TO_ADD,
-    });
-
-    await cerebralTest.runSequence('submitEditPetitionerSequence');
-
-    expect(cerebralTest.getState('validationErrors')).toEqual({});
-
-    expect(cerebralTest.getState('modal.showModal')).toBe(
-      'MatchingEmailFoundModal',
-    );
-    expect(cerebralTest.getState('currentPage')).toEqual(
-      'EditPetitionerInformationInternal',
-    );
-
-    await cerebralTest.runSequence(
-      'submitUpdatePetitionerInformationFromModalSequence',
-    );
-
-    expect(cerebralTest.getState('modal.showModal')).toBeUndefined();
-    expect(cerebralTest.getState('currentPage')).toEqual('CaseDetailInternal');
-
-    contactPrimary = contactPrimaryFromState(cerebralTest);
-
-    expect(contactPrimary.email).toEqual(EMAIL_TO_ADD);
-    expect(contactPrimary.serviceIndicator).toEqual(
-      SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
-    );
-
-    await refreshElasticsearchIndex();
-  });
+  admissionsClerkEditsPetitionerEmail(cerebralTest, EMAIL_TO_ADD);
 
   loginAs(cerebralTest, 'petitioner2@example.com');
   it('petitioner with existing account verifies case is added to dashboard', async () => {

--- a/web-client/integration-tests/admissionsClerkAddsPetitionerWithExistingAccountToCase.test.js
+++ b/web-client/integration-tests/admissionsClerkAddsPetitionerWithExistingAccountToCase.test.js
@@ -1,10 +1,8 @@
 import { admissionsClerkEditsPetitionerEmail } from './journey/admissionsClerkEditsPetitionerEmail';
-import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
 import {
   contactPrimaryFromState,
   fakeFile,
   loginAs,
-  refreshElasticsearchIndex,
   setupTest,
 } from './helpers';
 import { petitionsClerkAddsPractitionersToCase } from './journey/petitionsClerkAddsPractitionersToCase';
@@ -13,8 +11,6 @@ import { petitionsClerkCreatesNewCase } from './journey/petitionsClerkCreatesNew
 const cerebralTest = setupTest();
 
 describe('admissions clerk adds petitioner with existing cognito account to case', () => {
-  const { SERVICE_INDICATOR_TYPES } = applicationContext.getConstants();
-
   const EMAIL_TO_ADD = 'petitioner2@example.com';
 
   beforeAll(() => {

--- a/web-client/integration-tests/docketClerkStrikesDocketEntry.test.js
+++ b/web-client/integration-tests/docketClerkStrikesDocketEntry.test.js
@@ -62,7 +62,7 @@ describe("Docket Clerk Edits a Docket Entry's Meta", () => {
   docketClerkStrikesDocketEntry(cerebralTest, 4);
 
   loginAs(cerebralTest, 'privatePractitioner@example.com');
-  practitionerViewsCaseDetail(cerebralTest, false);
+  practitionerViewsCaseDetail(cerebralTest);
   privatePractitionerSeesStrickenDocketEntry(cerebralTest, 4);
   privatePractitionerAttemptsToViewStrickenDocumentUnsuccessfully(cerebralTest);
   userSearchesForStrickenDocument(cerebralTest);

--- a/web-client/integration-tests/journey/admissionsClerkEditsPetitionerEmail.js
+++ b/web-client/integration-tests/journey/admissionsClerkEditsPetitionerEmail.js
@@ -1,0 +1,67 @@
+import { SERVICE_INDICATOR_TYPES } from '../../../shared/src/business/entities/EntityConstants';
+import {
+  contactPrimaryFromState,
+  refreshElasticsearchIndex,
+} from '../helpers';
+
+export const admissionsClerkEditsPetitionerEmail = (
+  cerebralTest,
+  emailToAdd,
+) => {
+  return it('admissions clerk adds petitioner email with existing cognito account to case', async () => {
+    await refreshElasticsearchIndex();
+
+    let contactPrimary = contactPrimaryFromState(cerebralTest);
+
+    await cerebralTest.runSequence(
+      'gotoEditPetitionerInformationInternalSequence',
+      {
+        contactId: contactPrimary.contactId,
+        docketNumber: cerebralTest.docketNumber,
+      },
+    );
+
+    expect(cerebralTest.getState('currentPage')).toEqual(
+      'EditPetitionerInformationInternal',
+    );
+    expect(cerebralTest.getState('form.updatedEmail')).toBeUndefined();
+    expect(cerebralTest.getState('form.confirmEmail')).toBeUndefined();
+
+    await cerebralTest.runSequence('updateFormValueSequence', {
+      key: 'contact.updatedEmail',
+      value: emailToAdd,
+    });
+
+    await cerebralTest.runSequence('updateFormValueSequence', {
+      key: 'contact.confirmEmail',
+      value: emailToAdd,
+    });
+
+    await cerebralTest.runSequence('submitEditPetitionerSequence');
+
+    expect(cerebralTest.getState('validationErrors')).toEqual({});
+
+    expect(cerebralTest.getState('modal.showModal')).toBe(
+      'MatchingEmailFoundModal',
+    );
+    expect(cerebralTest.getState('currentPage')).toEqual(
+      'EditPetitionerInformationInternal',
+    );
+
+    await cerebralTest.runSequence(
+      'submitUpdatePetitionerInformationFromModalSequence',
+    );
+
+    expect(cerebralTest.getState('modal.showModal')).toBeUndefined();
+    expect(cerebralTest.getState('currentPage')).toEqual('CaseDetailInternal');
+
+    contactPrimary = contactPrimaryFromState(cerebralTest);
+
+    expect(contactPrimary.email).toEqual(emailToAdd);
+    expect(contactPrimary.serviceIndicator).toEqual(
+      SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+    );
+
+    await refreshElasticsearchIndex();
+  });
+};

--- a/web-client/integration-tests/journey/admissionsClerkEditsPetitionerEmail.js
+++ b/web-client/integration-tests/journey/admissionsClerkEditsPetitionerEmail.js
@@ -1,22 +1,26 @@
 import { SERVICE_INDICATOR_TYPES } from '../../../shared/src/business/entities/EntityConstants';
 import {
   contactPrimaryFromState,
+  contactSecondaryFromState,
   refreshElasticsearchIndex,
 } from '../helpers';
 
 export const admissionsClerkEditsPetitionerEmail = (
   cerebralTest,
   emailToAdd,
+  editSecondary = false,
 ) => {
   return it('admissions clerk adds petitioner email with existing cognito account to case', async () => {
     await refreshElasticsearchIndex();
 
-    let contactPrimary = contactPrimaryFromState(cerebralTest);
+    let contact = editSecondary
+      ? contactSecondaryFromState(cerebralTest)
+      : contactPrimaryFromState(cerebralTest);
 
     await cerebralTest.runSequence(
       'gotoEditPetitionerInformationInternalSequence',
       {
-        contactId: contactPrimary.contactId,
+        contactId: contact.contactId,
         docketNumber: cerebralTest.docketNumber,
       },
     );
@@ -55,10 +59,12 @@ export const admissionsClerkEditsPetitionerEmail = (
     expect(cerebralTest.getState('modal.showModal')).toBeUndefined();
     expect(cerebralTest.getState('currentPage')).toEqual('CaseDetailInternal');
 
-    contactPrimary = contactPrimaryFromState(cerebralTest);
+    contact = editSecondary
+      ? contactSecondaryFromState(cerebralTest)
+      : contactPrimaryFromState(cerebralTest);
 
-    expect(contactPrimary.email).toEqual(emailToAdd);
-    expect(contactPrimary.serviceIndicator).toEqual(
+    expect(contact.email).toEqual(emailToAdd);
+    expect(contact.serviceIndicator).toEqual(
       SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
     );
 

--- a/web-client/integration-tests/journey/docketClerkRemovesPetitionerFromCase.js
+++ b/web-client/integration-tests/journey/docketClerkRemovesPetitionerFromCase.js
@@ -7,7 +7,7 @@ import { getPetitionerById } from '../../../shared/src/business/entities/cases/C
 
 export const docketClerkRemovesPetitionerFromCase = (
   cerebralTest,
-  removesSecondaryPetitioner = false,
+  removeSecondaryPetitioner = false,
 ) => {
   return it('docket clerk removes petitioner', async () => {
     await cerebralTest.runSequence('gotoCaseDetailSequence', {
@@ -18,7 +18,7 @@ export const docketClerkRemovesPetitionerFromCase = (
       CASE_STATUS_TYPES.new,
     );
 
-    const contactId = removesSecondaryPetitioner
+    const contactId = removeSecondaryPetitioner
       ? contactSecondaryFromState(cerebralTest).contactId
       : contactPrimaryFromState(cerebralTest).contactId;
 

--- a/web-client/integration-tests/journey/docketClerkRemovesPetitionerFromCase.js
+++ b/web-client/integration-tests/journey/docketClerkRemovesPetitionerFromCase.js
@@ -2,10 +2,13 @@ import {
   CASE_STATUS_TYPES,
   PARTY_VIEW_TABS,
 } from '../../../shared/src/business/entities/EntityConstants';
-import { contactPrimaryFromState } from '../helpers';
+import { contactPrimaryFromState, contactSecondaryFromState } from '../helpers';
 import { getPetitionerById } from '../../../shared/src/business/entities/cases/Case';
 
-export const docketClerkRemovesPetitionerFromCase = cerebralTest => {
+export const docketClerkRemovesPetitionerFromCase = (
+  cerebralTest,
+  removesSecondaryPetitioner = false,
+) => {
   return it('docket clerk removes petitioner', async () => {
     await cerebralTest.runSequence('gotoCaseDetailSequence', {
       docketNumber: cerebralTest.docketNumber,
@@ -15,13 +18,14 @@ export const docketClerkRemovesPetitionerFromCase = cerebralTest => {
       CASE_STATUS_TYPES.new,
     );
 
-    const contactPrimaryContactId =
-      contactPrimaryFromState(cerebralTest).contactId;
+    const contactId = removesSecondaryPetitioner
+      ? contactSecondaryFromState(cerebralTest).contactId
+      : contactPrimaryFromState(cerebralTest).contactId;
 
     await cerebralTest.runSequence(
       'gotoEditPetitionerInformationInternalSequence',
       {
-        contactId: contactPrimaryContactId,
+        contactId,
         docketNumber: cerebralTest.docketNumber,
       },
     );
@@ -36,10 +40,7 @@ export const docketClerkRemovesPetitionerFromCase = cerebralTest => {
     await cerebralTest.runSequence('removePetitionerAndUpdateCaptionSequence');
 
     expect(
-      getPetitionerById(
-        cerebralTest.getState('caseDetail'),
-        contactPrimaryContactId,
-      ),
+      getPetitionerById(cerebralTest.getState('caseDetail'), contactId),
     ).toBeUndefined();
 
     expect(cerebralTest.getState('alertSuccess.message')).toBe(

--- a/web-client/integration-tests/journey/petitionsClerkRemovesPractitionerFromCase.js
+++ b/web-client/integration-tests/journey/petitionsClerkRemovesPractitionerFromCase.js
@@ -1,9 +1,5 @@
 export const petitionsClerkRemovesPractitionerFromCase = cerebralTest => {
   return it('Petitions clerk removes a practitioner from a case', async () => {
-    const initialPractitionerCount = cerebralTest.getState(
-      'caseDetail.privatePractitioners',
-    ).length;
-
     const barNumber = cerebralTest.getState(
       'caseDetail.privatePractitioners.0.barNumber',
     );
@@ -29,7 +25,7 @@ export const petitionsClerkRemovesPractitionerFromCase = cerebralTest => {
     expect(cerebralTest.getState('validationErrors')).toEqual({});
 
     expect(
-      cerebralTest.getState('caseDetail.privatePractitioners').length,
-    ).toEqual(initialPractitionerCount - 1);
+      cerebralTest.getState('caseDetail.privatePractitioners'),
+    ).not.toContain(expect.objectContaining({ barNumber }));
   });
 };

--- a/web-client/integration-tests/journey/petitionsClerkRemovesPractitionerFromCase.js
+++ b/web-client/integration-tests/journey/petitionsClerkRemovesPractitionerFromCase.js
@@ -1,8 +1,8 @@
 export const petitionsClerkRemovesPractitionerFromCase = cerebralTest => {
   return it('Petitions clerk removes a practitioner from a case', async () => {
-    expect(
-      cerebralTest.getState('caseDetail.privatePractitioners').length,
-    ).toEqual(2);
+    const initialPractitionerCount = cerebralTest.getState(
+      'caseDetail.privatePractitioners',
+    ).length;
 
     const barNumber = cerebralTest.getState(
       'caseDetail.privatePractitioners.0.barNumber',
@@ -30,6 +30,6 @@ export const petitionsClerkRemovesPractitionerFromCase = cerebralTest => {
 
     expect(
       cerebralTest.getState('caseDetail.privatePractitioners').length,
-    ).toEqual(1);
+    ).toEqual(initialPractitionerCount - 1);
   });
 };

--- a/web-client/integration-tests/journey/practitionerVerifiesCasePractitionerAssociation.js
+++ b/web-client/integration-tests/journey/practitionerVerifiesCasePractitionerAssociation.js
@@ -9,12 +9,14 @@ export const practitionerVerifiesCasePractitionerAssociation = (
 
     const currentUser = cerebralTest.getState('user');
 
-    casePractitionerAssociationExists
-      ? expect(privatePractitioners).toContainEqual(
-          expect.objectContaining({ userId: currentUser.userId }),
-        )
-      : expect(privatePractitioners).not.toContainEqual(
-          expect.objectContaining({ userId: currentUser.userId }),
-        );
+    if (casePractitionerAssociationExists) {
+      expect(privatePractitioners).toContainEqual(
+        expect.objectContaining({ userId: currentUser.userId }),
+      );
+    } else {
+      expect(privatePractitioners).not.toContainEqual(
+        expect.objectContaining({ userId: currentUser.userId }),
+      );
+    }
   });
 };

--- a/web-client/integration-tests/journey/practitionerVerifiesCasePractitionerAssociation.js
+++ b/web-client/integration-tests/journey/practitionerVerifiesCasePractitionerAssociation.js
@@ -1,0 +1,20 @@
+export const practitionerVerifiesCasePractitionerAssociation = (
+  cerebralTest,
+  casePractitionerAssociationExists = true,
+) => {
+  return it('Check practitioner can still practice law stuff on this case', () => {
+    const privatePractitioners = cerebralTest.getState(
+      'caseDetail.privatePractitioners',
+    );
+
+    const currentUser = cerebralTest.getState('user');
+
+    casePractitionerAssociationExists
+      ? expect(privatePractitioners).toContainEqual(
+          expect.objectContaining({ userId: currentUser.userId }),
+        )
+      : expect(privatePractitioners).not.toContainEqual(
+          expect.objectContaining({ userId: currentUser.userId }),
+        );
+  });
+};

--- a/web-client/integration-tests/journey/practitionerVerifiesCasePractitionerAssociation.js
+++ b/web-client/integration-tests/journey/practitionerVerifiesCasePractitionerAssociation.js
@@ -2,7 +2,7 @@ export const practitionerVerifiesCasePractitionerAssociation = (
   cerebralTest,
   casePractitionerAssociationExists = true,
 ) => {
-  return it('Check practitioner can still practice law stuff on this case', () => {
+  return it('Check whether practitioner still appears in privatePractitioner array on case', () => {
     const privatePractitioners = cerebralTest.getState(
       'caseDetail.privatePractitioners',
     );

--- a/web-client/integration-tests/journey/practitionerViewsCaseDetail.js
+++ b/web-client/integration-tests/journey/practitionerViewsCaseDetail.js
@@ -1,7 +1,4 @@
-export const practitionerViewsCaseDetail = (
-  cerebralTest,
-  isAssociated = true,
-) => {
+export const practitionerViewsCaseDetail = cerebralTest => {
   return it('Practitioner views case detail', async () => {
     cerebralTest.setState('caseDetail', {});
     await cerebralTest.runSequence('gotoCaseDetailSequence', {
@@ -9,10 +6,5 @@ export const practitionerViewsCaseDetail = (
     });
 
     expect(cerebralTest.getState('currentPage')).toEqual('CaseDetail');
-    if (isAssociated) {
-      expect(cerebralTest.getState('caseDetail.privatePractitioners')).toEqual(
-        [],
-      );
-    }
   });
 };

--- a/web-client/integration-tests/journey/practitionerViewsDashboard.js
+++ b/web-client/integration-tests/journey/practitionerViewsDashboard.js
@@ -7,10 +7,11 @@ export const practitionerViewsDashboard = cerebralTest => {
     expect(cerebralTest.getState('currentPage')).toEqual(
       'DashboardPractitioner',
     );
+
     expect(cerebralTest.getState('openCases').length).toBeGreaterThan(0);
-    const latestDocketNumber = cerebralTest.getState(
-      'openCases.0.docketNumber',
+    const allOpenCases = cerebralTest.getState('openCases');
+    expect(allOpenCases).toContainEqual(
+      expect.objectContaining({ docketNumber: cerebralTest.docketNumber }),
     );
-    expect(cerebralTest.docketNumber).toEqual(latestDocketNumber);
   });
 };

--- a/web-client/integration-tests/petitionerServiceIndicatorJourney.test.js
+++ b/web-client/integration-tests/petitionerServiceIndicatorJourney.test.js
@@ -1,9 +1,9 @@
 import { SERVICE_INDICATOR_TYPES } from '../../shared/src/business/entities/EntityConstants';
+import { admissionsClerkEditsPetitionerEmail } from './journey/admissionsClerkEditsPetitionerEmail';
 import {
   contactPrimaryFromState,
   fakeFile,
   loginAs,
-  refreshElasticsearchIndex,
   setupTest,
 } from './helpers';
 import { formattedCaseDetail } from '../src/presenter/computeds/formattedCaseDetail';
@@ -52,48 +52,8 @@ describe('Petitioner Service Indicator Journey', () => {
   });
 
   loginAs(cerebralTest, 'admissionsclerk@example.com');
-  it('Admissions Clerk updates petitioner email address', async () => {
-    await refreshElasticsearchIndex();
-    await cerebralTest.runSequence('gotoCaseDetailSequence', {
-      docketNumber: cerebralTest.docketNumber,
-    });
 
-    const contactPrimary = contactPrimaryFromState(cerebralTest);
-
-    await cerebralTest.runSequence(
-      'gotoEditPetitionerInformationInternalSequence',
-      {
-        contactId: contactPrimary.contactId,
-        docketNumber: cerebralTest.docketNumber,
-      },
-    );
-
-    await cerebralTest.runSequence('updateFormValueSequence', {
-      key: 'contact.updatedEmail',
-      value: 'petitioner4@example.com',
-    });
-
-    await cerebralTest.runSequence('updateFormValueSequence', {
-      key: 'contact.confirmEmail',
-      value: 'petitioner4@example.com',
-    });
-
-    await cerebralTest.runSequence('submitEditPetitionerSequence');
-    expect(cerebralTest.getState('validationErrors')).toEqual({});
-
-    expect(cerebralTest.getState('modal.showModal')).toEqual(
-      'MatchingEmailFoundModal',
-    );
-
-    await cerebralTest.runSequence(
-      'submitUpdatePetitionerInformationFromModalSequence',
-    );
-
-    expect(cerebralTest.getState('currentPage')).toEqual('CaseDetailInternal');
-    expect(cerebralTest.getState('alertSuccess.message')).toEqual(
-      'Changes saved.',
-    );
-  });
+  admissionsClerkEditsPetitionerEmail(cerebralTest, 'petitioner4@example.com');
 
   // verify it is electronic
 

--- a/web-client/integration-tests/petitionerServiceIndicatorJourney.test.js
+++ b/web-client/integration-tests/petitionerServiceIndicatorJourney.test.js
@@ -3,6 +3,7 @@ import {
   contactPrimaryFromState,
   fakeFile,
   loginAs,
+  refreshElasticsearchIndex,
   setupTest,
 } from './helpers';
 import { formattedCaseDetail } from '../src/presenter/computeds/formattedCaseDetail';
@@ -52,6 +53,7 @@ describe('Petitioner Service Indicator Journey', () => {
 
   loginAs(cerebralTest, 'admissionsclerk@example.com');
   it('Admissions Clerk updates petitioner email address', async () => {
+    await refreshElasticsearchIndex();
     await cerebralTest.runSequence('gotoCaseDetailSequence', {
       docketNumber: cerebralTest.docketNumber,
     });

--- a/web-client/integration-tests/practitionerCaseJourney.test.js
+++ b/web-client/integration-tests/practitionerCaseJourney.test.js
@@ -85,7 +85,7 @@ describe('Practitioner requests access to case', () => {
   practitionerSearchesForNonexistentCase(cerebralTest);
   practitionerViewsDashboardBeforeAddingCase(cerebralTest);
   practitionerSearchesForCase(cerebralTest);
-  practitionerViewsCaseDetail(cerebralTest, false);
+  practitionerViewsCaseDetail(cerebralTest);
   practitionerRequestsAccessToCase(cerebralTest, fakeFile);
   practitionerViewsDashboard(cerebralTest);
   practitionerViewsCaseDetailOfOwnedCase(cerebralTest);

--- a/web-client/integration-tests/privatePractitionerFilesAsPetitioner.test.js
+++ b/web-client/integration-tests/privatePractitionerFilesAsPetitioner.test.js
@@ -53,18 +53,32 @@ describe('Bug 9323', () => {
     practitionerViewsDashboard(cerebralTest);
   });
 
-  describe('BUG-9323 privatePractitioner remains on case as practitioner after petitioner removal', () => {
+  describe('BUG-9323 privatePractitioner representing both petitioners remains on case as practitioner after petitioner removal', () => {
     const privatePractitionerEmail = 'privatePractitioner@example.com';
     const petitionsClerkEmail = 'petitionsclerk@example.com';
 
     loginAs(cerebralTest, privatePractitionerEmail);
-    practitionerCreatesNewCase(cerebralTest, fakeFile); //test needs petition to have two petitioners which happens here
+    practitionerCreatesNewCase(cerebralTest, fakeFile);
 
-    //1. represents both petitioners and they are one of those petitioners, doesn't matter which gets deleted = stays associated, stays privatepractioner associated
-    //2a. represents only themself and not the other petitioner, other petitioner deleted = stays associated, stays privatepractioner associated
-    //2b. represents only themself and not the other petitioner, themself petitioner deleted = not associated, not privatepractioner associated
-    //3a. they represent only the other petitioner that isn't themself, other petitioner deleted = stays associated, not privatepractioner associated
-    //3b. they represent only the other petitioner that isn't themself, themself petitioner deleted = stays associated, stays privatepractioner associated
+    loginAs(cerebralTest, petitionsClerkEmail);
+    petitionsClerkServesElectronicCaseToIrs(cerebralTest);
+
+    loginAs(cerebralTest, 'admissionsclerk@example.com');
+    admissionsClerkEditsPetitionerEmail(cerebralTest, privatePractitionerEmail);
+
+    loginAs(cerebralTest, 'docketclerk@example.com');
+    docketClerkRemovesPetitionerFromCase(cerebralTest);
+
+    loginAs(cerebralTest, privatePractitionerEmail);
+    practitionerViewsDashboard(cerebralTest);
+  });
+
+  describe('BUG-9323 privatePractitioner representing only themselves remains on case as practitioner after second petitioner removal', () => {
+    const privatePractitionerEmail = 'privatePractitioner@example.com';
+    const petitionsClerkEmail = 'petitionsclerk@example.com';
+
+    loginAs(cerebralTest, petitionsClerkEmail);
+    petitionsClerkCreatesNewCase(cerebralTest, fakeFile); //test needs petition to have two petitioners which happens here
 
     loginAs(cerebralTest, petitionsClerkEmail);
     petitionsClerkServesElectronicCaseToIrs(cerebralTest);
@@ -79,3 +93,9 @@ describe('Bug 9323', () => {
     practitionerViewsDashboard(cerebralTest);
   });
 });
+
+//XXXXX 1. represents both petitioners and they are one of those petitioners, doesn't matter which gets deleted = stays associated, stays privatepractioner associated
+//2a. represents only themself and not the other petitioner, other petitioner deleted = stays associated, stays privatepractioner associated
+//2b. represents only themself and not the other petitioner, themself petitioner deleted = not associated, not privatepractioner associated
+//3a. they represent only the other petitioner that isn't themself, other petitioner deleted = stays associated, not privatepractioner associated
+//3b. they represent only the other petitioner that isn't themself, themself petitioner deleted = stays associated, stays privatepractioner associated

--- a/web-client/integration-tests/privatePractitionerFilesAsPetitioner.test.js
+++ b/web-client/integration-tests/privatePractitionerFilesAsPetitioner.test.js
@@ -7,7 +7,7 @@ import { petitionsClerkCreatesNewCase } from './journey/petitionsClerkCreatesNew
 
 const cerebralTest = setupTest();
 
-describe('admissions clerk practitioner journey', () => {
+describe('privatePractitioner files as a petitioner', () => {
   // const { COUNTRY_TYPES, PARTY_TYPES } = applicationContext.getConstants();
 
   beforeAll(() => {
@@ -23,6 +23,33 @@ describe('admissions clerk practitioner journey', () => {
   //2. Admissions clerk associates the private practitioner with the petitioner via private practitioner's e-mail
   //3. Admissions clerk assigns the private practitioner to the petitioner on the case.
   //4. Assert that the private practitioner to the petitioner on the case.
+
+  loginAs(cerebralTest, 'petitionsclerk@example.com');
+  petitionsClerkCreatesNewCase(cerebralTest, fakeFile, undefined, true);
+
+  loginAs(cerebralTest, 'admissionsclerk@example.com');
+  admissionsClerkEditsPetitionerEmail(
+    cerebralTest,
+    'privatePractitioner@example.com',
+  );
+  loginAs(cerebralTest, 'petitionsclerk@example.com');
+  petitionsClerkAddsPractitionersToCase(cerebralTest, true);
+});
+
+describe('BUG-9323 privatePractitioner remains on case as petitioner after removal', () => {
+  beforeAll(() => {
+    jest.setTimeout(30000);
+  });
+
+  afterAll(() => {
+    cerebralTest.closeSocket();
+  });
+
+  //Order of operations
+  //1. Practitioner files petition
+  //2. Admissions clerk associates the private practitioner with the petitioner via private practitioner's e-mail
+  //3. Any clerk removes privatePractitioner from the case
+  //4. Assert that the private practitioner remains the petitioner on the case
 
   loginAs(cerebralTest, 'petitionsclerk@example.com');
   petitionsClerkCreatesNewCase(cerebralTest, fakeFile, undefined, true);

--- a/web-client/integration-tests/privatePractitionerFilesAsPetitioner.test.js
+++ b/web-client/integration-tests/privatePractitionerFilesAsPetitioner.test.js
@@ -48,7 +48,7 @@ describe('Bug 9323', () => {
     //3. Any clerk removes privatePractitioner from the case
     //4. Assert that the private practitioner remains the petitioner on the case
 
-    loginAs(privatePractitionerEmail);
+    loginAs(cerebralTest, privatePractitionerEmail);
     practitionerCreatesNewCase(cerebralTest, fakeFile);
 
     loginAs(cerebralTest, petitionsClerkEmail);
@@ -60,7 +60,7 @@ describe('Bug 9323', () => {
     loginAs(cerebralTest, petitionsClerkEmail);
     petitionsClerkRemovesPractitionerFromCase(cerebralTest);
 
-    loginAs(privatePractitionerEmail);
+    loginAs(cerebralTest, privatePractitionerEmail);
     practitionerViewsDashboard(cerebralTest);
   });
 });

--- a/web-client/integration-tests/privatePractitionerFilesAsPetitioner.test.js
+++ b/web-client/integration-tests/privatePractitionerFilesAsPetitioner.test.js
@@ -30,8 +30,8 @@ describe('admissions clerk practitioner journey', () => {
   loginAs(cerebralTest, 'admissionsclerk@example.com');
   admissionsClerkEditsPetitionerEmail(
     cerebralTest,
-    'privatePractioner1@example.com',
+    'privatePractitioner@example.com',
   );
-
+  loginAs(cerebralTest, 'petitionsclerk@example.com');
   petitionsClerkAddsPractitionersToCase(cerebralTest, true);
 });

--- a/web-client/integration-tests/privatePractitionerFilesAsPetitioner.test.js
+++ b/web-client/integration-tests/privatePractitionerFilesAsPetitioner.test.js
@@ -20,12 +20,6 @@ describe('Bug 9323', () => {
   });
 
   describe('privatePractitioner files as a petitioner', () => {
-    //Order of operations
-    //1. Petitions clerk creates a petition with no e-mail for the petitioner
-    //2. Admissions clerk associates the private practitioner with the petitioner via private practitioner's e-mail
-    //3. Admissions clerk assigns the private practitioner to the petitioner on the case.
-    //4. Assert that the private practitioner to the petitioner on the case.
-
     loginAs(cerebralTest, 'petitionsclerk@example.com');
     petitionsClerkCreatesNewCase(cerebralTest, fakeFile, undefined, true);
 
@@ -42,12 +36,6 @@ describe('Bug 9323', () => {
     const privatePractitionerEmail = 'privatePractitioner@example.com';
     const petitionsClerkEmail = 'petitionsclerk@example.com';
 
-    //Order of operations
-    //1. Practitioner files petition
-    //2. Admissions clerk associates the private practitioner with the petitioner via private practitioner's e-mail
-    //3. Any clerk removes privatePractitioner from the case
-    //4. Assert that the private practitioner remains the petitioner on the case
-
     loginAs(cerebralTest, privatePractitionerEmail);
     practitionerCreatesNewCase(cerebralTest, fakeFile);
 
@@ -63,4 +51,6 @@ describe('Bug 9323', () => {
     loginAs(cerebralTest, privatePractitionerEmail);
     practitionerViewsDashboard(cerebralTest);
   });
+
+  // TODO - Write inverse test of the one directly above
 });

--- a/web-client/integration-tests/privatePractitionerFilesAsPetitioner.test.js
+++ b/web-client/integration-tests/privatePractitionerFilesAsPetitioner.test.js
@@ -1,0 +1,67 @@
+import { ADVANCED_SEARCH_TABS } from '../../shared/src/business/entities/EntityConstants';
+import { admissionsClerkAddsNewPractitioner } from './journey/admissionsClerkAddsNewPractitioner';
+import { admissionsClerkAddsPractitionerEmail } from './journey/admissionsClerkAddsPractitionerEmail';
+import { admissionsClerkEditsPractitionerInfo } from './journey/admissionsClerkEditsPractitionerInfo';
+import { admissionsClerkMigratesPractitionerWithoutEmail } from './journey/admissionsClerkMigratesPractitionerWithoutEmail';
+import { admissionsClerkSearchesForPractitionerByBarNumber } from './journey/admissionsClerkSearchesForPractitionerByBarNumber';
+import { admissionsClerkSearchesForPractitionersByName } from './journey/admissionsClerkSearchesForPractitionersByName';
+import { admissionsClerkVerifiesPractitionerServiceIndicator } from './journey/admissionsClerkVerifiesPractitionerServiceIndicator';
+import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
+import {
+  loginAs,
+  refreshElasticsearchIndex,
+  setupTest,
+  uploadPetition,
+} from './helpers';
+import { petitionsClerkAddsPractitionersToCase } from './journey/petitionsClerkAddsPractitionersToCase';
+import { petitionsClerkServesPetitionFromDocumentView } from './journey/petitionsClerkServesPetitionFromDocumentView';
+import { petitionsClerkViewsCaseDetail } from './journey/petitionsClerkViewsCaseDetail';
+
+const cerebralTest = setupTest();
+
+describe('admissions clerk practitioner journey', () => {
+  const { COUNTRY_TYPES, PARTY_TYPES } =
+    applicationContext.getConstants();
+
+  beforeAll(() => {
+    jest.setTimeout(30000);
+  });
+
+  afterAll(() => {
+    cerebralTest.closeSocket();
+  });
+
+  //Order of operations
+  //1. Petitions clerk creates a petition with no e-mail for the petitioner
+  //2. Admissions clerk associates the private practitioner with the petitioner via private practitioner's e-mail
+  //3. Admissions clerk assigns the private practitioner to the petitioner on the case.
+  //4. Assert that the private practitioner to the petitioner on the case.
+
+  loginAs(cerebralTest, 'admissionsclerk@example.com');
+  admissionsClerkAddsNewPractitioner(cerebralTest);
+  admissionsClerkSearchesForPractitionersByName(cerebralTest);
+  admissionsClerkSearchesForPractitionerByBarNumber(cerebralTest);
+
+  loginAs(cerebralTest, 'petitioner@example.com');
+  it('Create test case', async () => {
+    const caseDetail = await uploadPetition(cerebralTest, {
+      contactSecondary: {
+        address1: '734 Cowley Parkway',
+        city: 'Amazing',
+        countryType: COUNTRY_TYPES.DOMESTIC,
+        name: 'Jimothy Schultz',
+        phone: '+1 (884) 358-9729',
+        postalCode: '77546',
+        state: 'AZ',
+      },
+      partyType: PARTY_TYPES.petitionerSpouse,
+    });
+    expect(caseDetail.docketNumber).toBeDefined();
+    cerebralTest.docketNumber = caseDetail.docketNumber;
+  });
+
+  loginAs(cerebralTest, 'petitionsclerk@example.com');
+  petitionsClerkViewsCaseDetail(cerebralTest);
+  petitionsClerkServesPetitionFromDocumentView(cerebralTest);
+  petitionsClerkAddsPractitionersToCase(cerebralTest, true);
+});

--- a/web-client/integration-tests/privatePractitionerFilesAsPetitioner.test.js
+++ b/web-client/integration-tests/privatePractitionerFilesAsPetitioner.test.js
@@ -1,29 +1,14 @@
-import { ADVANCED_SEARCH_TABS } from '../../shared/src/business/entities/EntityConstants';
-import { admissionsClerkAddsNewPractitioner } from './journey/admissionsClerkAddsNewPractitioner';
-import { admissionsClerkAddsPractitionerEmail } from './journey/admissionsClerkAddsPractitionerEmail';
-import { admissionsClerkEditsPractitionerInfo } from './journey/admissionsClerkEditsPractitionerInfo';
-import { admissionsClerkMigratesPractitionerWithoutEmail } from './journey/admissionsClerkMigratesPractitionerWithoutEmail';
-import { admissionsClerkSearchesForPractitionerByBarNumber } from './journey/admissionsClerkSearchesForPractitionerByBarNumber';
-import { admissionsClerkSearchesForPractitionersByName } from './journey/admissionsClerkSearchesForPractitionersByName';
-import { admissionsClerkVerifiesPractitionerServiceIndicator } from './journey/admissionsClerkVerifiesPractitionerServiceIndicator';
-import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
+import { admissionsClerkEditsPetitionerEmail } from './journey/admissionsClerkEditsPetitionerEmail';
+// import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
 import { fakeFile } from '../integration-tests-public/helpers';
-import {
-  loginAs,
-  refreshElasticsearchIndex,
-  setupTest,
-  uploadPetition,
-} from './helpers';
+import { loginAs, setupTest } from './helpers';
 import { petitionsClerkAddsPractitionersToCase } from './journey/petitionsClerkAddsPractitionersToCase';
 import { petitionsClerkCreatesNewCase } from './journey/petitionsClerkCreatesNewCase';
-import { petitionsClerkServesPetitionFromDocumentView } from './journey/petitionsClerkServesPetitionFromDocumentView';
-import { petitionsClerkViewsCaseDetail } from './journey/petitionsClerkViewsCaseDetail';
-import { admissionsClerkEditsPetitionerEmail } from "./journey/admissionsClerkEditsPetitionerEmail";
 
 const cerebralTest = setupTest();
 
 describe('admissions clerk practitioner journey', () => {
-  const { COUNTRY_TYPES, PARTY_TYPES } = applicationContext.getConstants();
+  // const { COUNTRY_TYPES, PARTY_TYPES } = applicationContext.getConstants();
 
   beforeAll(() => {
     jest.setTimeout(30000);
@@ -50,5 +35,3 @@ describe('admissions clerk practitioner journey', () => {
 
   petitionsClerkAddsPractitionersToCase(cerebralTest, true);
 });
-
-

--- a/web-client/integration-tests/privatePractitionerFilesAsPetitioner.test.js
+++ b/web-client/integration-tests/privatePractitionerFilesAsPetitioner.test.js
@@ -1,4 +1,5 @@
 import { admissionsClerkEditsPetitionerEmail } from './journey/admissionsClerkEditsPetitionerEmail';
+import { docketClerkAddsPetitionerToCase } from './journey/docketClerkAddsPetitionerToCase';
 import { docketClerkRemovesPetitionerFromCase } from './journey/docketClerkRemovesPetitionerFromCase';
 import { fakeFile } from '../integration-tests-public/helpers';
 import { loginAs, setupTest } from './helpers';
@@ -20,6 +21,10 @@ describe('Bug 9323', () => {
     cerebralTest.closeSocket();
   });
 
+  const privatePractitionerEmail = 'privatePractitioner@example.com';
+  const petitionsClerkEmail = 'petitionsclerk@example.com';
+  const docketClerkEmail = 'docketclerk@example.com';
+
   describe('privatePractitioner files as a petitioner', () => {
     loginAs(cerebralTest, 'petitionsclerk@example.com');
     petitionsClerkCreatesNewCase(cerebralTest, fakeFile, undefined, true);
@@ -34,9 +39,6 @@ describe('Bug 9323', () => {
   });
 
   describe('BUG-9323 privatePractitioner remains on case as petitioner after practitioner removal', () => {
-    const privatePractitionerEmail = 'privatePractitioner@example.com';
-    const petitionsClerkEmail = 'petitionsclerk@example.com';
-
     loginAs(cerebralTest, privatePractitionerEmail);
     practitionerCreatesNewCase(cerebralTest, fakeFile);
 
@@ -54,9 +56,7 @@ describe('Bug 9323', () => {
   });
 
   describe('BUG-9323 privatePractitioner representing both petitioners remains on case as practitioner after petitioner removal', () => {
-    const privatePractitionerEmail = 'privatePractitioner@example.com';
-    const petitionsClerkEmail = 'petitionsclerk@example.com';
-
+    // scenario 1
     loginAs(cerebralTest, privatePractitionerEmail);
     practitionerCreatesNewCase(cerebralTest, fakeFile);
 
@@ -74,23 +74,25 @@ describe('Bug 9323', () => {
   });
 
   describe('BUG-9323 privatePractitioner representing only themselves remains on case as practitioner after second petitioner removal', () => {
-    const privatePractitionerEmail = 'privatePractitioner@example.com';
-    const petitionsClerkEmail = 'petitionsclerk@example.com';
+    // scenario 2a
+    loginAs(cerebralTest, petitionsClerkEmail);
+    petitionsClerkCreatesNewCase(cerebralTest, fakeFile);
+
+    loginAs(cerebralTest, docketClerkEmail);
+    docketClerkAddsPetitionerToCase(cerebralTest, docketClerkEmail);
 
     loginAs(cerebralTest, petitionsClerkEmail);
-    petitionsClerkCreatesNewCase(cerebralTest, fakeFile); //test needs petition to have two petitioners which happens here
-
-    loginAs(cerebralTest, petitionsClerkEmail);
-    petitionsClerkServesElectronicCaseToIrs(cerebralTest);
+    petitionsClerkAddsPractitionersToCase(cerebralTest, true);
 
     loginAs(cerebralTest, 'admissionsclerk@example.com');
     admissionsClerkEditsPetitionerEmail(cerebralTest, privatePractitionerEmail);
 
     loginAs(cerebralTest, 'docketclerk@example.com');
-    docketClerkRemovesPetitionerFromCase(cerebralTest);
+    docketClerkRemovesPetitionerFromCase(cerebralTest, true);
 
     loginAs(cerebralTest, privatePractitionerEmail);
     practitionerViewsDashboard(cerebralTest);
+    // TODO: check that practitioner is still _practitioner_ on case
   });
 });
 

--- a/web-client/integration-tests/privatePractitionerFilesAsPetitioner.test.js
+++ b/web-client/integration-tests/privatePractitionerFilesAsPetitioner.test.js
@@ -10,9 +10,7 @@ import { practitionerViewsDashboard } from './journey/practitionerViewsDashboard
 
 const cerebralTest = setupTest();
 
-describe('privatePractitioner files as a petitioner', () => {
-  // const { COUNTRY_TYPES, PARTY_TYPES } = applicationContext.getConstants();
-
+describe('Bug 9323', () => {
   beforeAll(() => {
     jest.setTimeout(30000);
   });
@@ -21,54 +19,48 @@ describe('privatePractitioner files as a petitioner', () => {
     cerebralTest.closeSocket();
   });
 
-  //Order of operations
-  //1. Petitions clerk creates a petition with no e-mail for the petitioner
-  //2. Admissions clerk associates the private practitioner with the petitioner via private practitioner's e-mail
-  //3. Admissions clerk assigns the private practitioner to the petitioner on the case.
-  //4. Assert that the private practitioner to the petitioner on the case.
+  describe('privatePractitioner files as a petitioner', () => {
+    //Order of operations
+    //1. Petitions clerk creates a petition with no e-mail for the petitioner
+    //2. Admissions clerk associates the private practitioner with the petitioner via private practitioner's e-mail
+    //3. Admissions clerk assigns the private practitioner to the petitioner on the case.
+    //4. Assert that the private practitioner to the petitioner on the case.
 
-  loginAs(cerebralTest, 'petitionsclerk@example.com');
-  petitionsClerkCreatesNewCase(cerebralTest, fakeFile, undefined, true);
+    loginAs(cerebralTest, 'petitionsclerk@example.com');
+    petitionsClerkCreatesNewCase(cerebralTest, fakeFile, undefined, true);
 
-  loginAs(cerebralTest, 'admissionsclerk@example.com');
-  admissionsClerkEditsPetitionerEmail(
-    cerebralTest,
-    'privatePractitioner@example.com',
-  );
-  loginAs(cerebralTest, 'petitionsclerk@example.com');
-  petitionsClerkAddsPractitionersToCase(cerebralTest, true);
-});
-
-describe('BUG-9323 privatePractitioner remains on case as petitioner after removal', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
+    loginAs(cerebralTest, 'admissionsclerk@example.com');
+    admissionsClerkEditsPetitionerEmail(
+      cerebralTest,
+      'privatePractitioner@example.com',
+    );
+    loginAs(cerebralTest, 'petitionsclerk@example.com');
+    petitionsClerkAddsPractitionersToCase(cerebralTest, true);
   });
 
-  afterAll(() => {
-    cerebralTest.closeSocket();
+  describe('BUG-9323 privatePractitioner remains on case as petitioner after removal', () => {
+    const privatePractitionerEmail = 'privatePractitioner@example.com';
+    const petitionsClerkEmail = 'petitionsclerk@example.com';
+
+    //Order of operations
+    //1. Practitioner files petition
+    //2. Admissions clerk associates the private practitioner with the petitioner via private practitioner's e-mail
+    //3. Any clerk removes privatePractitioner from the case
+    //4. Assert that the private practitioner remains the petitioner on the case
+
+    loginAs(privatePractitionerEmail);
+    practitionerCreatesNewCase(cerebralTest, fakeFile);
+
+    loginAs(cerebralTest, petitionsClerkEmail);
+    petitionsClerkServesElectronicCaseToIrs(cerebralTest);
+
+    loginAs(cerebralTest, 'admissionsclerk@example.com');
+    admissionsClerkEditsPetitionerEmail(cerebralTest, privatePractitionerEmail);
+
+    loginAs(cerebralTest, petitionsClerkEmail);
+    petitionsClerkRemovesPractitionerFromCase(cerebralTest);
+
+    loginAs(privatePractitionerEmail);
+    practitionerViewsDashboard(cerebralTest);
   });
-
-  const privatePractitionerEmail = 'privatePractitioner@example.com';
-  const petitionsClerkEmail = 'petitionsclerk@example.com';
-
-  //Order of operations
-  //1. Practitioner files petition
-  //2. Admissions clerk associates the private practitioner with the petitioner via private practitioner's e-mail
-  //3. Any clerk removes privatePractitioner from the case
-  //4. Assert that the private practitioner remains the petitioner on the case
-
-  loginAs(privatePractitionerEmail);
-  practitionerCreatesNewCase(cerebralTest, fakeFile);
-
-  loginAs(cerebralTest, petitionsClerkEmail);
-  petitionsClerkServesElectronicCaseToIrs(cerebralTest);
-
-  loginAs(cerebralTest, 'admissionsclerk@example.com');
-  admissionsClerkEditsPetitionerEmail(cerebralTest, privatePractitionerEmail);
-
-  loginAs(cerebralTest, petitionsClerkEmail);
-  petitionsClerkRemovesPractitionerFromCase(cerebralTest);
-
-  loginAs(privatePractitionerEmail);
-  practitionerViewsDashboard(cerebralTest);
 });

--- a/web-client/integration-tests/privatePractitionerFilesAsPetitioner.test.js
+++ b/web-client/integration-tests/privatePractitionerFilesAsPetitioner.test.js
@@ -1,4 +1,5 @@
 import { admissionsClerkEditsPetitionerEmail } from './journey/admissionsClerkEditsPetitionerEmail';
+import { docketClerkRemovesPetitionerFromCase } from './journey/docketClerkRemovesPetitionerFromCase';
 import { fakeFile } from '../integration-tests-public/helpers';
 import { loginAs, setupTest } from './helpers';
 import { petitionsClerkAddsPractitionersToCase } from './journey/petitionsClerkAddsPractitionersToCase';
@@ -32,7 +33,7 @@ describe('Bug 9323', () => {
     petitionsClerkAddsPractitionersToCase(cerebralTest, true);
   });
 
-  describe('BUG-9323 privatePractitioner remains on case as petitioner after removal', () => {
+  describe('BUG-9323 privatePractitioner remains on case as petitioner after practitioner removal', () => {
     const privatePractitionerEmail = 'privatePractitioner@example.com';
     const petitionsClerkEmail = 'petitionsclerk@example.com';
 
@@ -52,5 +53,29 @@ describe('Bug 9323', () => {
     practitionerViewsDashboard(cerebralTest);
   });
 
-  // TODO - Write inverse test of the one directly above
+  describe('BUG-9323 privatePractitioner remains on case as practitioner after petitioner removal', () => {
+    const privatePractitionerEmail = 'privatePractitioner@example.com';
+    const petitionsClerkEmail = 'petitionsclerk@example.com';
+
+    loginAs(cerebralTest, privatePractitionerEmail);
+    practitionerCreatesNewCase(cerebralTest, fakeFile); //test needs petition to have two petitioners which happens here
+
+    //1. represents both petitioners and they are one of those petitioners, doesn't matter which gets deleted = stays associated, stays privatepractioner associated
+    //2a. represents only themself and not the other petitioner, other petitioner deleted = stays associated, stays privatepractioner associated
+    //2b. represents only themself and not the other petitioner, themself petitioner deleted = not associated, not privatepractioner associated
+    //3a. they represent only the other petitioner that isn't themself, other petitioner deleted = stays associated, not privatepractioner associated
+    //3b. they represent only the other petitioner that isn't themself, themself petitioner deleted = stays associated, stays privatepractioner associated
+
+    loginAs(cerebralTest, petitionsClerkEmail);
+    petitionsClerkServesElectronicCaseToIrs(cerebralTest);
+
+    loginAs(cerebralTest, 'admissionsclerk@example.com');
+    admissionsClerkEditsPetitionerEmail(cerebralTest, privatePractitionerEmail);
+
+    loginAs(cerebralTest, 'docketclerk@example.com');
+    docketClerkRemovesPetitionerFromCase(cerebralTest);
+
+    loginAs(cerebralTest, privatePractitionerEmail);
+    practitionerViewsDashboard(cerebralTest);
+  });
 });


### PR DESCRIPTION
Addresses [BUG 9323](https://github.com/flexion/ef-cms/issues/9323), where private practitioners were found that had a `user|case` record but no `case|privatePractitioner` record for the corresponding case. After speaking with court Admissions, it was determined that users with a `privatePractitioner` role SHOULD be eligible to _be_ petitioners on a case. Dawson currently does not support multiple roles for any user, so this fix simply checks the `case|privatePractitioner` association rather that the `user|case` association, allowing Admissions to stop using workarounds until a broader change is made. 

Currently, when a private practitioner that already has a `user|case` record is added to a case it fails silently, with a success message but no private practitioner on the case.

Hopefully, this fix will avoid creating any new broken data while allowing cases with missing records to be fixed, and more importantly, not add or remove any functionality that did not already exist: it is currently possible to add a private practitioner as a petitioner on a case (and create the resulting `user|case` record). It does NOT address the other role-based issues associated with a user having a `privatePractitioner` role while acting as a petitioner on a case.

[Flow chart](https://lucid.app/lucidchart/dcc65aa0-70fb-40a7-96fa-f4c98edab3fd/edit?invitationId=inv_55a5e6fe-0115-4f4f-ab93-19ba528bd5d3&page=0_0#) for logic around removing petitioners from a case.

Comments welcome