### PR TITLE
Update docs onboarding

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,13 @@ If you're ready for the challenge, navigate to the [Getting Started Guide](/gett
 
 Otherwise, if you're just interested in a particular topic, you can find it in the sidebar.
 
+## Onboarding Resources
+
+The onboarding checklist and quick reference guide will be handy as you navigate your first couple months. Please reach out to your onboarding buddy with questions. If you don't have a buddy and want one, please ask the team about it!
+
+1. [Onboarding Checklist](https://docs.google.com/document/d/1zhvp8vcWnVSvUbTKZ-0sHrf5lA6OTlpXqvjeLgKJtVk): Your personal checklist of important tasks as you onboard
+2. [Onboarding Quick Reference Guide](https://docs.google.com/document/d/1jOd0wAsqTDBKsFeEvUj9ezvdTimTsqTwkYd6Imibl3c): A hodge-podge of helpful links, information, who's who, what's what
+
 ## Looking for Old Docs?
 
 Most of the older documentation was moved directly into this docsify directory.  The goal is to eventually incorporate them into the top level sections of this documentation, or move them to a common sub directory if they don't fit well into the incremental introduction approach the documentation is attempting to follow. They can be found on one of the following links:

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,8 +30,8 @@ Otherwise, if you're just interested in a particular topic, you can find it in t
 
 The onboarding checklist and quick reference guide will be handy as you navigate your first couple months. Please reach out to your onboarding buddy with questions. If you don't have a buddy and want one, please ask the team about it!
 
-1. [Onboarding Checklist](https://docs.google.com/document/d/1zhvp8vcWnVSvUbTKZ-0sHrf5lA6OTlpXqvjeLgKJtVk): Your personal checklist of important tasks as you onboard
-2. [Onboarding Quick Reference Guide](https://docs.google.com/document/d/1jOd0wAsqTDBKsFeEvUj9ezvdTimTsqTwkYd6Imibl3c): A hodge-podge of helpful links, information, who's who, what's what
+1. [Onboarding Checklist](https://docs.google.com/document/d/12twlx5nLG6B4R6ds96wh_gZ6wR5Y_PGjsmSeP98V6o0): Make a copy as this will be your personal checklist of important tasks as you onboard
+2. [Onboarding Quick Reference Guide](https://docs.google.com/document/d/1ObraR8X5YUzR1GIwsm903EhS7-AQbpy90--5aAWysKU): A hodge-podge of helpful links, information, who's who, what's what
 
 ## Looking for Old Docs?
 

--- a/docs/team-process.md
+++ b/docs/team-process.md
@@ -2,15 +2,6 @@
 
 Now that you've logged in and played around with our Dawson system a bit on a deployed environment, let's talk about our team process and what is expected from our fellow teammates.  This part of the documentation should help members get on the same page when it comes to the soft-skills required to work as a well-oiled agile machine.
 
-## Onboarding
-
-Here are some few resources for documentation associated with onboarding:
-
-1. [Onboarding checklist](https://docs.google.com/document/d/1zhvp8vcWnVSvUbTKZ-0sHrf5lA6OTlpXqvjeLgKJtVk)
-2. [Onboarding Reference Guide](https://docs.google.com/document/d/1jOd0wAsqTDBKsFeEvUj9ezvdTimTsqTwkYd6Imibl3c)
-
-If you do not have permissions to view these documents, please reach out to the document owner.
-
 ## Working Agreement
 
 We have talked about writing some form of working agreement so team members have a common understanding of what is expected from them during their daily work.  Great teams strive for open communication, safe spaces to speak their mind, and continuous improvement in process.  Embracing some of the following ideologies will help grow and sustain a healthy team.


### PR DESCRIPTION
- Moved onboarding resources to higher in the docs
- Updated the links to go to the USTC shared drive, where the template onboarding checklist and quick reference guide have been moved