### PR TITLE
Remove Unnecessary Environment Variable Check

### DIFF
--- a/scripts/dynamo/get-migrate-flag.sh
+++ b/scripts/dynamo/get-migrate-flag.sh
@@ -8,10 +8,8 @@
 # Arguments
 #   - $1 - the environment to check
 
-
 ( ! command -v jq > /dev/null ) && echo "jq must be installed on your machine." && exit 1
 [ -z "$1" ] && echo "The environment to check must be provided as the \$1 argument." && exit 1
-[ -z "${USTC_ADMIN_PASS}" ] && echo "You must have USTC_ADMIN_PASS set in your environment" && exit 1
 [ -z "${AWS_ACCESS_KEY_ID}" ] && echo "You must have AWS_ACCESS_KEY_ID set in your environment" && exit 1
 [ -z "${AWS_SECRET_ACCESS_KEY}" ] && echo "You must have AWS_SECRET_ACCESS_KEY set in your environment" && exit 1
 


### PR DESCRIPTION
# Purpose

Removes an unnecessary variable check from `scripts/dynamo/get-migrate-flag.sh`. The `USTC_ADMIN_PASS` variable is not used in this script, so should not be checked here.