### PR TITLE
9421 - Using Promise.all to fix issue with fetching eligible cases

### DIFF
--- a/shared/src/persistence/dynamo/trialSessions/getEligibleCasesForTrialSession.js
+++ b/shared/src/persistence/dynamo/trialSessions/getEligibleCasesForTrialSession.js
@@ -31,21 +31,21 @@ exports.getEligibleCasesForTrialSession = async ({
     })),
   });
 
-  const aggregatedResults = [];
+  const aggregatedResults = await Promise.all(
+    results.map(async result => {
+      const caseItems = await applicationContext
+        .getPersistenceGateway()
+        .getCaseByDocketNumber({
+          applicationContext,
+          docketNumber: result.docketNumber,
+        });
 
-  for (let result of results) {
-    const caseItems = await applicationContext
-      .getPersistenceGateway()
-      .getCaseByDocketNumber({
-        applicationContext,
-        docketNumber: result.docketNumber,
-      });
-
-    aggregatedResults.push({
-      ...result,
-      ...caseItems,
-    });
-  }
+      return {
+        ...result,
+        ...caseItems,
+      };
+    }),
+  );
 
   const afterMapping = docketNumbers.map(docketNumber => ({
     ...aggregatedResults.find(r => docketNumber === r.docketNumber),


### PR DESCRIPTION
the old approach was looping one by one over each cases which was slow; changing to promise.all