### PR TITLE
Bug 9590: Check for inactivePractitioner role

### DIFF
--- a/shared/src/business/useCases/users/setUserEmailFromPendingEmailInteractor.js
+++ b/shared/src/business/useCases/users/setUserEmailFromPendingEmailInteractor.js
@@ -58,7 +58,8 @@ exports.setUserEmailFromPendingEmailInteractor = async (
   let userEntity;
   if (
     user.role === ROLES.privatePractitioner ||
-    user.role === ROLES.irsPractitioner
+    user.role === ROLES.irsPractitioner ||
+    user.role === ROLES.inactivePractitioner
   ) {
     userEntity = new Practitioner({
       ...user,

--- a/shared/src/business/useCases/users/setUserEmailFromPendingEmailInteractor.test.js
+++ b/shared/src/business/useCases/users/setUserEmailFromPendingEmailInteractor.test.js
@@ -154,4 +154,29 @@ describe('setUserEmailFromPendingEmailInteractor', () => {
       }),
     ).rejects.toThrow(mockErrorMessage);
   });
+
+  it('should not turn an inactive Practitioner into a User', async () => {
+    applicationContext
+      .getPersistenceGateway()
+      .getCasesByUserId.mockReturnValue(userCases);
+
+    await setUserEmailFromPendingEmailInteractor(applicationContext, {
+      user: {
+        ...mockPractitioner,
+        email: UPDATED_EMAIL,
+        role: ROLES.inactivePractitioner,
+        serviceIndicator: SERVICE_INDICATOR_TYPES.SI_PAPER,
+      },
+    });
+
+    expect(
+      applicationContext.getPersistenceGateway().updateUser.mock.calls[0][0]
+        .user,
+    ).toMatchObject({
+      email: UPDATED_EMAIL,
+      entityName: 'Practitioner',
+      pendingEmail: undefined,
+      serviceIndicator: SERVICE_INDICATOR_TYPES.SI_ELECTRONIC,
+    });
+  });
 });


### PR DESCRIPTION
# [Bug 9590](https://github.com/flexion/ef-cms/issues/9590)

As noted in the bug, the changes are simply to treat the `inactivePractitioner` role the same as other practitioner roles.