### PR TITLE
Devex 1040: Fixing test deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,10 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v14-npm-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+            - v15-npm-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
       - restore_cache:
           keys:
-            - v14-cypress-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+            - v15-cypress-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
       - run:
           name: Install node dependencies
           command: |
@@ -32,26 +32,30 @@ commands:
           name: Reset package-lock
           command: 'git checkout -- package-lock.json'
       - save_cache:
-          key: v14-npm-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+          key: v15-npm-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
       - save_cache:
-          key: v14-cypress-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+          key: v15-cypress-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
           paths:
             - ~/.cache/Cypress
   npm-install:
     steps:
       - restore_cache:
           keys:
-            - v14-npm-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+            - v15-npm-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
       - run:
           name: Install node dependencies
-          command: '[ ! -d node_modules ] && npm ci || echo package.json and package-lock.json are unchanged. Using cached dependency folder.'
-      - run:
+          command: |
+            if [ ! -d node_modules ]; then
+              npm ci
+            else
+              echo package.json and package-lock.json are unchanged. Using cached node_modules folder.             
+            fi
           name: Reset package-lock
           command: 'git checkout -- package-lock.json'
       - save_cache:
-          key: v14-npm-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+          key: v15-npm-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
 


### PR DESCRIPTION
<img width="1391" alt="Screen Shot 2022-04-25 at 1 51 59 PM" src="https://user-images.githubusercontent.com/20249233/165173076-75a5c77d-be0c-4e9f-94ef-5669b8d969cf.png">

We believe the issue with tests on ustc/test is due to a corrupted value in the cache. It seems like the pa11y-public tests were the "fastest" to install the v14 dependencies because they failed, therefore, they proceeded to the "Save Cache" step faster than any other parallel job. We are addressing this issue by updating the Circle config to not proceed when install fails. This led to Circle inadvertently uploading a corrupted node_modules folder which is why any subsequent test run using cache v14 will fail on USTC Circle jobs and why they won't fail on Flexion's Circle jobs.

The root cause of the install failure seems to be due to the fact that npm package updates usually occur on Mondays and while the original failing job was running, a package we rely on was publishing a new version.
