### PR TITLE
OpEx 1069: Elastic Search Replicas

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,6 +462,7 @@ jobs:
       - run:
           name: Setup Elasticsearch Index Settings
           command: |
+            . ./scripts/load-environment-from-secrets.sh
             ./web-api/setup-elasticsearch-index.sh $ENV
       - run:
           name: Admin User Setup

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -170,7 +170,7 @@ To run the performance tests, you can run one of the following:
 - `npm run test:performance` (runs the ./artillery/private-app.yml file)
 - `npm run test:performance:order` (runs the ./artillery/private-advanced-order.yml file)
 
-
+Each lower environment's ElasticSearch cluster indices' replica count is 0.  If you want to performance test these lower environments, set the `OVERRIDE_ES_NUMBER_OF_REPLICAS` to the production count in AWS Secrets Manager and redeploy the environment beforehand.
 
 ## Testing / Coverage Tips
 

--- a/shared/admin-tools/elasticsearch/test-elasticsearch.js
+++ b/shared/admin-tools/elasticsearch/test-elasticsearch.js
@@ -3,7 +3,6 @@ const { get, pick } = require('lodash');
 const { getClient } = require('../../../web-api/elasticsearch/client');
 
 // const mappings = require('../elasticsearch/elasticsearch-mappings');
-// const { settings } = require('../elasticsearch/elasticsearch-settings');
 
 const environmentName = process.argv[2] || 'exp1';
 const version = process.argv[3] || 'alpha';

--- a/web-api/elasticsearch/elasticsearch-settings.js
+++ b/web-api/elasticsearch/elasticsearch-settings.js
@@ -8,54 +8,70 @@ considerations:
 */
 module.exports = {
   ELASTICSEARCH_API_VERSION: '7.7', // when this changes, ensure elasticsearch.tf files are also updated
-  settings: {
-    index: {
-      analysis: {
-        analyzer: {
-          english_exact: {
-            filter: ['lowercase'],
-            tokenizer: 'standard',
-          },
-          ustc_analyzer: {
-            default: {
-              type: 'simple',
+  settings: ({ environment, overriddenNumberOfReplicasIfNonProd }) => {
+    let actualNumberOfReplicas = 2;
+    if (environment && environment !== 'prod') {
+      actualNumberOfReplicas = 0;
+
+      if (overriddenNumberOfReplicasIfNonProd) {
+        actualNumberOfReplicas = overriddenNumberOfReplicasIfNonProd;
+      }
+    }
+
+    console.log(
+      'Configuring the index number_of_replicas to',
+      actualNumberOfReplicas,
+    );
+
+    return {
+      index: {
+        analysis: {
+          analyzer: {
+            english_exact: {
+              filter: ['lowercase'],
+              tokenizer: 'standard',
             },
-            default_search: {
+            ustc_analyzer: {
+              default: {
+                type: 'simple',
+              },
+              default_search: {
+                type: 'stop',
+              },
+              filter: [
+                'lowercase',
+                'asciifolding',
+                'english',
+                'ustc_stop',
+                'filter_stemmer',
+                'filter_shingle',
+              ],
+              tokenizer: 'standard',
+            },
+          },
+          filter: {
+            english: { stopwords: '_english_', type: 'stop' },
+            filter_shingle: {
+              max_shingle_size: 3,
+              min_shingle_size: 2,
+              output_unigrams: true,
+              type: 'shingle',
+            },
+            filter_stemmer: {
+              language: '_english_',
+              type: 'porter_stem',
+            },
+            ustc_stop: {
+              stopwords: ['tax', 'court'],
               type: 'stop',
             },
-            filter: [
-              'lowercase',
-              'asciifolding',
-              'english',
-              'ustc_stop',
-              'filter_stemmer',
-              'filter_shingle',
-            ],
-            tokenizer: 'standard',
           },
         },
-        filter: {
-          english: { stopwords: '_english_', type: 'stop' },
-          filter_shingle: {
-            max_shingle_size: 3,
-            min_shingle_size: 2,
-            output_unigrams: true,
-            type: 'shingle',
-          },
-          filter_stemmer: {
-            language: '_english_',
-            type: 'porter_stem',
-          },
-          ustc_stop: {
-            stopwords: ['tax', 'court'],
-            type: 'stop',
-          },
-        },
+        'mapping.total_fields.limit': '1000',
+        max_result_window: 20000,
+        number_of_replicas: actualNumberOfReplicas,
+        number_of_shards: 1,
       },
-      'mapping.total_fields.limit': '1000',
-      max_result_window: 20000,
-      number_of_replicas: 2,
-      number_of_shards: 1,
-    },
+    };
   },
 };

--- a/web-api/elasticsearch/elasticsearch-settings.js
+++ b/web-api/elasticsearch/elasticsearch-settings.js
@@ -11,11 +11,7 @@ module.exports = {
   settings: ({ environment, overriddenNumberOfReplicasIfNonProd }) => {
     let actualNumberOfReplicas = 2;
     if (environment && environment !== 'prod') {
-      actualNumberOfReplicas = 0;
-
-      if (overriddenNumberOfReplicasIfNonProd) {
-        actualNumberOfReplicas = overriddenNumberOfReplicasIfNonProd;
-      }
+      actualNumberOfReplicas = overriddenNumberOfReplicasIfNonProd || 0;
     }
 
     console.log(


### PR DESCRIPTION
# [OpEx 1069](https://trello.com/c/2iuR2yPh)

- Reduces the number of replicas in each ElasticSearch index to `0` for the lower environments by default.
- Keeps the number of replicas as `2` for production.
- Able to override the number of replicas for the lower environments by specifying `OVERRIDE_ES_NUMBER_OF_REPLICAS` in that environment's Secrets Manager configuration.
- Added documentation the performance testing section about overriding the number of replicas.