### PR TITLE
9326 NOCRP

### DIFF
--- a/shared/src/business/useCases/practitioners/updatePractitionerUserInteractor.js
+++ b/shared/src/business/useCases/practitioners/updatePractitionerUserInteractor.js
@@ -174,8 +174,4 @@ exports.updatePractitionerUserInteractor = async (
     },
     userId: requestUser.userId,
   });
-
-  return new Practitioner(updatedUser, { applicationContext })
-    .validate()
-    .toRawObject();
 };

--- a/shared/src/business/useCases/practitioners/updatePractitionerUserInteractor.js
+++ b/shared/src/business/useCases/practitioners/updatePractitionerUserInteractor.js
@@ -55,7 +55,6 @@ const getUpdatedFieldNames = ({ applicationContext, oldUser, updatedUser }) => {
  * @param {object} providers the providers object
  * @param {object} providers.barNumber the barNumber of the user to update
  * @param {object} providers.user the user data
- * @returns {Promise} the promise of the createUser call
  */
 exports.updatePractitionerUserInteractor = async (
   applicationContext,

--- a/shared/src/business/useCases/practitioners/updatePractitionerUserInteractor.test.js
+++ b/shared/src/business/useCases/practitioners/updatePractitionerUserInteractor.test.js
@@ -78,37 +78,35 @@ describe('updatePractitionerUserInteractor', () => {
       serviceIndicator: SERVICE_INDICATOR_TYPES.SI_PAPER,
     };
 
-    const updatedUser = await updatePractitionerUserInteractor(
-      applicationContext,
-      {
-        barNumber: 'AB1111',
-        user: {
-          ...mockPractitioner,
-          barNumber: 'AB2222',
-          confirmEmail: 'bc@example.com',
-          updatedEmail: 'bc@example.com',
-        },
+    await updatePractitionerUserInteractor(applicationContext, {
+      barNumber: 'AB1111',
+      user: {
+        ...mockPractitioner,
+        barNumber: 'AB2222',
+        confirmEmail: 'bc@example.com',
+        updatedEmail: 'bc@example.com',
       },
-    );
+    });
 
-    expect(updatedUser.serviceIndicator).toBe(SERVICE_INDICATOR_TYPES.SI_PAPER);
+    expect(
+      applicationContext.getPersistenceGateway().createNewPractitionerUser.mock
+        .calls[0][0].user,
+    ).toMatchObject({
+      serviceIndicator: SERVICE_INDICATOR_TYPES.SI_PAPER,
+    });
   });
 
   it('updates the practitioner user and does NOT override a bar number or email when the original user had an email', async () => {
-    const updatedUser = await updatePractitionerUserInteractor(
-      applicationContext,
-      {
-        barNumber: 'AB1111',
-        user: {
-          ...mockPractitioner,
-          barNumber: 'AB2222',
-          confirmEmail: 'bc@example.com',
-          updatedEmail: 'bc@example.com',
-        },
+    await updatePractitionerUserInteractor(applicationContext, {
+      barNumber: 'AB1111',
+      user: {
+        ...mockPractitioner,
+        barNumber: 'AB2222',
+        confirmEmail: 'bc@example.com',
+        updatedEmail: 'bc@example.com',
       },
-    );
+    });
 
-    expect(updatedUser).toBeDefined();
     expect(
       applicationContext.getPersistenceGateway().updatePractitionerUser,
     ).toBeCalled();
@@ -126,19 +124,15 @@ describe('updatePractitionerUserInteractor', () => {
         email: undefined,
       });
 
-    const updatedUser = await updatePractitionerUserInteractor(
-      applicationContext,
-      {
-        barNumber: 'AB1111',
-        user: {
-          ...mockPractitioner,
-          confirmEmail: 'admissionsclerk@example.com',
-          updatedEmail: 'admissionsclerk@example.com',
-        },
+    await updatePractitionerUserInteractor(applicationContext, {
+      barNumber: 'AB1111',
+      user: {
+        ...mockPractitioner,
+        confirmEmail: 'admissionsclerk@example.com',
+        updatedEmail: 'admissionsclerk@example.com',
       },
-    );
+    });
 
-    expect(updatedUser).toBeDefined();
     expect(
       applicationContext.getPersistenceGateway().createNewPractitionerUser,
     ).toBeCalled();

--- a/shared/src/business/useCases/trialSessions/batchDownloadTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/batchDownloadTrialSessionInteractor.js
@@ -269,7 +269,6 @@ exports.generateValidDocketEntryFilename = ({
  * @param {object} applicationContext the application context
  * @param {object} providers the providers object
  * @param {string} providers.trialSessionId the id of the trial session
- * @returns {Promise} the promise of the batchDownloadTrialSessionInteractor call
  */
 exports.batchDownloadTrialSessionInteractor = async (
   applicationContext,

--- a/shared/src/business/useCases/trialSessions/setNoticesForCalendaredTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/setNoticesForCalendaredTrialSessionInteractor.js
@@ -261,7 +261,6 @@ const setNoticeForCase = async ({
  * @param {object} providers the providers object
  * @param {string} providers.trialSessionId the trial session id
  * @param {string} providers.docketNumber optional docketNumber to explicitly set the notice on the ONE specified case
- * @returns {Promise} the promises for the updateCase calls
  */
 exports.setNoticesForCalendaredTrialSessionInteractor = async (
   applicationContext,

--- a/shared/src/business/useCases/trialSessions/updateTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/updateTrialSessionInteractor.js
@@ -197,9 +197,9 @@ exports.updateTrialSessionInteractor = async (
     applicationContext,
     message: {
       action: 'update_trial_session_complete',
-      docketEntryId: serviceInfo?.docketEntryId,
       hasPaper: serviceInfo?.hasPaper,
       pdfUrl,
+      trialSessionId: trialSession.trialSessionId,
     },
     userId: user.userId,
   });

--- a/shared/src/business/useCases/trialSessions/updateTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/updateTrialSessionInteractor.js
@@ -203,9 +203,4 @@ exports.updateTrialSessionInteractor = async (
     },
     userId: user.userId,
   });
-
-  return {
-    newTrialSession: newTrialSessionEntity.toRawObject(),
-    serviceInfo: pdfUrl,
-  };
 };

--- a/shared/src/business/useCases/trialSessions/updateTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/updateTrialSessionInteractor.js
@@ -130,7 +130,6 @@ exports.updateTrialSessionInteractor = async (
     const calendaredCases = currentTrialSession.caseOrder;
     const { PDFDocument } = await applicationContext.getPdfLib();
     const paperServicePdfsCombined = await PDFDocument.create();
-    let processedCases = 0;
 
     for (let calendaredCase of calendaredCases) {
       const caseToUpdate = await applicationContext
@@ -155,19 +154,6 @@ exports.updateTrialSessionInteractor = async (
             user,
           });
 
-        processedCases++;
-
-        await applicationContext
-          .getNotificationGateway()
-          .sendNotificationToUser({
-            applicationContext,
-            message: {
-              action: 'notice_generation_update_progress',
-              processedCases,
-              totalCases: calendaredCases.length,
-            },
-            userId: user.userId,
-          });
         caseEntity.updateTrialSessionInformation(newTrialSessionEntity);
 
         await applicationContext.getUseCaseHelpers().updateCaseAndAssociations({
@@ -210,7 +196,7 @@ exports.updateTrialSessionInteractor = async (
   await applicationContext.getNotificationGateway().sendNotificationToUser({
     applicationContext,
     message: {
-      action: 'notice_generation_complete',
+      action: 'update_trial_session_complete',
       docketEntryId: serviceInfo?.docketEntryId,
       hasPaper: serviceInfo?.hasPaper,
       pdfUrl,

--- a/shared/src/business/useCases/trialSessions/updateTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/updateTrialSessionInteractor.js
@@ -16,7 +16,6 @@ const { UnauthorizedError } = require('../../../errors/errors');
  * @param {object} applicationContext the application context
  * @param {object} providers the providers object
  * @param {object} providers.trialSession the trial session data
- * @returns {object} the created trial session
  */
 exports.updateTrialSessionInteractor = async (
   applicationContext,

--- a/shared/src/business/useCases/trialSessions/updateTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/updateTrialSessionInteractor.js
@@ -198,6 +198,15 @@ exports.updateTrialSessionInteractor = async (
     pdfUrl = serviceInfo.url;
   }
 
+  if (trialSession.swingSession && trialSession.swingSessionId) {
+    newTrialSessionEntity.setAsSwingSession(trialSession.swingSessionId);
+  }
+
+  await applicationContext.getPersistenceGateway().updateTrialSession({
+    applicationContext,
+    trialSessionToUpdate: newTrialSessionEntity.validate().toRawObject(),
+  });
+
   await applicationContext.getNotificationGateway().sendNotificationToUser({
     applicationContext,
     message: {
@@ -207,15 +216,6 @@ exports.updateTrialSessionInteractor = async (
       pdfUrl,
     },
     userId: user.userId,
-  });
-
-  if (trialSession.swingSession && trialSession.swingSessionId) {
-    newTrialSessionEntity.setAsSwingSession(trialSession.swingSessionId);
-  }
-
-  await applicationContext.getPersistenceGateway().updateTrialSession({
-    applicationContext,
-    trialSessionToUpdate: newTrialSessionEntity.validate().toRawObject(),
   });
 
   return {

--- a/shared/src/business/useCases/trialSessions/updateTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/updateTrialSessionInteractor.js
@@ -208,6 +208,10 @@ exports.updateTrialSessionInteractor = async (
     });
   }
 
+  if (trialSession.swingSession && trialSession.swingSessionId) {
+    newTrialSessionEntity.setAsSwingSession(trialSession.swingSessionId);
+  }
+
   await applicationContext.getPersistenceGateway().updateTrialSession({
     applicationContext,
     trialSessionToUpdate: newTrialSessionEntity.validate().toRawObject(),

--- a/shared/src/business/useCases/trialSessions/updateTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/updateTrialSessionInteractor.js
@@ -125,6 +125,7 @@ exports.updateTrialSessionInteractor = async (
   }
 
   let pdfUrl = null;
+  let serviceInfo = null;
   if (currentTrialSession.caseOrder && currentTrialSession.caseOrder.length) {
     const calendaredCases = currentTrialSession.caseOrder;
     const { PDFDocument } = await applicationContext.getPdfLib();
@@ -188,25 +189,25 @@ exports.updateTrialSessionInteractor = async (
       }
     }
 
-    const serviceInfo = await applicationContext
+    serviceInfo = await applicationContext
       .getUseCaseHelpers()
       .savePaperServicePdf({
         applicationContext,
         document: paperServicePdfsCombined,
       });
     pdfUrl = serviceInfo.url;
-
-    await applicationContext.getNotificationGateway().sendNotificationToUser({
-      applicationContext,
-      message: {
-        action: 'notice_generation_complete',
-        docketEntryId: serviceInfo.docketEntryId,
-        hasPaper: serviceInfo.hasPaper,
-        pdfUrl,
-      },
-      userId: user.userId,
-    });
   }
+
+  await applicationContext.getNotificationGateway().sendNotificationToUser({
+    applicationContext,
+    message: {
+      action: 'notice_generation_complete',
+      docketEntryId: serviceInfo?.docketEntryId,
+      hasPaper: serviceInfo?.hasPaper,
+      pdfUrl,
+    },
+    userId: user.userId,
+  });
 
   if (trialSession.swingSession && trialSession.swingSessionId) {
     newTrialSessionEntity.setAsSwingSession(trialSession.swingSessionId);

--- a/shared/src/business/useCases/trialSessions/updateTrialSessionInteractor.test.js
+++ b/shared/src/business/useCases/trialSessions/updateTrialSessionInteractor.test.js
@@ -482,5 +482,18 @@ describe('updateTrialSessionInteractor', () => {
     expect(
       applicationContext.getNotificationGateway().sendNotificationToUser,
     ).toHaveBeenCalled();
+
+    expect(
+      applicationContext.getNotificationGateway().sendNotificationToUser.mock
+        .calls[0][0],
+    ).toMatchObject({
+      message: {
+        action: 'update_trial_session_complete',
+        hasPaper: serviceInfo?.hasPaper,
+        pdfUrl: 'www.example.com',
+        trialSessionId: '959c4338-0fac-42eb-b0eb-d53b8d0195cc',
+      },
+      userId: user.userId,
+    });
   });
 });

--- a/shared/src/business/useCases/users/updateUserContactInformationInteractor.js
+++ b/shared/src/business/useCases/users/updateUserContactInformationInteractor.js
@@ -129,7 +129,6 @@ const updateUserContactInformationHelper = async (
  * @param {object} providers the providers object
  * @param {string} providers.contactInfo the contactInfo to update the contact info
  * @param {string} providers.userId the userId to update the contact info
- * @returns {Promise} an object is successful
  */
 exports.updateUserContactInformationInteractor = async (
   applicationContext,

--- a/shared/src/business/useCases/users/verifyUserPendingEmailInteractor.js
+++ b/shared/src/business/useCases/users/verifyUserPendingEmailInteractor.js
@@ -238,7 +238,6 @@ exports.updatePractitionerCases = updatePractitionerCases;
  * @param {object} applicationContext the application context
  * @param {object} providers the providers object
  * @param {string} providers.pendingEmail the pending email
- * @returns {Promise} the updated user object
  */
 exports.verifyUserPendingEmailInteractor = async (
   applicationContext,

--- a/shared/src/proxies/trialSessions/updateTrialSessionProxy.js
+++ b/shared/src/proxies/trialSessions/updateTrialSessionProxy.js
@@ -15,6 +15,6 @@ exports.updateTrialSessionInteractor = (
   return put({
     applicationContext,
     body: trialSession,
-    endpoint: '/trial-sessions',
+    endpoint: '/async/trial-sessions',
   });
 };

--- a/web-api/src/app.js
+++ b/web-api/src/app.js
@@ -899,7 +899,7 @@ app.get(
   );
   app.put(
     '/async/practitioners/:barNumber',
-    lambdaWrapper(updatePractitionerUserLambda),
+    lambdaWrapper(updatePractitionerUserLambda, { isAsync: true }),
   );
   app.get(
     '/practitioners/:userId/printable-case-list',
@@ -959,7 +959,7 @@ app.get(
 {
   app.post(
     '/async/trial-sessions/:trialSessionId/generate-notices',
-    lambdaWrapper(setNoticesForCalendaredTrialSessionLambda),
+    lambdaWrapper(setNoticesForCalendaredTrialSessionLambda, { isAsync: true }),
   );
   app.post(
     '/trial-sessions/:trialSessionId/set-swing-session',
@@ -987,7 +987,7 @@ app.get(
   );
   app.get(
     '/async/trial-sessions/:trialSessionId/batch-download',
-    lambdaWrapper(batchDownloadTrialSessionLambda),
+    lambdaWrapper(batchDownloadTrialSessionLambda, { isAsync: true }),
   );
   app.put(
     '/trial-sessions/:trialSessionId/remove-case/:docketNumber',
@@ -1051,7 +1051,7 @@ app.get(
 );
 app.put(
   '/async/users/:userId/contact-info',
-  lambdaWrapper(updateUserContactInformationLambda),
+  lambdaWrapper(updateUserContactInformationLambda, { isAsync: true }),
 );
 app.get(
   '/users/:userId/pending-email',
@@ -1065,7 +1065,7 @@ app.get(
 app.put('/users/pending-email', lambdaWrapper(updateUserPendingEmailLambda));
 app.put(
   '/async/users/verify-email',
-  lambdaWrapper(verifyUserPendingEmailLambda),
+  lambdaWrapper(verifyUserPendingEmailLambda, { isAsync: true }),
 );
 app.get(
   '/users/email-availability',

--- a/web-api/src/app.js
+++ b/web-api/src/app.js
@@ -1011,7 +1011,10 @@ app.get(
   );
   app.get('/trial-sessions', lambdaWrapper(getTrialSessionsLambda));
   app.post('/trial-sessions', lambdaWrapper(createTrialSessionLambda));
-  app.put('/async/trial-sessions', lambdaWrapper(updateTrialSessionLambda));
+  app.put(
+    '/async/trial-sessions',
+    lambdaWrapper(updateTrialSessionLambda, { isAsync: true }),
+  );
   app.post(
     '/trial-sessions/:trialSessionId/set-hearing/:docketNumber',
     lambdaWrapper(setForHearingLambda),

--- a/web-api/src/app.js
+++ b/web-api/src/app.js
@@ -1011,7 +1011,7 @@ app.get(
   );
   app.get('/trial-sessions', lambdaWrapper(getTrialSessionsLambda));
   app.post('/trial-sessions', lambdaWrapper(createTrialSessionLambda));
-  app.put('/trial-sessions', lambdaWrapper(updateTrialSessionLambda));
+  app.put('/async/trial-sessions', lambdaWrapper(updateTrialSessionLambda));
   app.post(
     '/trial-sessions/:trialSessionId/set-hearing/:docketNumber',
     lambdaWrapper(setForHearingLambda),

--- a/web-api/src/lambdaWrapper.js
+++ b/web-api/src/lambdaWrapper.js
@@ -10,7 +10,7 @@ exports.headerOverride = {
   'X-Content-Type-Options': 'nosniff',
 };
 
-exports.lambdaWrapper = lambda => {
+exports.lambdaWrapper = (lambda, options = {}) => {
   return async (req, res) => {
     // If you'd like to test the terminal user functionality locally, make this boolean true
     const currentInvoke = getCurrentInvoke();
@@ -32,7 +32,11 @@ exports.lambdaWrapper = lambda => {
       logger: req.locals.logger,
     });
 
-    res.status(response.statusCode);
+    if (options.isAsync) {
+      res.status(204);
+    } else {
+      res.status(response.statusCode);
+    }
 
     res.set({
       ...response.headers,

--- a/web-client/integration-tests/admissionsClerkModifiesPractitionerEmail.test.js
+++ b/web-client/integration-tests/admissionsClerkModifiesPractitionerEmail.test.js
@@ -4,6 +4,7 @@ import {
   refreshElasticsearchIndex,
   setupTest,
   uploadPetition,
+  waitForLoadingComponentToHide,
 } from './helpers';
 import { petitionsClerkAddsPractitionersToCase } from './journey/petitionsClerkAddsPractitionersToCase';
 import { petitionsClerkViewsCaseDetail } from './journey/petitionsClerkViewsCaseDetail';
@@ -97,6 +98,8 @@ describe('admissions clerk practitioner journey', () => {
     });
 
     await cerebralTest.runSequence('submitUpdatePractitionerUserSequence');
+
+    await waitForLoadingComponentToHide(cerebralTest);
 
     expect(cerebralTest.getState('modal.showModal')).toBe(
       'EmailVerificationModal',

--- a/web-client/integration-tests/helpers.js
+++ b/web-client/integration-tests/helpers.js
@@ -848,7 +848,7 @@ export const wait = time => {
   });
 };
 
-export const waitMaxTime = async (cerebralTest, maxWait = 10000) => {
+export const waitMaxTimeForResponse = async (cerebralTest, maxWait = 10000) => {
   let waitTime = 0;
   while (
     cerebralTest.getState('progressIndicator.waitingForResponse') &&

--- a/web-client/integration-tests/helpers.js
+++ b/web-client/integration-tests/helpers.js
@@ -859,7 +859,7 @@ export const waitForLoadingComponentToHide = async (
     waitTime += 500;
     await wait(500);
   }
-  console.log(`waited ${waitTime}ms for response`);
+  console.log(`Waited ${waitTime}ms for the loading component to hide`);
 };
 
 export const refreshElasticsearchIndex = async (time = 2000) => {

--- a/web-client/integration-tests/helpers.js
+++ b/web-client/integration-tests/helpers.js
@@ -847,8 +847,10 @@ export const wait = time => {
     setTimeout(resolve, time);
   });
 };
-
-export const waitMaxTimeForResponse = async (cerebralTest, maxWait = 10000) => {
+export const waitForLoadingComponentToHide = async (
+  cerebralTest,
+  maxWait = 10000,
+) => {
   let waitTime = 0;
   while (
     cerebralTest.getState('progressIndicator.waitingForResponse') &&
@@ -857,6 +859,7 @@ export const waitMaxTimeForResponse = async (cerebralTest, maxWait = 10000) => {
     waitTime += 500;
     await wait(500);
   }
+  console.log(`waited ${waitTime}ms for response`);
 };
 
 export const refreshElasticsearchIndex = async (time = 2000) => {

--- a/web-client/integration-tests/helpers.js
+++ b/web-client/integration-tests/helpers.js
@@ -848,6 +848,17 @@ export const wait = time => {
   });
 };
 
+export const waitMaxTime = async (cerebralTest, maxWait = 10000) => {
+  let waitTime = 0;
+  while (
+    cerebralTest.getState('progressIndicator.waitingForResponse') &&
+    waitTime < maxWait
+  ) {
+    waitTime += 500;
+    await wait(500);
+  }
+};
+
 export const refreshElasticsearchIndex = async (time = 2000) => {
   // refresh all ES indices:
   // https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html#refresh-api-all-ex

--- a/web-client/integration-tests/journey/admissionsClerkAddsPractitionerEmail.js
+++ b/web-client/integration-tests/journey/admissionsClerkAddsPractitionerEmail.js
@@ -93,6 +93,10 @@ export const admissionsClerkAddsPractitionerEmail = cerebralTest => {
 
     expect(cerebralTest.getState('validationErrors')).toEqual({});
 
+    await cerebralTest.runSequence(
+      'closeVerifyEmailModalAndNavigateToPractitionerDetailSequence',
+    );
+
     practitionerDetailHelperComputed = runCompute(
       withAppContextDecorator(practitionerDetailHelper),
       {

--- a/web-client/integration-tests/journey/admissionsClerkAddsPractitionerEmail.js
+++ b/web-client/integration-tests/journey/admissionsClerkAddsPractitionerEmail.js
@@ -1,6 +1,9 @@
 import { applicationContextForClient as applicationContext } from '../../../shared/src/business/test/createTestApplicationContext';
 import { practitionerDetailHelper } from '../../src/presenter/computeds/practitionerDetailHelper';
-import { refreshElasticsearchIndex } from '../helpers';
+import {
+  refreshElasticsearchIndex,
+  waitForLoadingComponentToHide,
+} from '../helpers';
 import { runCompute } from 'cerebral/test';
 import { withAppContextDecorator } from '../../src/withAppContext';
 const { faker } = require('@faker-js/faker');
@@ -13,6 +16,7 @@ export const admissionsClerkAddsPractitionerEmail = cerebralTest => {
   return it('admissions clerk edits practitioner information', async () => {
     await refreshElasticsearchIndex();
 
+    console.log('cerebralTest.barNumber', cerebralTest.barNumber);
     await cerebralTest.runSequence('gotoEditPractitionerUserSequence', {
       barNumber: cerebralTest.barNumber,
     });
@@ -27,6 +31,8 @@ export const admissionsClerkAddsPractitionerEmail = cerebralTest => {
     });
 
     await cerebralTest.runSequence('submitUpdatePractitionerUserSequence');
+
+    await waitForLoadingComponentToHide(cerebralTest);
 
     expect(cerebralTest.getState('validationErrors')).toEqual({});
 
@@ -75,9 +81,13 @@ export const admissionsClerkAddsPractitionerEmail = cerebralTest => {
       value: mockAvailableEmail,
     });
 
+    console.log('mockAvailableEmail', mockAvailableEmail);
+
     cerebralTest.setState('practitionerDetail', {});
 
     await cerebralTest.runSequence('submitUpdatePractitionerUserSequence');
+
+    await waitForLoadingComponentToHide(cerebralTest);
 
     await refreshElasticsearchIndex();
 

--- a/web-client/integration-tests/journey/admissionsClerkAddsPractitionerEmail.js
+++ b/web-client/integration-tests/journey/admissionsClerkAddsPractitionerEmail.js
@@ -16,7 +16,6 @@ export const admissionsClerkAddsPractitionerEmail = cerebralTest => {
   return it('admissions clerk edits practitioner information', async () => {
     await refreshElasticsearchIndex();
 
-    console.log('cerebralTest.barNumber', cerebralTest.barNumber);
     await cerebralTest.runSequence('gotoEditPractitionerUserSequence', {
       barNumber: cerebralTest.barNumber,
     });
@@ -80,8 +79,6 @@ export const admissionsClerkAddsPractitionerEmail = cerebralTest => {
       key: 'confirmEmail',
       value: mockAvailableEmail,
     });
-
-    console.log('mockAvailableEmail', mockAvailableEmail);
 
     cerebralTest.setState('practitionerDetail', {});
 

--- a/web-client/integration-tests/journey/docketClerkCreatesARemoteTrialSession.js
+++ b/web-client/integration-tests/journey/docketClerkCreatesARemoteTrialSession.js
@@ -1,4 +1,7 @@
-import { TRIAL_SESSION_PROCEEDING_TYPES } from '../../../shared/src/business/entities/EntityConstants';
+import {
+  TRIAL_SESSION_PROCEEDING_TYPES,
+  TRIAL_SESSION_SCOPE_TYPES,
+} from '../../../shared/src/business/entities/EntityConstants';
 import { TrialSession } from '../../../shared/src/business/entities/trialSessions/TrialSession';
 
 const errorMessages = TrialSession.VALIDATION_ERROR_MESSAGES;
@@ -26,6 +29,11 @@ export const docketClerkCreatesARemoteTrialSession = (
     await cerebralTest.runSequence('updateTrialSessionFormDataSequence', {
       key: 'proceedingType',
       value: TRIAL_SESSION_PROCEEDING_TYPES.remote,
+    });
+
+    await cerebralTest.runSequence('updateTrialSessionFormDataSequence', {
+      key: 'sessionScope',
+      value: TRIAL_SESSION_SCOPE_TYPES.standaloneRemote,
     });
 
     await cerebralTest.runSequence('updateTrialSessionFormDataSequence', {
@@ -73,7 +81,6 @@ export const docketClerkCreatesARemoteTrialSession = (
     expect(cerebralTest.getState('validationErrors')).toEqual({
       startDate: errorMessages.startDate[1],
       term: errorMessages.term,
-      trialLocation: errorMessages.trialLocation,
     });
 
     await cerebralTest.runSequence('updateTrialSessionFormDataSequence', {

--- a/web-client/integration-tests/journey/docketClerkEditsTrialSession.js
+++ b/web-client/integration-tests/journey/docketClerkEditsTrialSession.js
@@ -1,6 +1,6 @@
 import { formattedTrialSessionDetails as formattedTrialSessionDetailsComputed } from '../../src/presenter/computeds/formattedTrialSessionDetails';
 import { runCompute } from 'cerebral/test';
-import { waitMaxTimeForResponse } from '../helpers.js';
+import { waitForLoadingComponentToHide } from '../helpers.js';
 import { withAppContextDecorator } from '../../src/withAppContext';
 
 const formattedTrialSessionDetails = withAppContextDecorator(
@@ -24,7 +24,7 @@ export const docketClerkEditsTrialSession = (cerebralTest, overrides = {}) => {
 
     expect(cerebralTest.getState('validationErrors')).toEqual({});
 
-    await waitMaxTimeForResponse(cerebralTest);
+    await waitForLoadingComponentToHide(cerebralTest);
     expect(cerebralTest.getState('currentPage')).toEqual('TrialSessionDetail');
 
     const formatted = runCompute(formattedTrialSessionDetails, {

--- a/web-client/integration-tests/journey/docketClerkEditsTrialSession.js
+++ b/web-client/integration-tests/journey/docketClerkEditsTrialSession.js
@@ -1,6 +1,6 @@
 import { formattedTrialSessionDetails as formattedTrialSessionDetailsComputed } from '../../src/presenter/computeds/formattedTrialSessionDetails';
 import { runCompute } from 'cerebral/test';
-import { waitMaxTime } from '../helpers.js';
+import { waitMaxTimeForResponse } from '../helpers.js';
 import { withAppContextDecorator } from '../../src/withAppContext';
 
 const formattedTrialSessionDetails = withAppContextDecorator(
@@ -24,7 +24,7 @@ export const docketClerkEditsTrialSession = (cerebralTest, overrides = {}) => {
 
     expect(cerebralTest.getState('validationErrors')).toEqual({});
 
-    await waitMaxTime(cerebralTest);
+    await waitMaxTimeForResponse(cerebralTest);
     expect(cerebralTest.getState('currentPage')).toEqual('TrialSessionDetail');
 
     const formatted = runCompute(formattedTrialSessionDetails, {

--- a/web-client/integration-tests/journey/docketClerkEditsTrialSession.js
+++ b/web-client/integration-tests/journey/docketClerkEditsTrialSession.js
@@ -29,10 +29,10 @@ export const docketClerkEditsTrialSession = (cerebralTest, overrides = {}) => {
       state: cerebralTest.getState(),
     });
 
-    const expectedUpdatedValue =
+    const receivedUpdatedValue =
       formatted[overrides.fieldToUpdate] || formatted.notes;
-    const receivedUpdatedValue = overrides.valueToUpdate || mockNote;
+    const expectedUpdatedValue = overrides.valueToUpdate || mockNote;
 
-    expect(expectedUpdatedValue).toEqual(receivedUpdatedValue);
+    expect(receivedUpdatedValue).toEqual(expectedUpdatedValue);
   });
 };

--- a/web-client/integration-tests/journey/docketClerkEditsTrialSession.js
+++ b/web-client/integration-tests/journey/docketClerkEditsTrialSession.js
@@ -1,5 +1,6 @@
 import { formattedTrialSessionDetails as formattedTrialSessionDetailsComputed } from '../../src/presenter/computeds/formattedTrialSessionDetails';
 import { runCompute } from 'cerebral/test';
+import { waitMaxTime } from '../helpers.js';
 import { withAppContextDecorator } from '../../src/withAppContext';
 
 const formattedTrialSessionDetails = withAppContextDecorator(
@@ -23,6 +24,7 @@ export const docketClerkEditsTrialSession = (cerebralTest, overrides = {}) => {
 
     expect(cerebralTest.getState('validationErrors')).toEqual({});
 
+    await waitMaxTime(cerebralTest);
     expect(cerebralTest.getState('currentPage')).toEqual('TrialSessionDetail');
 
     const formatted = runCompute(formattedTrialSessionDetails, {

--- a/web-client/integration-tests/journey/docketClerkViewsNewTrialSession.js
+++ b/web-client/integration-tests/journey/docketClerkViewsNewTrialSession.js
@@ -3,9 +3,9 @@ import { runCompute } from 'cerebral/test';
 import { withAppContextDecorator } from '../../src/withAppContext';
 
 export const docketClerkViewsNewTrialSession = (
-  { calendarNote, cerebralTest, checkCase, expectedStatus } = {
-    expectedStatus: 'New',
-  },
+  cerebralTest,
+  checkCase,
+  calendarNote,
 ) => {
   return it('Docket Clerk Views a new trial session', async () => {
     await cerebralTest.runSequence('gotoTrialSessionDetailSequence', {
@@ -19,7 +19,7 @@ export const docketClerkViewsNewTrialSession = (
       },
     );
 
-    expect(trialSessionFormatted.computedStatus).toEqual(expectedStatus);
+    expect(trialSessionFormatted.computedStatus).toEqual('New');
 
     if (checkCase) {
       const foundCase = trialSessionFormatted.caseOrder.find(

--- a/web-client/integration-tests/journey/docketClerkViewsNewTrialSession.js
+++ b/web-client/integration-tests/journey/docketClerkViewsNewTrialSession.js
@@ -3,9 +3,9 @@ import { runCompute } from 'cerebral/test';
 import { withAppContextDecorator } from '../../src/withAppContext';
 
 export const docketClerkViewsNewTrialSession = (
-  cerebralTest,
-  checkCase,
-  calendarNote,
+  { calendarNote, cerebralTest, checkCase, expectedStatus } = {
+    expectedStatus: 'New',
+  },
 ) => {
   return it('Docket Clerk Views a new trial session', async () => {
     await cerebralTest.runSequence('gotoTrialSessionDetailSequence', {
@@ -19,7 +19,7 @@ export const docketClerkViewsNewTrialSession = (
       },
     );
 
-    expect(trialSessionFormatted.computedStatus).toEqual('New');
+    expect(trialSessionFormatted.computedStatus).toEqual(expectedStatus);
 
     if (checkCase) {
       const foundCase = trialSessionFormatted.caseOrder.find(

--- a/web-client/integration-tests/journey/petitionsClerkCompletesAndSetsTrialSession.js
+++ b/web-client/integration-tests/journey/petitionsClerkCompletesAndSetsTrialSession.js
@@ -1,4 +1,4 @@
-import { wait } from '../helpers';
+import { waitForLoadingComponentToHide } from '../helpers';
 
 export const petitionsClerkCompletesAndSetsTrialSession = (
   cerebralTest,
@@ -58,7 +58,8 @@ export const petitionsClerkCompletesAndSetsTrialSession = (
     expect(cerebralTest.getState('currentPage')).toEqual('TrialSessionDetail');
 
     await cerebralTest.runSequence('setTrialSessionCalendarSequence');
-    await wait(1000); // we need to wait for some reason
+
+    await waitForLoadingComponentToHide(cerebralTest);
 
     if (overrides.hasPaper) {
       expect(cerebralTest.getState('currentPage')).toEqual(

--- a/web-client/integration-tests/journey/petitionsClerkSetsATrialSessionsSchedule.js
+++ b/web-client/integration-tests/journey/petitionsClerkSetsATrialSessionsSchedule.js
@@ -1,4 +1,4 @@
-import { wait } from '../helpers';
+import { waitForLoadingComponentToHide } from '../helpers';
 
 export const petitionsClerkSetsATrialSessionsSchedule = cerebralTest => {
   return it('Petitions Clerk Sets A Trial Sessions Schedule', async () => {
@@ -10,6 +10,6 @@ export const petitionsClerkSetsATrialSessionsSchedule = cerebralTest => {
     expect(cerebralTest.getState('alertWarning.message')).toBeUndefined();
 
     await cerebralTest.runSequence('setTrialSessionCalendarSequence');
-    await wait(1000);
+    await waitForLoadingComponentToHide(cerebralTest);
   });
 };

--- a/web-client/integration-tests/journey/petitionsClerkViewsOpenTrialSession.js
+++ b/web-client/integration-tests/journey/petitionsClerkViewsOpenTrialSession.js
@@ -1,0 +1,20 @@
+import { formattedTrialSessionDetails } from '../../src/presenter/computeds/formattedTrialSessionDetails';
+import { runCompute } from 'cerebral/test';
+import { withAppContextDecorator } from '../../src/withAppContext';
+
+export const petitionsClerkViewsOpenTrialSession = cerebralTest => {
+  return it('petitions clerk views a open trial session', async () => {
+    await cerebralTest.runSequence('gotoTrialSessionDetailSequence', {
+      trialSessionId: cerebralTest.trialSessionId,
+    });
+
+    const trialSessionFormatted = runCompute(
+      withAppContextDecorator(formattedTrialSessionDetails),
+      {
+        state: cerebralTest.getState(),
+      },
+    );
+
+    expect(trialSessionFormatted.computedStatus).toEqual('Open');
+  });
+};

--- a/web-client/integration-tests/journey/practitionerUpdatesAddress.js
+++ b/web-client/integration-tests/journey/practitionerUpdatesAddress.js
@@ -1,3 +1,5 @@
+import { waitForLoadingComponentToHide } from '../helpers';
+
 const { faker } = require('@faker-js/faker');
 const { refreshElasticsearchIndex } = require('../helpers');
 
@@ -34,6 +36,8 @@ export const practitionerUpdatesAddress = cerebralTest => {
     );
 
     expect(cerebralTest.getState('validationErrors')).toEqual({});
+
+    await waitForLoadingComponentToHide(cerebralTest);
 
     await cerebralTest.runSequence('userContactUpdateCompleteSequence');
 

--- a/web-client/integration-tests/journey/userSuccessfullyUpdatesEmailAddress.js
+++ b/web-client/integration-tests/journey/userSuccessfullyUpdatesEmailAddress.js
@@ -1,5 +1,6 @@
 import { headerHelper as headerHelperComputed } from '../../src/presenter/computeds/headerHelper';
 import { runCompute } from 'cerebral/test';
+import { waitForLoadingComponentToHide } from '../helpers';
 import { withAppContextDecorator } from '../../src/withAppContext';
 
 const headerHelper = withAppContextDecorator(headerHelperComputed);
@@ -25,6 +26,8 @@ export const userSuccessfullyUpdatesEmailAddress = (
     await cerebralTest.runSequence('submitChangeLoginAndServiceEmailSequence');
 
     expect(cerebralTest.getState('validationErrors')).toEqual({});
+
+    await waitForLoadingComponentToHide(cerebralTest);
 
     expect(cerebralTest.getState('modal.showModal')).toEqual(
       'VerifyNewEmailModal',

--- a/web-client/integration-tests/journey/userVerifiesUpdatedEmailAddress.js
+++ b/web-client/integration-tests/journey/userVerifiesUpdatedEmailAddress.js
@@ -1,15 +1,18 @@
-import { getUserRecordById } from '../helpers';
+import { getUserRecordById, wait } from '../helpers';
 
 export const userVerifiesUpdatedEmailAddress = (cerebralTest, user) =>
   it(`${user} verifies updated email address`, async () => {
     const userFromState = cerebralTest.getState('user');
-    const userFromPersistence = await getUserRecordById(userFromState.userId);
+    let userFromPersistence = await getUserRecordById(userFromState.userId);
     const emailVerificationToken =
       userFromPersistence.pendingEmailVerificationToken;
 
     await cerebralTest.runSequence('navigateToPathSequence', {
       path: `/verify-email?token=${emailVerificationToken}`,
     });
+
+    //we need to wait for the async verify-email endpoint to complete.  It can take longer if there are more cases that the petitioner is associated with.  The endpoint doesn't currently (2022-03-22) emit an event when it is done.
+    await wait(5000);
 
     expect(window.location.replace).toHaveBeenCalledWith(
       'http://localhost:5678/email-verification-success',

--- a/web-client/integration-tests/petitionsClerkSetsRemoteTrialSessionCalendar.test.js
+++ b/web-client/integration-tests/petitionsClerkSetsRemoteTrialSessionCalendar.test.js
@@ -7,6 +7,7 @@ import { formattedTrialSessionDetails } from '../src/presenter/computeds/formatt
 import { manuallyAddCaseToTrial } from './utils/manuallyAddCaseToTrial';
 import { petitionsClerkCreatesNewCase } from './journey/petitionsClerkCreatesNewCase';
 import { petitionsClerkSubmitsCaseToIrs } from './journey/petitionsClerkSubmitsCaseToIrs.js';
+import { petitionsClerkViewsOpenTrialSession } from './journey/petitionsClerkViewsOpenTrialSession';
 import { runCompute } from 'cerebral/test';
 import { withAppContextDecorator } from '../src/withAppContext';
 
@@ -84,19 +85,15 @@ describe('petitions clerk sets a remote trial session calendar', () => {
   });
 
   describe('petitions clerk views the trial session', () => {
-    it('the trial session should be open and have 1 manually added cases on it', async () => {
-      await cerebralTest.runSequence('gotoTrialSessionDetailSequence', {
-        trialSessionId: cerebralTest.trialSessionId,
-      });
+    petitionsClerkViewsOpenTrialSession(cerebralTest);
 
+    it('the trial session should be open and have 1 manually added cases on it', async () => {
       const trialSessionFormatted = runCompute(
         withAppContextDecorator(formattedTrialSessionDetails),
         {
           state: cerebralTest.getState(),
         },
       );
-
-      expect(trialSessionFormatted.computedStatus).toEqual('Open');
       expect(trialSessionFormatted.openCases.length).toEqual(1);
     });
   });

--- a/web-client/integration-tests/petitionsClerkSetsRemoteTrialSessionCalendar.test.js
+++ b/web-client/integration-tests/petitionsClerkSetsRemoteTrialSessionCalendar.test.js
@@ -1,16 +1,12 @@
 import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
 import { docketClerkCreatesARemoteTrialSession } from './journey/docketClerkCreatesARemoteTrialSession';
 import { docketClerkSetsCaseReadyForTrial } from './journey/docketClerkSetsCaseReadyForTrial';
-import { docketClerkViewsNewTrialSession } from './journey/docketClerkViewsNewTrialSession';
 import { docketClerkViewsTrialSessionList } from './journey/docketClerkViewsTrialSessionList';
 import { fakeFile, loginAs, setupTest, uploadPetition } from './helpers';
 import { formattedTrialSessionDetails } from '../src/presenter/computeds/formattedTrialSessionDetails';
-import { markAllCasesAsQCed } from './journey/markAllCasesAsQCed';
+import { manuallyAddCaseToTrial } from './utils/manuallyAddCaseToTrial';
 import { petitionsClerkCreatesNewCase } from './journey/petitionsClerkCreatesNewCase';
-import { petitionsClerkManuallyAddsCaseToTrial } from './journey/petitionsClerkManuallyAddsCaseToTrial';
-import { petitionsClerkSetsARemoteTrialSessionsSchedule } from './journey/petitionsClerkSetsARemoteTrialSessionsSchedule';
 import { petitionsClerkSubmitsCaseToIrs } from './journey/petitionsClerkSubmitsCaseToIrs.js';
-import { petitionsClerkViewsNewTrialSession } from './journey/petitionsClerkViewsNewTrialSession';
 import { runCompute } from 'cerebral/test';
 import { withAppContextDecorator } from '../src/withAppContext';
 
@@ -38,7 +34,21 @@ describe('petitions clerk sets a remote trial session calendar', () => {
     loginAs(cerebralTest, 'docketclerk@example.com');
     docketClerkCreatesARemoteTrialSession(cerebralTest, overrides);
     docketClerkViewsTrialSessionList(cerebralTest);
-    docketClerkViewsNewTrialSession(cerebralTest);
+  });
+
+  it('status of remote trial sessions should be open', async () => {
+    await cerebralTest.runSequence('gotoTrialSessionDetailSequence', {
+      trialSessionId: cerebralTest.trialSessionId,
+    });
+
+    const trialSessionFormatted = runCompute(
+      withAppContextDecorator(formattedTrialSessionDetails),
+      {
+        state: cerebralTest.getState(),
+      },
+    );
+
+    expect(trialSessionFormatted.computedStatus).toEqual('Open');
   });
 
   describe('Create cases', () => {
@@ -69,23 +79,12 @@ describe('petitions clerk sets a remote trial session calendar', () => {
       loginAs(cerebralTest, 'petitionsclerk@example.com');
       cerebralTest.casesReadyForTrial = [];
       petitionsClerkCreatesNewCase(cerebralTest, fakeFile, trialLocation);
-      petitionsClerkManuallyAddsCaseToTrial(cerebralTest);
+      manuallyAddCaseToTrial(cerebralTest);
     });
   });
 
-  describe('petitions clerk sets calendar for trial session', () => {
-    petitionsClerkViewsNewTrialSession(cerebralTest);
-    markAllCasesAsQCed(cerebralTest, () => [cerebralTest.docketNumber]);
-
-    petitionsClerkSetsARemoteTrialSessionsSchedule(cerebralTest);
-
-    it('petitions clerk should be redirected to print paper service for the trial session', () => {
-      expect(cerebralTest.getState('currentPage')).toEqual(
-        'PrintPaperTrialNotices',
-      );
-    });
-
-    it('petitions clerk verifies that both cases were set on the trial session', async () => {
+  describe('petitions clerk views the trial session', () => {
+    it('the trial session should be open and have 1 manually added cases on it', async () => {
       await cerebralTest.runSequence('gotoTrialSessionDetailSequence', {
         trialSessionId: cerebralTest.trialSessionId,
       });
@@ -97,6 +96,7 @@ describe('petitions clerk sets a remote trial session calendar', () => {
         },
       );
 
+      expect(trialSessionFormatted.computedStatus).toEqual('Open');
       expect(trialSessionFormatted.openCases.length).toEqual(1);
     });
   });

--- a/web-client/integration-tests/trialSessionChangeToRemoteProceedingJourney.test.js
+++ b/web-client/integration-tests/trialSessionChangeToRemoteProceedingJourney.test.js
@@ -257,6 +257,17 @@ describe('Trial Session Eligible Cases Journey', () => {
 
     expect(cerebralTest.getState('validationErrors')).toEqual({});
 
+    expect(cerebralTest.getState('currentPage')).toBe('TrialSessionDetail');
+
+    let waitTime = 0;
+    const maxWait = 10000; // wait for ~10s max
+    while (
+      cerebralTest.getState('progressIndicator.waitingForResponse') &&
+      waitTime < maxWait
+    ) {
+      waitTime += 500;
+      await wait(500);
+    }
     expect(cerebralTest.getState('currentPage')).toBe('PrintPaperTrialNotices');
   });
 

--- a/web-client/integration-tests/trialSessionChangeToRemoteProceedingJourney.test.js
+++ b/web-client/integration-tests/trialSessionChangeToRemoteProceedingJourney.test.js
@@ -15,6 +15,7 @@ import {
   setupTest,
   uploadPetition,
   wait,
+  waitMaxTime,
 } from './helpers';
 import { markAllCasesAsQCed } from './journey/markAllCasesAsQCed';
 import { runCompute } from 'cerebral/test';
@@ -257,17 +258,7 @@ describe('Trial Session Eligible Cases Journey', () => {
 
     expect(cerebralTest.getState('validationErrors')).toEqual({});
 
-    expect(cerebralTest.getState('currentPage')).toBe('TrialSessionDetail');
-
-    let waitTime = 0;
-    const maxWait = 10000; // wait for ~10s max
-    while (
-      cerebralTest.getState('progressIndicator.waitingForResponse') &&
-      waitTime < maxWait
-    ) {
-      waitTime += 500;
-      await wait(500);
-    }
+    await waitMaxTime(cerebralTest);
     expect(cerebralTest.getState('currentPage')).toBe('PrintPaperTrialNotices');
   });
 
@@ -293,6 +284,7 @@ describe('Trial Session Eligible Cases Journey', () => {
             .eventCode,
       );
 
+      await waitMaxTime(cerebralTest);
       if (caseDetail.status !== CASE_STATUS_TYPES.closed) {
         expect(norpDocketEntry).toMatchObject({
           servedParties: [

--- a/web-client/integration-tests/trialSessionChangeToRemoteProceedingJourney.test.js
+++ b/web-client/integration-tests/trialSessionChangeToRemoteProceedingJourney.test.js
@@ -15,7 +15,7 @@ import {
   setupTest,
   uploadPetition,
   wait,
-  waitMaxTimeForResponse,
+  waitForLoadingComponentToHide,
 } from './helpers';
 import { markAllCasesAsQCed } from './journey/markAllCasesAsQCed';
 import { runCompute } from 'cerebral/test';
@@ -258,7 +258,7 @@ describe('Trial Session Eligible Cases Journey', () => {
 
     expect(cerebralTest.getState('validationErrors')).toEqual({});
 
-    await waitMaxTimeForResponse(cerebralTest);
+    await waitForLoadingComponentToHide(cerebralTest);
     expect(cerebralTest.getState('currentPage')).toBe('PrintPaperTrialNotices');
   });
 
@@ -284,7 +284,7 @@ describe('Trial Session Eligible Cases Journey', () => {
             .eventCode,
       );
 
-      await waitMaxTimeForResponse(cerebralTest);
+      await waitForLoadingComponentToHide(cerebralTest);
       if (caseDetail.status !== CASE_STATUS_TYPES.closed) {
         expect(norpDocketEntry).toMatchObject({
           servedParties: [

--- a/web-client/integration-tests/trialSessionChangeToRemoteProceedingJourney.test.js
+++ b/web-client/integration-tests/trialSessionChangeToRemoteProceedingJourney.test.js
@@ -15,7 +15,7 @@ import {
   setupTest,
   uploadPetition,
   wait,
-  waitMaxTime,
+  waitMaxTimeForResponse,
 } from './helpers';
 import { markAllCasesAsQCed } from './journey/markAllCasesAsQCed';
 import { runCompute } from 'cerebral/test';
@@ -258,7 +258,7 @@ describe('Trial Session Eligible Cases Journey', () => {
 
     expect(cerebralTest.getState('validationErrors')).toEqual({});
 
-    await waitMaxTime(cerebralTest);
+    await waitMaxTimeForResponse(cerebralTest);
     expect(cerebralTest.getState('currentPage')).toBe('PrintPaperTrialNotices');
   });
 
@@ -284,7 +284,7 @@ describe('Trial Session Eligible Cases Journey', () => {
             .eventCode,
       );
 
-      await waitMaxTime(cerebralTest);
+      await waitMaxTimeForResponse(cerebralTest);
       if (caseDetail.status !== CASE_STATUS_TYPES.closed) {
         expect(norpDocketEntry).toMatchObject({
           servedParties: [

--- a/web-client/integration-tests/utils/manuallyAddCaseToTrial.js
+++ b/web-client/integration-tests/utils/manuallyAddCaseToTrial.js
@@ -1,6 +1,3 @@
-// import { wait } from '../helpers';
-// import { withAppContextDecorator } from '../../src/withAppContext';
-
 export const manuallyAddCaseToTrial = cerebralTest => {
   return it('manually add a case to a trial session', async () => {
     await cerebralTest.runSequence('gotoCaseDetailSequence', {
@@ -20,7 +17,5 @@ export const manuallyAddCaseToTrial = cerebralTest => {
     });
 
     await cerebralTest.runSequence('addCaseToTrialSessionSequence');
-
-    // await wait(1000);
   });
 };

--- a/web-client/integration-tests/utils/manuallyAddCaseToTrial.js
+++ b/web-client/integration-tests/utils/manuallyAddCaseToTrial.js
@@ -1,0 +1,26 @@
+// import { wait } from '../helpers';
+// import { withAppContextDecorator } from '../../src/withAppContext';
+
+export const manuallyAddCaseToTrial = cerebralTest => {
+  return it('manually add a case to a trial session', async () => {
+    await cerebralTest.runSequence('gotoCaseDetailSequence', {
+      docketNumber: cerebralTest.docketNumber,
+    });
+
+    await cerebralTest.runSequence('openAddToTrialModalSequence');
+
+    await cerebralTest.runSequence('updateModalValueSequence', {
+      key: 'showAllLocations',
+      value: true,
+    });
+
+    await cerebralTest.runSequence('updateModalValueSequence', {
+      key: 'trialSessionId',
+      value: cerebralTest.trialSessionId,
+    });
+
+    await cerebralTest.runSequence('addCaseToTrialSessionSequence');
+
+    // await wait(1000);
+  });
+};

--- a/web-client/src/presenter/actions/CaseDetail/setDefaultUnsealDocketEntryModalStateAction.test.js
+++ b/web-client/src/presenter/actions/CaseDetail/setDefaultUnsealDocketEntryModalStateAction.test.js
@@ -1,0 +1,30 @@
+import { applicationContextForClient as applicationContext } from '../../../../../shared/src/business/test/createTestApplicationContext';
+import { presenter } from '../../presenter-mock';
+import { runAction } from 'cerebral/test';
+import { setDefaultUnsealDocketEntryModalStateAction } from './setDefaultUnsealDocketEntryModalStateAction';
+
+describe('setDefaultUnsealDocketEntryModalStateAction', () => {
+  const DOCKET_ENTRY_ID = '123';
+
+  beforeAll(() => {
+    presenter.providers.applicationContext = applicationContext;
+  });
+
+  it('should set state.modal.docketEntryId to match props', async () => {
+    const { state } = await runAction(
+      setDefaultUnsealDocketEntryModalStateAction,
+      {
+        modal: {},
+        modules: {
+          presenter,
+        },
+        props: {
+          docketEntryId: DOCKET_ENTRY_ID,
+        },
+        state: {},
+      },
+    );
+
+    expect(state.modal.docketEntryId).toEqual(DOCKET_ENTRY_ID);
+  });
+});

--- a/web-client/src/presenter/actions/TrialSession/setPrintPaperDoneUrlAction.js
+++ b/web-client/src/presenter/actions/TrialSession/setPrintPaperDoneUrlAction.js
@@ -1,10 +1,11 @@
 import { state } from 'cerebral';
 
 /**
- * sets the printPaperDoneUrl onto the state used for knowing where to redirect when pressing done on the PrintPaperService component.
+ * sets the the printPaperDoneUrl on state so that the PrintPaperService component knows
+ * where to redirect users when they click the Done button.
  *
  * @param {object} providers the providers object
- * @param {object} providers.store the cerebral store used for setting the state.eligibleCases
+ * @param {object} providers.store the cerebral store used for setting the state.printPaperDoneUrl
  * @param {object} providers.props the cerebral props passed from the sequences
  * @returns {void}
  */

--- a/web-client/src/presenter/actions/TrialSession/setPrintPaperDoneUrlAction.js
+++ b/web-client/src/presenter/actions/TrialSession/setPrintPaperDoneUrlAction.js
@@ -1,0 +1,17 @@
+import { state } from 'cerebral';
+
+/**
+ * sets the printPaperDoneUrl onto the state used for knowing where to redirect when pressing done on the PrintPaperService component.
+ *
+ * @param {object} providers the providers object
+ * @param {object} providers.store the cerebral store used for setting the state.eligibleCases
+ * @param {object} providers.props the cerebral props passed from the sequences
+ * @returns {void}
+ */
+export const setPrintPaperDoneUrlAction = ({ props, store }) => {
+  let urlToRedirectTo = '/trial-sessions';
+  if (props.trialSessionId) {
+    urlToRedirectTo = `/trial-session-detail/${props.trialSessionId}`;
+  }
+  store.set(state.printPaperDoneUrl, urlToRedirectTo);
+};

--- a/web-client/src/presenter/actions/TrialSession/setPrintPaperDoneUrlAction.test.js
+++ b/web-client/src/presenter/actions/TrialSession/setPrintPaperDoneUrlAction.test.js
@@ -1,0 +1,35 @@
+import { presenter } from '../../presenter-mock';
+import { runAction } from 'cerebral/test';
+import { setPrintPaperDoneUrlAction } from './setPrintPaperDoneUrlAction';
+
+describe('setPrintPaperDoneUrlAction', () => {
+  it('sets the printPaperDoneUrl to /trial-sessions when trialSessionId is not on props', async () => {
+    const result = await runAction(setPrintPaperDoneUrlAction, {
+      modules: {
+        presenter,
+      },
+      props: {},
+      state: {
+        printPaperDoneUrl: null,
+      },
+    });
+
+    expect(result.state.printPaperDoneUrl).toEqual('/trial-sessions');
+  });
+
+  it('sets the printPaperDoneUrl to /trial-session-detail/abc when props.trialSessionId is set to abc', async () => {
+    const result = await runAction(setPrintPaperDoneUrlAction, {
+      modules: {
+        presenter,
+      },
+      props: {
+        trialSessionId: 'abc',
+      },
+      state: {
+        printPaperDoneUrl: null,
+      },
+    });
+
+    expect(result.state.printPaperDoneUrl).toEqual('/trial-session-detail/abc');
+  });
+});

--- a/web-client/src/presenter/actions/TrialSession/setPrintPaperDoneUrlAction.test.js
+++ b/web-client/src/presenter/actions/TrialSession/setPrintPaperDoneUrlAction.test.js
@@ -18,18 +18,21 @@ describe('setPrintPaperDoneUrlAction', () => {
   });
 
   it('sets the printPaperDoneUrl to /trial-session-detail/abc when props.trialSessionId is set to abc', async () => {
+    const EXPECTED_TRIAL_SESSION_ID = 'abc';
     const result = await runAction(setPrintPaperDoneUrlAction, {
       modules: {
         presenter,
       },
       props: {
-        trialSessionId: 'abc',
+        trialSessionId: EXPECTED_TRIAL_SESSION_ID,
       },
       state: {
         printPaperDoneUrl: null,
       },
     });
 
-    expect(result.state.printPaperDoneUrl).toEqual('/trial-session-detail/abc');
+    expect(result.state.printPaperDoneUrl).toEqual(
+      `/trial-session-detail/${EXPECTED_TRIAL_SESSION_ID}`,
+    );
   });
 });

--- a/web-client/src/presenter/actions/TrialSession/updateTrialSessionAction.js
+++ b/web-client/src/presenter/actions/TrialSession/updateTrialSessionAction.js
@@ -39,15 +39,6 @@ export const updateTrialSessionAction = async ({
       .updateTrialSessionInteractor(applicationContext, {
         trialSession: { ...trialSession, startDate },
       });
-
-    if (trialSession.swingSession && trialSession.swingSessionId) {
-      await applicationContext
-        .getUseCases()
-        .setTrialSessionAsSwingSessionInteractor(applicationContext, {
-          swingSessionId: result.newTrialSession.trialSessionId,
-          trialSessionId: trialSession.swingSessionId,
-        });
-    }
   } catch (err) {
     return path.error({
       alertError: {
@@ -67,6 +58,6 @@ export const updateTrialSessionAction = async ({
       message: 'Trial session updated.',
     },
     pdfUrl,
-    trialSessionId: result.newTrialSession.trialSessionId,
+    trialSessionId: trialSession.trialSessionId,
   });
 };

--- a/web-client/src/presenter/actions/TrialSession/updateTrialSessionAction.js
+++ b/web-client/src/presenter/actions/TrialSession/updateTrialSessionAction.js
@@ -49,7 +49,7 @@ export const updateTrialSessionAction = async ({
   }
 
   let pdfUrl;
-  if (result.serviceInfo) {
+  if (result && result.serviceInfo) {
     pdfUrl = result.serviceInfo;
   }
 

--- a/web-client/src/presenter/actions/TrialSession/updateTrialSessionAction.js
+++ b/web-client/src/presenter/actions/TrialSession/updateTrialSessionAction.js
@@ -32,9 +32,8 @@ export const updateTrialSessionAction = async ({
     ['year', 'month', 'day'],
   );
 
-  let result;
   try {
-    result = await applicationContext
+    await applicationContext
       .getUseCases()
       .updateTrialSessionInteractor(applicationContext, {
         trialSession: { ...trialSession, startDate },
@@ -48,16 +47,5 @@ export const updateTrialSessionAction = async ({
     });
   }
 
-  let pdfUrl;
-  if (result && result.serviceInfo) {
-    pdfUrl = result.serviceInfo;
-  }
-
-  return path.success({
-    alertSuccess: {
-      message: 'Trial session updated.',
-    },
-    pdfUrl,
-    trialSessionId: trialSession.trialSessionId,
-  });
+  return path.success();
 };

--- a/web-client/src/presenter/actions/TrialSession/updateTrialSessionAction.test.js
+++ b/web-client/src/presenter/actions/TrialSession/updateTrialSessionAction.test.js
@@ -47,31 +47,6 @@ describe('updateTrialSessionAction', () => {
     expect(successMock).toHaveBeenCalled();
   });
 
-  it('calls setTrialSessionAsSwingSession if swingSession is true and swingSessionId is set', async () => {
-    await runAction(updateTrialSessionAction, {
-      modules: {
-        presenter,
-      },
-      state: {
-        form: { ...MOCK_TRIAL },
-      },
-    });
-
-    expect(
-      applicationContext.getUseCases().updateTrialSessionInteractor,
-    ).toHaveBeenCalled();
-    expect(
-      applicationContext.getUseCases().setTrialSessionAsSwingSessionInteractor,
-    ).toHaveBeenCalled();
-    expect(
-      applicationContext.getUseCases().setTrialSessionAsSwingSessionInteractor
-        .mock.calls[0][1],
-    ).toMatchObject({
-      swingSessionId: '123',
-      trialSessionId: '456',
-    });
-  });
-
   it('goes to error path if error', async () => {
     applicationContext
       .getUseCases()
@@ -106,9 +81,6 @@ describe('updateTrialSessionAction', () => {
       },
     });
 
-    expect(successMock.mock.calls[0][0].pdfUrl).toBe(mockPdfUrl);
-    expect(successMock.mock.calls[0][0].trialSessionId).toBe(
-      MOCK_TRIAL.trialSessionId,
-    );
+    expect(successMock).toHaveBeenCalled();
   });
 });

--- a/web-client/src/presenter/actions/navigateToMaintenanceAction.test.js
+++ b/web-client/src/presenter/actions/navigateToMaintenanceAction.test.js
@@ -1,0 +1,25 @@
+import { navigateToMaintenanceAction } from './navigateToMaintenanceAction';
+import { presenter } from '../presenter-mock';
+import { runAction } from 'cerebral/test';
+
+describe('navigateToMaintenanceAction', () => {
+  let routeStub;
+
+  beforeAll(() => {
+    routeStub = jest.fn();
+
+    presenter.providers.router = {
+      route: routeStub,
+    };
+  });
+
+  it('navigates to FilePetitionSuccess', async () => {
+    await runAction(navigateToMaintenanceAction, {
+      modules: {
+        presenter,
+      },
+    });
+
+    expect(routeStub).toHaveBeenCalledWith('/maintenance');
+  });
+});

--- a/web-client/src/presenter/actions/navigateToMaintenanceAction.test.js
+++ b/web-client/src/presenter/actions/navigateToMaintenanceAction.test.js
@@ -13,7 +13,7 @@ describe('navigateToMaintenanceAction', () => {
     };
   });
 
-  it('navigates to FilePetitionSuccess', async () => {
+  it('navigates to maintenance page', async () => {
     await runAction(navigateToMaintenanceAction, {
       modules: {
         presenter,

--- a/web-client/src/presenter/actions/setWaitingForResponseAction.js
+++ b/web-client/src/presenter/actions/setWaitingForResponseAction.js
@@ -9,4 +9,5 @@ import { state } from 'cerebral';
 export const setWaitingForResponseAction = ({ store }) => {
   store.increment(state.progressIndicator.waitingForResponseRequests);
   store.set(state.progressIndicator.waitingForResponse, true);
+  store.unset(state.progressIndicator.waitText);
 };

--- a/web-client/src/presenter/actions/setWaitingForResponseAction.js
+++ b/web-client/src/presenter/actions/setWaitingForResponseAction.js
@@ -9,5 +9,4 @@ import { state } from 'cerebral';
 export const setWaitingForResponseAction = ({ store }) => {
   store.increment(state.progressIndicator.waitingForResponseRequests);
   store.set(state.progressIndicator.waitingForResponse, true);
-  store.unset(state.progressIndicator.waitText);
 };

--- a/web-client/src/presenter/actions/setWaitingForResponseAction.test.js
+++ b/web-client/src/presenter/actions/setWaitingForResponseAction.test.js
@@ -10,6 +10,7 @@ describe('setWaitingForResponseAction', () => {
       },
       state: {
         progressIndicator: {
+          waitText: 'testing',
           waitingForResponse: false,
           waitingForResponseRequests: 0,
         },
@@ -19,5 +20,6 @@ describe('setWaitingForResponseAction', () => {
       waitingForResponse: true,
       waitingForResponseRequests: 1,
     });
+    expect(result.state.progressIndicator.waitText).toBeUndefined();
   });
 });

--- a/web-client/src/presenter/actions/setWaitingForResponseAction.test.js
+++ b/web-client/src/presenter/actions/setWaitingForResponseAction.test.js
@@ -17,9 +17,9 @@ describe('setWaitingForResponseAction', () => {
       },
     });
     expect(result.state.progressIndicator).toMatchObject({
+      waitText: 'testing',
       waitingForResponse: true,
       waitingForResponseRequests: 1,
     });
-    expect(result.state.progressIndicator.waitText).toBeUndefined();
   });
 });

--- a/web-client/src/presenter/actions/setWaitingTextAction.js
+++ b/web-client/src/presenter/actions/setWaitingTextAction.js
@@ -1,0 +1,13 @@
+import { state } from 'cerebral';
+
+/**
+ * sets the wait text on the spinner
+ *
+ * @param {string} waitText the string to show on the spinner
+ * @returns {object} the set waiting for response action
+ */
+export const setWaitingTextAction =
+  waitText =>
+  ({ store }) => {
+    store.set(state.progressIndicator.waitText, waitText);
+  };

--- a/web-client/src/presenter/actions/setWaitingTextAction.test.js
+++ b/web-client/src/presenter/actions/setWaitingTextAction.test.js
@@ -1,0 +1,20 @@
+import { presenter } from '../presenter-mock';
+import { runAction } from 'cerebral/test';
+import { setWaitingTextAction } from './setWaitingTextAction';
+
+describe('setWaitingTextAction', () => {
+  it('should set the wait text when invoked with a string', async () => {
+    const EXPECTED_WAIT_TEXT = 'This is the wait text';
+    const result = await runAction(setWaitingTextAction(EXPECTED_WAIT_TEXT), {
+      modules: {
+        presenter,
+      },
+      state: {
+        progressIndicator: {
+          waitText: undefined,
+        },
+      },
+    });
+    expect(result.state.progressIndicator.waitText).toEqual(EXPECTED_WAIT_TEXT);
+  });
+});

--- a/web-client/src/presenter/actions/unsetWaitingForResponseAction.js
+++ b/web-client/src/presenter/actions/unsetWaitingForResponseAction.js
@@ -16,4 +16,5 @@ export const unsetWaitingForResponseAction = ({ get, store }) => {
 
   store.set(state.progressIndicator.waitingForResponseRequests, requestCount);
   store.set(state.progressIndicator.waitingForResponse, requestCount > 0);
+  store.unset(state.progressIndicator.waitText);
 };

--- a/web-client/src/presenter/actions/unsetWaitingForResponseAction.test.js
+++ b/web-client/src/presenter/actions/unsetWaitingForResponseAction.test.js
@@ -10,6 +10,7 @@ describe('unsetWaitingForResponseAction', () => {
       },
       state: {
         progressIndicator: {
+          waitText: 'hello',
           waitingForResponse: false,
           waitingForResponseRequests: 0,
         },
@@ -19,6 +20,7 @@ describe('unsetWaitingForResponseAction', () => {
       waitingForResponse: false,
       waitingForResponseRequests: 0,
     });
+    expect(result.state.progressIndicator.waitText).toBeUndefined();
   });
 
   it('decrements request count and sets waiting to false if only one remaining', async () => {

--- a/web-client/src/presenter/actions/updatePractitionerUserAction.js
+++ b/web-client/src/presenter/actions/updatePractitionerUserAction.js
@@ -17,7 +17,7 @@ export const updatePractitionerUserAction = async ({
   const user = get(state.form);
 
   try {
-    const practitionerUser = await applicationContext
+    await applicationContext
       .getUseCases()
       .updatePractitionerUserInteractor(applicationContext, {
         barNumber: user.barNumber,
@@ -27,8 +27,6 @@ export const updatePractitionerUserAction = async ({
       alertSuccess: {
         message: 'Practitioner updated.',
       },
-      barNumber: practitionerUser.barNumber,
-      practitionerDetail: practitionerUser,
     });
   } catch (err) {
     return path.error({

--- a/web-client/src/presenter/presenter.js
+++ b/web-client/src/presenter/presenter.js
@@ -428,6 +428,7 @@ import { updateSessionMetadataSequence } from './sequences/updateSessionMetadata
 import { updateStartCaseFormValueSequence } from './sequences/updateStartCaseFormValueSequence';
 import { updateStartCaseInternalPartyTypeSequence } from './sequences/updateStartCaseInternalPartyTypeSequence';
 import { updateStatisticsFormValueSequence } from './sequences/updateStatisticsFormValueSequence';
+import { updateTrialSessionCompleteSequence } from './sequences/updateTrialSessionCompleteSequence';
 import { updateTrialSessionFormDataSequence } from './sequences/updateTrialSessionFormDataSequence';
 import { updateTrialSessionSequence } from './sequences/updateTrialSessionSequence';
 import { updateUserCaseNoteOnWorkingCopySequence } from './sequences/updateUserCaseNoteOnWorkingCopySequence';
@@ -918,6 +919,7 @@ export const presenter = {
     updateStartCaseFormValueSequence,
     updateStartCaseInternalPartyTypeSequence,
     updateStatisticsFormValueSequence,
+    updateTrialSessionCompleteSequence,
     updateTrialSessionFormDataSequence,
     updateTrialSessionSequence,
     updateUserCaseNoteOnWorkingCopySequence,

--- a/web-client/src/presenter/sequences/noticeGenerationCompleteSequence.js
+++ b/web-client/src/presenter/sequences/noticeGenerationCompleteSequence.js
@@ -8,6 +8,7 @@ import { setAlertWarningAction } from '../actions/setAlertWarningAction';
 import { setCaseAction } from '../actions/setCaseAction';
 import { setCurrentPageAction } from '../actions/setCurrentPageAction';
 import { setPdfPreviewUrlSequence } from './setPdfPreviewUrlSequence';
+import { setPrintPaperDoneUrlAction } from '../actions/TrialSession/setPrintPaperDoneUrlAction';
 import { setTrialSessionCalendarAlertWarningAction } from '../actions/TrialSession/setTrialSessionCalendarAlertWarningAction';
 import { shouldRefreshCaseAction } from '../actions/shouldRefreshCaseAction';
 import { unsetWaitingForResponseAction } from '../actions/unsetWaitingForResponseAction';
@@ -29,6 +30,7 @@ export const noticeGenerationCompleteSequence = [
     ],
     paper: [
       setPdfPreviewUrlSequence,
+      setPrintPaperDoneUrlAction,
       setCurrentPageAction('PrintPaperTrialNotices'),
       setTrialSessionCalendarAlertWarningAction,
       setAlertWarningAction,

--- a/web-client/src/presenter/sequences/submitUpdatePractitionerUserSequence.js
+++ b/web-client/src/presenter/sequences/submitUpdatePractitionerUserSequence.js
@@ -4,7 +4,6 @@ import { clearScreenMetadataAction } from '../actions/clearScreenMetadataAction'
 import { getComputedAdmissionsDateAction } from '../actions/getComputedAdmissionsDateAction';
 import { hasUpdatedEmailFactoryAction } from '../actions/hasUpdatedEmailFactoryAction';
 import { setAlertErrorAction } from '../actions/setAlertErrorAction';
-import { setPractitionerDetailAction } from '../actions/setPractitionerDetailAction';
 import { setValidationAlertErrorsAction } from '../actions/setValidationAlertErrorsAction';
 import { setValidationErrorsAction } from '../actions/setValidationErrorsAction';
 import { setWaitingForResponseAction } from '../actions/setWaitingForResponseAction';
@@ -18,7 +17,7 @@ const afterSuccess = [
   updatePractitionerUserAction,
   {
     error: [setAlertErrorAction, unsetWaitingForResponseAction],
-    success: [setPractitionerDetailAction, clearScreenMetadataAction],
+    success: [clearScreenMetadataAction],
   },
 ];
 

--- a/web-client/src/presenter/sequences/updateTrialSessionCompleteSequence.js
+++ b/web-client/src/presenter/sequences/updateTrialSessionCompleteSequence.js
@@ -1,0 +1,44 @@
+import { clearModalAction } from '../actions/clearModalAction';
+import { clearModalStateAction } from '../actions/clearModalStateAction';
+import { getCaseAction } from '../actions/getCaseAction';
+import { hasPaperAction } from '../actions/hasPaperAction';
+import { navigateToTrialSessionDetailAction } from '../actions/TrialSession/navigateToTrialSessionDetailAction';
+import { setAlertSuccessAction } from '../actions/setAlertSuccessAction';
+import { setAlertWarningAction } from '../actions/setAlertWarningAction';
+import { setCaseAction } from '../actions/setCaseAction';
+import { setCurrentPageAction } from '../actions/setCurrentPageAction';
+import { setPdfPreviewUrlSequence } from './setPdfPreviewUrlSequence';
+import { setSaveAlertsForNavigationAction } from '../actions/setSaveAlertsForNavigationAction';
+import { setTrialSessionCalendarAlertWarningAction } from '../actions/TrialSession/setTrialSessionCalendarAlertWarningAction';
+import { shouldRefreshCaseAction } from '../actions/shouldRefreshCaseAction';
+import { unsetWaitingForResponseAction } from '../actions/unsetWaitingForResponseAction';
+
+export const updateTrialSessionCompleteSequence = [
+  unsetWaitingForResponseAction,
+  clearModalStateAction,
+  clearModalAction,
+  shouldRefreshCaseAction,
+  {
+    no: [],
+    yes: [getCaseAction, setCaseAction],
+  },
+  hasPaperAction,
+  {
+    electronic: [
+      () => ({
+        alertSuccess: {
+          message: 'Trial session updated.',
+        },
+      }),
+      setAlertSuccessAction,
+      setSaveAlertsForNavigationAction,
+      navigateToTrialSessionDetailAction,
+    ],
+    paper: [
+      setPdfPreviewUrlSequence,
+      setCurrentPageAction('PrintPaperTrialNotices'),
+      setTrialSessionCalendarAlertWarningAction,
+      setAlertWarningAction,
+    ],
+  },
+];

--- a/web-client/src/presenter/sequences/updateTrialSessionCompleteSequence.js
+++ b/web-client/src/presenter/sequences/updateTrialSessionCompleteSequence.js
@@ -8,6 +8,7 @@ import { setAlertWarningAction } from '../actions/setAlertWarningAction';
 import { setCaseAction } from '../actions/setCaseAction';
 import { setCurrentPageAction } from '../actions/setCurrentPageAction';
 import { setPdfPreviewUrlSequence } from './setPdfPreviewUrlSequence';
+import { setPrintPaperDoneUrlAction } from '../actions/TrialSession/setPrintPaperDoneUrlAction';
 import { setSaveAlertsForNavigationAction } from '../actions/setSaveAlertsForNavigationAction';
 import { setTrialSessionCalendarAlertWarningAction } from '../actions/TrialSession/setTrialSessionCalendarAlertWarningAction';
 import { shouldRefreshCaseAction } from '../actions/shouldRefreshCaseAction';
@@ -36,6 +37,7 @@ export const updateTrialSessionCompleteSequence = [
     ],
     paper: [
       setPdfPreviewUrlSequence,
+      setPrintPaperDoneUrlAction,
       setCurrentPageAction('PrintPaperTrialNotices'),
       setTrialSessionCalendarAlertWarningAction,
       setAlertWarningAction,

--- a/web-client/src/presenter/sequences/updateTrialSessionSequence.js
+++ b/web-client/src/presenter/sequences/updateTrialSessionSequence.js
@@ -10,12 +10,14 @@ import { setPdfPreviewUrlAction } from '../actions/CourtIssuedOrder/setPdfPrevie
 import { setSaveAlertsForNavigationAction } from '../actions/setSaveAlertsForNavigationAction';
 import { setValidationAlertErrorsAction } from '../actions/setValidationAlertErrorsAction';
 import { setValidationErrorsAction } from '../actions/setValidationErrorsAction';
+import { setWaitingForResponseAction } from '../actions/setWaitingForResponseAction';
 import { showProgressSequenceDecorator } from '../utilities/showProgressSequenceDecorator';
 import { startShowValidationAction } from '../actions/startShowValidationAction';
 import { updateTrialSessionAction } from '../actions/TrialSession/updateTrialSessionAction';
 import { validateTrialSessionAction } from '../actions/TrialSession/validateTrialSessionAction';
 
 export const updateTrialSessionSequence = [
+  setWaitingForResponseAction,
   clearAlertsAction,
   startShowValidationAction,
   getComputedFormDateFactoryAction(null),

--- a/web-client/src/presenter/sequences/updateTrialSessionSequence.js
+++ b/web-client/src/presenter/sequences/updateTrialSessionSequence.js
@@ -1,22 +1,20 @@
 import { clearAlertsAction } from '../actions/clearAlertsAction';
+import { clearPdfPreviewUrlAction } from '../actions/CourtIssuedOrder/clearPdfPreviewUrlAction';
 import { computeTrialSessionFormDataAction } from '../actions/TrialSession/computeTrialSessionFormDataAction';
 import { getComputedFormDateFactoryAction } from '../actions/getComputedFormDateFactoryAction';
-import { isPrintPreviewPreparedAction } from '../actions/CourtIssuedOrder/isPrintPreviewPreparedAction';
 import { navigateToTrialSessionDetailAction } from '../actions/TrialSession/navigateToTrialSessionDetailAction';
 import { setAlertErrorAction } from '../actions/setAlertErrorAction';
 import { setAlertSuccessAction } from '../actions/setAlertSuccessAction';
-import { setCurrentPageAction } from '../actions/setCurrentPageAction';
-import { setPdfPreviewUrlAction } from '../actions/CourtIssuedOrder/setPdfPreviewUrlAction';
 import { setSaveAlertsForNavigationAction } from '../actions/setSaveAlertsForNavigationAction';
 import { setValidationAlertErrorsAction } from '../actions/setValidationAlertErrorsAction';
 import { setValidationErrorsAction } from '../actions/setValidationErrorsAction';
 import { setWaitingForResponseAction } from '../actions/setWaitingForResponseAction';
-import { showProgressSequenceDecorator } from '../utilities/showProgressSequenceDecorator';
 import { startShowValidationAction } from '../actions/startShowValidationAction';
 import { updateTrialSessionAction } from '../actions/TrialSession/updateTrialSessionAction';
 import { validateTrialSessionAction } from '../actions/TrialSession/validateTrialSessionAction';
 
 export const updateTrialSessionSequence = [
+  clearPdfPreviewUrlAction,
   setWaitingForResponseAction,
   clearAlertsAction,
   startShowValidationAction,
@@ -29,21 +27,16 @@ export const updateTrialSessionSequence = [
       setValidationErrorsAction,
       setValidationAlertErrorsAction,
     ],
-    success: showProgressSequenceDecorator([
+    success: [
       updateTrialSessionAction,
       {
         error: [setAlertErrorAction],
         success: [
-          setPdfPreviewUrlAction,
           setSaveAlertsForNavigationAction,
           setAlertSuccessAction,
-          isPrintPreviewPreparedAction,
-          {
-            no: [navigateToTrialSessionDetailAction],
-            yes: [setCurrentPageAction('PrintPaperTrialNotices')],
-          },
+          navigateToTrialSessionDetailAction,
         ],
       },
-    ]),
+    ],
   },
 ];

--- a/web-client/src/presenter/sequences/updateTrialSessionSequence.js
+++ b/web-client/src/presenter/sequences/updateTrialSessionSequence.js
@@ -6,13 +6,13 @@ import { setAlertErrorAction } from '../actions/setAlertErrorAction';
 import { setValidationAlertErrorsAction } from '../actions/setValidationAlertErrorsAction';
 import { setValidationErrorsAction } from '../actions/setValidationErrorsAction';
 import { setWaitingForResponseAction } from '../actions/setWaitingForResponseAction';
+import { setWaitingTextAction } from '../actions/setWaitingTextAction';
 import { startShowValidationAction } from '../actions/startShowValidationAction';
 import { updateTrialSessionAction } from '../actions/TrialSession/updateTrialSessionAction';
 import { validateTrialSessionAction } from '../actions/TrialSession/validateTrialSessionAction';
 
 export const updateTrialSessionSequence = [
   clearPdfPreviewUrlAction,
-  setWaitingForResponseAction,
   clearAlertsAction,
   startShowValidationAction,
   getComputedFormDateFactoryAction(null),
@@ -25,6 +25,10 @@ export const updateTrialSessionSequence = [
       setValidationAlertErrorsAction,
     ],
     success: [
+      setWaitingForResponseAction,
+      setWaitingTextAction(
+        'Please stay on this page while we process your request.',
+      ),
       updateTrialSessionAction,
       {
         error: [setAlertErrorAction],

--- a/web-client/src/presenter/sequences/updateTrialSessionSequence.js
+++ b/web-client/src/presenter/sequences/updateTrialSessionSequence.js
@@ -2,10 +2,7 @@ import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearPdfPreviewUrlAction } from '../actions/CourtIssuedOrder/clearPdfPreviewUrlAction';
 import { computeTrialSessionFormDataAction } from '../actions/TrialSession/computeTrialSessionFormDataAction';
 import { getComputedFormDateFactoryAction } from '../actions/getComputedFormDateFactoryAction';
-import { navigateToTrialSessionDetailAction } from '../actions/TrialSession/navigateToTrialSessionDetailAction';
 import { setAlertErrorAction } from '../actions/setAlertErrorAction';
-import { setAlertSuccessAction } from '../actions/setAlertSuccessAction';
-import { setSaveAlertsForNavigationAction } from '../actions/setSaveAlertsForNavigationAction';
 import { setValidationAlertErrorsAction } from '../actions/setValidationAlertErrorsAction';
 import { setValidationErrorsAction } from '../actions/setValidationErrorsAction';
 import { setWaitingForResponseAction } from '../actions/setWaitingForResponseAction';
@@ -31,11 +28,7 @@ export const updateTrialSessionSequence = [
       updateTrialSessionAction,
       {
         error: [setAlertErrorAction],
-        success: [
-          setSaveAlertsForNavigationAction,
-          setAlertSuccessAction,
-          navigateToTrialSessionDetailAction,
-        ],
+        success: [],
       },
     ],
   },

--- a/web-client/src/providers/socketRouter.js
+++ b/web-client/src/providers/socketRouter.js
@@ -11,6 +11,11 @@ export const socketRouter = (app, onMessageCallbackFn) => {
           ...message,
         });
         break;
+      case 'update_trial_session_complete':
+        await app.getSequence('updateTrialSessionCompleteSequence')({
+          ...message,
+        });
+        break;
       case 'batch_download_ready':
         await app.getSequence('batchDownloadReadySequence')({
           ...message,

--- a/web-client/src/styles/progress.scss
+++ b/web-client/src/styles/progress.scss
@@ -14,6 +14,13 @@
 }
 
 .progress-indicator {
+  &.show-wait-text {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding-top: 160px;
+  }
+
   .spinner {
     position: absolute;
     top: 50%;

--- a/web-client/src/views/Loading.jsx
+++ b/web-client/src/views/Loading.jsx
@@ -2,22 +2,27 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { connect } from '@cerebral/react';
 import { state } from 'cerebral';
 import React from 'react';
+import classNames from 'classnames';
 
 export const Loading = connect(
   {
     loadingHelper: state.loadingHelper,
+    waitText: state.progressIndicator.waitText,
     waitingForResponse: state.progressIndicator.waitingForResponse,
   },
-  function Loading({ loadingHelper, waitingForResponse }) {
+  function Loading({ loadingHelper, waitingForResponse, waitText }) {
     return (
       !loadingHelper.pageIsInterstitial &&
       waitingForResponse && (
         <div
           aria-label="please wait"
           aria-live="polite"
-          className="loading-overlay progress-indicator"
+          className={classNames('loading-overlay', 'progress-indicator', {
+            'show-wait-text': waitText,
+          })}
         >
           <FontAwesomeIcon className="fa-spin spinner" icon="sync" size="6x" />
+          {waitText && <div>{waitText}</div>}
         </div>
       )
     );

--- a/web-client/src/views/PrintPaperTrialNotices.jsx
+++ b/web-client/src/views/PrintPaperTrialNotices.jsx
@@ -2,11 +2,14 @@ import { Button } from '../ustc-ui/Button/Button';
 import { PdfPreview } from '../ustc-ui/PdfPreview/PdfPreview';
 import { WarningNotification } from './WarningNotification';
 import { connect } from '@cerebral/react';
+import { state } from 'cerebral';
 import React from 'react';
 
 export const PrintPaperTrialNotices = connect(
-  {},
-  function PrintPaperTrialNotices() {
+  {
+    printPaperDoneUrl: state.printPaperDoneUrl,
+  },
+  function PrintPaperTrialNotices({ printPaperDoneUrl }) {
     return (
       <>
         <div className="big-blue-header">
@@ -24,7 +27,7 @@ export const PrintPaperTrialNotices = connect(
             <div className="grid-col-4">
               <Button
                 className="push-right margin-right-0 margin-top-6"
-                href="/trial-sessions"
+                href={printPaperDoneUrl}
               >
                 Done
               </Button>


### PR DESCRIPTION
Converting the notice of change to remote proceeding behind a websocket to allow for longer execution times.

In addition, we added the ability to mimic the asynchronous nature of a real API Gateway while running code locally.  This led us to discover places where our tests depended on data coming back from the async endpoints when, in reality, nothing would be coming back.