### PR TITLE
Devex 950 Run Against Current Color Correctly

### DIFF
--- a/scripts/run-cypress.sh
+++ b/scripts/run-cypress.sh
@@ -36,7 +36,6 @@ Help()
 ############################################################
 ############################################################
 
-export COLOR=deploying
 INTEGRATION=true
 PORT=1234
 NON_PUBLIC=app-
@@ -45,7 +44,7 @@ NON_PUBLIC=app-
 while getopts ":chloprs" option; do
    case $option in
       c) # run against currently deployed color
-         export COLOR=current
+         CURRENT=true
          ;;
       h) # display Help
          Help
@@ -111,11 +110,15 @@ else
   export CYPRESS_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
   export CYPRESS_AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN
   export CYPRESS_DEFAULT_ACCOUNT_PASS=$DEFAULT_ACCOUNT_PASS
-  export CYPRESS_DEPLOYING_COLOR=$DEPLOYING_COLOR
+  if [ -n "${CURRENT}" ]; then
+    export CYPRESS_DEPLOYING_COLOR=$CURRENT_COLOR
+  else
+    export CYPRESS_DEPLOYING_COLOR=$DEPLOYING_COLOR
+  fi
   export CYPRESS_DISABLE_EMAILS=$DISABLE_EMAILS
   export CYPRESS_EFCMS_DOMAIN=$EFCMS_DOMAIN
   export CYPRESS_USTC_ADMIN_PASS=$USTC_ADMIN_PASS
-  export CYPRESS_BASE_URL="https://${NON_PUBLIC}${DEPLOYING_COLOR}.${EFCMS_DOMAIN}"
+  export CYPRESS_BASE_URL="https://${NON_PUBLIC}${CYPRESS_DEPLOYING_COLOR}.${EFCMS_DOMAIN}"
 fi
 
 if [ -n "${OPEN}" ]; then

--- a/scripts/setup-cypress-variables.sh
+++ b/scripts/setup-cypress-variables.sh
@@ -9,10 +9,7 @@
 . ./scripts/load-environment-from-secrets.sh
 
 DEPLOYING_COLOR=$(./scripts/dynamo/get-deploying-color.sh "${ENV}")
-CURRENT_COLOR=$(./scripts/dynamo/get-current-color.sh "${ENV}")
-
-if [ -n "${1}" ]; then
-  DEPLOYING_COLOR="${CURRENT_COLOR}"
-fi
-
 export DEPLOYING_COLOR
+
+CURRENT_COLOR=$(./scripts/dynamo/get-current-color.sh "${ENV}")
+export CURRENT_COLOR


### PR DESCRIPTION
# Simplify Running Smoke Tests Locally
[DevEx 950](https://trello.com/c/r7hiFUBs/950-simplify-running-smoke-tests-locally)
[Deployment to exp3](https://app.circleci.com/pipelines/github/flexion/ef-cms/36145/workflows/6785cab5-7f10-45f4-a82f-d931569aba3e)

## Extend Functionality
This follows up on the work performed on PR #2307 and PR #2279.

## Properly Handle `-c` Option
If the -c option is provided, properly replaces `DEPLOYING_COLOR` with `CURRENT_COLOR`.