### PR TITLE
3569: Fix mistakes

### DIFF
--- a/shared/src/business/useCases/courtIssuedDocument/fileAndServeCourtIssuedDocumentInteractor.consolidatedCases.test.js
+++ b/shared/src/business/useCases/courtIssuedDocument/fileAndServeCourtIssuedDocumentInteractor.consolidatedCases.test.js
@@ -141,7 +141,7 @@ describe('consolidated cases', () => {
       });
   });
 
-  it('should call serveDocumentAndGetPaperServicePdf and pass the resulting url to `sendNotificationToUser`', async () => {
+  it('should call serveDocumentAndGetPaperServicePdf and pass the resulting url and success message to `sendNotificationToUser`', async () => {
     await fileAndServeCourtIssuedDocumentInteractor(applicationContext, {
       docketEntryId: leadCaseDocketEntries[0].docketEntryId,
       docketNumbers: [
@@ -163,6 +163,10 @@ describe('consolidated cases', () => {
     ).toMatchObject({
       message: expect.objectContaining({
         action: 'file_and_serve_court_issued_document_complete',
+        alertSuccess: {
+          message: 'Document served to selected cases in group. ',
+          overwritable: false,
+        },
         pdfUrl: mockPdfUrl,
       }),
     });

--- a/shared/src/business/useCases/courtIssuedDocument/fileAndServeCourtIssuedDocumentInteractor.consolidatedCases.test.js
+++ b/shared/src/business/useCases/courtIssuedDocument/fileAndServeCourtIssuedDocumentInteractor.consolidatedCases.test.js
@@ -82,7 +82,7 @@ describe('consolidated cases', () => {
 
     applicationContext
       .getUseCases()
-      .getFeatureFlagValueInteractor.mockReturnValue(true);
+      .getFeatureFlagValueInteractor.mockReturnValue(Promise.resolve(true));
 
     leadCaseDocketEntries = [
       mockDocketEntryWithWorkItem,
@@ -398,7 +398,9 @@ describe('consolidated cases', () => {
   it('should only process the subject case when the feature flag is disabled and there are other consolidated cases', async () => {
     applicationContext
       .getUseCases()
-      .getFeatureFlagValueInteractor.mockReturnValueOnce(false);
+      .getFeatureFlagValueInteractor.mockReturnValueOnce(
+        Promise.resolve(false),
+      );
 
     await fileAndServeCourtIssuedDocumentInteractor(applicationContext, {
       docketEntryId: leadCaseDocketEntries[0].docketEntryId,

--- a/shared/src/business/useCases/courtIssuedDocument/fileAndServeCourtIssuedDocumentInteractor.js
+++ b/shared/src/business/useCases/courtIssuedDocument/fileAndServeCourtIssuedDocumentInteractor.js
@@ -188,11 +188,20 @@ exports.fileAndServeCourtIssuedDocumentInteractor = async (
     key: originalSubjectDocketEntry.docketEntryId,
   });
 
+  const successMessage =
+    docketNumbers.length > 1
+      ? 'Document served to selected cases in group. '
+      : 'Document served. ';
+
   // return serviceResults;
   await applicationContext.getNotificationGateway().sendNotificationToUser({
     applicationContext,
     message: {
       action: 'file_and_serve_court_issued_document_complete',
+      alertSuccess: {
+        message: successMessage,
+        overwritable: false,
+      },
       pdfUrl: serviceResults ? serviceResults.pdfUrl : undefined,
     },
     userId: user.userId,

--- a/shared/src/business/useCases/courtIssuedDocument/fileAndServeCourtIssuedDocumentInteractor.js
+++ b/shared/src/business/useCases/courtIssuedDocument/fileAndServeCourtIssuedDocumentInteractor.js
@@ -59,12 +59,13 @@ exports.fileAndServeCourtIssuedDocumentInteractor = async (
 
   const eventCodeCanOnlyBeServedOnSubjectCase =
     ENTERED_AND_SERVED_EVENT_CODES.includes(form.eventCode);
-  const consolidateCaseDuplicateDocketEntries = applicationContext
+  const consolidateCaseDuplicateDocketEntries = await applicationContext
     .getUseCases()
     .getFeatureFlagValueInteractor(applicationContext, {
       featureFlag:
         ALLOWLIST_FEATURE_FLAGS.CONSOLIDATED_CASES_PROPAGATE_DOCKET_ENTRIES.key,
     });
+
   if (
     eventCodeCanOnlyBeServedOnSubjectCase ||
     !consolidateCaseDuplicateDocketEntries

--- a/shared/src/business/useCases/courtIssuedDocument/fileAndServeCourtIssuedDocumentInteractor.test.js
+++ b/shared/src/business/useCases/courtIssuedDocument/fileAndServeCourtIssuedDocumentInteractor.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 const {
   applicationContext,
   testPdfDoc,
@@ -336,7 +337,7 @@ describe('fileAndServeCourtIssuedDocumentInteractor', () => {
     ).toBeCalled();
   });
 
-  it('should call serveDocumentAndGetPaperServicePdf and pass the resulting url to `sendNotificationToUser`', async () => {
+  it('should call serveDocumentAndGetPaperServicePdf and pass the resulting url and success message to `sendNotificationToUser`', async () => {
     caseRecord.petitioners[0].serviceIndicator =
       SERVICE_INDICATOR_TYPES.SI_PAPER;
 
@@ -353,6 +354,10 @@ describe('fileAndServeCourtIssuedDocumentInteractor', () => {
     ).toMatchObject({
       message: expect.objectContaining({
         action: 'file_and_serve_court_issued_document_complete',
+        alertSuccess: {
+          message: 'Document served. ',
+          overwritable: false,
+        },
         pdfUrl: mockPdfUrl,
       }),
     });

--- a/web-client/integration-tests/docketClerkConsolidatesCases.test.js
+++ b/web-client/integration-tests/docketClerkConsolidatesCases.test.js
@@ -99,6 +99,15 @@ describe('Case Consolidation Journey', () => {
   docketClerkSignsOrder(cerebralTest, 0);
   docketClerkServesDocumentOnLeadCase(cerebralTest, 0);
 
+  it('should have a success message that mentions serving multiple cases', async () => {
+    const alertSuccess = cerebralTest.getState('alertSuccess');
+
+    expect(alertSuccess.message).toEqual(
+      'Document served to selected cases in group. ',
+    );
+    expect(alertSuccess.overwritable).toEqual(false);
+  });
+
   it('should verify that document is served on all checked consolidated cases', async () => {
     const consolidatedCases = cerebralTest.getState(
       'caseDetail.consolidatedCases',
@@ -151,6 +160,13 @@ describe('Case Consolidation Journey', () => {
   });
   docketClerkSignsOrder(cerebralTest, 0);
   docketClerkAddsAndServesDocketEntryFromOrder(cerebralTest, 0, false);
+
+  it('should have a success message that mentions the document was served (and not on multiple cases)', async () => {
+    const alertSuccess = cerebralTest.getState('alertSuccess');
+
+    expect(alertSuccess.message).toEqual('Document served. ');
+    expect(alertSuccess.overwritable).toEqual(false);
+  });
 
   //   verify no new docket entry on non-lead cases
   it('should verify that document is served on only the lead case when the feature flag is disabled', async () => {

--- a/web-client/integration-tests/docketClerkConsolidatesCases.test.js
+++ b/web-client/integration-tests/docketClerkConsolidatesCases.test.js
@@ -151,8 +151,6 @@ describe('Case Consolidation Journey', () => {
     await setConsolidatedCasesPropagateEntriesFlag(false);
   });
 
-  // TODO: duplicate appropriate steps from above
-  //   create new docket entry on lead case
   docketClerkCreatesAnOrder(cerebralTest, {
     documentTitle: 'Order to do something only on the lead case',
     eventCode: 'O',
@@ -168,7 +166,6 @@ describe('Case Consolidation Journey', () => {
     expect(alertSuccess.overwritable).toEqual(false);
   });
 
-  //   verify no new docket entry on non-lead cases
   it('should verify that document is served on only the lead case when the feature flag is disabled', async () => {
     const consolidatedCases = cerebralTest.getState(
       'caseDetail.consolidatedCases',

--- a/web-client/integration-tests/docketClerkConsolidatesCases.test.js
+++ b/web-client/integration-tests/docketClerkConsolidatesCases.test.js
@@ -171,7 +171,6 @@ describe('Case Consolidation Journey', () => {
       );
 
       if (cerebralTest.leadDocketNumber === consolidatedCase.docketNumber) {
-        console.log('orderDocument::', orderDocument);
         expect(orderDocument.servedAt).toBeDefined();
         expect(orderDocument.workItem.docketEntry.docketEntryId).toEqual(
           orderDocument.docketEntryId,

--- a/web-client/integration-tests/helpers.js
+++ b/web-client/integration-tests/helpers.js
@@ -3,7 +3,6 @@ import { Case } from '../../shared/src/business/entities/cases/Case';
 import { CerebralTest, runCompute } from 'cerebral/test';
 import { DynamoDB, S3 } from 'aws-sdk';
 import { JSDOM } from 'jsdom';
-import { SERVICE_INDICATOR_TYPES } from '../../shared/src/business/entities/EntityConstants';
 import { applicationContext } from '../src/applicationContext';
 import {
   back,
@@ -73,7 +72,12 @@ import qs from 'qs';
 import riotRoute from 'riot-route';
 import sass from 'sass';
 
-const { CASE_TYPES_MAP, PARTY_TYPES } = applicationContext.getConstants();
+const {
+  ALLOWLIST_FEATURE_FLAGS,
+  CASE_TYPES_MAP,
+  PARTY_TYPES,
+  SERVICE_INDICATOR_TYPES,
+} = applicationContext.getConstants();
 
 const formattedDocketEntries = withAppContextDecorator(
   formattedDocketEntriesComputed,
@@ -361,12 +365,23 @@ export const setJudgeTitle = (judgeUserId, newJudgeTitle) => {
   });
 };
 
-export const setOrderSearchEnabled = (isEnabled, keyPrefix) => {
-  return client.put({
+export const setOrderSearchEnabled = async (isEnabled, keyPrefix) => {
+  return await setFeatureFlag(isEnabled, `${keyPrefix}-order-search-enabled`);
+};
+
+export const setConsolidatedCasesPropagateEntriesFlag = async isEnabled => {
+  return await setFeatureFlag(
+    isEnabled,
+    ALLOWLIST_FEATURE_FLAGS.CONSOLIDATED_CASES_PROPAGATE_DOCKET_ENTRIES.key,
+  );
+};
+
+export const setFeatureFlag = async (isEnabled, key) => {
+  return await client.put({
     Item: {
       current: isEnabled,
-      pk: `${keyPrefix}-order-search-enabled`,
-      sk: `${keyPrefix}-order-search-enabled`,
+      pk: key,
+      sk: key,
     },
     applicationContext,
   });

--- a/web-client/integration-tests/helpers.js
+++ b/web-client/integration-tests/helpers.js
@@ -442,6 +442,7 @@ export const serveDocument = async ({
   await cerebralTest.runSequence(
     'serveCourtIssuedDocumentFromDocketEntrySequence',
   );
+  await waitForLoadingComponentToHide({ cerebralTest });
 };
 
 export const createCourtIssuedDocketEntry = async ({

--- a/web-client/integration-tests/journey/docketClerkAddsAndServesDocketEntryFromOrder.js
+++ b/web-client/integration-tests/journey/docketClerkAddsAndServesDocketEntryFromOrder.js
@@ -7,6 +7,7 @@ import { withAppContextDecorator } from '../../src/withAppContext';
 export const docketClerkAddsAndServesDocketEntryFromOrder = (
   cerebralTest,
   draftOrderIndex,
+  testFormBehavior = true,
 ) => {
   return it(`Docket Clerk adds and serves a docket entry from the given order ${draftOrderIndex}`, async () => {
     let caseDetailFormatted;
@@ -72,110 +73,112 @@ export const docketClerkAddsAndServesDocketEntryFromOrder = (
     expect(cerebralTest.getState('form.freeText')).toEqual('Order');
     expect(cerebralTest.getState('form.serviceStamp')).toBeFalsy();
 
-    // eventCode: OCA
-    await cerebralTest.runSequence(
-      'updateCourtIssuedDocketEntryFormValueSequence',
-      {
-        key: 'eventCode',
-        value: 'OCA',
-      },
-    );
+    if (testFormBehavior) {
+      // eventCode: OCA
+      await cerebralTest.runSequence(
+        'updateCourtIssuedDocketEntryFormValueSequence',
+        {
+          key: 'eventCode',
+          value: 'OCA',
+        },
+      );
 
-    nonstandardHelperComputed = runCompute(
-      withAppContextDecorator(addCourtIssuedDocketEntryNonstandardHelper),
-      {
-        state: cerebralTest.getState(),
-      },
-    );
+      nonstandardHelperComputed = runCompute(
+        withAppContextDecorator(addCourtIssuedDocketEntryNonstandardHelper),
+        {
+          state: cerebralTest.getState(),
+        },
+      );
 
-    expect(nonstandardHelperComputed.showFreeText).toBeTruthy();
-    expect(cerebralTest.getState('form.freeText')).toBeFalsy();
+      expect(nonstandardHelperComputed.showFreeText).toBeTruthy();
+      expect(cerebralTest.getState('form.freeText')).toBeFalsy();
 
-    // eventCode: OAJ
-    await cerebralTest.runSequence(
-      'updateCourtIssuedDocketEntryFormValueSequence',
-      {
-        key: 'eventCode',
-        value: 'OAJ',
-      },
-    );
+      // eventCode: OAJ
+      await cerebralTest.runSequence(
+        'updateCourtIssuedDocketEntryFormValueSequence',
+        {
+          key: 'eventCode',
+          value: 'OAJ',
+        },
+      );
 
-    nonstandardHelperComputed = runCompute(
-      withAppContextDecorator(addCourtIssuedDocketEntryNonstandardHelper),
-      {
-        state: cerebralTest.getState(),
-      },
-    );
+      nonstandardHelperComputed = runCompute(
+        withAppContextDecorator(addCourtIssuedDocketEntryNonstandardHelper),
+        {
+          state: cerebralTest.getState(),
+        },
+      );
 
-    expect(nonstandardHelperComputed.showFreeText).toBeTruthy();
-    expect(cerebralTest.getState('form.freeText')).toBeFalsy();
-    expect(nonstandardHelperComputed.showJudge).toBeTruthy();
-    expect(cerebralTest.getState('form.judge')).toBeFalsy();
+      expect(nonstandardHelperComputed.showFreeText).toBeTruthy();
+      expect(cerebralTest.getState('form.freeText')).toBeFalsy();
+      expect(nonstandardHelperComputed.showJudge).toBeTruthy();
+      expect(cerebralTest.getState('form.judge')).toBeFalsy();
 
-    // eventCode: OAL
-    await cerebralTest.runSequence(
-      'updateCourtIssuedDocketEntryFormValueSequence',
-      {
-        key: 'eventCode',
-        value: 'OAL',
-      },
-    );
+      // eventCode: OAL
+      await cerebralTest.runSequence(
+        'updateCourtIssuedDocketEntryFormValueSequence',
+        {
+          key: 'eventCode',
+          value: 'OAL',
+        },
+      );
 
-    nonstandardHelperComputed = runCompute(
-      withAppContextDecorator(addCourtIssuedDocketEntryNonstandardHelper),
-      {
-        state: cerebralTest.getState(),
-      },
-    );
+      nonstandardHelperComputed = runCompute(
+        withAppContextDecorator(addCourtIssuedDocketEntryNonstandardHelper),
+        {
+          state: cerebralTest.getState(),
+        },
+      );
 
-    expect(nonstandardHelperComputed.showFreeText).toBeFalsy();
-    expect(nonstandardHelperComputed.showDocketNumbers).toBeTruthy();
-    expect(cerebralTest.getState('form.docketNumbers')).toBeFalsy();
+      expect(nonstandardHelperComputed.showFreeText).toBeFalsy();
+      expect(nonstandardHelperComputed.showDocketNumbers).toBeTruthy();
+      expect(cerebralTest.getState('form.docketNumbers')).toBeFalsy();
 
-    // eventCode: OAP
-    await cerebralTest.runSequence(
-      'updateCourtIssuedDocketEntryFormValueSequence',
-      {
-        key: 'eventCode',
-        value: 'OAP',
-      },
-    );
+      // eventCode: OAP
+      await cerebralTest.runSequence(
+        'updateCourtIssuedDocketEntryFormValueSequence',
+        {
+          key: 'eventCode',
+          value: 'OAP',
+        },
+      );
 
-    nonstandardHelperComputed = runCompute(
-      withAppContextDecorator(addCourtIssuedDocketEntryNonstandardHelper),
-      {
-        state: cerebralTest.getState(),
-      },
-    );
+      nonstandardHelperComputed = runCompute(
+        withAppContextDecorator(addCourtIssuedDocketEntryNonstandardHelper),
+        {
+          state: cerebralTest.getState(),
+        },
+      );
 
-    expect(nonstandardHelperComputed.showFreeText).toBeTruthy();
-    expect(cerebralTest.getState('form.freeText')).toBeFalsy();
-    expect(nonstandardHelperComputed.showDateFirst).toBeTruthy();
-    expect(cerebralTest.getState('form.month')).toBeFalsy();
-    expect(cerebralTest.getState('form.day')).toBeFalsy();
-    expect(cerebralTest.getState('form.year')).toBeFalsy();
+      expect(nonstandardHelperComputed.showFreeText).toBeTruthy();
+      expect(cerebralTest.getState('form.freeText')).toBeFalsy();
+      expect(nonstandardHelperComputed.showDateFirst).toBeTruthy();
+      expect(cerebralTest.getState('form.month')).toBeFalsy();
+      expect(cerebralTest.getState('form.day')).toBeFalsy();
+      expect(cerebralTest.getState('form.year')).toBeFalsy();
 
-    // eventCode: OODS
-    await cerebralTest.runSequence(
-      'updateCourtIssuedDocketEntryFormValueSequence',
-      {
-        key: 'eventCode',
-        value: 'OODS',
-      },
-    );
+      // eventCode: OODS
+      await cerebralTest.runSequence(
+        'updateCourtIssuedDocketEntryFormValueSequence',
+        {
+          key: 'eventCode',
+          value: 'OODS',
+        },
+      );
 
-    nonstandardHelperComputed = runCompute(
-      withAppContextDecorator(addCourtIssuedDocketEntryNonstandardHelper),
-      {
-        state: cerebralTest.getState(),
-      },
-    );
+      nonstandardHelperComputed = runCompute(
+        withAppContextDecorator(addCourtIssuedDocketEntryNonstandardHelper),
+        {
+          state: cerebralTest.getState(),
+        },
+      );
 
-    expect(nonstandardHelperComputed.showFreeText).toBeFalsy();
-    expect(nonstandardHelperComputed.showDateFirst).toBeTruthy();
-    expect(cerebralTest.getState('form.month')).toBeFalsy();
-    expect(cerebralTest.getState('form.day')).toBeFalsy();
-    expect(cerebralTest.getState('form.year')).toBeFalsy();
+      expect(nonstandardHelperComputed.showFreeText).toBeFalsy();
+      expect(nonstandardHelperComputed.showDateFirst).toBeTruthy();
+      expect(cerebralTest.getState('form.month')).toBeFalsy();
+      expect(cerebralTest.getState('form.day')).toBeFalsy();
+      expect(cerebralTest.getState('form.year')).toBeFalsy();
+    }
 
     // test defined
     await cerebralTest.runSequence(
@@ -229,5 +232,6 @@ export const docketClerkAddsAndServesDocketEntryFromOrder = (
     await cerebralTest.runSequence(
       'serveCourtIssuedDocumentFromDocketEntrySequence',
     );
+    cerebralTest.draftOrders.shift();
   });
 };

--- a/web-client/integration-tests/journey/docketClerkAddsAndServesDocketEntryFromOrder.js
+++ b/web-client/integration-tests/journey/docketClerkAddsAndServesDocketEntryFromOrder.js
@@ -2,6 +2,7 @@ import { addCourtIssuedDocketEntryHelper } from '../../src/presenter/computeds/a
 import { addCourtIssuedDocketEntryNonstandardHelper } from '../../src/presenter/computeds/addCourtIssuedDocketEntryNonstandardHelper';
 import { formattedCaseDetail } from '../../src/presenter/computeds/formattedCaseDetail';
 import { runCompute } from 'cerebral/test';
+import { waitForLoadingComponentToHide } from '../helpers';
 import { withAppContextDecorator } from '../../src/withAppContext';
 
 export const docketClerkAddsAndServesDocketEntryFromOrder = (
@@ -233,5 +234,7 @@ export const docketClerkAddsAndServesDocketEntryFromOrder = (
       'serveCourtIssuedDocumentFromDocketEntrySequence',
     );
     cerebralTest.draftOrders.shift();
+
+    await waitForLoadingComponentToHide({ cerebralTest });
   });
 };

--- a/web-client/integration-tests/journey/docketClerkAddsDocketEntryFromOrder.js
+++ b/web-client/integration-tests/journey/docketClerkAddsDocketEntryFromOrder.js
@@ -43,7 +43,6 @@ export const docketClerkAddsDocketEntryFromOrder = (
       draftOrderDocument.documentType,
     );
 
-    // eventCode: O
     await cerebralTest.runSequence(
       'updateCourtIssuedDocketEntryFormValueSequence',
       {
@@ -73,7 +72,6 @@ export const docketClerkAddsDocketEntryFromOrder = (
     expect(cerebralTest.getState('form.freeText')).toEqual('Order');
     expect(cerebralTest.getState('form.serviceStamp')).toBeFalsy();
 
-    // eventCode: OCA
     await cerebralTest.runSequence(
       'updateCourtIssuedDocketEntryFormValueSequence',
       {
@@ -92,7 +90,6 @@ export const docketClerkAddsDocketEntryFromOrder = (
     expect(nonstandardHelperComputed.showFreeText).toBeTruthy();
     expect(cerebralTest.getState('form.freeText')).toBeFalsy();
 
-    // eventCode: OAJ
     await cerebralTest.runSequence(
       'updateCourtIssuedDocketEntryFormValueSequence',
       {
@@ -113,7 +110,6 @@ export const docketClerkAddsDocketEntryFromOrder = (
     expect(nonstandardHelperComputed.showJudge).toBeTruthy();
     expect(cerebralTest.getState('form.judge')).toBeFalsy();
 
-    // eventCode: OAL
     await cerebralTest.runSequence(
       'updateCourtIssuedDocketEntryFormValueSequence',
       {
@@ -133,7 +129,6 @@ export const docketClerkAddsDocketEntryFromOrder = (
     expect(nonstandardHelperComputed.showDocketNumbers).toBeTruthy();
     expect(cerebralTest.getState('form.docketNumbers')).toBeFalsy();
 
-    // eventCode: OAP
     await cerebralTest.runSequence(
       'updateCourtIssuedDocketEntryFormValueSequence',
       {
@@ -156,7 +151,6 @@ export const docketClerkAddsDocketEntryFromOrder = (
     expect(cerebralTest.getState('form.day')).toBeFalsy();
     expect(cerebralTest.getState('form.year')).toBeFalsy();
 
-    // eventCode: OODS
     await cerebralTest.runSequence(
       'updateCourtIssuedDocketEntryFormValueSequence',
       {

--- a/web-client/integration-tests/journey/docketClerkServesDocumentOnLeadCase.js
+++ b/web-client/integration-tests/journey/docketClerkServesDocumentOnLeadCase.js
@@ -61,7 +61,6 @@ export const docketClerkServesDocumentOnLeadCase = (
     await cerebralTest.runSequence('consolidatedCaseCheckboxAllChangeSequence');
     expect(cerebralTest.getState('consolidatedCaseAllCheckbox')).toEqual(false);
 
-    // verify that doc is served on lead case and first consolidated case
     await cerebralTest.runSequence('updateCaseCheckboxSequence', {
       docketNumber: caseDetail.consolidatedCases[1].docketNumber,
     });
@@ -75,6 +74,7 @@ export const docketClerkServesDocumentOnLeadCase = (
     await cerebralTest.runSequence(
       'serveCourtIssuedDocumentFromDocketEntrySequence',
     );
+    cerebralTest.draftOrders.shift();
 
     await waitForLoadingComponentToHide({ cerebralTest });
 

--- a/web-client/src/presenter/actions/CourtIssuedDocketEntry/fileAndServeCourtIssuedDocumentAction.js
+++ b/web-client/src/presenter/actions/CourtIssuedDocketEntry/fileAndServeCourtIssuedDocumentAction.js
@@ -49,14 +49,6 @@ export const fileAndServeCourtIssuedDocumentAction = async ({
     docketNumbers = [caseDetail.docketNumber];
   }
 
-  console.log(
-    'fileAndServeCourtIssuedDocumentAction docketNumbers::',
-    docketNumbers,
-  );
-  console.log(
-    'fileAndServeCourtIssuedDocumentAction subjectCase::',
-    caseDetail.docketNumber,
-  );
   await applicationContext
     .getUseCases()
     .fileAndServeCourtIssuedDocumentInteractor(applicationContext, {

--- a/web-client/src/presenter/actions/CourtIssuedDocketEntry/fileAndServeCourtIssuedDocumentAction.js
+++ b/web-client/src/presenter/actions/CourtIssuedDocketEntry/fileAndServeCourtIssuedDocumentAction.js
@@ -32,6 +32,10 @@ export const fileAndServeCourtIssuedDocumentAction = async ({
 
   const consolidatedCases = get(state.caseDetail.consolidatedCases) || [];
 
+  const consolidatedCasesPropagateDocketEntriesFlag = get(
+    state.featureFlagHelper.consolidatedCasesPropagateDocketEntries,
+  );
+
   let docketNumbers = consolidatedCases
     .filter(consolidatedCase => consolidatedCase.checked)
     .map(consolidatedCase => consolidatedCase.docketNumber);
@@ -40,6 +44,7 @@ export const fileAndServeCourtIssuedDocumentAction = async ({
 
   if (
     !isLeadCase ||
+    !consolidatedCasesPropagateDocketEntriesFlag ||
     docketNumbers.length === 0 ||
     !currentDocketEntryCompatibleWithConsolidation
   ) {

--- a/web-client/src/presenter/actions/CourtIssuedDocketEntry/fileAndServeCourtIssuedDocumentAction.js
+++ b/web-client/src/presenter/actions/CourtIssuedDocketEntry/fileAndServeCourtIssuedDocumentAction.js
@@ -40,8 +40,6 @@ export const fileAndServeCourtIssuedDocumentAction = async ({
     .filter(consolidatedCase => consolidatedCase.checked)
     .map(consolidatedCase => consolidatedCase.docketNumber);
 
-  let successMessage = 'Document served to selected cases in group. ';
-
   if (
     !isLeadCase ||
     !consolidatedCasesPropagateDocketEntriesFlag ||
@@ -49,10 +47,17 @@ export const fileAndServeCourtIssuedDocumentAction = async ({
     !currentDocketEntryCompatibleWithConsolidation
   ) {
     docketNumbers = [caseDetail.docketNumber];
-    successMessage = 'Document served. ';
   }
 
-  const result = await applicationContext
+  console.log(
+    'fileAndServeCourtIssuedDocumentAction docketNumbers::',
+    docketNumbers,
+  );
+  console.log(
+    'fileAndServeCourtIssuedDocumentAction subjectCase::',
+    caseDetail.docketNumber,
+  );
+  await applicationContext
     .getUseCases()
     .fileAndServeCourtIssuedDocumentInteractor(applicationContext, {
       docketEntryId,
@@ -60,12 +65,4 @@ export const fileAndServeCourtIssuedDocumentAction = async ({
       form,
       subjectCaseDocketNumber: caseDetail.docketNumber,
     });
-
-  return {
-    alertSuccess: {
-      message: successMessage,
-      overwritable: false,
-    },
-    pdfUrl: result ? result.pdfUrl : undefined,
-  };
 };

--- a/web-client/src/presenter/actions/CourtIssuedDocketEntry/fileAndServeCourtIssuedDocumentAction.test.js
+++ b/web-client/src/presenter/actions/CourtIssuedDocketEntry/fileAndServeCourtIssuedDocumentAction.test.js
@@ -42,48 +42,6 @@ describe('submitCourtIssuedDocketEntryAction', () => {
     ).toEqual([thisDocketNumber]);
   });
 
-  it('should return a pdfUrl when one is generated, the success message is set for unconsolidated cases, and overwritable is false', async () => {
-    const mockPdfUrl = 'www.example.com';
-    applicationContext
-      .getUseCases()
-      .fileAndServeCourtIssuedDocumentInteractor.mockReturnValue({
-        pdfUrl: mockPdfUrl,
-      });
-
-    const result = await runAction(fileAndServeCourtIssuedDocumentAction, {
-      modules: {
-        presenter,
-      },
-      state: {
-        caseDetail: {
-          docketNumber: '123-20',
-        },
-        docketEntryId: 'abc',
-        featureFlagHelper: {
-          consolidatedCasesPropagateDocketEntries: true,
-        },
-        form: {
-          attachments: false,
-          date: '2019-01-01T00:00:00.000Z',
-          documentTitle: '[Anything]',
-          documentType: 'Order',
-          eventCode: 'O',
-          freeText: 'Testing',
-          generatedDocumentTitle: 'Order F',
-          scenario: 'Type A',
-        },
-      },
-    });
-
-    expect(result.output).toEqual({
-      alertSuccess: {
-        message: 'Document served. ',
-        overwritable: false,
-      },
-      pdfUrl: mockPdfUrl,
-    });
-  });
-
   describe('consolidated cases', () => {
     const {
       COURT_ISSUED_EVENT_CODES_REQUIRING_COVERSHEET,
@@ -95,12 +53,12 @@ describe('submitCourtIssuedDocketEntryAction', () => {
       ...COURT_ISSUED_EVENT_CODES_REQUIRING_COVERSHEET,
     ];
 
-    it('should pass the docket number for each checked case, the correct success message is returned, and overwritable is false', async () => {
+    it('should pass the docket number for each checked case', async () => {
       const leadDocketNumber = '123-20';
       const checkedDocketNumber1 = 'DogCow';
       const checkedDocketNumber2 = 'Moof';
 
-      const result = await runAction(fileAndServeCourtIssuedDocumentAction, {
+      await runAction(fileAndServeCourtIssuedDocumentAction, {
         modules: {
           presenter,
         },
@@ -141,11 +99,6 @@ describe('submitCourtIssuedDocketEntryAction', () => {
           .fileAndServeCourtIssuedDocumentInteractor.mock.calls[0][1]
           .docketNumbers,
       ).toEqual([leadDocketNumber, checkedDocketNumber1, checkedDocketNumber2]);
-
-      expect(result.output.alertSuccess).toEqual({
-        message: 'Document served to selected cases in group. ',
-        overwritable: false,
-      });
     });
 
     it("should pass only one docket number if this isn't lead case", async () => {


### PR DESCRIPTION
- Await call to `getFeatureFlagInteractor` (don't know how we missed this)
- Check flag prior to calling `fileAndServeCourtIssuedDocumentInteractor`, just to be double sure
- Fixed `alertSuccess` message not being set correctly.
- TESTS!