### PR TITLE
Update documentation to include USTC ECR mentions

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -109,7 +109,7 @@ jobs:
 
 ## Docker
 
-We use Docker on our project to build some of the images we need in the CI/CD pipeline.  A majority of the Circle jobs must be run in a docker container, which means we needed to specify which image Circle should use.  We build the [Dockerfile](https://github.com/ustaxcourt/ef-cms/blob/staging/Dockerfile) and publish it to our AWS ecr repository whenever we need to update some of the dependencies.  The script [docker-to-erc.sh](https://github.com/ustaxcourt/ef-cms/blob/staging/docker-to-ecr.sh) can be use to build and publish the latest version of our CI image.
+We use Docker on our project to build some of the images we need in the CI/CD pipeline.  A majority of the Circle jobs must be run in a docker container, which means we needed to specify which image Circle should use.  We build the [Dockerfile](https://github.com/ustaxcourt/ef-cms/blob/staging/Dockerfile) and publish it to our AWS ecr repository whenever we need to update some of the dependencies.  The script [docker-to-erc.sh](https://github.com/ustaxcourt/ef-cms/blob/staging/docker-to-ecr.sh) can be use to build and publish the latest version of our CI image. This script will need to be run for both the Flexion and USTC accounts separately.
 
 We also use a separate image called [Dockerfile](https://github.com/ustaxcourt/ef-cms/blob/staging/Dockerfile) for Circle deploy jobs since we don't care about Cypress when doing deploys.  This image is built and run using the machine executor in Circle, so you don't have to worry about manually building and deploying this image.
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -49,6 +49,7 @@ This document covers the initial setup needed to get EF-CMS continuous integrati
 - Configure the Dynamsoft TWAIN library, which is used to enable scanning from EF-CMS:
   - Upload the library `.tar.gz` to a folder called Dynamsoft in the S3 bucket named `${EFCMS_DOMAIN}-software`. Note its ARN for CircleCI setup later.
   - Deploy Docker images to Amazon ECR with `./docker-to-ecr.sh`. This will build an image per the `Dockerfile` config, tag it as `latest`, and push it to the repo in ECR.
+    - Both Flexion and USTC AWS accounts have container registries, so the image needs to be published to both registries.
 
 ### 4. Configure CircleCI to test and release code to this environment.
 

--- a/docs/team-process.md
+++ b/docs/team-process.md
@@ -72,7 +72,7 @@ If dependencies have no patch, replace it with an alternative, or wait for the l
 
 3. `terraform`: check for a newer version on the [Terraform site](https://www.terraform.io/downloads).
 
-    - Once verification is complete, you will need to increment the docker image version being used in `.circleci/config.yml` and publish a docker image tagged with the incremented version number to ECR.
+    - Once verification is complete, you will need to increment the docker image version being used in `.circleci/config.yml` and publish a docker image tagged with the incremented version number to ECR for both Flexion and USTC accounts.
 
 4. `docker`: Update [docker base image](https://hub.docker.com/r/cypress/base/tags?page=1&name=14.) if an update is available for the current node version the project is using.
 


### PR DESCRIPTION
Explicitly mention both Flexion and USTC AWS accounts in reference to publishing Docker image.