### PR TITLE
DevEx - Speed up Scss Compile Times

### DIFF
--- a/web-client/src/app.jsx
+++ b/web-client/src/app.jsx
@@ -1,3 +1,5 @@
+import './uswds.scss';
+// leave this comment here: it prevents eslint from auto-sorting these in the wrong order
 import './index.scss';
 
 import '../../node_modules/@fortawesome/fontawesome-svg-core/styles.css';

--- a/web-client/src/appPublic.jsx
+++ b/web-client/src/appPublic.jsx
@@ -1,3 +1,5 @@
+import './uswds.scss';
+// leave this comment here: it prevents eslint from auto-sorting these in the wrong order
 import './index.scss';
 
 import '../../node_modules/@fortawesome/fontawesome-svg-core/styles.css';

--- a/web-client/src/index.scss
+++ b/web-client/src/index.scss
@@ -1,18 +1,18 @@
-@import './fonts/fonts.scss';
-@import './styles/variables.scss'; // must be imported first
-@import '../../node_modules/uswds/src/stylesheets/uswds.scss';
-@import './styles/buttons.scss';
-@import './styles/cards.scss';
-@import './styles/custom.scss';
-@import './styles/forms.scss';
-@import './styles/icons.scss';
-@import './styles/modals.scss';
-@import './styles/nav.scss';
-@import './styles/overrides.scss';
-@import './styles/progress.scss';
-@import './styles/tables.scss';
-@import './styles/tabs.scss';
-@import './styles/menus.scss';
-@import './styles/typography.scss';
-@import './styles/print.scss';
-@import './styles/public.scss';
+@import './fonts/fonts';
+@import './styles/variables'; // must be imported before uswds-required
+@import './uswds-required';
+@import './styles/buttons';
+@import './styles/cards';
+@import './styles/custom';
+@import './styles/forms';
+@import './styles/icons';
+@import './styles/modals';
+@import './styles/nav';
+@import './styles/overrides';
+@import './styles/progress';
+@import './styles/tables';
+@import './styles/tabs';
+@import './styles/menus';
+@import './styles/typography';
+@import './styles/print';
+@import './styles/public';

--- a/web-client/src/uswds-required.scss
+++ b/web-client/src/uswds-required.scss
@@ -1,0 +1,12 @@
+// These are the bare minimum USWDS imports needed to be able to successfully
+// compile dawson without needing to import the entire uswds sass packages.
+// This was split out into a separate file to speed up webpack.  This approach
+// takes the compile times down from 10+ seconds to 2 seconds.
+
+@import '../../node_modules/uswds/src/stylesheets/settings/settings-general';
+@import '../../node_modules/uswds/src/stylesheets/settings/settings-typography';
+@import '../../node_modules/uswds/src/stylesheets/settings/settings-color';
+@import '../../node_modules/uswds/src/stylesheets/settings/settings-spacing';
+@import '../../node_modules/uswds/src/stylesheets/core/functions';
+@import '../../node_modules/uswds/src/stylesheets/core/system-tokens';
+@import '../../node_modules/uswds/src/stylesheets/core/variables';

--- a/web-client/src/uswds.scss
+++ b/web-client/src/uswds.scss
@@ -1,0 +1,2 @@
+@import './styles/variables';
+@import '../../node_modules/uswds/src/stylesheets/uswds';


### PR DESCRIPTION
When trying to modify any of our sass files, webpack takes about 10+ seconds to recompile and refresh the page.  This change involves splitting up the required uswds styles for dawson into a separate file so that we can quickly modify styles and get a page refresh within 2 seconds.