### PR TITLE
bugfix - adding fallbacks onto the entity for userNotes and calendaredCases

### DIFF
--- a/shared/src/business/entities/trialSessions/TrialSession.js
+++ b/shared/src/business/entities/trialSessions/TrialSession.js
@@ -51,6 +51,7 @@ TrialSession.prototype.init = function (rawSession, { applicationContext }) {
   this.createdAt = rawSession.createdAt || createISODateString();
   this.irsCalendarAdministrator = rawSession.irsCalendarAdministrator;
   this.isCalendared = rawSession.isCalendared || false;
+  this.calendaredCases = rawSession.calendaredCases || [];
   this.joinPhoneNumber = rawSession.joinPhoneNumber;
   this.maxCases = rawSession.maxCases;
   this.meetingId = rawSession.meetingId;

--- a/shared/src/business/entities/trialSessions/TrialSession.test.js
+++ b/shared/src/business/entities/trialSessions/TrialSession.test.js
@@ -28,6 +28,19 @@ describe('TrialSession entity', () => {
     expect(() => new TrialSession({}, {})).toThrow();
   });
 
+  describe('constructor', () => {
+    it('should default the calendaredCases to an empty array if undefined', () => {
+      const trialSession = new TrialSession(
+        { ...VALID_TRIAL_SESSION, calendaredCases: null },
+        {
+          applicationContext,
+        },
+      );
+
+      expect(trialSession.calendaredCases).toEqual([]);
+    });
+  });
+
   describe('isValid', () => {
     it('should be true when a valid trial session is provided', () => {
       const trialSession = new TrialSession(VALID_TRIAL_SESSION, {
@@ -551,6 +564,7 @@ describe('TrialSession entity', () => {
           sessionScope: TRIAL_SESSION_SCOPE_TYPES.locationBased,
           trialLocation: mockTrialLocation,
         },
+        // eslint-disable-next-line max-lines
         {
           applicationContext,
         },

--- a/shared/src/business/entities/trialSessions/TrialSessionWorkingCopy.js
+++ b/shared/src/business/entities/trialSessions/TrialSessionWorkingCopy.js
@@ -34,6 +34,7 @@ TrialSessionWorkingCopy.prototype.init = function init(rawSession) {
   this.sort = rawSession.sort;
   this.sortOrder = rawSession.sortOrder;
   this.trialSessionId = rawSession.trialSessionId;
+  this.userNotes = rawSession.userNotes || {};
   this.userId = rawSession.userId;
 };
 

--- a/shared/src/business/entities/trialSessions/TrialSessionWorkingCopy.test.js
+++ b/shared/src/business/entities/trialSessions/TrialSessionWorkingCopy.test.js
@@ -6,6 +6,16 @@ const VALID_TRIAL_SESSION_WORKING_COPY = {
 };
 
 describe('TrialSessionWorkingCopy entity', () => {
+  describe('constructor', () => {
+    it('should default the userNotes to an empty object if not defined', () => {
+      const workingCopy = new TrialSessionWorkingCopy({
+        ...VALID_TRIAL_SESSION_WORKING_COPY,
+        userNotes: undefined,
+      });
+      expect(workingCopy.userNotes).toEqual({});
+    });
+  });
+
   describe('isValid', () => {
     it('creates a valid trial session working copy with only required values', () => {
       const workingCopy = new TrialSessionWorkingCopy(


### PR DESCRIPTION
the bug:
- login as a trialclerk1@example.com
- open any new trial session that is a working copy (mobile, Alabama)
- uI crashes