### PR TITLE
9515: Online Cited Sources

### DIFF
--- a/cypress-smoketests/support/pages/advanced-search.js
+++ b/cypress-smoketests/support/pages/advanced-search.js
@@ -75,7 +75,7 @@ exports.addDocketEntryAndServeOpinion = testData => {
   cy.get('#judge').select('Foley');
 
   testData.documentDescription = faker.company.catchPhrase();
-  cy.get('#free-text').type(testData.documentDescription);
+  cy.get('#free-text').clear().type(testData.documentDescription);
 
   cy.get('#serve-to-parties-btn').click();
   cy.get('button').contains('Yes, Serve').click();

--- a/shared/src/business/entities/EntityConstants.js
+++ b/shared/src/business/entities/EntityConstants.js
@@ -513,6 +513,7 @@ const EVENT_CODES_VISIBLE_TO_PUBLIC = [
   'DEC',
   'ODL',
   'SPTN',
+  'OCS',
 ];
 
 const SYSTEM_GENERATED_DOCUMENT_TYPES = {

--- a/shared/src/business/entities/cases/PublicDocketEntry.js
+++ b/shared/src/business/entities/cases/PublicDocketEntry.js
@@ -32,6 +32,7 @@ PublicDocketEntry.prototype.init = function init(rawDocketEntry) {
   this.eventCode = rawDocketEntry.eventCode;
   this.filedBy = rawDocketEntry.filedBy;
   this.filingDate = rawDocketEntry.filingDate;
+  this.freeText = rawDocketEntry.freeText;
   this.index = rawDocketEntry.index;
   this.isFileAttached = rawDocketEntry.isFileAttached;
   this.isLegacyServed = rawDocketEntry.isLegacyServed;
@@ -71,6 +72,7 @@ PublicDocketEntry.VALIDATION_RULES = joi.object().keys({
   filingDate: JoiValidationConstants.ISO_DATE.max('now')
     .required()
     .description('Date that this Document was filed.'),
+  freeText: JoiValidationConstants.STRING.max(1000).optional(),
   index: DOCKET_ENTRY_VALIDATION_RULE_KEYS.index,
   isFileAttached: DOCKET_ENTRY_VALIDATION_RULE_KEYS.isFileAttached,
   isLegacyServed: DOCKET_ENTRY_VALIDATION_RULE_KEYS.isLegacyServed,

--- a/shared/src/tools/courtIssuedEventCodes.json
+++ b/shared/src/tools/courtIssuedEventCodes.json
@@ -488,7 +488,7 @@
     "eventCode": "OCS",
     "documentType": "Online Cited Source",
     "documentTitle": "Online Cited Source",
-    "scenario": "Type X",
+    "scenario": "Type A",
     "isUnservable": true
   }
 ]

--- a/shared/src/tools/courtIssuedEventCodes.json
+++ b/shared/src/tools/courtIssuedEventCodes.json
@@ -483,5 +483,12 @@
     "scenario": "Type A",
     "isUnservable": true,
     "requiresCoversheet": true
+  },
+  {
+    "eventCode": "OCS",
+    "documentType": "Online Cited Source",
+    "documentTitle": "Online Cited Source",
+    "scenario": "Type X",
+    "isUnservable": true
   }
 ]

--- a/web-client/integration-tests/docketClerkServedOrderOfAmendedPetition.test.js
+++ b/web-client/integration-tests/docketClerkServedOrderOfAmendedPetition.test.js
@@ -61,7 +61,7 @@ describe('Docket Clerk serves a Order of Amended Petition', () => {
         d => d.docketEntryId === cerebralTest.docketRecordEntry.docketEntryId,
       );
     expect(servedEntry.documentTitle).toEqual(
-      'Order for Amended Petition on 02-02-2050',
+      'Order for Amended Petition on 02-02-2050 Order to do something',
     );
   });
 });

