### PR TITLE
OpEx 1058: Ignore Changes to lambda_config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -530,6 +530,10 @@ jobs:
           name: 'Deploy - Verify Private Elasticsearch'
           command: |
             npm run verify-private-elasticsearch -- $ENV
+      - run:
+          name: 'Deploy - Verify Cognito Lambda Triggers'
+          command: |
+            npm run verify-cognito-lambda-triggers -- $ENV
       - store_artifacts:
           path: /home/app/cypress-smoketests/videos/
       - run:

--- a/package.json
+++ b/package.json
@@ -288,6 +288,7 @@
     "verify-authorizers": "./scripts/verify-authorizers.sh",
     "verify-private-elasticsearch": "./scripts/verify-private-elasticsearch.sh",
     "verify-private-s3-buckets": "./scripts/verify-private-s3-buckets.sh",
+    "verify-cognito-lambda-triggers": "./scripts/verify-cognito-lambda-triggers.sh",
     "watch": "nodemon -e yml --exec sls offline start"
   },
   "resolutions": {

--- a/scripts/verify-cognito-lambda-triggers.sh
+++ b/scripts/verify-cognito-lambda-triggers.sh
@@ -13,7 +13,7 @@ ENV="${1}"
 
 cognito_user_pool_name="efcms-${ENV}"
 
-user_pool_has_both_lambda_triggers=$(aws cognito-idp list-user-pools --max-results=60 | jq '.UserPools[] | select(.Name=="'"${cognito_user_pool_name}"'") | .LambdaConfig | .PostConfirmation and .PostAuthentication')
+user_pool_has_both_lambda_triggers=$(aws cognito-idp list-user-pools --max-results=60 --region=us-east-1 | jq '.UserPools[] | select(.Name=="'"${cognito_user_pool_name}"'") | .LambdaConfig | .PostConfirmation and .PostAuthentication')
 
 if [ "${user_pool_has_both_lambda_triggers}" != 'true' ]; then
   echo "ERROR: Cognito user pool ${cognito_user_pool_name} is missing either the PostConfirmation or PostAuthentication Lambda trigger"

--- a/scripts/verify-cognito-lambda-triggers.sh
+++ b/scripts/verify-cognito-lambda-triggers.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Usage
+#   smoketest to verify the Cognito pool retains its Lambda triggers
+
+# Arguments
+#   - $1 - the environment [dev, stg, prod, exp1, exp1, etc]
+
+( ! command -v jq > /dev/null ) && echo "jq must be installed on your machine." && exit 1
+[ -z "${1}" ] && echo "ERROR: The env to run smoketest is missing from the \$1 argument.  An example value of this includes [dev, stg, prod... ]" && exit 1
+
+ENV="${1}"
+
+cognito_user_pool_name="efcms-${ENV}"
+
+user_pool_has_both_lambda_triggers=$(aws cognito-idp list-user-pools --max-results=60 | jq '.UserPools[] | select(.Name=="'"${cognito_user_pool_name}"'") | .LambdaConfig | .PostConfirmation and .PostAuthentication')
+
+if [ "${user_pool_has_both_lambda_triggers}" != 'true' ]; then
+  echo "ERROR: Cognito user pool ${cognito_user_pool_name} is missing either the PostConfirmation or PostAuthentication Lambda trigger"
+  exit 1
+fi
+
+echo "Cognito user pool ${cognito_user_pool_name} has all its Lambda triggers"

--- a/web-api/terraform/template/cognito.tf
+++ b/web-api/terraform/template/cognito.tf
@@ -95,6 +95,10 @@ resource "aws_cognito_user_pool" "pool" {
 
   lifecycle {
     prevent_destroy = true
+
+    # the lambda_config isn't specified in this block because we only want to change its configuration during the color-change step of a deployment
+    # but we also don't want the lambda_config to be deleted, so we need to ignore its configuration
+    ignore_changes = [lambda_config]
   }
 }
 


### PR DESCRIPTION
# OpEx 1058

When we deploy, Terraform checks the current state of the Cognito pool and notices that it has some Lambda triggers, but the Terraform IaC states zero lambda triggers.  This leads Terraform to delete the Lambda triggers.  This leads to a) new users being unable to successfully sign-up during the time between a deploy and the color switch, or b) new users being unable to successfully sign-up ever if the prod deploy failed.

We now tell Terraform to ignore the `lambda_config` configuration which leads it to _not_ delete the Lambda triggers on deploy.  This results in the Lambda triggers remaining all the way until the color switch (which is when they switch out to the new color).

_FYI: a lot of Flexion exp environments are missing the Cognito Lambda triggers ostensibly because they've failed their deployment after the deploy job but before the color-switch job.  After this is merged and your deploy fails due to this new verify check, manually add the Lambda triggers and the next deployment will work correctly._

## Before

Notice the `-` (minus, i.e. delete) on the `lambda_config` block.

```
  # module.ef-cms_apis.aws_cognito_user_pool.pool will be updated in-place
  ~ resource "aws_cognito_user_pool" "pool" {
        id                         = "us-east-1_FJ6j52QGj"
        name                       = "efcms-test"
        tags                       = {}
        # (14 unchanged attributes hidden)



      ~ email_configuration {
          ~ from_email_address     = "\"U.S. Tax Court\" <noreply@test.ef-cms.ustaxcourt.gov>" -> "U.S. Tax Court <noreply@test.ef-cms.ustaxcourt.gov>"
            # (3 unchanged attributes hidden)
        }

      - lambda_config {
          - post_authentication = "arn:aws:lambda:us-east-1:350455059537:function:cognito_post_authentication_lambda_test_green" -> null
          - post_confirmation   = "arn:aws:lambda:us-east-1:350455059537:function:cognito_post_confirmation_lambda_test_green" -> null
        }



        # (8 unchanged blocks hidden)
    }
```

## After

Notice the `lambda_config` block is missing which means it will not be deleted.

```
  # module.ef-cms_apis.aws_cognito_user_pool.pool will be updated in-place
  ~ resource "aws_cognito_user_pool" "pool" {
        id                         = "us-east-1_FJ6j52QGj"
        name                       = "efcms-test"
        tags                       = {}
        # (14 unchanged attributes hidden)



      ~ email_configuration {
          ~ from_email_address     = "\"U.S. Tax Court\" <noreply@test.ef-cms.ustaxcourt.gov>" -> "U.S. Tax Court <noreply@test.ef-cms.ustaxcourt.gov>"
            # (3 unchanged attributes hidden)
        }




        # (9 unchanged blocks hidden)
    }
```