### PR TITLE
increasing ES wait time so the order shows up in results

### DIFF
--- a/cypress-smoketests/integration/search.spec.js
+++ b/cypress-smoketests/integration/search.spec.js
@@ -121,6 +121,7 @@ describe('Opinion Search', () => {
     goToCaseDetail(testData.createdPaperDocketNumber);
     createOpinion();
     addDocketEntryAndServeOpinion(testData);
+    cy.waitForElasticsearch();
   });
 
   it('should be able to search for an opinion by keyword', () => {

--- a/cypress-smoketests/support/commands.js
+++ b/cypress-smoketests/support/commands.js
@@ -9,7 +9,7 @@ Cypress.Commands.add('goToRoute', (...args) => {
 });
 
 Cypress.Commands.add('waitForElasticsearch', () => {
-  const ES_WAIT_TIME = 2000;
+  const ES_WAIT_TIME = 5000;
   /* eslint-disable cypress/no-unnecessary-waiting */
   return cy.wait(ES_WAIT_TIME);
 });


### PR DESCRIPTION
the order test keeps timing out because no results come back with the order (even though is was created successfully).  Increasing the timeout seems to allow it to come back in the results set.