### PR TITLE
USTC-1810 - Define a timeout for the info rotator lambda

### DIFF
--- a/iam/terraform/account-specific/main/lambda-rotate-info-indices.tf
+++ b/iam/terraform/account-specific/main/lambda-rotate-info-indices.tf
@@ -5,13 +5,13 @@ data "archive_file" "zip_rotate_info_indices_lambda" {
 }
 
 resource "aws_lambda_function" "rotate_info_indices" {
-  filename      = data.archive_file.zip_rotate_info_indices_lambda.output_path
-  function_name = "RotateInfoIndices"
-  handler       = "index.handler"
-  role          = aws_iam_role.lambda_elasticsearch_execution_role.arn
-  runtime       = "nodejs14.x"
-
+  filename         = data.archive_file.zip_rotate_info_indices_lambda.output_path
+  function_name    = "RotateInfoIndices"
+  handler          = "index.handler"
+  role             = aws_iam_role.lambda_elasticsearch_execution_role.arn
+  runtime          = "nodejs14.x"
   source_code_hash = "${filebase64sha256(data.archive_file.zip_rotate_info_indices_lambda.output_path)}-${aws_iam_role.lambda_elasticsearch_execution_role.name}"
+  timeout          = 60
 
   environment {
     variables = {


### PR DESCRIPTION
Going with a large timeout (60s), at least at first, to give our lambda time to churn through a few months of snapshots the first time it runs. We'll reduce this later.