### PR TITLE
Cypress video compression experiment

### DIFF
--- a/cypress-smoketests.json
+++ b/cypress-smoketests.json
@@ -4,7 +4,6 @@
   "reporterOptions": {
     "toConsole": true
   },
-  "video": false,
   "fixturesFolder": "cypress-smoketests/fixtures",
   "integrationFolder": "cypress-smoketests/integration",
   "pluginsFile": "cypress-smoketests/plugins/index.js",
@@ -16,5 +15,7 @@
   "viewportWidth": 1200,
   "viewportHeight": 900,
   "retries": 3,
-  "chromeWebSecurity": false
+  "chromeWebSecurity": false,
+  "videoCompression": 15,
+  "videoUploadOnPasses": false
 }

--- a/cypress-smoketests.json
+++ b/cypress-smoketests.json
@@ -4,6 +4,7 @@
   "reporterOptions": {
     "toConsole": true
   },
+  "video": true,
   "fixturesFolder": "cypress-smoketests/fixtures",
   "integrationFolder": "cypress-smoketests/integration",
   "pluginsFile": "cypress-smoketests/plugins/index.js",
@@ -16,6 +17,5 @@
   "viewportHeight": 900,
   "retries": 3,
   "chromeWebSecurity": false,
-  "videoCompression": 15,
-  "videoUploadOnPasses": false
+  "videoCompression": 15
 }


### PR DESCRIPTION
Instead of remove video recording, reduce video compression to eliminate timeout error. 

Reference #2153