### PR TITLE
devex - skip the email service check since it often fails constanstly

### DIFF
--- a/cypress-readonly/integration/public/health-check.cy.js
+++ b/cypress-readonly/integration/public/health-check.cy.js
@@ -4,7 +4,7 @@ const HEALTH_CHECK_IDS = [
   'dynamo-deploy-table',
   'dynamsoft',
   'elasticsearch',
-  'emailService',
+  // 'emailService', disable for now due to flaky tests
   's3-app',
   's3-app-failover',
   's3-east-documents',


### PR DESCRIPTION
this health check endpoint often fails our smoke tests when doing deploys due to throttling issues on AWS. skipping this check for now since we see little value in checking this and it's causing more of an issue