### PR TITLE
Devex - Trying to fix issue with routing

### DIFF
--- a/web-client/src/router.js
+++ b/web-client/src/router.js
@@ -98,6 +98,7 @@ const router = {
     const registerRoute = (path, cb) => {
       originalRegisterRoute(path, function () {
         processQueue = processQueue.then(() => {
+          // eslint-disable-next-line promise/no-callback-in-promise
           return cb(...arguments);
         });
       });

--- a/web-client/src/router.test.js
+++ b/web-client/src/router.test.js
@@ -109,24 +109,24 @@ describe('router', () => {
     });
 
     describe('fires only upon change of location', () => {
-      it('does not fire for "/" because that is already the window location', () => {
+      it('does not fire for "/" because that is already the window location', async () => {
         expect(window.location.pathname).toBe('/'); // the default route
-        route('/');
+        await route('/');
         expect(window.document.title).toEqual(
           expect.stringMatching('Dashboard'),
         );
         expect(getSequenceMock).not.toHaveBeenCalled();
       });
 
-      it('tries to navigate to /does-not-exist', () => {
-        route('/does-not-exist');
+      it('tries to navigate to /does-not-exist', async () => {
+        await route('/does-not-exist');
         expect(window.document.title).toEqual(expect.stringMatching('Error'));
         expect(getSequenceMock).toBeCalledWith('notFoundErrorSequence');
       });
 
-      it('successfully navigates to / if that is not the current url', () => {
+      it('successfully navigates to / if that is not the current url', async () => {
         expect(window.location.pathname).not.toBe('/');
-        route('/');
+        await route('/');
         expect(window.document.title).toEqual(
           expect.stringMatching('Dashboard'),
         );
@@ -134,8 +134,8 @@ describe('router', () => {
       });
     });
 
-    it('/case-detail/*', () => {
-      route('/case-detail/123-45');
+    it('/case-detail/*', async () => {
+      await route('/case-detail/123-45');
       expect(window.document.title).toEqual(
         expect.stringMatching('Docket 123-45'),
       );
@@ -143,8 +143,8 @@ describe('router', () => {
       expect(sequenceMock).toBeCalledWith({ docketNumber: '123-45' });
     });
 
-    it('/case-detail/*?openModal=*', () => {
-      route('/case-detail/123-45?openModal=MyModal');
+    it('/case-detail/*?openModal=*', async () => {
+      await route('/case-detail/123-45?openModal=MyModal');
       expect(window.document.title).toEqual(
         expect.stringMatching('Docket 123-45'),
       );
@@ -155,12 +155,12 @@ describe('router', () => {
       });
     });
 
-    it('/case-detail/*/documents/*/add-court-issued-docket-entry/*', () => {
+    it('/case-detail/*/documents/*/add-court-issued-docket-entry/*', async () => {
       const docketNumber = '111-44';
       const docketEntryId = '000-001';
       const parentMessageId = '222-555';
 
-      route(
+      await route(
         `/case-detail/${docketNumber}/documents/${docketEntryId}/add-court-issued-docket-entry/${parentMessageId}`,
       );
       expect(window.document.title).toEqual(


### PR DESCRIPTION
Adding some decoration to potentially fix a race condition in our UI related to changing routes. We use riot-router and it works by using an event listener to the window object when the push state occurs, which can cause two of our routes to run in parallel. This causes our UI to get into bad states where the url in the browser says /case-detail, but we are actually viewing the trial-session page.  These race conditions also cause our integration tests and smoke tests to become very flaky.