### PR TITLE
Smoketests Timeout Fix Attempt: try adding videoUploadOnPasses set to false 

### DIFF
--- a/cypress-smoketests.json
+++ b/cypress-smoketests.json
@@ -5,6 +5,7 @@
     "toConsole": true
   },
   "video": true,
+  "videoUploadOnPasses": false,
   "fixturesFolder": "cypress-smoketests/fixtures",
   "integrationFolder": "cypress-smoketests/integration",
   "pluginsFile": "cypress-smoketests/plugins/index.js",

--- a/cypress-smoketests.json
+++ b/cypress-smoketests.json
@@ -18,5 +18,5 @@
   "viewportHeight": 900,
   "retries": 3,
   "chromeWebSecurity": false,
-  "videoCompression": 15
+  "videoCompression": 10
 }


### PR DESCRIPTION
Error: ERR_TIMED_OUT on browser_init is still an open [issue](https://github.com/cypress-io/cypress/issues/17627) but one suggestion that's working according to some recent posts is setting this flag. Either way, when smoketests pass it doesn't seem necessary for us to have videos to watch and reduces the test run by about a minute looking at exp5 [before](https://app.circleci.com/pipelines/github/flexion/ef-cms/35007/workflows/1446f173-755f-4e96-98c4-003a12eddd66) and [after](https://app.circleci.com/pipelines/github/flexion/ef-cms/35008/workflows/231395b7-1a1b-4193-91d6-82b75310a1e5) 

Looking at a couple failures [1](https://app.circleci.com/pipelines/github/ustaxcourt/ef-cms/3399/workflows/8f828322-bc46-47b6-a19d-518da5bbb01a/jobs/35041) and [2](https://app.circleci.com/pipelines/github/ustaxcourt/ef-cms/3390/workflows/59f4884d-eb3a-42ad-ba0d-b62db239b5c8/jobs/34921) on `test`, we're still timing facing this timeout.