### PR TITLE
9093 Addressing PO Review for PDF Styles & Disabling Cypress Videos

### DIFF
--- a/cypress-public.json
+++ b/cypress-public.json
@@ -5,6 +5,7 @@
   "reporterOptions": {
     "toConsole": true
   },
+  "video": false,
   "fixturesFolder": "cypress-integration/fixtures",
   "integrationFolder": "cypress-integration/integration",
   "pluginsFile": "cypress-integration/plugins/index.js",

--- a/cypress-smoketests-public.json
+++ b/cypress-smoketests-public.json
@@ -4,6 +4,7 @@
   "reporterOptions": {
     "toConsole": true
   },
+  "video": false,
   "fixturesFolder": "cypress-smoketests/fixtures",
   "integrationFolder": "cypress-smoketests/integration",
   "pluginsFile": "cypress-smoketests/plugins/index.js",

--- a/cypress-smoketests-readonly-public.json
+++ b/cypress-smoketests-readonly-public.json
@@ -4,6 +4,7 @@
   "reporterOptions": {
     "toConsole": true
   },
+  "video": false,
   "fixturesFolder": "cypress-readonly/fixtures",
   "integrationFolder": "cypress-readonly/integration",
   "pluginsFile": "cypress-readonly/plugins/index.js",

--- a/cypress-smoketests-readonly.json
+++ b/cypress-smoketests-readonly.json
@@ -4,6 +4,7 @@
   "reporterOptions": {
     "toConsole": true
   },
+  "video": false,
   "fixturesFolder": "cypress-readonly/fixtures",
   "integrationFolder": "cypress-readonly/integration",
   "pluginsFile": "cypress-readonly/plugins/index.js",

--- a/cypress-smoketests.json
+++ b/cypress-smoketests.json
@@ -4,6 +4,7 @@
   "reporterOptions": {
     "toConsole": true
   },
+  "video": false,
   "fixturesFolder": "cypress-smoketests/fixtures",
   "integrationFolder": "cypress-smoketests/integration",
   "pluginsFile": "cypress-smoketests/plugins/index.js",

--- a/cypress.json
+++ b/cypress.json
@@ -5,6 +5,7 @@
   "reporterOptions": {
     "toConsole": true
   },
+  "video": false,
   "fixturesFolder": "cypress-integration/fixtures",
   "integrationFolder": "cypress-integration/integration",
   "pluginsFile": "cypress-integration/plugins/index.js",

--- a/shared/src/business/utilities/documentGenerators/noticeOfChangeToRemoteProceeding.test.js
+++ b/shared/src/business/utilities/documentGenerators/noticeOfChangeToRemoteProceeding.test.js
@@ -67,7 +67,7 @@ describe('documentGenerators', () => {
         expect(applicationContext.getChromiumBrowser).toHaveBeenCalled();
         const { PDFDocument } = await applicationContext.getPdfLib();
         const pdfDoc = await PDFDocument.load(new Uint8Array(pdf));
-        expect(pdfDoc.getPages().length).toEqual(1);
+        expect(pdfDoc.getPages().length).toEqual(2);
       }
 
       expect(

--- a/shared/src/business/utilities/documentGenerators/noticeOfTrialIssued.test.js
+++ b/shared/src/business/utilities/documentGenerators/noticeOfTrialIssued.test.js
@@ -65,7 +65,7 @@ describe('documentGenerators', () => {
         expect(applicationContext.getChromiumBrowser).toHaveBeenCalled();
         const { PDFDocument } = await applicationContext.getPdfLib();
         const pdfDoc = await PDFDocument.load(new Uint8Array(pdf));
-        expect(pdfDoc.getPages().length).toEqual(2);
+        expect(pdfDoc.getPages().length).toEqual(1);
       }
 
       expect(

--- a/shared/src/business/utilities/documentGenerators/trialCalendar.test.js
+++ b/shared/src/business/utilities/documentGenerators/trialCalendar.test.js
@@ -47,12 +47,14 @@ describe('documentGenerators', () => {
             {
               caseTitle: 'Paul Simon',
               docketNumber: '123-45S',
+              docketNumberWithSuffix: '123-45S',
               petitionerCounsel: ['Ben Matlock', 'Atticus Finch'],
               respondentCounsel: ['Sonny Crockett', 'Ricardo Tubbs'],
             },
             {
               caseTitle: 'Art Garfunkel',
               docketNumber: '234-56',
+              docketNumberWithSuffix: '234-56',
               petitionerCounsel: ['Mick Haller'],
               respondentCounsel: ['Joy Falotico'],
             },

--- a/shared/src/business/utilities/htmlGenerator/shared.scss
+++ b/shared/src/business/utilities/htmlGenerator/shared.scss
@@ -1,5 +1,6 @@
 body {
   margin: 35px 50px;
+  font-family: 'nimbus_roman', sans-serif;
 }
 
 @page {

--- a/shared/src/business/utilities/pdfGenerator/components/OrderDocketHeader.jsx
+++ b/shared/src/business/utilities/pdfGenerator/components/OrderDocketHeader.jsx
@@ -9,10 +9,14 @@ export const OrderDocketHeader = ({
   return (
     <div className="order-docket-header">
       <div id="caption">
-        <div id="caption-title">{caseTitle}</div>
+        <div id="caption-title">{caseTitle},</div>
         <div id="caption-extension">{caseCaptionExtension}</div>
         <div id="caption-v">v.</div>
-        <div id="caption-commissioner">COMMISSIONER OF INTERNAL REVENUE</div>
+        <div id="caption-commissioner">
+          COMMISSIONER OF INTERNAL
+          <br />
+          REVENUE,
+        </div>
         <div id="caption-respondent">Respondent</div>
       </div>
       <div id="docket-number">Docket No. {docketNumberWithSuffix}</div>


### PR DESCRIPTION
- Addressing PO Review for PDF Styles
- Disabling Cypress Videos to help improve the smoketests reliability (there is an open github issue saying the cypress videos can cause the TIMEOUT -7 errors)