### PR TITLE
OpEx 1054: Delete API Gateway Mappings Only in Production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -756,7 +756,11 @@ jobs:
       - run:
           name: Delete Source API Gateway Mappings
           command: |
-            npm run delete:api-gateway-mappings -- $EFCMS_DOMAIN $DEPLOYING_COLOR
+            if [ "${CIRCLE_BRANCH}" == "prod" ]; then
+              npm run delete:api-gateway-mappings -- "${EFCMS_DOMAIN}" "${DEPLOYING_COLOR}"
+            else
+              echo "Skipping..."
+            fi
       - run:
           name: Destroy Migration Infrastructure
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -733,7 +733,7 @@ jobs:
               npm run backup:dynamo-table -- $TABLE_NAME
             fi
 
-  cleanup:
+  delete-api-mappings:
     docker:
       - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:1.1.0
         aws_auth:
@@ -749,18 +749,30 @@ jobs:
             cat "./env-for-circle/${CIRCLE_BRANCH}${CONFIG_SUFFIX}.sh" >> $BASH_ENV
             source $BASH_ENV
             echo "export DEPLOYING_COLOR=$(./scripts/dynamo/get-deploying-color.sh $ENV)" >> $BASH_ENV
+      - run:
+          name: Delete Source API Gateway Mappings
+          command: |
+            npm run delete:api-gateway-mappings -- "${EFCMS_DOMAIN}" "${DEPLOYING_COLOR}"
+
+  cleanup:
+    docker:
+      - image: $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:1.1.0
+        aws_auth:
+          aws_access_key_id: $AWS_ACCESS_KEY_ID
+          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
+    resource_class: small
+    steps:
+      - git-shallow-clone/checkout
+      - npm-install
+      - run:
+          name: Setup Env
+          command: |
+            cat "./env-for-circle/${CIRCLE_BRANCH}${CONFIG_SUFFIX}.sh" >> $BASH_ENV
+            source $BASH_ENV
             echo "export DESTINATION_TABLE=$(./scripts/dynamo/get-destination-table.sh $ENV)" >> $BASH_ENV
             echo "export MIGRATE_FLAG=$(./scripts/dynamo/get-migrate-flag.sh $ENV)" >> $BASH_ENV
             echo "export SOURCE_TABLE=$(./scripts/dynamo/get-source-table.sh $ENV)" >> $BASH_ENV
             echo "export SOURCE_ELASTICSEARCH=$(./scripts/elasticsearch/get-source-elasticsearch.sh $ENV)" >> $BASH_ENV
-      - run:
-          name: Delete Source API Gateway Mappings
-          command: |
-            if [ "${CIRCLE_BRANCH}" == "prod" ]; then
-              npm run delete:api-gateway-mappings -- "${EFCMS_DOMAIN}" "${DEPLOYING_COLOR}"
-            else
-              echo "Skipping..."
-            fi
       - run:
           name: Destroy Migration Infrastructure
           command: |
@@ -991,7 +1003,12 @@ workflows:
           <<: *build-and-deploy-with-context-defaults
           requires:
             - switch-colors
+      - delete-api-mappings:
+          <<: *build-and-deploy-with-context-defaults
+          requires:
+            - switch-colors
       - cleanup:
           <<: *build-and-deploy-with-context-defaults
           requires:
             - backup-source-dynamo-table
+            - delete-api-mappings


### PR DESCRIPTION
[OpEx Card](https://trello.com/c/aLe5aGOh).

We are only deleting the API Gateway mappings for production.

Created a new job that only deletes the API Gateway mappings.  This new job is only called in the production-only workflow `build-and-deploy-with-context`.  The workflow after `switch-colors` runs both `backup-source-dynamo-table` and `delete-api-mappings` in parallel before coming back together to run `cleanup`.  This will allow for the DynamoDB back-up and the API Gateway mapping deletion to happen concurrently.