### PR TITLE
921 - DEVEX - refactored the use of createSilentApplicationContext to…

### DIFF
--- a/shared/src/business/test/createSilentApplicationContext.js
+++ b/shared/src/business/test/createSilentApplicationContext.js
@@ -1,0 +1,16 @@
+const createApplicationContext = require('../../../../web-api/src/applicationContext');
+
+module.exports = user => {
+  const applicationContext = createApplicationContext(user, {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  });
+
+  applicationContext.environment.dynamoDbTableName = 'mocked';
+  applicationContext.getPersistenceGateway().getMaintenanceMode = jest
+    .fn()
+    .mockReturnValue(false);
+
+  return applicationContext;
+};

--- a/web-api/src/v1/getCaseLambda.test.js
+++ b/web-api/src/v1/getCaseLambda.test.js
@@ -1,4 +1,4 @@
-const createApplicationContext = require('../applicationContext');
+const createSilentApplicationContext = require('../../../shared/src/business/test/createSilentApplicationContext');
 const {
   MOCK_CASE_WITH_TRIAL_SESSION,
 } = require('../../../shared/src/test/mockCase');
@@ -21,21 +21,6 @@ const REQUEST_EVENT = {
   queryStringParameters: {},
 };
 
-const createSilentAppContext = user => {
-  const applicationContext = createApplicationContext(user, {
-    debug: jest.fn(),
-    error: jest.fn(),
-    info: jest.fn(),
-  });
-
-  applicationContext.environment.dynamoDbTableName = 'mocked';
-  applicationContext.getPersistenceGateway().getMaintenanceMode = jest
-    .fn()
-    .mockReturnValue(false);
-
-  return applicationContext;
-};
-
 describe('getCaseLambda (which fails if version increase is needed, DO NOT CHANGE TESTS)', () => {
   let CI;
   // disable logging by mimicking CI for this test
@@ -50,7 +35,7 @@ describe('getCaseLambda (which fails if version increase is needed, DO NOT CHANG
 
   it('returns 404 when the user is not authorized and the case is not found', async () => {
     const user = { role: 'roleWithNoPermissions' };
-    const applicationContext = createSilentAppContext(user);
+    const applicationContext = createSilentApplicationContext(user);
 
     // Case is retrieved before determining authorization
     applicationContext.getDocumentClient = jest.fn().mockReturnValue({
@@ -77,7 +62,7 @@ describe('getCaseLambda (which fails if version increase is needed, DO NOT CHANG
 
   it('returns 200 when the user is not associated and the case is found', async () => {
     const user = { role: 'roleWithNoPermissions' };
-    const applicationContext = createSilentAppContext(user);
+    const applicationContext = createSilentApplicationContext(user);
 
     // Case is retrieved before determining authorization
     applicationContext.getDocumentClient = jest.fn().mockReturnValue({
@@ -110,7 +95,7 @@ describe('getCaseLambda (which fails if version increase is needed, DO NOT CHANG
 
   it('returns 404 when the docket number isn’t found', async () => {
     const user = MOCK_USERS['b7d90c05-f6cd-442c-a168-202db587f16f'];
-    const applicationContext = createSilentAppContext(user);
+    const applicationContext = createSilentApplicationContext(user);
 
     applicationContext.getDocumentClient = jest.fn().mockReturnValue({
       query: jest.fn().mockReturnValue({
@@ -136,7 +121,7 @@ describe('getCaseLambda (which fails if version increase is needed, DO NOT CHANG
 
   it('returns 500 on an unexpected error', async () => {
     const user = MOCK_USERS['b7d90c05-f6cd-442c-a168-202db587f16f'];
-    const applicationContext = createSilentAppContext(user);
+    const applicationContext = createSilentApplicationContext(user);
 
     applicationContext.getDocumentClient = jest.fn().mockReturnValue({
       query: jest.fn().mockReturnValue({
@@ -162,7 +147,7 @@ describe('getCaseLambda (which fails if version increase is needed, DO NOT CHANG
     // Careful! Changing this test would mean that the v1 format is changing;
     // this would mean breaking changes for any user of the v1 API
     const user = MOCK_USERS['b7d90c05-f6cd-442c-a168-202db587f16f'];
-    const applicationContext = createSilentAppContext(user);
+    const applicationContext = createSilentApplicationContext(user);
 
     applicationContext.getDocumentClient = jest.fn().mockReturnValue({
       query: jest.fn().mockReturnValue({

--- a/web-api/src/v1/getDocumentDownloadUrlLambda.test.js
+++ b/web-api/src/v1/getDocumentDownloadUrlLambda.test.js
@@ -1,4 +1,4 @@
-const createApplicationContext = require('../applicationContext');
+const createSilentApplicationContext = require('../../../shared/src/business/test/createSilentApplicationContext');
 const {
   getDocumentDownloadUrlLambda,
 } = require('./getDocumentDownloadUrlLambda');
@@ -10,21 +10,6 @@ const REQUEST_EVENT = {
   path: '',
   pathParameters: {},
   queryStringParameters: {},
-};
-
-const createSilentAppContext = user => {
-  const applicationContext = createApplicationContext(user, {
-    debug: jest.fn(),
-    error: jest.fn(),
-    info: jest.fn(),
-  });
-
-  applicationContext.environment.dynamoDbTableName = 'mocked';
-  applicationContext.getPersistenceGateway().getMaintenanceMode = jest
-    .fn()
-    .mockReturnValue(false);
-
-  return applicationContext;
 };
 
 describe('getDocumentDownloadUrlLambda', () => {
@@ -41,7 +26,7 @@ describe('getDocumentDownloadUrlLambda', () => {
 
   it('returns 403 when the user is not authorized', async () => {
     const user = { role: 'roleWithNoPermissions' };
-    const applicationContext = createSilentAppContext(user);
+    const applicationContext = createSilentApplicationContext(user);
 
     const response = await getDocumentDownloadUrlLambda(REQUEST_EVENT, {
       applicationContext,
@@ -54,7 +39,7 @@ describe('getDocumentDownloadUrlLambda', () => {
 
   it('returns 404 when the docket number isn’t found', async () => {
     const user = MOCK_USERS['b7d90c05-f6cd-442c-a168-202db587f16f'];
-    const applicationContext = createSilentAppContext(user);
+    const applicationContext = createSilentApplicationContext(user);
     const request = Object.assign({}, REQUEST_EVENT, {
       pathParameters: {
         docketNumber: '1234-19',
@@ -96,7 +81,7 @@ describe('getDocumentDownloadUrlLambda', () => {
 
   it('returns 404 when the entity GUID isn’t found', async () => {
     const user = MOCK_USERS['2eee98ac-613f-46bc-afd5-2574d1b15664'];
-    const applicationContext = createSilentAppContext(user);
+    const applicationContext = createSilentApplicationContext(user);
     const request = Object.assign({}, REQUEST_EVENT, {
       pathParameters: {
         docketNumber: '123-30',
@@ -153,7 +138,7 @@ describe('getDocumentDownloadUrlLambda', () => {
 
   it('returns 500 on an unexpected error', async () => {
     const user = MOCK_USERS['b7d90c05-f6cd-442c-a168-202db587f16f'];
-    const applicationContext = createSilentAppContext(user);
+    const applicationContext = createSilentApplicationContext(user);
     const request = Object.assign({}, REQUEST_EVENT, {
       pathParameters: {
         docketNumber: '123-30',
@@ -183,7 +168,7 @@ describe('getDocumentDownloadUrlLambda', () => {
 
   it('returns the document download URL in v1 format', async () => {
     const user = MOCK_USERS['b7d90c05-f6cd-442c-a168-202db587f16f'];
-    const applicationContext = createSilentAppContext(user);
+    const applicationContext = createSilentApplicationContext(user);
     const request = Object.assign({}, REQUEST_EVENT, {
       pathParameters: {
         docketNumber: '123-30',

--- a/web-api/src/v2/getCaseLambda.test.js
+++ b/web-api/src/v2/getCaseLambda.test.js
@@ -1,4 +1,4 @@
-const createApplicationContext = require('../applicationContext');
+const createSilentApplicationContext = require('../../../shared/src/business/test/createSilentApplicationContext');
 const {
   MOCK_CASE_WITH_TRIAL_SESSION,
 } = require('../../../shared/src/test/mockCase');
@@ -44,21 +44,6 @@ const REQUEST_EVENT = {
   queryStringParameters: {},
 };
 
-const createSilentAppContext = user => {
-  const applicationContext = createApplicationContext(user, {
-    debug: jest.fn(),
-    error: jest.fn(),
-    info: jest.fn(),
-  });
-
-  applicationContext.environment.dynamoDbTableName = 'mocked';
-  applicationContext.getPersistenceGateway().getMaintenanceMode = jest
-    .fn()
-    .mockReturnValue(false);
-
-  return applicationContext;
-};
-
 describe('getCaseLambda (which fails if version increase is needed, DO NOT CHANGE TESTS)', () => {
   let CI;
   // disable logging by mimicking CI for this test
@@ -73,7 +58,7 @@ describe('getCaseLambda (which fails if version increase is needed, DO NOT CHANG
 
   it('returns 404 when the user is not authorized and the case is not found', async () => {
     const user = { role: 'roleWithNoPermissions' };
-    const applicationContext = createSilentAppContext(user);
+    const applicationContext = createSilentApplicationContext(user);
 
     // Case is retrieved before determining authorization
     applicationContext.getDocumentClient = jest.fn().mockReturnValue({
@@ -100,7 +85,7 @@ describe('getCaseLambda (which fails if version increase is needed, DO NOT CHANG
 
   it('returns 200 when the user is not associated and the case is found', async () => {
     const user = { role: 'roleWithNoPermissions' };
-    const applicationContext = createSilentAppContext(user);
+    const applicationContext = createSilentApplicationContext(user);
 
     // Case is retrieved before determining authorization
     applicationContext.getDocumentClient = jest.fn().mockReturnValue({
@@ -133,7 +118,7 @@ describe('getCaseLambda (which fails if version increase is needed, DO NOT CHANG
 
   it('returns 404 when the docket number isn’t found', async () => {
     const user = MOCK_USERS['b7d90c05-f6cd-442c-a168-202db587f16f'];
-    const applicationContext = createSilentAppContext(user);
+    const applicationContext = createSilentApplicationContext(user);
 
     applicationContext.getDocumentClient = jest.fn().mockReturnValue({
       query: jest.fn().mockReturnValue({
@@ -159,7 +144,7 @@ describe('getCaseLambda (which fails if version increase is needed, DO NOT CHANG
 
   it('returns 500 on an unexpected error', async () => {
     const user = MOCK_USERS['b7d90c05-f6cd-442c-a168-202db587f16f'];
-    const applicationContext = createSilentAppContext(user);
+    const applicationContext = createSilentApplicationContext(user);
 
     applicationContext.getDocumentClient = jest.fn().mockReturnValue({
       query: jest.fn().mockReturnValue({
@@ -185,7 +170,7 @@ describe('getCaseLambda (which fails if version increase is needed, DO NOT CHANG
     // Careful! Changing this test would mean that the v2 format is changing;
     // this would mean breaking changes for any user of the v1 API
     const user = MOCK_USERS['b7d90c05-f6cd-442c-a168-202db587f16f'];
-    const applicationContext = createSilentAppContext(user);
+    const applicationContext = createSilentApplicationContext(user);
 
     applicationContext.getDocumentClient = jest.fn().mockReturnValue({
       query: jest.fn().mockReturnValue({

--- a/web-api/src/v2/getDocumentDownloadUrlLambda.test.js
+++ b/web-api/src/v2/getDocumentDownloadUrlLambda.test.js
@@ -1,4 +1,4 @@
-const createApplicationContext = require('../applicationContext');
+const createSilentApplicationContext = require('../../../shared/src/business/test/createSilentApplicationContext');
 const {
   getDocumentDownloadUrlLambda,
 } = require('./getDocumentDownloadUrlLambda');
@@ -10,21 +10,6 @@ const REQUEST_EVENT = {
   path: '',
   pathParameters: {},
   queryStringParameters: {},
-};
-
-const createSilentAppContext = user => {
-  const applicationContext = createApplicationContext(user, {
-    debug: jest.fn(),
-    error: jest.fn(),
-    info: jest.fn(),
-  });
-
-  applicationContext.environment.dynamoDbTableName = 'mocked';
-  applicationContext.getPersistenceGateway().getMaintenanceMode = jest
-    .fn()
-    .mockReturnValue(false);
-
-  return applicationContext;
 };
 
 describe('getDocumentDownloadUrlLambda', () => {
@@ -41,7 +26,7 @@ describe('getDocumentDownloadUrlLambda', () => {
 
   it('returns 403 when the user is not authorized', async () => {
     const user = { role: 'roleWithNoPermissions' };
-    const applicationContext = createSilentAppContext(user);
+    const applicationContext = createSilentApplicationContext(user);
 
     const response = await getDocumentDownloadUrlLambda(REQUEST_EVENT, {
       applicationContext,
@@ -54,7 +39,7 @@ describe('getDocumentDownloadUrlLambda', () => {
 
   it('returns 404 when the docket number isn’t found', async () => {
     const user = MOCK_USERS['b7d90c05-f6cd-442c-a168-202db587f16f'];
-    const applicationContext = createSilentAppContext(user);
+    const applicationContext = createSilentApplicationContext(user);
     const request = Object.assign({}, REQUEST_EVENT, {
       pathParameters: {
         docketNumber: '1234-19',
@@ -96,7 +81,7 @@ describe('getDocumentDownloadUrlLambda', () => {
 
   it('returns 404 when the entity GUID isn’t found', async () => {
     const user = MOCK_USERS['2eee98ac-613f-46bc-afd5-2574d1b15664'];
-    const applicationContext = createSilentAppContext(user);
+    const applicationContext = createSilentApplicationContext(user);
     const request = Object.assign({}, REQUEST_EVENT, {
       pathParameters: {
         docketNumber: '123-30',
@@ -153,7 +138,7 @@ describe('getDocumentDownloadUrlLambda', () => {
 
   it('returns 500 on an unexpected error', async () => {
     const user = MOCK_USERS['b7d90c05-f6cd-442c-a168-202db587f16f'];
-    const applicationContext = createSilentAppContext(user);
+    const applicationContext = createSilentApplicationContext(user);
     const request = Object.assign({}, REQUEST_EVENT, {
       pathParameters: {
         docketNumber: '123-30',
@@ -183,7 +168,7 @@ describe('getDocumentDownloadUrlLambda', () => {
 
   it('returns the document download URL in v2 format', async () => {
     const user = MOCK_USERS['b7d90c05-f6cd-442c-a168-202db587f16f'];
-    const applicationContext = createSilentAppContext(user);
+    const applicationContext = createSilentApplicationContext(user);
     const request = Object.assign({}, REQUEST_EVENT, {
       pathParameters: {
         docketNumber: '123-30',


### PR DESCRIPTION
#### DEVEX task to refactor the use of createSilentApplicationContext.

This function was used in: 
- getCaseLambda.test.js (v1 + v2)
- getDocumentDownloadUrlLambda.test.js (v1 + v2)

I extracted the function into its own file and updated the imports and invocations of the function in the above mentioned test files.

[Link](https://trello.com/c/nSwiH5YC/921-add-silentapplicationcontext-to-helper-see-web-api-src-v2-getdocumentdownloadurllambdatestjs) to respective trello card.