### PR TITLE
9515: add 'the' before 'docket' in docket entry success message

### DIFF
--- a/web-client/src/presenter/actions/DocketEntry/getDocketEntryAlertSuccessAction.js
+++ b/web-client/src/presenter/actions/DocketEntry/getDocketEntryAlertSuccessAction.js
@@ -15,7 +15,7 @@ export const getDocketEntryAlertSuccessAction = ({ get }) => {
   if (isUpdatingWithFile) {
     message = 'Entry updated.';
   } else {
-    message = 'Your entry has been added to docket record.';
+    message = 'Your entry has been added to the docket record.';
   }
 
   return {


### PR DESCRIPTION
Per UX request, added "the" before "docket record" on the success message for adding an entry onto the docket record.