### PR TITLE
9323: Adding logging to ensure bug-9323 scenario is logged

### DIFF
--- a/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.js
+++ b/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.js
@@ -29,14 +29,18 @@ exports.associatePrivatePractitionerToCase = async ({
       userId: user.userId,
     });
 
-  if (!isAssociated) {
-    const caseToUpdate = await applicationContext
-      .getPersistenceGateway()
-      .getCaseByDocketNumber({
-        applicationContext,
-        docketNumber,
-      });
+  const caseToUpdate = await applicationContext
+    .getPersistenceGateway()
+    .getCaseByDocketNumber({
+      applicationContext,
+      docketNumber,
+    });
 
+  const isPrivatePractitionerOnCase = caseToUpdate.privatePractitioners?.some(
+    practitioner => practitioner.userId === user.userId,
+  );
+
+  if (!isAssociated) {
     const userCaseEntity = new UserCase(caseToUpdate);
 
     await applicationContext.getPersistenceGateway().associateUserWithCase({
@@ -70,5 +74,9 @@ exports.associatePrivatePractitionerToCase = async ({
     });
 
     return caseEntity.toRawObject();
+  } else if (!isPrivatePractitionerOnCase) {
+    applicationContext.logger.warn(
+      `BUG 9323: Private Practitioner with userId: ${user.userId} was already associated with case ${docketNumber} but did not appear in the privatePractitioners array.`,
+    );
   }
 };

--- a/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.test.js
+++ b/shared/src/business/useCaseHelper/caseAssociation/associatePrivatePractitionerToCase.test.js
@@ -201,4 +201,59 @@ describe('associatePrivatePractitionerToCase', () => {
       serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
     });
   });
+
+  it('BUG 9323: should create log if practitioner is already associated with case but does not appear in the privatePractitioners array', async () => {
+    applicationContext
+      .getPersistenceGateway()
+      .verifyCaseForUser.mockResolvedValueOnce(true);
+
+    applicationContext
+      .getPersistenceGateway()
+      .getCaseByDocketNumber.mockResolvedValueOnce({
+        ...caseRecord,
+        privatePractitioners: [],
+      });
+
+    await associatePrivatePractitionerToCase({
+      applicationContext,
+      docketNumber: caseRecord.docketNumber,
+      representing: [],
+      user: practitionerUser,
+    });
+
+    expect(
+      applicationContext.getPersistenceGateway().associateUserWithCase,
+    ).not.toHaveBeenCalled();
+
+    expect(applicationContext.logger.warn).toHaveBeenCalled();
+    expect(applicationContext.logger.warn.mock.calls[0][0]).toEqual(
+      `BUG 9323: Private Practitioner with userId: ${practitionerUser.userId} was already associated with case ${caseRecord.docketNumber} but did not appear in the privatePractitioners array.`,
+    );
+  });
+
+  it('BUG 9323: should create NO log if practitioner is already associated with case and DOES appear in the privatePractitioners array', async () => {
+    applicationContext
+      .getPersistenceGateway()
+      .verifyCaseForUser.mockResolvedValueOnce(true);
+
+    applicationContext
+      .getPersistenceGateway()
+      .getCaseByDocketNumber.mockResolvedValueOnce({
+        ...caseRecord,
+        privatePractitioners: [{ userId: practitionerUser.userId }],
+      });
+
+    await associatePrivatePractitionerToCase({
+      applicationContext,
+      docketNumber: caseRecord.docketNumber,
+      representing: [caseRecord.petitioners[0].contactId],
+      user: practitionerUser,
+    });
+
+    expect(
+      applicationContext.getPersistenceGateway().associateUserWithCase,
+    ).not.toHaveBeenCalled();
+
+    expect(applicationContext.logger.warn).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Adds logging to record events similar to those in bug [9323](https://app.zenhub.com/workspaces/flexionef-cms-5bbe4bed4b5806bc2bec65d3/issues/flexion/ef-cms/9323). 

When private practitioners who already have a user-case association/record (possibly due to being a petitioner on the case) but are not yet _practitioners_ on the case are added to said case, we will now have a log to aid in remedying any resulting broken data.