### PR TITLE
3318: Court User: Case Type Filter on Blocked Cases Report

### DIFF
--- a/shared/src/persistence/elasticsearch/getBlockedCases.js
+++ b/shared/src/persistence/elasticsearch/getBlockedCases.js
@@ -25,6 +25,7 @@ exports.getBlockedCases = async ({ applicationContext, trialLocation }) => {
           'docketNumberSuffix',
           'docketNumberWithSuffix',
           'status',
+          'procedureType',
         ],
         query: {
           bool: {

--- a/web-client/integration-tests/journey/petitionsClerkBlocksCase.js
+++ b/web-client/integration-tests/journey/petitionsClerkBlocksCase.js
@@ -1,8 +1,7 @@
 import { applicationContextForClient as applicationContext } from '../../../shared/src/business/test/createTestApplicationContext';
 import { refreshElasticsearchIndex } from '../helpers';
 
-const { DOCKET_NUMBER_SUFFIXES, STATUS_TYPES } =
-  applicationContext.getConstants();
+const { STATUS_TYPES } = applicationContext.getConstants();
 
 export const petitionsClerkBlocksCase = (
   cerebralTest,
@@ -55,8 +54,7 @@ export const petitionsClerkBlocksCase = (
             overrides.caseCaption ||
             'Daenerys Stormborn, Deceased, Daenerys Stormborn, Surviving Spouse, Petitioner',
           docketNumber: cerebralTest.docketNumber,
-          docketNumberSuffix:
-            overrides.docketNumberSuffix || DOCKET_NUMBER_SUFFIXES.SMALL,
+          docketNumberSuffix: overrides.docketNumberSuffix || null,
           status:
             overrides.caseStatus || STATUS_TYPES.generalDocketReadyForTrial,
         }),

--- a/web-client/integration-tests/journey/petitionsClerkCreatesNewCase.js
+++ b/web-client/integration-tests/journey/petitionsClerkCreatesNewCase.js
@@ -11,6 +11,7 @@ export const petitionsClerkCreatesNewCase = (
   fakeFile,
   trialLocation = 'Birmingham, Alabama',
   shouldServe = true,
+  overrides = {},
 ) => {
   return it('Petitions clerk creates a new case', async () => {
     await cerebralTest.runSequence('gotoStartCaseWizardSequence');
@@ -132,7 +133,7 @@ export const petitionsClerkCreatesNewCase = (
 
     await cerebralTest.runSequence('updateFormValueSequence', {
       key: 'procedureType',
-      value: 'Small',
+      value: overrides.procedureType || 'Small',
     });
 
     await cerebralTest.runSequence('updateFormValueSequence', {

--- a/web-client/integration-tests/petitionsClerkBlockCase.test.js
+++ b/web-client/integration-tests/petitionsClerkBlockCase.test.js
@@ -48,7 +48,9 @@ describe('Blocking a Case', () => {
   loginAs(cerebralTest, 'petitionsclerk@example.com');
   //manual block and unblock - check eligible list
   petitionsClerkViewsATrialSessionsEligibleCases(cerebralTest, 1);
-  petitionsClerkBlocksCase(cerebralTest, trialLocation);
+  petitionsClerkBlocksCase(cerebralTest, trialLocation, {
+    docketNumberSuffix: 'S',
+  });
   petitionsClerkViewsATrialSessionsEligibleCases(cerebralTest, 0);
   petitionsClerkUnblocksCase(cerebralTest, trialLocation);
   petitionsClerkViewsATrialSessionsEligibleCases(cerebralTest, 1);
@@ -117,7 +119,9 @@ describe('Blocking a Case', () => {
   petitionsClerkViewsATrialSessionsEligibleCases(cerebralTest, 1);
 
   //automatic and manual block
-  petitionsClerkBlocksCase(cerebralTest, trialLocation);
+  petitionsClerkBlocksCase(cerebralTest, trialLocation, {
+    docketNumberSuffix: 'S',
+  });
   petitionsClerkCreatesACaseDeadline(cerebralTest);
   it('petitions clerk views blocked report with an automatically and manually blocked case', async () => {
     await refreshElasticsearchIndex();

--- a/web-client/integration-tests/petitionsClerkFiltersBlockedCaseReport.test.js
+++ b/web-client/integration-tests/petitionsClerkFiltersBlockedCaseReport.test.js
@@ -178,4 +178,20 @@ describe('Blocking a Case', () => {
       ),
     );
   });
+
+  it('should reset the procedureType select back to All when changing the trial location dropdown', async () => {
+    await cerebralTest.runSequence('updateFormValueSequence', {
+      key: 'procedureType',
+      value: 'Small',
+    });
+
+    expect(cerebralTest.getState('form.procedureType')).toEqual('Small');
+
+    await cerebralTest.runSequence('getBlockedCasesByTrialLocationSequence', {
+      key: 'trialLocation',
+      value: 'No existing trial location',
+    });
+
+    expect(cerebralTest.getState('form.procedureType')).toEqual('All');
+  });
 });

--- a/web-client/integration-tests/petitionsClerkFiltersBlockedCaseReport.test.js
+++ b/web-client/integration-tests/petitionsClerkFiltersBlockedCaseReport.test.js
@@ -1,0 +1,198 @@
+import { AUTOMATIC_BLOCKED_REASONS } from '../../shared/src/business/entities/EntityConstants';
+import { docketClerkCreatesATrialSession } from './journey/docketClerkCreatesATrialSession';
+import { docketClerkSetsCaseReadyForTrial } from './journey/docketClerkSetsCaseReadyForTrial';
+import { docketClerkViewsTrialSessionList } from './journey/docketClerkViewsTrialSessionList';
+import {
+  fakeFile,
+  loginAs,
+  refreshElasticsearchIndex,
+  setupTest,
+  uploadProposedStipulatedDecision,
+  viewCaseDetail,
+} from './helpers';
+import { markAllCasesAsQCed } from './journey/markAllCasesAsQCed';
+import { petitionsClerkBlocksCase } from './journey/petitionsClerkBlocksCase';
+import { petitionsClerkCreatesACaseDeadline } from './journey/petitionsClerkCreatesACaseDeadline';
+import { petitionsClerkCreatesNewCase } from './journey/petitionsClerkCreatesNewCase';
+import { petitionsClerkDeletesCaseDeadline } from './journey/petitionsClerkDeletesCaseDeadline';
+import { petitionsClerkRemovesPendingItemFromCase } from './journey/petitionsClerkRemovesPendingItemFromCase';
+import { petitionsClerkSetsATrialSessionsSchedule } from './journey/petitionsClerkSetsATrialSessionsSchedule';
+import { petitionsClerkUnblocksCase } from './journey/petitionsClerkUnblocksCase';
+import { petitionsClerkViewsATrialSessionsEligibleCases } from './journey/petitionsClerkViewsATrialSessionsEligibleCases';
+
+describe('Blocking a Case', () => {
+  const cerebralTest = setupTest();
+
+  beforeAll(() => {
+    jest.setTimeout(50000);
+  });
+
+  afterAll(() => {
+    cerebralTest.closeSocket();
+  });
+
+  const trialLocation = `Charleston, West Virginia, ${Date.now()}`;
+  const overrides = {
+    trialLocation,
+  };
+
+  loginAs(cerebralTest, 'petitionsclerk@example.com');
+  petitionsClerkCreatesNewCase(cerebralTest, fakeFile, trialLocation);
+
+  loginAs(cerebralTest, 'docketclerk@example.com');
+  docketClerkSetsCaseReadyForTrial(cerebralTest);
+  loginAs(cerebralTest, 'docketclerk@example.com');
+  docketClerkCreatesATrialSession(cerebralTest, overrides);
+  docketClerkViewsTrialSessionList(cerebralTest);
+
+  loginAs(cerebralTest, 'petitionsclerk@example.com');
+  //manual block and unblock - check eligible list
+  petitionsClerkViewsATrialSessionsEligibleCases(cerebralTest, 1);
+  petitionsClerkBlocksCase(cerebralTest, trialLocation);
+  petitionsClerkViewsATrialSessionsEligibleCases(cerebralTest, 0);
+  petitionsClerkUnblocksCase(cerebralTest, trialLocation);
+  petitionsClerkViewsATrialSessionsEligibleCases(cerebralTest, 1);
+
+  // automatic block with a due date
+  petitionsClerkCreatesACaseDeadline(cerebralTest);
+
+  it('petitions clerk views blocked report with an automatically blocked case for due date', async () => {
+    await refreshElasticsearchIndex();
+
+    await cerebralTest.runSequence('gotoBlockedCasesReportSequence');
+
+    await cerebralTest.runSequence('getBlockedCasesByTrialLocationSequence', {
+      key: 'trialLocation',
+      value: trialLocation,
+    });
+
+    expect(cerebralTest.getState('blockedCases')).toMatchObject([
+      {
+        automaticBlocked: true,
+        automaticBlockedReason: AUTOMATIC_BLOCKED_REASONS.pendingAndDueDate,
+        blocked: false,
+        docketNumber: cerebralTest.docketNumber,
+      },
+    ]);
+  });
+
+  petitionsClerkRemovesPendingItemFromCase(cerebralTest);
+  petitionsClerkViewsATrialSessionsEligibleCases(cerebralTest, 0);
+  petitionsClerkDeletesCaseDeadline(cerebralTest);
+  petitionsClerkViewsATrialSessionsEligibleCases(cerebralTest, 1);
+
+  //automatic block with a pending item
+  loginAs(cerebralTest, 'irsPractitioner@example.com');
+
+  it('respondent uploads a proposed stipulated decision (pending item)', async () => {
+    await viewCaseDetail({
+      cerebralTest,
+      docketNumber: setupTest.docketNumber,
+    });
+    await uploadProposedStipulatedDecision(cerebralTest);
+  });
+
+  loginAs(cerebralTest, 'petitionsclerk@example.com');
+  it('petitions clerk views blocked report with an automatically blocked case for pending item', async () => {
+    await refreshElasticsearchIndex();
+
+    await cerebralTest.runSequence('gotoBlockedCasesReportSequence');
+
+    await cerebralTest.runSequence('getBlockedCasesByTrialLocationSequence', {
+      key: 'trialLocation',
+      value: trialLocation,
+    });
+
+    expect(cerebralTest.getState('blockedCases')).toMatchObject([
+      {
+        automaticBlocked: true,
+        automaticBlockedReason: AUTOMATIC_BLOCKED_REASONS.pending,
+        blocked: false,
+        docketNumber: cerebralTest.docketNumber,
+      },
+    ]);
+  });
+  petitionsClerkViewsATrialSessionsEligibleCases(cerebralTest, 0);
+  petitionsClerkRemovesPendingItemFromCase(cerebralTest);
+  petitionsClerkViewsATrialSessionsEligibleCases(cerebralTest, 1);
+
+  //automatic and manual block
+  petitionsClerkBlocksCase(cerebralTest, trialLocation);
+  petitionsClerkCreatesACaseDeadline(cerebralTest);
+  it('petitions clerk views blocked report with an automatically and manually blocked case', async () => {
+    await refreshElasticsearchIndex();
+
+    await cerebralTest.runSequence('gotoBlockedCasesReportSequence');
+
+    await cerebralTest.runSequence('getBlockedCasesByTrialLocationSequence', {
+      key: 'trialLocation',
+      value: trialLocation,
+    });
+
+    expect(cerebralTest.getState('blockedCases')).toMatchObject([
+      {
+        automaticBlocked: true,
+        automaticBlockedReason: AUTOMATIC_BLOCKED_REASONS.dueDate,
+        blocked: true,
+        blockedReason: 'just because',
+        docketNumber: cerebralTest.docketNumber,
+      },
+    ]);
+  });
+  petitionsClerkUnblocksCase(cerebralTest, trialLocation, false);
+  petitionsClerkDeletesCaseDeadline(cerebralTest);
+  petitionsClerkViewsATrialSessionsEligibleCases(cerebralTest, 1);
+
+  //add deadline for a case that was manually added to a non-calendared session - it shouldn't actually be set to blocked
+  it('petitions clerk manually adds case to trial', async () => {
+    await cerebralTest.runSequence('gotoCaseDetailSequence', {
+      docketNumber: cerebralTest.docketNumber,
+    });
+
+    await cerebralTest.runSequence('openAddToTrialModalSequence');
+
+    await cerebralTest.runSequence('updateModalValueSequence', {
+      key: 'showAllLocations',
+      value: true,
+    });
+
+    await cerebralTest.runSequence('updateModalValueSequence', {
+      key: 'trialSessionId',
+      value: cerebralTest.trialSessionId,
+    });
+
+    await cerebralTest.runSequence('addCaseToTrialSessionSequence');
+    await refreshElasticsearchIndex();
+  });
+
+  petitionsClerkCreatesACaseDeadline(cerebralTest);
+  it('petitions clerk views blocked report with no blocked cases', async () => {
+    await cerebralTest.runSequence('gotoBlockedCasesReportSequence');
+
+    await refreshElasticsearchIndex();
+
+    await cerebralTest.runSequence('getBlockedCasesByTrialLocationSequence', {
+      key: 'trialLocation',
+      value: trialLocation,
+    });
+
+    expect(cerebralTest.getState('blockedCases')).toMatchObject([]);
+  });
+
+  markAllCasesAsQCed(cerebralTest, () => [cerebralTest.docketNumber]);
+  petitionsClerkSetsATrialSessionsSchedule(cerebralTest);
+
+  petitionsClerkCreatesACaseDeadline(cerebralTest);
+  it('petitions clerk views blocked report with no blocked cases', async () => {
+    await cerebralTest.runSequence('gotoBlockedCasesReportSequence');
+
+    await refreshElasticsearchIndex();
+
+    await cerebralTest.runSequence('getBlockedCasesByTrialLocationSequence', {
+      key: 'trialLocation',
+      value: trialLocation,
+    });
+
+    expect(cerebralTest.getState('blockedCases')).toMatchObject([]);
+  });
+});

--- a/web-client/integration-tests/petitionsClerkFiltersBlockedCaseReport.test.js
+++ b/web-client/integration-tests/petitionsClerkFiltersBlockedCaseReport.test.js
@@ -111,7 +111,7 @@ describe('Blocking a Case', () => {
     );
   });
 
-  it('petitions clerk views small cases on blocked report', async () => {
+  it('petitions clerk views Small cases on blocked report', async () => {
     await refreshElasticsearchIndex();
 
     await cerebralTest.runSequence('gotoBlockedCasesReportSequence');
@@ -139,25 +139,43 @@ describe('Blocking a Case', () => {
     );
   });
 
-  it('petitions clerk views small cases on blocked report', async () => {
-    await refreshElasticsearchIndex();
-
-    await cerebralTest.runSequence('gotoBlockedCasesReportSequence');
-
-    await cerebralTest.runSequence('getBlockedCasesByTrialLocationSequence', {
-      key: 'trialLocation',
-      value: trialLocation,
-    });
-
+  it('petitions clerk views Regular cases on blocked report', async () => {
     await cerebralTest.runSequence('updateFormValueSequence', {
       key: 'procedureType',
-      value: 'Small',
+      value: 'Regular',
     });
 
     const { blockedCasesFormatted } = runCompute(blockedCasesReportHelper, {
       state: cerebralTest.getState(),
     });
 
-    expect(blockedCasesFormatted.length).toEqual(2);
+    expect(blockedCasesFormatted).not.toMatchObject(
+      expect.arrayContaining([
+        expect.objectContaining({
+          procedureType: 'Small',
+        }),
+      ]),
+    );
+  });
+
+  it('petitions clerk views All cases on blocked report', async () => {
+    await cerebralTest.runSequence('updateFormValueSequence', {
+      key: 'procedureType',
+      value: 'All',
+    });
+
+    const { blockedCasesFormatted } = runCompute(blockedCasesReportHelper, {
+      state: cerebralTest.getState(),
+    });
+
+    expect(blockedCasesFormatted).toMatchObject(
+      expect.arrayContaining(
+        blockedCases.map(blockedCase =>
+          expect.objectContaining({
+            docketNumber: blockedCase.docketNumber,
+          }),
+        ),
+      ),
+    );
   });
 });

--- a/web-client/integration-tests/petitionsClerkFiltersBlockedCaseReport.test.js
+++ b/web-client/integration-tests/petitionsClerkFiltersBlockedCaseReport.test.js
@@ -61,7 +61,7 @@ describe('Blocking a Case', () => {
     cerebralTest,
     'Regular',
     trialLocation,
-    null,
+    undefined,
     docketNumbers,
   );
   createAndBlockCase(
@@ -77,7 +77,7 @@ describe('Blocking a Case', () => {
     cerebralTest,
     'Regular',
     trialLocation,
-    null,
+    undefined,
     docketNumbers,
   );
 

--- a/web-client/integration-tests/petitionsClerkFiltersBlockedCaseReport.test.js
+++ b/web-client/integration-tests/petitionsClerkFiltersBlockedCaseReport.test.js
@@ -1,3 +1,4 @@
+import { blockedCasesReportHelper as blockedCasesReportHelperComputed } from '../src/presenter/computeds/blockedCasesReportHelper';
 import { docketClerkCreatesATrialSession } from './journey/docketClerkCreatesATrialSession';
 import { docketClerkSetsCaseReadyForTrial } from './journey/docketClerkSetsCaseReadyForTrial';
 import {
@@ -12,7 +13,7 @@ import { runCompute } from 'cerebral/test';
 import { withAppContextDecorator } from '../src/withAppContext';
 
 const blockedCasesReportHelper = withAppContextDecorator(
-  blockedCasesReportHelper,
+  blockedCasesReportHelperComputed,
 );
 
 const createAndBlockCase = (
@@ -53,7 +54,6 @@ describe('Blocking a Case', () => {
   loginAs(cerebralTest, 'docketclerk@example.com');
   docketClerkCreatesATrialSession(cerebralTest, { trialLocation });
 
-  //manual block and unblock - check eligible list
   createAndBlockCase(
     cerebralTest,
     'Small',
@@ -118,11 +118,15 @@ describe('Blocking a Case', () => {
       value: trialLocation,
     });
 
-    // run sequence to update form
-    const { formattedBlockedCases } = runCompute(blockedCasesReportHelper, {
+    await cerebralTest.runSequence('updateFormValueSequence', {
+      key: 'procedureType',
+      value: 'Small',
+    });
+
+    const { blockedCasesFormatted } = runCompute(blockedCasesReportHelper, {
       state: cerebralTest.getState(),
     });
 
-    expect(formattedBlockedCases.length).toEqual(2);
+    expect(blockedCasesFormatted.length).toEqual(2);
   });
 });

--- a/web-client/integration-tests/petitionsClerkFiltersBlockedCaseReport.test.js
+++ b/web-client/integration-tests/petitionsClerkFiltersBlockedCaseReport.test.js
@@ -1,24 +1,32 @@
-import { AUTOMATIC_BLOCKED_REASONS } from '../../shared/src/business/entities/EntityConstants';
 import { docketClerkCreatesATrialSession } from './journey/docketClerkCreatesATrialSession';
 import { docketClerkSetsCaseReadyForTrial } from './journey/docketClerkSetsCaseReadyForTrial';
-import { docketClerkViewsTrialSessionList } from './journey/docketClerkViewsTrialSessionList';
 import {
   fakeFile,
   loginAs,
   refreshElasticsearchIndex,
   setupTest,
-  uploadProposedStipulatedDecision,
-  viewCaseDetail,
 } from './helpers';
-import { markAllCasesAsQCed } from './journey/markAllCasesAsQCed';
 import { petitionsClerkBlocksCase } from './journey/petitionsClerkBlocksCase';
-import { petitionsClerkCreatesACaseDeadline } from './journey/petitionsClerkCreatesACaseDeadline';
 import { petitionsClerkCreatesNewCase } from './journey/petitionsClerkCreatesNewCase';
-import { petitionsClerkDeletesCaseDeadline } from './journey/petitionsClerkDeletesCaseDeadline';
-import { petitionsClerkRemovesPendingItemFromCase } from './journey/petitionsClerkRemovesPendingItemFromCase';
-import { petitionsClerkSetsATrialSessionsSchedule } from './journey/petitionsClerkSetsATrialSessionsSchedule';
-import { petitionsClerkUnblocksCase } from './journey/petitionsClerkUnblocksCase';
-import { petitionsClerkViewsATrialSessionsEligibleCases } from './journey/petitionsClerkViewsATrialSessionsEligibleCases';
+
+const createAndBlockCase = (
+  cerebralTest,
+  procedureType,
+  trialLocation,
+  overrides = {},
+) => {
+  loginAs(cerebralTest, 'petitionsclerk@example.com');
+  petitionsClerkCreatesNewCase(cerebralTest, fakeFile, trialLocation, true, {
+    procedureType,
+  });
+
+  loginAs(cerebralTest, 'docketclerk@example.com');
+  docketClerkSetsCaseReadyForTrial(cerebralTest);
+  docketClerkCreatesATrialSession(cerebralTest, { trialLocation });
+  // docketClerkViewsTrialSessionList(cerebralTest);
+  loginAs(cerebralTest, 'petitionsclerk@example.com');
+  petitionsClerkBlocksCase(cerebralTest, trialLocation, overrides);
+};
 
 describe('Blocking a Case', () => {
   const cerebralTest = setupTest();
@@ -32,31 +40,18 @@ describe('Blocking a Case', () => {
   });
 
   const trialLocation = `Charleston, West Virginia, ${Date.now()}`;
-  const overrides = {
-    trialLocation,
-  };
 
-  loginAs(cerebralTest, 'petitionsclerk@example.com');
-  petitionsClerkCreatesNewCase(cerebralTest, fakeFile, trialLocation);
-
-  loginAs(cerebralTest, 'docketclerk@example.com');
-  docketClerkSetsCaseReadyForTrial(cerebralTest);
-  loginAs(cerebralTest, 'docketclerk@example.com');
-  docketClerkCreatesATrialSession(cerebralTest, overrides);
-  docketClerkViewsTrialSessionList(cerebralTest);
-
-  loginAs(cerebralTest, 'petitionsclerk@example.com');
   //manual block and unblock - check eligible list
-  petitionsClerkViewsATrialSessionsEligibleCases(cerebralTest, 1);
-  petitionsClerkBlocksCase(cerebralTest, trialLocation);
-  petitionsClerkViewsATrialSessionsEligibleCases(cerebralTest, 0);
-  petitionsClerkUnblocksCase(cerebralTest, trialLocation);
-  petitionsClerkViewsATrialSessionsEligibleCases(cerebralTest, 1);
+  createAndBlockCase(cerebralTest, 'Small', trialLocation);
+  createAndBlockCase(cerebralTest, 'Regular', trialLocation, {
+    docketNumberSuffix: '',
+  });
+  createAndBlockCase(cerebralTest, 'Small', trialLocation);
+  createAndBlockCase(cerebralTest, 'Regular', trialLocation, {
+    docketNumberSuffix: '',
+  });
 
-  // automatic block with a due date
-  petitionsClerkCreatesACaseDeadline(cerebralTest);
-
-  it('petitions clerk views blocked report with an automatically blocked case for due date', async () => {
+  it('petitions clerk views all cases on blocked report', async () => {
     await refreshElasticsearchIndex();
 
     await cerebralTest.runSequence('gotoBlockedCasesReportSequence');
@@ -66,133 +61,14 @@ describe('Blocking a Case', () => {
       value: trialLocation,
     });
 
-    expect(cerebralTest.getState('blockedCases')).toMatchObject([
-      {
-        automaticBlocked: true,
-        automaticBlockedReason: AUTOMATIC_BLOCKED_REASONS.pendingAndDueDate,
-        blocked: false,
-        docketNumber: cerebralTest.docketNumber,
-      },
-    ]);
-  });
-
-  petitionsClerkRemovesPendingItemFromCase(cerebralTest);
-  petitionsClerkViewsATrialSessionsEligibleCases(cerebralTest, 0);
-  petitionsClerkDeletesCaseDeadline(cerebralTest);
-  petitionsClerkViewsATrialSessionsEligibleCases(cerebralTest, 1);
-
-  //automatic block with a pending item
-  loginAs(cerebralTest, 'irsPractitioner@example.com');
-
-  it('respondent uploads a proposed stipulated decision (pending item)', async () => {
-    await viewCaseDetail({
-      cerebralTest,
-      docketNumber: setupTest.docketNumber,
-    });
-    await uploadProposedStipulatedDecision(cerebralTest);
-  });
-
-  loginAs(cerebralTest, 'petitionsclerk@example.com');
-  it('petitions clerk views blocked report with an automatically blocked case for pending item', async () => {
-    await refreshElasticsearchIndex();
-
-    await cerebralTest.runSequence('gotoBlockedCasesReportSequence');
-
-    await cerebralTest.runSequence('getBlockedCasesByTrialLocationSequence', {
-      key: 'trialLocation',
-      value: trialLocation,
-    });
-
-    expect(cerebralTest.getState('blockedCases')).toMatchObject([
-      {
-        automaticBlocked: true,
-        automaticBlockedReason: AUTOMATIC_BLOCKED_REASONS.pending,
-        blocked: false,
-        docketNumber: cerebralTest.docketNumber,
-      },
-    ]);
-  });
-  petitionsClerkViewsATrialSessionsEligibleCases(cerebralTest, 0);
-  petitionsClerkRemovesPendingItemFromCase(cerebralTest);
-  petitionsClerkViewsATrialSessionsEligibleCases(cerebralTest, 1);
-
-  //automatic and manual block
-  petitionsClerkBlocksCase(cerebralTest, trialLocation);
-  petitionsClerkCreatesACaseDeadline(cerebralTest);
-  it('petitions clerk views blocked report with an automatically and manually blocked case', async () => {
-    await refreshElasticsearchIndex();
-
-    await cerebralTest.runSequence('gotoBlockedCasesReportSequence');
-
-    await cerebralTest.runSequence('getBlockedCasesByTrialLocationSequence', {
-      key: 'trialLocation',
-      value: trialLocation,
-    });
-
-    expect(cerebralTest.getState('blockedCases')).toMatchObject([
-      {
-        automaticBlocked: true,
-        automaticBlockedReason: AUTOMATIC_BLOCKED_REASONS.dueDate,
-        blocked: true,
-        blockedReason: 'just because',
-        docketNumber: cerebralTest.docketNumber,
-      },
-    ]);
-  });
-  petitionsClerkUnblocksCase(cerebralTest, trialLocation, false);
-  petitionsClerkDeletesCaseDeadline(cerebralTest);
-  petitionsClerkViewsATrialSessionsEligibleCases(cerebralTest, 1);
-
-  //add deadline for a case that was manually added to a non-calendared session - it shouldn't actually be set to blocked
-  it('petitions clerk manually adds case to trial', async () => {
-    await cerebralTest.runSequence('gotoCaseDetailSequence', {
-      docketNumber: cerebralTest.docketNumber,
-    });
-
-    await cerebralTest.runSequence('openAddToTrialModalSequence');
-
-    await cerebralTest.runSequence('updateModalValueSequence', {
-      key: 'showAllLocations',
-      value: true,
-    });
-
-    await cerebralTest.runSequence('updateModalValueSequence', {
-      key: 'trialSessionId',
-      value: cerebralTest.trialSessionId,
-    });
-
-    await cerebralTest.runSequence('addCaseToTrialSessionSequence');
-    await refreshElasticsearchIndex();
-  });
-
-  petitionsClerkCreatesACaseDeadline(cerebralTest);
-  it('petitions clerk views blocked report with no blocked cases', async () => {
-    await cerebralTest.runSequence('gotoBlockedCasesReportSequence');
-
-    await refreshElasticsearchIndex();
-
-    await cerebralTest.runSequence('getBlockedCasesByTrialLocationSequence', {
-      key: 'trialLocation',
-      value: trialLocation,
-    });
-
-    expect(cerebralTest.getState('blockedCases')).toMatchObject([]);
-  });
-
-  markAllCasesAsQCed(cerebralTest, () => [cerebralTest.docketNumber]);
-  petitionsClerkSetsATrialSessionsSchedule(cerebralTest);
-
-  petitionsClerkCreatesACaseDeadline(cerebralTest);
-  it('petitions clerk views blocked report with no blocked cases', async () => {
-    await cerebralTest.runSequence('gotoBlockedCasesReportSequence');
-
-    await refreshElasticsearchIndex();
-
-    await cerebralTest.runSequence('getBlockedCasesByTrialLocationSequence', {
-      key: 'trialLocation',
-      value: trialLocation,
-    });
-
-    expect(cerebralTest.getState('blockedCases')).toMatchObject([]);
+    expect(cerebralTest.getState('blockedCases').length).toEqual(4);
+    // expect(cerebralTest.getState('blockedCases')).toMatchObject([
+    //   {
+    //     automaticBlocked: true,
+    //     automaticBlockedReason: AUTOMATIC_BLOCKED_REASONS.pendingAndDueDate,
+    //     blocked: false,
+    //     docketNumber: cerebralTest.docketNumber,
+    //   },
+    // ]);
   });
 });

--- a/web-client/integration-tests/petitionsClerkFiltersBlockedCaseReport.test.js
+++ b/web-client/integration-tests/petitionsClerkFiltersBlockedCaseReport.test.js
@@ -22,8 +22,7 @@ const createAndBlockCase = (
 
   loginAs(cerebralTest, 'docketclerk@example.com');
   docketClerkSetsCaseReadyForTrial(cerebralTest);
-  docketClerkCreatesATrialSession(cerebralTest, { trialLocation });
-  // docketClerkViewsTrialSessionList(cerebralTest);
+
   loginAs(cerebralTest, 'petitionsclerk@example.com');
   petitionsClerkBlocksCase(cerebralTest, trialLocation, overrides);
 };
@@ -40,16 +39,18 @@ describe('Blocking a Case', () => {
   });
 
   const trialLocation = `Charleston, West Virginia, ${Date.now()}`;
+  loginAs(cerebralTest, 'docketclerk@example.com');
+  docketClerkCreatesATrialSession(cerebralTest, { trialLocation });
 
   //manual block and unblock - check eligible list
-  createAndBlockCase(cerebralTest, 'Small', trialLocation);
-  createAndBlockCase(cerebralTest, 'Regular', trialLocation, {
-    docketNumberSuffix: '',
+  createAndBlockCase(cerebralTest, 'Small', trialLocation, {
+    docketNumberSuffix: 'S',
   });
-  createAndBlockCase(cerebralTest, 'Small', trialLocation);
-  createAndBlockCase(cerebralTest, 'Regular', trialLocation, {
-    docketNumberSuffix: '',
+  createAndBlockCase(cerebralTest, 'Regular', trialLocation);
+  createAndBlockCase(cerebralTest, 'Small', trialLocation, {
+    docketNumberSuffix: 'S',
   });
+  createAndBlockCase(cerebralTest, 'Regular', trialLocation);
 
   it('petitions clerk views all cases on blocked report', async () => {
     await refreshElasticsearchIndex();
@@ -62,13 +63,5 @@ describe('Blocking a Case', () => {
     });
 
     expect(cerebralTest.getState('blockedCases').length).toEqual(4);
-    // expect(cerebralTest.getState('blockedCases')).toMatchObject([
-    //   {
-    //     automaticBlocked: true,
-    //     automaticBlockedReason: AUTOMATIC_BLOCKED_REASONS.pendingAndDueDate,
-    //     blocked: false,
-    //     docketNumber: cerebralTest.docketNumber,
-    //   },
-    // ]);
   });
 });

--- a/web-client/src/presenter/actions/setProcedureTypeToAllAction.js
+++ b/web-client/src/presenter/actions/setProcedureTypeToAllAction.js
@@ -1,0 +1,11 @@
+import { state } from 'cerebral';
+
+/**
+ * sets the procedure type filter to 'All'
+ *
+ * @param {object} providers the providers object
+ * @param {object} providers.store the cerebral store
+ */
+export const setProcedureTypeToAllAction = ({ store }) => {
+  store.set(state.form.procedureType, 'All');
+};

--- a/web-client/src/presenter/computeds/blockedCasesReportHelper.js
+++ b/web-client/src/presenter/computeds/blockedCasesReportHelper.js
@@ -39,11 +39,14 @@ export const blockedCasesReportHelper = (get, applicationContext) => {
           ),
           docketNumberWithSuffix: blockedCase.docketNumberWithSuffix,
         };
+      })
+      .filter(blockedCase => {
+        return blockedCase.procedureType === 'Small';
       });
   }
 
   return {
-    blockedCasesCount: blockedCases && blockedCases.length,
+    blockedCasesCount: blockedCasesFormatted && blockedCasesFormatted.length,
     blockedCasesFormatted,
   };
 };

--- a/web-client/src/presenter/computeds/blockedCasesReportHelper.js
+++ b/web-client/src/presenter/computeds/blockedCasesReportHelper.js
@@ -42,9 +42,9 @@ export const blockedCasesReportHelper = (get, applicationContext) => {
         };
       })
       .filter(blockedCase => {
-        return procedureTypeFilter === 'All'
-          ? true
-          : blockedCase.procedureType === procedureTypeFilter;
+        return procedureTypeFilter && procedureTypeFilter !== 'All'
+          ? blockedCase.procedureType === procedureTypeFilter
+          : true;
       });
   }
 

--- a/web-client/src/presenter/computeds/blockedCasesReportHelper.js
+++ b/web-client/src/presenter/computeds/blockedCasesReportHelper.js
@@ -2,6 +2,7 @@ import { state } from 'cerebral';
 
 export const blockedCasesReportHelper = (get, applicationContext) => {
   const blockedCases = get(state.blockedCases);
+  const procedureTypeFilter = get(state.form.procedureType);
 
   let blockedCasesFormatted = [];
 
@@ -41,7 +42,9 @@ export const blockedCasesReportHelper = (get, applicationContext) => {
         };
       })
       .filter(blockedCase => {
-        return blockedCase.procedureType === 'Small';
+        return procedureTypeFilter === 'All'
+          ? true
+          : blockedCase.procedureType === procedureTypeFilter;
       });
   }
 

--- a/web-client/src/presenter/computeds/blockedCasesReportHelper.js
+++ b/web-client/src/presenter/computeds/blockedCasesReportHelper.js
@@ -1,5 +1,13 @@
 import { state } from 'cerebral';
 
+/**
+ * gets the blocked cases and formats them and filters based on procedureType
+ *
+ * @param {Function} get the cerebral get function used
+ * for getting state.form.procedureType and state.blockedCases
+ * @param {object} applicationContext the application context
+ * @returns {object} {blockedCasesFormatted: *[], blockedCasesCount: number}
+ */
 export const blockedCasesReportHelper = (get, applicationContext) => {
   const blockedCases = get(state.blockedCases);
   const procedureTypeFilter = get(state.form.procedureType);

--- a/web-client/src/presenter/computeds/blockedCasesReportHelper.test.js
+++ b/web-client/src/presenter/computeds/blockedCasesReportHelper.test.js
@@ -33,6 +33,9 @@ describe('blockedCasesReportHelper', () => {
           { docketNumber: '102-19' },
           { docketNumber: '103-19' },
         ],
+        form: {
+          procedureType: 'All',
+        },
       },
     });
     expect(result).toMatchObject({ blockedCasesCount: 3 });

--- a/web-client/src/presenter/computeds/blockedCasesReportHelper.test.js
+++ b/web-client/src/presenter/computeds/blockedCasesReportHelper.test.js
@@ -189,4 +189,63 @@ describe('blockedCasesReportHelper', () => {
       ]),
     );
   });
+
+  it('should return blocked regular cases when regular is selected', () => {
+    const result = runCompute(blockedCasesReportHelper, {
+      state: {
+        blockedCases: [
+          {
+            blocked: true,
+            blockedDate: '2019-03-01T21:42:29.073Z',
+            caseCaption: 'Brett Osborne, Petitioner',
+            docketNumber: '105-19',
+            docketNumberWithSuffix: '105-19S',
+            procedureType: 'Small',
+          },
+          {
+            automaticBlocked: true,
+            automaticBlockedDate: '2018-03-05T21:42:29.073Z',
+            blocked: true,
+            blockedDate: '2019-07-01T21:42:29.073Z',
+            caseCaption: 'Selma Horn & Cairo Harris, Petitioners',
+            docketNumber: '102-19',
+            docketNumberWithSuffix: '102-19',
+            procedureType: 'Regular',
+          },
+          {
+            automaticBlocked: true,
+            automaticBlockedDate: '2019-03-05T21:42:29.073Z',
+            blocked: true,
+            blockedDate: '2018-03-05T21:42:29.073Z',
+            caseCaption:
+              'Tatum Craig, Wayne Obrien, Partnership Representative, Petitioner(s)',
+            docketNumber: '103-18',
+            docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.SMALL,
+            docketNumberWithSuffix: '103-18S',
+            procedureType: 'Small',
+          },
+          {
+            automaticBlocked: true,
+            automaticBlockedDate: '2019-03-05T21:42:29.073Z',
+            caseCaption: 'Bob Barker, Petitioner',
+            docketNumber: '104-19',
+            docketNumberWithSuffix: '104-19',
+            procedureType: 'Regular',
+          },
+        ],
+        form: { procedureType: 'Regular' },
+      },
+    });
+    expect(result.blockedCasesCount).toBe(2);
+    expect(result.blockedCasesFormatted).toMatchObject(
+      expect.arrayContaining([
+        expect.objectContaining({
+          docketNumber: '102-19',
+        }),
+        expect.objectContaining({
+          docketNumber: '104-19',
+        }),
+      ]),
+    );
+  });
 });

--- a/web-client/src/presenter/computeds/blockedCasesReportHelper.test.js
+++ b/web-client/src/presenter/computeds/blockedCasesReportHelper.test.js
@@ -248,4 +248,53 @@ describe('blockedCasesReportHelper', () => {
       ]),
     );
   });
+
+  it('should return all cases if the procedureType is undefined', () => {
+    const result = runCompute(blockedCasesReportHelper, {
+      state: {
+        blockedCases: [
+          {
+            blocked: true,
+            blockedDate: '2019-03-01T21:42:29.073Z',
+            caseCaption: 'Brett Osborne, Petitioner',
+            docketNumber: '105-19',
+            docketNumberWithSuffix: '105-19S',
+            procedureType: 'Small',
+          },
+          {
+            automaticBlocked: true,
+            automaticBlockedDate: '2018-03-05T21:42:29.073Z',
+            blocked: true,
+            blockedDate: '2019-07-01T21:42:29.073Z',
+            caseCaption: 'Selma Horn & Cairo Harris, Petitioners',
+            docketNumber: '102-19',
+            docketNumberWithSuffix: '102-19',
+            procedureType: 'Regular',
+          },
+          {
+            automaticBlocked: true,
+            automaticBlockedDate: '2019-03-05T21:42:29.073Z',
+            blocked: true,
+            blockedDate: '2018-03-05T21:42:29.073Z',
+            caseCaption:
+              'Tatum Craig, Wayne Obrien, Partnership Representative, Petitioner(s)',
+            docketNumber: '103-18',
+            docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.SMALL,
+            docketNumberWithSuffix: '103-18S',
+            procedureType: 'Small',
+          },
+          {
+            automaticBlocked: true,
+            automaticBlockedDate: '2019-03-05T21:42:29.073Z',
+            caseCaption: 'Bob Barker, Petitioner',
+            docketNumber: '104-19',
+            docketNumberWithSuffix: '104-19',
+            procedureType: 'Regular',
+          },
+        ],
+        form: { procedureType: undefined },
+      },
+    });
+    expect(result.blockedCasesCount).toBe(4);
+  });
 });

--- a/web-client/src/presenter/computeds/blockedCasesReportHelper.test.js
+++ b/web-client/src/presenter/computeds/blockedCasesReportHelper.test.js
@@ -9,11 +9,11 @@ describe('blockedCasesReportHelper', () => {
   const blockedCasesReportHelper = withAppContextDecorator(
     blockedCasesReportHelperComputed,
   );
-  it('returns blockedCasesCount as undefined if blockedCases is not on the state', () => {
+  it('returns blockedCasesCount as 0 if blockedCases is not on the state', () => {
     const result = runCompute(blockedCasesReportHelper, {
       state: {},
     });
-    expect(result).toMatchObject({ blockedCasesCount: undefined });
+    expect(result).toMatchObject({ blockedCasesCount: 0 });
   });
 
   it('returns blockedCasesCount as 0 if the blockedCases array is empty', () => {

--- a/web-client/src/presenter/computeds/blockedCasesReportHelper.test.js
+++ b/web-client/src/presenter/computeds/blockedCasesReportHelper.test.js
@@ -127,4 +127,63 @@ describe('blockedCasesReportHelper', () => {
       ],
     });
   });
+
+  it('should return blocked small cases when small is selected', () => {
+    const result = runCompute(blockedCasesReportHelper, {
+      state: {
+        blockedCases: [
+          {
+            blocked: true,
+            blockedDate: '2019-03-01T21:42:29.073Z',
+            caseCaption: 'Brett Osborne, Petitioner',
+            docketNumber: '105-19',
+            docketNumberWithSuffix: '105-19S',
+            procedureType: 'Small',
+          },
+          {
+            automaticBlocked: true,
+            automaticBlockedDate: '2018-03-05T21:42:29.073Z',
+            blocked: true,
+            blockedDate: '2019-07-01T21:42:29.073Z',
+            caseCaption: 'Selma Horn & Cairo Harris, Petitioners',
+            docketNumber: '102-19',
+            docketNumberWithSuffix: '102-19',
+            procedureType: 'Regular',
+          },
+          {
+            automaticBlocked: true,
+            automaticBlockedDate: '2019-03-05T21:42:29.073Z',
+            blocked: true,
+            blockedDate: '2018-03-05T21:42:29.073Z',
+            caseCaption:
+              'Tatum Craig, Wayne Obrien, Partnership Representative, Petitioner(s)',
+            docketNumber: '103-18',
+            docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.SMALL,
+            docketNumberWithSuffix: '103-18S',
+            procedureType: 'Small',
+          },
+          {
+            automaticBlocked: true,
+            automaticBlockedDate: '2019-03-05T21:42:29.073Z',
+            caseCaption: 'Bob Barker, Petitioner',
+            docketNumber: '104-19',
+            docketNumberWithSuffix: '104-19',
+            procedureType: 'Regular',
+          },
+        ],
+        form: { procedureType: 'Small' },
+      },
+    });
+    expect(result.blockedCasesCount).toBe(2);
+    expect(result.blockedCasesFormatted).toMatchObject(
+      expect.arrayContaining([
+        expect.objectContaining({
+          docketNumber: '105-19',
+        }),
+        expect.objectContaining({
+          docketNumber: '103-18',
+        }),
+      ]),
+    );
+  });
 });

--- a/web-client/src/presenter/sequences/getBlockedCasesByTrialLocationSequence.js
+++ b/web-client/src/presenter/sequences/getBlockedCasesByTrialLocationSequence.js
@@ -1,10 +1,12 @@
 import { getBlockedCasesByTrialLocationAction } from '../actions/CaseDetail/getBlockedCasesByTrialLocationAction';
 import { setBlockedCasesAction } from '../actions/CaseDetail/setBlockedCasesAction';
 import { setFormValueAction } from '../actions/setFormValueAction';
+import { setProcedureTypeToAllAction } from '../actions/setProcedureTypeToAllAction';
 import { showProgressSequenceDecorator } from '../utilities/showProgressSequenceDecorator';
 
 export const getBlockedCasesByTrialLocationSequence =
   showProgressSequenceDecorator([
+    setProcedureTypeToAllAction,
     setFormValueAction,
     getBlockedCasesByTrialLocationAction,
     setBlockedCasesAction,

--- a/web-client/src/views/BlockedCasesReport/SelectCriteria.jsx
+++ b/web-client/src/views/BlockedCasesReport/SelectCriteria.jsx
@@ -47,6 +47,7 @@ export const SelectCriteria = connect(
             </label>
             <select
               className="usa-select"
+              disabled={!form.trialLocation}
               id="procedure-type"
               name="procedureType"
               value={form.procedureType}

--- a/web-client/src/views/BlockedCasesReport/SelectCriteria.jsx
+++ b/web-client/src/views/BlockedCasesReport/SelectCriteria.jsx
@@ -42,7 +42,7 @@ export const SelectCriteria = connect(
             </select>
           </div>
           <div className="usa-form-group margin-bottom-0">
-            <label className="usa-label" htmlFor="trial-location">
+            <label className="usa-label" htmlFor="procedure-type">
               Case Type
             </label>
             <select

--- a/web-client/src/views/BlockedCasesReport/SelectCriteria.jsx
+++ b/web-client/src/views/BlockedCasesReport/SelectCriteria.jsx
@@ -8,8 +8,13 @@ export const SelectCriteria = connect(
     form: state.form,
     getBlockedCasesByTrialLocationSequence:
       sequences.getBlockedCasesByTrialLocationSequence,
+    updateFormValueSequence: sequences.updateFormValueSequence,
   },
-  function SelectCriteria({ form, getBlockedCasesByTrialLocationSequence }) {
+  function SelectCriteria({
+    form,
+    getBlockedCasesByTrialLocationSequence,
+    updateFormValueSequence,
+  }) {
     return (
       <>
         <div className="header-with-blue-background">
@@ -42,19 +47,19 @@ export const SelectCriteria = connect(
             </label>
             <select
               className="usa-select"
-              id="case-type"
-              name="caseType"
-              value={form.caseType}
-              // onChange={e => {
-              // getBlockedCasesByTrialLocationSequence({
-              //   key: e.target.name,
-              //   value: e.target.value,
-              // });
-              // }}
+              id="procedure-type"
+              name="procedureType"
+              value={form.procedureType}
+              onChange={e => {
+                updateFormValueSequence({
+                  key: e.target.name,
+                  value: e.target.value,
+                });
+              }}
             >
-              <option value="all">All</option>
-              <option value="small">Small</option>
-              <option value="regular">Regular</option>
+              <option value="All">All</option>
+              <option value="Small">Small</option>
+              <option value="Regular">Regular</option>
             </select>
           </div>
         </div>

--- a/web-client/src/views/BlockedCasesReport/SelectCriteria.jsx
+++ b/web-client/src/views/BlockedCasesReport/SelectCriteria.jsx
@@ -16,7 +16,7 @@ export const SelectCriteria = connect(
           <h3>Select criteria</h3>
         </div>
         <div className="blue-container">
-          <div className="usa-form-group margin-bottom-0">
+          <div className="usa-form-group margin-bottom-3">
             <label className="usa-label" htmlFor="trial-location">
               Trial location
             </label>
@@ -34,6 +34,27 @@ export const SelectCriteria = connect(
             >
               <option value="">-- Select --</option>
               <TrialCityOptions procedureType="All" />
+            </select>
+          </div>
+          <div className="usa-form-group margin-bottom-0">
+            <label className="usa-label" htmlFor="trial-location">
+              Case Type
+            </label>
+            <select
+              className="usa-select"
+              id="case-type"
+              name="caseType"
+              value={form.caseType}
+              // onChange={e => {
+              // getBlockedCasesByTrialLocationSequence({
+              //   key: e.target.name,
+              //   value: e.target.value,
+              // });
+              // }}
+            >
+              <option value="all">All</option>
+              <option value="small">Small</option>
+              <option value="regular">Regular</option>
             </select>
           </div>
         </div>


### PR DESCRIPTION
# Case Type Filter on Blocked Cases Report

[Link](https://app.zenhub.com/workspaces/flexionef-cms-5bbe4bed4b5806bc2bec65d3/issues/flexion/ef-cms/3318) to story.

Adds a new select for filtering the blocked cases report on procedure type.

## Default

The default is to display all blocked cases. Until a trial location has been selected, the new select is disabled. Additionally, upon selecting a different trial location, the procedure type filter is reset to the default.