### PR TITLE
9506 - Fixing issue with index not being defined on coversheet

### DIFF
--- a/shared/src/business/useCaseHelper/service/createChangeItems.js
+++ b/shared/src/business/useCaseHelper/service/createChangeItems.js
@@ -84,6 +84,8 @@ const createDocketEntryForChange = async ({
     { applicationContext },
   );
 
+  caseEntity.addDocketEntry(changeOfAddressDocketEntry);
+
   const { pdfData: changeOfAddressPdfWithCover } = await addCoverToPdf({
     applicationContext,
     caseEntity,
@@ -97,9 +99,8 @@ const createDocketEntryForChange = async ({
       applicationContext,
       documentBytes: changeOfAddressPdfWithCover,
     });
-
-  caseEntity.addDocketEntry(changeOfAddressDocketEntry);
   changeOfAddressDocketEntry.setAsServed(servedParties.all);
+
   await applicationContext.getPersistenceGateway().saveDocumentFromLambda({
     applicationContext,
     document: changeOfAddressPdfWithCover,

--- a/shared/src/business/useCaseHelper/service/createChangeItems.test.js
+++ b/shared/src/business/useCaseHelper/service/createChangeItems.test.js
@@ -191,6 +191,39 @@ describe('generateAndServeDocketEntry', () => {
     ).toHaveBeenCalled();
   });
 
+  it('should pass the correct index to the coverSheet', async () => {
+    await generateAndServeDocketEntry({
+      ...testArguments,
+      caseEntity: new Case(
+        {
+          ...testCaseEntity,
+          petitioners: [
+            {
+              ...testCaseEntity.petitioners[0],
+              serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+            },
+          ],
+        },
+        { applicationContext },
+      ),
+      user: {
+        ...testUser,
+        role: ROLES.privatePractitioner,
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_PAPER,
+      },
+    });
+
+    expect(
+      applicationContext.getDocumentGenerators().coverSheet,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          index: 2,
+        }),
+      }),
+    );
+  });
+
   it('does not throw an error if docketMeta is undefined', async () => {
     await expect(
       generateAndServeDocketEntry({

--- a/shared/src/business/useCases/updateContactInteractor.js
+++ b/shared/src/business/useCases/updateContactInteractor.js
@@ -185,6 +185,8 @@ exports.updateContactInteractor = async (
       });
     }
 
+    caseEntity.addDocketEntry(changeOfAddressDocketEntry);
+
     const { pdfData: changeOfAddressPdfWithCover } = await addCoverToPdf({
       applicationContext,
       caseEntity,
@@ -198,8 +200,6 @@ exports.updateContactInteractor = async (
         applicationContext,
         documentBytes: changeOfAddressPdfWithCover,
       });
-
-    caseEntity.addDocketEntry(changeOfAddressDocketEntry);
 
     await applicationContext.getUseCaseHelpers().sendServedPartiesEmails({
       applicationContext,

--- a/shared/src/business/useCases/updateContactInteractor.test.js
+++ b/shared/src/business/useCases/updateContactInteractor.test.js
@@ -95,6 +95,15 @@ describe('updates the contact on a case', () => {
     const changeOfAddressDocument = updatedCase.docketEntries.find(
       d => d.documentType === 'Notice of Change of Address',
     );
+    expect(
+      applicationContext.getDocumentGenerators().coverSheet,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          index: 2,
+        }),
+      }),
+    );
     expect(getContactPrimary(updatedCase)).toMatchObject({
       address1: '453 Electric Ave',
       city: 'Philadelphia',


### PR DESCRIPTION
The issue was we were adding the docket entry to the to the case AFTER generating the coversheet which was causing the index to be undefined.