--- a/web-client/src/presenter/actions/CourtIssuedDocketEntry/clearCourtIssuedDocketEntryFormValuesAction.js
+++ b/web-client/src/presenter/actions/CourtIssuedDocketEntry/clearCourtIssuedDocketEntryFormValuesAction.js
@@ -8,11 +8,31 @@ import { state } from 'cerebral';
  * @param {object} providers.props the cerebral props object
  */
 export const clearCourtIssuedDocketEntryFormValuesAction = ({
+  applicationContext,
+  get,
   props,
   store,
 }) => {
-  if (props.key === 'eventCode') {
-    store.unset(state.form.freeText);
+  const scenariosWhichIncludeFreeText = [
+    'Type A',
+    'Type B',
+    'Type D',
+    'Type H',
+  ];
+  if (props.key === 'eventCode' && props.value) {
+    const eventCodes =
+      applicationContext.getConstants().COURT_ISSUED_EVENT_CODES;
+
+    const eventCodeObject = eventCodes.find(e => e.eventCode === props.value);
+
+    const shouldClearFreeTextField =
+      !scenariosWhichIncludeFreeText.includes(eventCodeObject.scenario) ||
+      get(state.form.freeText) === 'Order' ||
+      get(state.form.freeText) === 'Notice';
+
+    if (shouldClearFreeTextField) {
+      store.unset(state.form.freeText);
+    }
     store.unset(state.form.judge);
     store.unset(state.form.docketNumbers);
     store.unset(state.form.trialLocation);

--- a/web-client/src/presenter/actions/CourtIssuedDocketEntry/clearCourtIssuedDocketEntryFormValuesAction.test.js
+++ b/web-client/src/presenter/actions/CourtIssuedDocketEntry/clearCourtIssuedDocketEntryFormValuesAction.test.js
@@ -1,12 +1,45 @@
+import { applicationContextForClient as applicationContext } from '../../../../../shared/src/business/test/createTestApplicationContext';
 import { clearCourtIssuedDocketEntryFormValuesAction } from './clearCourtIssuedDocketEntryFormValuesAction';
 import { presenter } from '../../presenter-mock';
 import { runAction } from 'cerebral/test';
 
 describe('clearCourtIssuedDocketEntryFormValuesAction', () => {
-  it('should clear nonstandard form values if props.key is eventCode', async () => {
+  presenter.providers.applicationContext = applicationContext;
+
+  it('should clear nonstandard form values if props.key is eventCode AND eventCode scenario does not include freetext', async () => {
     const result = await runAction(
       clearCourtIssuedDocketEntryFormValuesAction,
       {
+        applicationContext,
+        modules: {
+          presenter,
+        },
+        props: {
+          key: 'eventCode',
+          value: 'OAL',
+        },
+        state: {
+          form: {
+            day: '12',
+            docketNumbers: '123-19',
+            freeText: 'something',
+            judge: 'Judge Colvin',
+            month: '12',
+            trialLocation: 'Boise, Idaho',
+            year: '2012',
+          },
+        },
+      },
+    );
+
+    expect(result.state.form).toEqual({});
+  });
+
+  it('should clear ALL nonstandard form values except freetext if props.key is eventCode AND eventCode scenario does include freetext', async () => {
+    const result = await runAction(
+      clearCourtIssuedDocketEntryFormValuesAction,
+      {
+        applicationContext,
         modules: {
           presenter,
         },
@@ -20,6 +53,62 @@ describe('clearCourtIssuedDocketEntryFormValuesAction', () => {
             docketNumbers: '123-19',
             freeText: 'something',
             judge: 'Judge Colvin',
+            month: '12',
+            trialLocation: 'Boise, Idaho',
+            year: '2012',
+          },
+        },
+      },
+    );
+
+    expect(result.state.form).toEqual({
+      freeText: 'something',
+    });
+  });
+
+  it('should clear ALL nonstandard form values INCLUDING freetext if props.key is eventCode AND freeText is "Order"', async () => {
+    const result = await runAction(
+      clearCourtIssuedDocketEntryFormValuesAction,
+      {
+        applicationContext,
+        modules: {
+          presenter,
+        },
+        props: {
+          key: 'eventCode',
+          value: 'OCS',
+        },
+        state: {
+          form: {
+            day: '12',
+            freeText: 'Order',
+            month: '12',
+            trialLocation: 'Boise, Idaho',
+            year: '2012',
+          },
+        },
+      },
+    );
+
+    expect(result.state.form).toEqual({});
+  });
+
+  it('should clear ALL nonstandard form values INCLUDING freetext if props.key is eventCode AND freeText is "Notice"', async () => {
+    const result = await runAction(
+      clearCourtIssuedDocketEntryFormValuesAction,
+      {
+        applicationContext,
+        modules: {
+          presenter,
+        },
+        props: {
+          key: 'eventCode',
+          value: 'OCS',
+        },
+        state: {
+          form: {
+            day: '12',
+            freeText: 'Notice',
             month: '12',
             trialLocation: 'Boise, Idaho',
             year: '2012',
@@ -45,6 +134,7 @@ describe('clearCourtIssuedDocketEntryFormValuesAction', () => {
     const result = await runAction(
       clearCourtIssuedDocketEntryFormValuesAction,
       {
+        applicationContext,
         modules: {
           presenter,
         },

--- a/web-client/src/presenter/computeds/Public/publicCaseDetailHelper.js
+++ b/web-client/src/presenter/computeds/Public/publicCaseDetailHelper.js
@@ -1,3 +1,5 @@
+/* eslint-disable complexity */
+
 import { cloneDeep } from 'lodash';
 import { state } from 'cerebral';
 
@@ -49,11 +51,17 @@ export const formatDocketEntryOnDocketRecord = (
       .getSealedDocketEntryTooltip(applicationContext, record);
   }
 
+  if (entry.eventCode === 'OCS' && record.freeText) {
+    record.descriptionDisplay = `${record.freeText} - ${record.descriptionDisplay}`;
+  } else {
+    record.descriptionDisplay = record.documentTitle || record.description;
+  }
+
   return {
     action: record.action,
     createdAtFormatted: record.createdAtFormatted,
     description: record.description,
-    descriptionDisplay: record.documentTitle || record.description,
+    descriptionDisplay: record.descriptionDisplay,
     docketEntryId: record.docketEntryId,
     eventCode: record.eventCode,
     filedBy: record.filedBy,

--- a/web-client/src/presenter/computeds/Public/publicCaseDetailHelper.test.js
+++ b/web-client/src/presenter/computeds/Public/publicCaseDetailHelper.test.js
@@ -158,6 +158,34 @@ describe('publicCaseDetailHelper', () => {
       });
     });
 
+    it('formats descriptionDisplay for `OCS` type documents correctly and makes it visible to public users', () => {
+      state.caseDetail.docketEntries = [
+        {
+          docketEntryId: 'd-1-2-3',
+          documentTitle: 'Online Cited Source',
+          documentType: 'Online Cited Source',
+          eventCode: 'OCS',
+          freeText: 'Test site viewed on 09/09/22',
+          isFileAttached: true,
+          isOnDocketRecord: true,
+          isUnservable: true,
+          processingStatus: DOCUMENT_PROCESSING_STATUS_OPTIONS.COMPLETE,
+        },
+      ];
+
+      const result = runCompute(publicCaseDetailHelper, { state });
+
+      expect(result.formattedDocketEntriesOnDocketRecord).toMatchObject([
+        {
+          descriptionDisplay:
+            'Test site viewed on 09/09/22 - Online Cited Source',
+          docketEntryId: 'd-1-2-3',
+          eventCode: 'OCS',
+          showLinkToDocument: true,
+        },
+      ]);
+    });
+
     it('should not display a link for the PMT event code', () => {
       state.caseDetail.docketEntries = [
         {

--- a/web-client/src/presenter/computeds/formattedDocketEntries.js
+++ b/web-client/src/presenter/computeds/formattedDocketEntries.js
@@ -169,10 +169,10 @@ export const getFormattedDocketEntry = ({
     formattedResult.descriptionDisplay = applicationContext
       .getUtilities()
       .getDocumentTitleWithAdditionalInfo({ docketEntry: entry });
-  }
 
-  if (entry.eventCode === 'OCS' && formattedResult.freeText) {
-    formattedResult.descriptionDisplay = `${formattedResult.freeText} - ${formattedResult.descriptionDisplay}`;
+    if (entry.eventCode === 'OCS' && formattedResult.freeText) {
+      formattedResult.descriptionDisplay = `${formattedResult.freeText} - ${formattedResult.descriptionDisplay}`;
+    }
   }
 
   formattedResult.showDocumentProcessing =

--- a/web-client/src/presenter/computeds/formattedDocketEntries.js
+++ b/web-client/src/presenter/computeds/formattedDocketEntries.js
@@ -171,6 +171,10 @@ export const getFormattedDocketEntry = ({
       .getDocumentTitleWithAdditionalInfo({ docketEntry: entry });
   }
 
+  if (entry.eventCode === 'OCS' && formattedResult.freeText) {
+    formattedResult.descriptionDisplay = `${formattedResult.freeText} - ${formattedResult.descriptionDisplay}`;
+  }
+
   formattedResult.showDocumentProcessing =
     !permissions.UPDATE_CASE &&
     entry.processingStatus !== DOCUMENT_PROCESSING_STATUS_OPTIONS.COMPLETE;

--- a/web-client/src/presenter/computeds/formattedDocketEntries.test.js
+++ b/web-client/src/presenter/computeds/formattedDocketEntries.test.js
@@ -211,6 +211,40 @@ describe('formattedDocketEntries', () => {
     ]);
   });
 
+  it('formats descriptionDisplay for `OCS` type documents correctly', () => {
+    const result = runCompute(formattedDocketEntries, {
+      state: {
+        ...getBaseState(petitionsClerkUser),
+        caseDetail: {
+          ...MOCK_CASE,
+          docketEntries: [
+            {
+              docketEntryId: 'd-1-2-3',
+              documentTitle: 'Online Cited Source',
+              documentType: 'Online Cited Source',
+              eventCode: 'OCS',
+              freeText: 'Test site viewed on 09/09/22',
+              isOnDocketRecord: true,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(result.formattedDocketEntriesOnDocketRecord).toMatchObject([
+      {
+        descriptionDisplay:
+          'Test site viewed on 09/09/22 - Online Cited Source',
+        docketEntryId: 'd-1-2-3',
+        documentType: 'Online Cited Source',
+        isCourtIssuedDocument: true,
+        isInProgress: false,
+        isPetition: false,
+        isStatusServed: false,
+      },
+    ]);
+  });
+
   describe('sorts docket records', () => {
     let sortedCaseDetail;
 


### PR DESCRIPTION
NOTE: Adds `freeText` to the `PublicDocketEntry` entity. We couldn't find a reason why this shouldn't be available to the public client- looking for feedback on this

- Fixes bug where "Description" field was cleared out after switching from "Miscellaneous" document type on "Add Docket Entry" form