### PR TITLE
9519 Docket: Add Standalone Remote as Trial Session Location

### DIFF
--- a/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeF.js
+++ b/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeF.js
@@ -3,6 +3,9 @@ const {
   CourtIssuedDocumentDefault,
 } = require('./CourtIssuedDocumentDefault');
 const {
+  getStandaloneRemoteDocumentTitle,
+} = require('../../utilities/getStandaloneRemoteDocumentTitle');
+const {
   joiValidationDecorator,
   validEntityDecorator,
 } = require('../JoiValidationDecorator');
@@ -29,10 +32,9 @@ CourtIssuedDocumentTypeF.prototype.getDocumentTitle = function () {
   const judge = this.judgeWithTitle || this.judge;
 
   if (this.trialLocation === TRIAL_SESSION_SCOPE_TYPES.standaloneRemote) {
-    this.documentTitle = this.documentTitle.replace(
-      'at [Place]',
-      'in standalone remote session',
-    );
+    this.documentTitle = getStandaloneRemoteDocumentTitle({
+      documentTitle: this.documentTitle,
+    });
 
     return replaceBracketed(this.documentTitle, judge, this.freeText);
   }

--- a/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeF.js
+++ b/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeF.js
@@ -8,6 +8,7 @@ const {
 } = require('../JoiValidationDecorator');
 const { JoiValidationConstants } = require('../JoiValidationConstants');
 const { replaceBracketed } = require('../../utilities/replaceBracketed');
+const { TRIAL_SESSION_SCOPE_TYPES } = require('../EntityConstants');
 const { VALIDATION_ERROR_MESSAGES } = require('./CourtIssuedDocumentConstants');
 
 /**
@@ -26,6 +27,16 @@ CourtIssuedDocumentTypeF.prototype.init = function init(rawProps) {
 
 CourtIssuedDocumentTypeF.prototype.getDocumentTitle = function () {
   const judge = this.judgeWithTitle || this.judge;
+
+  if (this.trialLocation === TRIAL_SESSION_SCOPE_TYPES.standaloneRemote) {
+    this.documentTitle = this.documentTitle.replace(
+      'at [Place]',
+      'in standalone remote session',
+    );
+
+    return replaceBracketed(this.documentTitle, judge, this.freeText);
+  }
+
   return replaceBracketed(
     this.documentTitle,
     judge,

--- a/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeF.test.js
+++ b/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeF.test.js
@@ -1,4 +1,5 @@
 const { CourtIssuedDocumentFactory } = require('./CourtIssuedDocumentFactory');
+const { TRIAL_SESSION_SCOPE_TYPES } = require('../EntityConstants');
 const { VALIDATION_ERROR_MESSAGES } = require('./CourtIssuedDocumentConstants');
 
 describe('CourtIssuedDocumentTypeF', () => {
@@ -115,6 +116,20 @@ describe('CourtIssuedDocumentTypeF', () => {
       });
       expect(extDoc.getDocumentTitle()).toEqual(
         'Further Trial before Colvin at Seattle, Washington',
+      );
+    });
+
+    it('should generate a title with "in standalone remote session" instead of "at [Place]" for Standalone Remote trial locations', () => {
+      const extDoc = CourtIssuedDocumentFactory({
+        attachments: false,
+        documentTitle: 'Further Trial before [Judge] at [Place]',
+        documentType: 'FTRL - Further Trial before ...',
+        judge: 'Colvin',
+        scenario: 'Type F',
+        trialLocation: TRIAL_SESSION_SCOPE_TYPES.standaloneRemote,
+      });
+      expect(extDoc.getDocumentTitle()).toEqual(
+        'Further Trial before Colvin in standalone remote session',
       );
     });
   });

--- a/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeG.js
+++ b/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeG.js
@@ -9,6 +9,7 @@ const {
 const { formatDateString, FORMATS } = require('../../utilities/DateHandler');
 const { JoiValidationConstants } = require('../JoiValidationConstants');
 const { replaceBracketed } = require('../../utilities/replaceBracketed');
+const { TRIAL_SESSION_SCOPE_TYPES } = require('../EntityConstants');
 const { VALIDATION_ERROR_MESSAGES } = require('./CourtIssuedDocumentConstants');
 
 /**
@@ -24,6 +25,18 @@ CourtIssuedDocumentTypeG.prototype.init = function init(rawProps) {
 };
 
 CourtIssuedDocumentTypeG.prototype.getDocumentTitle = function () {
+  if (this.trialLocation === TRIAL_SESSION_SCOPE_TYPES.standaloneRemote) {
+    this.documentTitle = this.documentTitle.replace(
+      'at [Place]',
+      'in standalone remote session',
+    );
+
+    return replaceBracketed(
+      this.documentTitle,
+      formatDateString(this.date, FORMATS.MMDDYYYY_DASHED),
+    );
+  }
+
   return replaceBracketed(
     this.documentTitle,
     formatDateString(this.date, FORMATS.MMDDYYYY_DASHED),

--- a/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeG.js
+++ b/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeG.js
@@ -3,6 +3,9 @@ const {
   CourtIssuedDocumentDefault,
 } = require('./CourtIssuedDocumentDefault');
 const {
+  getStandaloneRemoteDocumentTitle,
+} = require('../../utilities/getStandaloneRemoteDocumentTitle');
+const {
   joiValidationDecorator,
   validEntityDecorator,
 } = require('../JoiValidationDecorator');
@@ -26,10 +29,9 @@ CourtIssuedDocumentTypeG.prototype.init = function init(rawProps) {
 
 CourtIssuedDocumentTypeG.prototype.getDocumentTitle = function () {
   if (this.trialLocation === TRIAL_SESSION_SCOPE_TYPES.standaloneRemote) {
-    this.documentTitle = this.documentTitle.replace(
-      'at [Place]',
-      'in standalone remote session',
-    );
+    this.documentTitle = getStandaloneRemoteDocumentTitle({
+      documentTitle: this.documentTitle,
+    });
 
     return replaceBracketed(
       this.documentTitle,

--- a/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeG.test.js
+++ b/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeG.test.js
@@ -1,4 +1,5 @@
 const { CourtIssuedDocumentFactory } = require('./CourtIssuedDocumentFactory');
+const { TRIAL_SESSION_SCOPE_TYPES } = require('../EntityConstants');
 const { VALIDATION_ERROR_MESSAGES } = require('./CourtIssuedDocumentConstants');
 
 describe('CourtIssuedDocumentTypeG', () => {
@@ -98,6 +99,20 @@ describe('CourtIssuedDocumentTypeG', () => {
       });
       expect(extDoc.getDocumentTitle()).toEqual(
         'Notice of Trial on 04-10-2025 at Seattle, Washington',
+      );
+    });
+
+    it('should generate a title with "in standalone remote session" instead of "at [Place]" for Standalone Remote trial locations', () => {
+      const extDoc = CourtIssuedDocumentFactory({
+        attachments: false,
+        date: '2025-04-10T04:00:00.000Z',
+        documentTitle: 'Notice of Trial on [Date] at [Place]',
+        documentType: 'Notice of Trial',
+        scenario: 'Type G',
+        trialLocation: TRIAL_SESSION_SCOPE_TYPES.standaloneRemote,
+      });
+      expect(extDoc.getDocumentTitle()).toEqual(
+        'Notice of Trial on 04-10-2025 in standalone remote session',
       );
     });
   });

--- a/shared/src/business/utilities/getStandaloneRemoteDocumentTitle.js
+++ b/shared/src/business/utilities/getStandaloneRemoteDocumentTitle.js
@@ -1,0 +1,9 @@
+/**
+ * Formats the documentTitle for standalone remote trial sessions
+ *
+ * @param {string} documentTitle the document title
+ * @returns {string} formatted documentTitle
+ */
+exports.getStandaloneRemoteDocumentTitle = ({ documentTitle }) => {
+  return documentTitle.replace('at [Place]', 'in standalone remote session');
+};

--- a/shared/src/business/utilities/getStandaloneRemoteDocumentTitle.test.js
+++ b/shared/src/business/utilities/getStandaloneRemoteDocumentTitle.test.js
@@ -1,0 +1,13 @@
+import { getStandaloneRemoteDocumentTitle } from './getStandaloneRemoteDocumentTitle';
+
+describe('getStandaloneRemoteDocumentTitle', () => {
+  it('should replace "at [Place]" in title with "in standalone remote session"', () => {
+    const result = getStandaloneRemoteDocumentTitle({
+      documentTitle: 'Further Trial before [Judge] at [Place]',
+    });
+
+    expect(result).toEqual(
+      'Further Trial before [Judge] in standalone remote session',
+    );
+  });
+});

--- a/web-client/src/applicationContext.js
+++ b/web-client/src/applicationContext.js
@@ -53,6 +53,7 @@ import { getFeatureFlagValueInteractor } from '../../shared/src/proxies/featureF
 import { getIsFeatureEnabled } from '../../shared/src/business/utilities/getIsFeatureEnabled';
 import { getMaintenanceModeInteractor } from '../../shared/src/proxies/maintenance/getMaintenanceModeProxy';
 import { getStampBoxCoordinates } from '../../shared/src/business/utilities/getStampBoxCoordinates';
+import { getStandaloneRemoteDocumentTitle } from '../../shared/src/business/utilities/getStandaloneRemoteDocumentTitle';
 import { getUserPendingEmailStatusInteractor } from '../../shared/src/proxies/users/getUserPendingEmailStatusProxy';
 import { isStandaloneRemoteSession } from '../../shared/src/business/entities/trialSessions/TrialSession';
 import { setupPdfDocument } from '../../shared/src/business/utilities/setupPdfDocument';
@@ -712,6 +713,7 @@ const applicationContext = {
       getSealedDocketEntryTooltip,
       getServedPartiesCode,
       getStampBoxCoordinates,
+      getStandaloneRemoteDocumentTitle,
       getTrialSessionStatus,
       getWorkQueueFilters,
       hasPartyWithServiceType,

--- a/web-client/src/views/CourtIssuedDocketEntry/CourtIssuedNonstandardForm.jsx
+++ b/web-client/src/views/CourtIssuedDocketEntry/CourtIssuedNonstandardForm.jsx
@@ -111,7 +111,7 @@ export const CourtIssuedNonstandardForm = connect(
               }}
             >
               <option value="">- Select -</option>
-              <TrialCityOptions procedureType="All" />
+              <TrialCityOptions procedureType="AllPlusStandalone" />
             </select>
           </FormGroup>
         )}


### PR DESCRIPTION
- Adds trial location option "Standalone Remote" for scenarios type F (HEAR, FTRL, PTRL, TRL) and type G (NTD) in dropdown when creating court issued nonstandard forms. These types both display the trial location on the form.
- Docket entry modified from "at [City/State]" to "in standalone remote session"

![image](https://user-images.githubusercontent.com/16403861/176488432-d16e3f60-5197-4848-94a0-bd33eb7a9b46.png)

![image](https://user-images.githubusercontent.com/16403861/176488264-b6e42431-6349-4267-928b-1ad3f1e5ce70.png)
![image](https://user-images.githubusercontent.com/16403861/176488758-2589bdde-98aa-49cf-b832-299686a1e6df.png)
