### PR TITLE
DevEx - Reduce Calendared Trial Session Return Size

### DIFF
--- a/shared/src/business/useCases/trialSessions/getCalendaredCasesForTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/getCalendaredCasesForTrialSessionInteractor.js
@@ -26,6 +26,7 @@ exports.getCalendaredCasesForTrialSessionInteractor = async (
     .getPersistenceGateway()
     .getCalendaredCasesForTrialSession({
       applicationContext,
+      omitDocketEntries: true,
       trialSessionId,
     });
 

--- a/shared/src/business/useCases/trialSessions/getCalendaredCasesForTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/getCalendaredCasesForTrialSessionInteractor.js
@@ -26,9 +26,19 @@ exports.getCalendaredCasesForTrialSessionInteractor = async (
     .getPersistenceGateway()
     .getCalendaredCasesForTrialSession({
       applicationContext,
-      omitDocketEntries: true,
       trialSessionId,
     });
 
-  return Case.validateRawCollection(cases, { applicationContext });
+  // instead of sending EVERY docket entry over, the front end only cares about the PMT documents not stricken
+  // to figure out the filingPartiesCode
+  const casesWithMinimalRequiredDocketEntries = cases.map(aCase => ({
+    ...aCase,
+    docketEntries: aCase.docketEntries.filter(
+      docketEntry => docketEntry.eventCode === 'PMT' && !docketEntry.isStricken,
+    ),
+  }));
+
+  return Case.validateRawCollection(casesWithMinimalRequiredDocketEntries, {
+    applicationContext,
+  });
 };

--- a/shared/src/business/useCases/trialSessions/getCalendaredCasesForTrialSessionInteractor.test.js
+++ b/shared/src/business/useCases/trialSessions/getCalendaredCasesForTrialSessionInteractor.test.js
@@ -55,4 +55,41 @@ describe('getCalendaredCasesForTrialSessionInteractor', () => {
       }),
     ).resolves.not.toThrow();
   });
+
+  it('should only return PMT docket entry on cases', async () => {
+    user = new User({
+      name: 'Docket Clerk',
+      role: ROLES.docketClerk,
+      userId: '6805d1ab-18d0-43ec-bafb-654e83405416',
+    });
+    applicationContext
+      .getPersistenceGateway()
+      .getCalendaredCasesForTrialSession.mockReturnValue([
+        {
+          ...MOCK_CASE,
+          docketEntries: [
+            {
+              ...MOCK_CASE.docketEntries[0],
+              eventCode: 'PMT',
+              isStricken: false,
+            },
+            {
+              ...MOCK_CASE.docketEntries[0],
+              eventCode: 'PMT',
+              isStricken: true,
+            },
+          ],
+        },
+      ]);
+
+    const cases = await getCalendaredCasesForTrialSessionInteractor(
+      applicationContext,
+      {
+        trialSessionId: '6805d1ab-18d0-43ec-bafb-654e83405416',
+      },
+    );
+
+    expect(cases[0].docketEntries.length).toEqual(1);
+    expect(cases[0].docketEntries[0].eventCode).toEqual('PMT');
+  });
 });

--- a/shared/src/persistence/dynamo/trialSessions/getCalendaredCasesForTrialSession.js
+++ b/shared/src/persistence/dynamo/trialSessions/getCalendaredCasesForTrialSession.js
@@ -1,5 +1,7 @@
 const client = require('../../dynamodbClientService');
-const { getCaseByDocketNumber } = require('../cases/getCaseByDocketNumber');
+const {
+  getCaseMetadataWithCounsel,
+} = require('../cases/getCaseMetadataWithCounsel');
 const { map } = require('lodash');
 
 exports.getCalendaredCasesForTrialSession = async ({
@@ -19,7 +21,7 @@ exports.getCalendaredCasesForTrialSession = async ({
 
   const casesByDocketNumber = await Promise.all(
     docketNumbers.map(docketNumber =>
-      getCaseByDocketNumber({
+      getCaseMetadataWithCounsel({
         applicationContext,
         docketNumber,
       }),

--- a/shared/src/persistence/dynamo/trialSessions/getCalendaredCasesForTrialSession.js
+++ b/shared/src/persistence/dynamo/trialSessions/getCalendaredCasesForTrialSession.js
@@ -1,13 +1,9 @@
 const client = require('../../dynamodbClientService');
-const {
-  getCaseMetadataWithCounsel,
-} = require('../cases/getCaseMetadataWithCounsel');
 const { getCaseByDocketNumber } = require('../cases/getCaseByDocketNumber');
 const { map } = require('lodash');
 
 exports.getCalendaredCasesForTrialSession = async ({
   applicationContext,
-  omitDocketEntries = false,
   trialSessionId,
 }) => {
   const trialSession = await client.get({
@@ -21,13 +17,9 @@ exports.getCalendaredCasesForTrialSession = async ({
   const { caseOrder } = trialSession;
   const docketNumbers = map(caseOrder, 'docketNumber');
 
-  const method = omitDocketEntries
-    ? getCaseMetadataWithCounsel
-    : getCaseByDocketNumber;
-
   const casesByDocketNumber = await Promise.all(
     docketNumbers.map(docketNumber =>
-      method({
+      getCaseByDocketNumber({
         applicationContext,
         docketNumber,
       }),

--- a/web-client/integration-tests/chambersViewsWorkingCopyTrialSession.test.js
+++ b/web-client/integration-tests/chambersViewsWorkingCopyTrialSession.test.js
@@ -73,11 +73,6 @@ describe('Chambers dashboard', () => {
       },
     );
 
-    console.log(
-      'trialSessionFormatted.allCases',
-      trialSessionFormatted.allCases.map(c => c.docketNumber),
-    );
-
     const caseWithPtmFiledByPetitioner = trialSessionFormatted.allCases.find(
       c => c.docketNumber === cerebralTest.docketNumber1,
     );

--- a/web-client/integration-tests/chambersViewsWorkingCopyTrialSession.test.js
+++ b/web-client/integration-tests/chambersViewsWorkingCopyTrialSession.test.js
@@ -73,6 +73,11 @@ describe('Chambers dashboard', () => {
       },
     );
 
+    console.log(
+      'trialSessionFormatted.allCases',
+      trialSessionFormatted.allCases.map(c => c.docketNumber),
+    );
+
     const caseWithPtmFiledByPetitioner = trialSessionFormatted.allCases.find(
       c => c.docketNumber === cerebralTest.docketNumber1,
     );


### PR DESCRIPTION
When dealing with very large trial sessions (250+ cases), we have seen the api gateway throw 502 errors.  This is probably due to some cases have a LOT of docket entries, so if you are trying to view the trail session that contains a case with a lot of docket entries, this api endpoint return the case and every entry along with it.  The front end logic only cares about a particular docket entry for this page, so this PR introduces a filter to only return the PMT, non stricken entries in the returned payload to reduce the size and speed up the request.

This is a screenshot of the request for a trial session with 103 cases.  Notice the response size is about 189kb:
<img width="1680" alt="Screen Shot 2022-08-11 at 3 16 52 PM" src="https://user-images.githubusercontent.com/1868782/184221330-969d1dd3-190b-44e2-928f-35acd0f58b98.png">

after deploying 44kb
<img width="1680" alt="Screen Shot 2022-08-24 at 10 49 45 AM" src="https://user-images.githubusercontent.com/1868782/186450004-adb4a563-6ef3-4f90-91d7-7e9d33ac0304.png">

