### PR TITLE
9577 Feature Flag - Stamp Disposition

### DIFF
--- a/scripts/dynamo/enable-stamp-disposition.sh
+++ b/scripts/dynamo/enable-stamp-disposition.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+# Sets the stamp disposition enabled flag to "true" in the dynamo deploy table
+
+# Usage
+#   ENV=dev ./enable-stamp-disposition.sh
+
+./check-env-variables.sh \
+  "ENV" \
+  "AWS_SECRET_ACCESS_KEY" \
+  "AWS_ACCESS_KEY_ID"
+
+aws dynamodb put-item --region us-east-1 --table-name "efcms-deploy-${ENV}" --item '{"pk":{"S":"stamp-disposition-enabled"},"sk":{"S":"stamp-disposition-enabled"},"current":{"BOOL":true}}'

--- a/scripts/setup-all-env-configuration.sh
+++ b/scripts/setup-all-env-configuration.sh
@@ -20,3 +20,4 @@
 ./scripts/dynamo/setup-maintenance-mode-flag.sh
 ./scripts/dynamo/setup-section-outbox-retrieval-days.sh
 ./scripts/dynamo/setup-consolidated-cases-propagate-docket-entries.sh
+./scripts/dynamo/enable-stamp-disposition.sh

--- a/shared/src/business/entities/EntityConstants.js
+++ b/shared/src/business/entities/EntityConstants.js
@@ -83,6 +83,9 @@ const ALLOWLIST_FEATURE_FLAGS = {
   PDFJS_EXPRESS_VIEWER: {
     key: 'pdfjs-express-viewer-enabled',
   },
+  STAMP_DISPOSITION: {
+    key: 'stamp-disposition-enabled',
+  },
 };
 
 const CONFIGURATION_ITEM_KEYS = {

--- a/web-api/storage/fixtures/seed/efcms-local.json
+++ b/web-api/storage/fixtures/seed/efcms-local.json
@@ -4752,6 +4752,11 @@
     "current": true
   },
   {
+    "pk": "stamp-disposition-enabled",
+    "sk": "stamp-disposition-enabled",
+    "current": true
+  },
+  {
     "sk": "user|5c43a30d-9c3d-41be-ad13-3b6d7cef54fc",
     "pk": "irsPractitioner|MS8888"
   },

