### PR TITLE
DevEx - Speed up case detail page

### DIFF
--- a/cypress-smoketests.json
+++ b/cypress-smoketests.json
@@ -4,7 +4,7 @@
   "reporterOptions": {
     "toConsole": true
   },
-  "video": true,
+  "video": false,
   "fixturesFolder": "cypress-smoketests/fixtures",
   "integrationFolder": "cypress-smoketests/integration",
   "pluginsFile": "cypress-smoketests/plugins/index.js",

--- a/cypress-smoketests.json
+++ b/cypress-smoketests.json
@@ -4,7 +4,7 @@
   "reporterOptions": {
     "toConsole": true
   },
-  "video": false,
+  "video": true,
   "fixturesFolder": "cypress-smoketests/fixtures",
   "integrationFolder": "cypress-smoketests/integration",
   "pluginsFile": "cypress-smoketests/plugins/index.js",

--- a/cypress-smoketests/support/pages/case-detail.js
+++ b/cypress-smoketests/support/pages/case-detail.js
@@ -20,6 +20,8 @@ exports.goToCaseOverview = docketNumber => {
   // will not reload
   cy.goToRoute('/');
   cy.get('.message-unread-column').should('exist');
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.wait(1000);
   cy.goToRoute(`/case-detail/${docketNumber}`);
   cy.get(`.big-blue-header h1 a:contains("${docketNumber}")`).should('exist');
   cy.get('#tab-case-information').click();

--- a/cypress-smoketests/support/pages/case-detail.js
+++ b/cypress-smoketests/support/pages/case-detail.js
@@ -20,8 +20,6 @@ exports.goToCaseOverview = docketNumber => {
   // will not reload
   cy.goToRoute('/');
   cy.get('.message-unread-column').should('exist');
-  // eslint-disable-next-line cypress/no-unnecessary-waiting
-  cy.wait(1000);
   cy.goToRoute(`/case-detail/${docketNumber}`);
   cy.get(`.big-blue-header h1 a:contains("${docketNumber}")`).should('exist');
   cy.get('#tab-case-information').click();

--- a/web-client/src/presenter/actions/TrialSession/getTrialSessionsOnCaseAction.js
+++ b/web-client/src/presenter/actions/TrialSession/getTrialSessionsOnCaseAction.js
@@ -1,0 +1,48 @@
+import { state } from 'cerebral';
+
+/**
+ * Fetches the trial sessions using the getTrialSessions use case
+ *
+ * @param {object} providers the providers object
+ * @param {object} providers.applicationContext needed for getting the getCase use case
+ * @returns {object} contains the trial sessions returned from the use case
+ */
+export const getTrialSessionsOnCaseAction = async ({
+  applicationContext,
+  get,
+  store,
+}) => {
+  const caseDetail = get(state.caseDetail);
+
+  let trialSessions = [];
+
+  if (caseDetail && caseDetail.trialSessionId) {
+    const trialSession = await applicationContext
+      .getUseCases()
+      .getTrialSessionDetailsInteractor(applicationContext, {
+        trialSessionId: caseDetail.trialSessionId,
+      });
+
+    trialSessions.push(trialSession);
+
+    store.set(
+      state.trialSessionJudge,
+      trialSession.judge || { name: 'Unassigned' },
+    );
+  }
+
+  trialSessions = [
+    ...trialSessions,
+    ...(await Promise.all(
+      caseDetail.hearings.map(hearing =>
+        applicationContext
+          .getUseCases()
+          .getTrialSessionDetailsInteractor(applicationContext, {
+            trialSessionId: hearing.trialSessionId,
+          }),
+      ),
+    )),
+  ];
+
+  return { trialSessions };
+};

--- a/web-client/src/presenter/actions/TrialSession/getTrialSessionsOnCaseAction.test.js
+++ b/web-client/src/presenter/actions/TrialSession/getTrialSessionsOnCaseAction.test.js
@@ -1,0 +1,83 @@
+import { applicationContextForClient as applicationContext } from '../../../../../shared/src/business/test/createTestApplicationContext';
+import { getTrialSessionsOnCaseAction } from './getTrialSessionsOnCaseAction';
+import { presenter } from '../../presenter-mock';
+import { runAction } from 'cerebral/test';
+
+describe('getTrialSessionsOnCaseAction', () => {
+  beforeAll(() => {
+    presenter.providers.applicationContext = applicationContext;
+  });
+
+  it('should return two trial sessions, one for the trialSessionId and one for the hearing', async () => {
+    applicationContext
+      .getUseCases()
+      .getTrialSessionDetailsInteractor.mockResolvedValue({
+        sort: 'practitioner',
+        sortOrder: 'desc',
+        trialSessionId: '123',
+        userId: '234',
+      });
+
+    const result = await runAction(getTrialSessionsOnCaseAction, {
+      modules: {
+        presenter,
+      },
+      props: {},
+      state: {
+        caseDetail: {
+          hearings: [
+            {
+              trialSessionId: 'abc',
+            },
+          ],
+          trialSessionId: '123',
+        },
+      },
+    });
+
+    expect(result.output.trialSessions.length).toEqual(2);
+  });
+
+  it('should set the judge name in state based on the trial session id', async () => {
+    applicationContext
+      .getUseCases()
+      .getTrialSessionDetailsInteractor.mockResolvedValue({
+        judge: 'Armen',
+        sort: 'practitioner',
+        sortOrder: 'desc',
+        trialSessionId: '123',
+        userId: '234',
+      });
+
+    const result = await runAction(getTrialSessionsOnCaseAction, {
+      modules: {
+        presenter,
+      },
+      props: {},
+      state: {
+        caseDetail: {
+          hearings: [],
+          trialSessionId: '123',
+        },
+      },
+    });
+
+    expect(result.state.trialSessionJudge).toEqual('Armen');
+  });
+
+  it('should return an empty array if no trial session id or hearing is set', async () => {
+    const result = await runAction(getTrialSessionsOnCaseAction, {
+      modules: {
+        presenter,
+      },
+      props: {},
+      state: {
+        caseDetail: {
+          hearings: [],
+        },
+      },
+    });
+
+    expect(result.output.trialSessions.length).toEqual(0);
+  });
+});

--- a/web-client/src/presenter/sequences/gotoCaseDetailSequence.js
+++ b/web-client/src/presenter/sequences/gotoCaseDetailSequence.js
@@ -1,7 +1,6 @@
 import { clearFormAction } from '../actions/clearFormAction';
 import { clearScreenMetadataAction } from '../actions/clearScreenMetadataAction';
 import { closeMobileMenuAction } from '../actions/closeMobileMenuAction';
-import { fetchUserNotificationsSequence } from './fetchUserNotificationsSequence';
 import { getCaseAction } from '../actions/getCaseAction';
 import { getCaseAssociationAction } from '../actions/getCaseAssociationAction';
 import { getCaseDeadlinesForCaseAction } from '../actions/CaseDeadline/getCaseDeadlinesForCaseAction';
@@ -10,8 +9,9 @@ import { getConstants } from '../../getConstants';
 import { getJudgeForCurrentUserAction } from '../actions/getJudgeForCurrentUserAction';
 import { getJudgesCaseNoteForCaseAction } from '../actions/TrialSession/getJudgesCaseNoteForCaseAction';
 import { getMessagesForCaseAction } from '../actions/CaseDetail/getMessagesForCaseAction';
+import { getNotificationsAction } from '../actions/getNotificationsAction';
 import { getPendingEmailsOnCaseAction } from '../actions/getPendingEmailsOnCaseAction';
-import { getTrialSessionsAction } from '../actions/TrialSession/getTrialSessionsAction';
+import { getTrialSessionsOnCaseAction } from '../actions/TrialSession/getTrialSessionsOnCaseAction';
 import { parallel } from 'cerebral/factories';
 import { resetHeaderAccordionsSequence } from './resetHeaderAccordionsSequence';
 import { runPathForUserRoleAction } from '../actions/runPathForUserRoleAction';
@@ -27,8 +27,8 @@ import { setDocketEntryIdAction } from '../actions/setDocketEntryIdAction';
 import { setIsPrimaryTabAction } from '../actions/setIsPrimaryTabAction';
 import { setJudgeUserAction } from '../actions/setJudgeUserAction';
 import { setJudgesCaseNoteOnCaseDetailAction } from '../actions/TrialSession/setJudgesCaseNoteOnCaseDetailAction';
+import { setNotificationsAction } from '../actions/setNotificationsAction';
 import { setPendingEmailsOnCaseAction } from '../actions/setPendingEmailsOnCaseAction';
-import { setTrialSessionJudgeAction } from '../actions/setTrialSessionJudgeAction';
 import { setTrialSessionsAction } from '../actions/TrialSession/setTrialSessionsAction';
 import { showModalFromQueryAction } from '../actions/showModalFromQueryAction';
 import { startWebSocketConnectionSequenceDecorator } from '../utilities/startWebSocketConnectionSequenceDecorator';
@@ -38,17 +38,16 @@ const { USER_ROLES } = getConstants();
 
 const gotoCaseDetailInternal = startWebSocketConnectionSequenceDecorator([
   resetHeaderAccordionsSequence,
-  getTrialSessionsAction,
-  setTrialSessionsAction,
-  setTrialSessionJudgeAction,
-  getJudgeForCurrentUserAction,
-  setJudgeUserAction,
   setDocketEntryIdAction,
   showModalFromQueryAction,
-  getCaseDeadlinesForCaseAction,
-  getMessagesForCaseAction,
-  getPendingEmailsOnCaseAction,
-  setPendingEmailsOnCaseAction,
+  parallel([
+    [getTrialSessionsOnCaseAction, setTrialSessionsAction],
+    [getJudgeForCurrentUserAction, setJudgeUserAction],
+    [getNotificationsAction, setNotificationsAction],
+    [getCaseDeadlinesForCaseAction],
+    [getMessagesForCaseAction],
+    [getPendingEmailsOnCaseAction, setPendingEmailsOnCaseAction],
+  ]),
   setCurrentPageAction('CaseDetailInternal'),
 ]);
 
@@ -103,7 +102,7 @@ export const gotoCaseDetailSequence = [
         USER_ROLES.reportersOffice,
         USER_ROLES.trialClerk,
       ],
-      [parallel([gotoCaseDetailInternal, fetchUserNotificationsSequence])],
+      [gotoCaseDetailInternal],
     ),
     ...takePathForRoles(
       [USER_ROLES.petitioner, USER_ROLES.irsSuperuser],

--- a/web-client/src/presenter/sequences/gotoCaseDetailSequence.js
+++ b/web-client/src/presenter/sequences/gotoCaseDetailSequence.js
@@ -1,6 +1,7 @@
 import { clearFormAction } from '../actions/clearFormAction';
 import { clearScreenMetadataAction } from '../actions/clearScreenMetadataAction';
 import { closeMobileMenuAction } from '../actions/closeMobileMenuAction';
+import { fetchUserNotificationsSequence } from './fetchUserNotificationsSequence';
 import { getCaseAction } from '../actions/getCaseAction';
 import { getCaseAssociationAction } from '../actions/getCaseAssociationAction';
 import { getCaseDeadlinesForCaseAction } from '../actions/CaseDeadline/getCaseDeadlinesForCaseAction';
@@ -9,7 +10,6 @@ import { getConstants } from '../../getConstants';
 import { getJudgeForCurrentUserAction } from '../actions/getJudgeForCurrentUserAction';
 import { getJudgesCaseNoteForCaseAction } from '../actions/TrialSession/getJudgesCaseNoteForCaseAction';
 import { getMessagesForCaseAction } from '../actions/CaseDetail/getMessagesForCaseAction';
-import { getNotificationsAction } from '../actions/getNotificationsAction';
 import { getPendingEmailsOnCaseAction } from '../actions/getPendingEmailsOnCaseAction';
 import { getTrialSessionsOnCaseAction } from '../actions/TrialSession/getTrialSessionsOnCaseAction';
 import { parallel } from 'cerebral/factories';
@@ -27,7 +27,6 @@ import { setDocketEntryIdAction } from '../actions/setDocketEntryIdAction';
 import { setIsPrimaryTabAction } from '../actions/setIsPrimaryTabAction';
 import { setJudgeUserAction } from '../actions/setJudgeUserAction';
 import { setJudgesCaseNoteOnCaseDetailAction } from '../actions/TrialSession/setJudgesCaseNoteOnCaseDetailAction';
-import { setNotificationsAction } from '../actions/setNotificationsAction';
 import { setPendingEmailsOnCaseAction } from '../actions/setPendingEmailsOnCaseAction';
 import { setTrialSessionsAction } from '../actions/TrialSession/setTrialSessionsAction';
 import { showModalFromQueryAction } from '../actions/showModalFromQueryAction';
@@ -43,7 +42,7 @@ const gotoCaseDetailInternal = startWebSocketConnectionSequenceDecorator([
   parallel([
     [getTrialSessionsOnCaseAction, setTrialSessionsAction],
     [getJudgeForCurrentUserAction, setJudgeUserAction],
-    [getNotificationsAction, setNotificationsAction],
+    [fetchUserNotificationsSequence],
     [getCaseDeadlinesForCaseAction],
     [getMessagesForCaseAction],
     [getPendingEmailsOnCaseAction, setPendingEmailsOnCaseAction],

--- a/web-client/src/presenter/sequences/openAddToTrialModalSequence.js
+++ b/web-client/src/presenter/sequences/openAddToTrialModalSequence.js
@@ -11,6 +11,7 @@ export const openAddToTrialModalSequence = showProgressSequenceDecorator([
   clearAlertsAction,
   getTrialSessionsAction,
   setTrialSessionsOnModalAction,
+  setTrialSessionsOnModalAction,
   setShowAllLocationsFalseAction,
   setShowModalFactoryAction('AddToTrialModal'),
 ]);

--- a/web-client/src/presenter/sequences/openAddToTrialModalSequence.js
+++ b/web-client/src/presenter/sequences/openAddToTrialModalSequence.js
@@ -2,6 +2,7 @@ import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { getTrialSessionsAction } from '../actions/TrialSession/getTrialSessionsAction';
 import { setShowAllLocationsFalseAction } from '../actions/setShowAllLocationsFalseAction';
 import { setShowModalFactoryAction } from '../actions/setShowModalFactoryAction';
+import { setTrialSessionsAction } from '../actions/TrialSession/setTrialSessionsAction';
 import { setTrialSessionsOnModalAction } from '../actions/TrialSession/setTrialSessionsOnModalAction';
 import { showProgressSequenceDecorator } from '../utilities/showProgressSequenceDecorator';
 import { stopShowValidationAction } from '../actions/stopShowValidationAction';
@@ -10,7 +11,7 @@ export const openAddToTrialModalSequence = showProgressSequenceDecorator([
   stopShowValidationAction,
   clearAlertsAction,
   getTrialSessionsAction,
-  setTrialSessionsOnModalAction,
+  setTrialSessionsAction,
   setTrialSessionsOnModalAction,
   setShowAllLocationsFalseAction,
   setShowModalFactoryAction('AddToTrialModal'),


### PR DESCRIPTION
The case detail internal page hits a lot of endpoints (deadlines, notes, trial sessions, messages, pending emails, judge).  These requests were being done in sequential order, so this PR refactors them to be executed in parallel to speed up the load time of the case detail page.

Another issue with the case detail page was it was fetching ALL of the trial sessions on page load.  All of the trial sessions are only used for when interacting with the add to trial modal (which we already fetch all the sessions on open).  This PR includes a change to only fetch the individual cases associated with the case instead of ALL trial sessions in our system.

Before this refactoring, notice how many requests this page loads (4s total):
![before-load-detail-153-20](https://user-images.githubusercontent.com/1868782/162051357-a017bc0e-8bdc-46de-8045-2eb1692aefca.png)

After the refactoring (1s):
![Screen Shot 2022-04-06 at 4 20 53 PM](https://user-images.githubusercontent.com/1868782/162064009-428abce9-c0ed-47e8-b2c4-8da7378df139.png)