--- a/web-client/src/presenter/computeds/documentViewerHelper.js
+++ b/web-client/src/presenter/computeds/documentViewerHelper.js
@@ -1,8 +1,10 @@
+/* eslint-disable complexity */
 import { getShowNotServedForDocument } from './getShowNotServedForDocument';
 import { state } from 'cerebral';
 
 export const documentViewerHelper = (get, applicationContext) => {
   const {
+    ALLOWLIST_FEATURE_FLAGS,
     COURT_ISSUED_EVENT_CODES,
     PROPOSED_STIPULATED_DECISION_EVENT_CODE,
     STAMPED_DOCUMENTS_ALLOWLIST,
@@ -89,7 +91,12 @@ export const documentViewerHelper = (get, applicationContext) => {
   const showCompleteQcButton =
     permissions.EDIT_DOCKET_ENTRY && formattedDocumentToDisplay.qcNeeded;
 
+  const isStampDispositionEnabled = get(
+    state.featureFlags[ALLOWLIST_FEATURE_FLAGS.STAMP_DISPOSITION.key],
+  );
+
   const showApplyStampButton =
+    isStampDispositionEnabled &&
     permissions.STAMP_MOTION &&
     STAMPED_DOCUMENTS_ALLOWLIST.includes(formattedDocumentToDisplay.eventCode);
 

--- a/web-client/src/presenter/computeds/messageDocumentHelper.js
+++ b/web-client/src/presenter/computeds/messageDocumentHelper.js
@@ -1,4 +1,5 @@
 /* eslint-disable complexity */
+import { ALLOWLIST_FEATURE_FLAGS } from '../../../../shared/src/business/entities/EntityConstants';
 import { getShowNotServedForDocument } from './getShowNotServedForDocument';
 import { state } from 'cerebral';
 
@@ -153,7 +154,12 @@ export const messageDocumentHelper = (get, applicationContext) => {
       d => d.eventCode === STIPULATED_DECISION_EVENT_CODE && !d.archived,
     );
 
+  const isStampDispositionEnabled = get(
+    state.featureFlags[ALLOWLIST_FEATURE_FLAGS.STAMP_DISPOSITION.key],
+  );
+
   const showApplyStampButton =
+    isStampDispositionEnabled &&
     permissions.STAMP_MOTION &&
     (STAMPED_DOCUMENTS_ALLOWLIST.includes(caseDocument.eventCode) ||
       STAMPED_DOCUMENTS_ALLOWLIST.includes(formattedDocument?.eventCode));

--- a/web-client/src/presenter/computeds/messageDocumentHelper.js
+++ b/web-client/src/presenter/computeds/messageDocumentHelper.js
@@ -1,5 +1,4 @@
 /* eslint-disable complexity */
-import { ALLOWLIST_FEATURE_FLAGS } from '../../../../shared/src/business/entities/EntityConstants';
 import { getShowNotServedForDocument } from './getShowNotServedForDocument';
 import { state } from 'cerebral';
 
@@ -13,6 +12,7 @@ export const messageDocumentHelper = (get, applicationContext) => {
   }
 
   const {
+    ALLOWLIST_FEATURE_FLAGS,
     COURT_ISSUED_EVENT_CODES,
     EVENT_CODES_REQUIRING_SIGNATURE,
     GENERIC_ORDER_EVENT_CODE,

--- a/web-client/src/presenter/computeds/messageDocumentHelper.showApplyStampButton.test.js
+++ b/web-client/src/presenter/computeds/messageDocumentHelper.showApplyStampButton.test.js
@@ -23,6 +23,31 @@ describe('messageDocumentHelper.showApplyStampButton', () => {
         eventCode: 'M006',
       });
   });
+  const { ALLOWLIST_FEATURE_FLAGS } = applicationContext.getConstants();
+
+  it('should be false when the stamp disposition feature is turned off', () => {
+    const { showApplyStampButton } = runCompute(messageDocumentHelper, {
+      state: {
+        caseDetail: {
+          docketEntries: [
+            {
+              docketEntryId: mockDocketEntryId,
+              eventCode: STAMPED_DOCUMENTS_ALLOWLIST[0],
+            },
+          ],
+        },
+        featureFlags: {
+          [ALLOWLIST_FEATURE_FLAGS.STAMP_DISPOSITION.key]: false,
+        },
+        messageViewerDocumentToDisplay: {
+          documentId: mockDocketEntryId,
+        },
+        permissions: { STAMP_MOTION: true },
+      },
+    });
+
+    expect(showApplyStampButton).toBe(false);
+  });
 
   it('should be false when the user does not have the STAMP_MOTION permission', () => {
     applicationContext
@@ -40,6 +65,9 @@ describe('messageDocumentHelper.showApplyStampButton', () => {
               eventCode: STAMPED_DOCUMENTS_ALLOWLIST[0],
             },
           ],
+        },
+        featureFlags: {
+          [ALLOWLIST_FEATURE_FLAGS.STAMP_DISPOSITION.key]: true,
         },
         messageViewerDocumentToDisplay: {
           documentId: mockDocketEntryId,
@@ -63,6 +91,9 @@ describe('messageDocumentHelper.showApplyStampButton', () => {
         caseDetail: {
           docketEntries: [],
         },
+        featureFlags: {
+          [ALLOWLIST_FEATURE_FLAGS.STAMP_DISPOSITION.key]: true,
+        },
         messageViewerDocumentToDisplay: {
           documentId: mockDocketEntryId,
         },
@@ -78,6 +109,9 @@ describe('messageDocumentHelper.showApplyStampButton', () => {
       state: {
         caseDetail: {
           docketEntries: [],
+        },
+        featureFlags: {
+          [ALLOWLIST_FEATURE_FLAGS.STAMP_DISPOSITION.key]: true,
         },
         messageViewerDocumentToDisplay: {
           documentId: mockDocketEntryId,
@@ -106,6 +140,9 @@ describe('messageDocumentHelper.showApplyStampButton', () => {
       state: {
         caseDetail: {
           docketEntries: [],
+        },
+        featureFlags: {
+          [ALLOWLIST_FEATURE_FLAGS.STAMP_DISPOSITION.key]: true,
         },
         messageViewerDocumentToDisplay: {
           documentId: mockDocketEntryId,

--- a/web-client/src/presenter/sequences/gotoCaseDetailSequence.js
+++ b/web-client/src/presenter/sequences/gotoCaseDetailSequence.js
@@ -7,6 +7,7 @@ import { getCaseAssociationAction } from '../actions/getCaseAssociationAction';
 import { getCaseDeadlinesForCaseAction } from '../actions/CaseDeadline/getCaseDeadlinesForCaseAction';
 import { getConsolidatedCasesByCaseAction } from '../actions/CaseConsolidation/getConsolidatedCasesByCaseAction';
 import { getConstants } from '../../getConstants';
+import { getFeatureFlagValueFactoryAction } from '../actions/getFeatureFlagValueFactoryAction';
 import { getJudgeForCurrentUserAction } from '../actions/getJudgeForCurrentUserAction';
 import { getJudgesCaseNoteForCaseAction } from '../actions/TrialSession/getJudgesCaseNoteForCaseAction';
 import { getMessagesForCaseAction } from '../actions/CaseDetail/getMessagesForCaseAction';
@@ -87,6 +88,10 @@ export const gotoCaseDetailSequence = [
   setConsolidatedCasesForCaseAction,
   setDefaultDocketRecordSortAction,
   setDefaultEditDocumentEntryPointAction,
+  getFeatureFlagValueFactoryAction(
+    getConstants().ALLOWLIST_FEATURE_FLAGS.STAMP_DISPOSITION,
+    true,
+  ),
   runPathForUserRoleAction,
   {
     ...takePathForRoles(

--- a/web-client/src/presenter/sequences/gotoMessageDetailSequence.js
+++ b/web-client/src/presenter/sequences/gotoMessageDetailSequence.js
@@ -1,7 +1,9 @@
 import { clearErrorAlertsAction } from '../actions/clearErrorAlertsAction';
 import { closeMobileMenuAction } from '../actions/closeMobileMenuAction';
 import { getCaseAction } from '../actions/getCaseAction';
+import { getConstants } from '../../getConstants';
 import { getDefaultAttachmentViewerDocumentToDisplayAction } from '../actions/getDefaultAttachmentViewerDocumentToDisplayAction';
+import { getFeatureFlagValueFactoryAction } from '../actions/getFeatureFlagValueFactoryAction';
 import { getMessageThreadAction } from '../actions/getMessageThreadAction';
 import { getMostRecentMessageInThreadAction } from '../actions/getMostRecentMessageInThreadAction';
 import { getShouldMarkMessageAsReadAction } from '../actions/getShouldMarkMessageAsReadAction';
@@ -32,6 +34,10 @@ const gotoMessageDetail = startWebSocketConnectionSequenceDecorator(
     getMostRecentMessageInThreadAction,
     getDefaultAttachmentViewerDocumentToDisplayAction,
     setMessageDetailViewerDocumentToDisplayAction,
+    getFeatureFlagValueFactoryAction(
+      getConstants().ALLOWLIST_FEATURE_FLAGS.STAMP_DISPOSITION,
+      true,
+    ),
     setDefaultIsExpandedAction,
     setCaseDetailPageTabActionGenerator('messages'),
     setCurrentPageAction('MessageDetail'),


### PR DESCRIPTION
Adding a feature flag in order to show/hide the Apply Stamp button

The script `./enable-stamp-disposition.sh` will need to be run on the desired environments so as to setup the stamp-disposition-enabled feature flag (default value being true).