### PR TITLE
Fix failing integration tests

### DIFF
--- a/web-client/integration-tests/petitionsClerkBlockConsolidatedCasesJourney.test.js
+++ b/web-client/integration-tests/petitionsClerkBlockConsolidatedCasesJourney.test.js
@@ -66,9 +66,7 @@ describe('Manually block consolidated cases', () => {
   it('should set case docket number to leadDocketNumber', () => {
     cerebralTest.docketNumber = leadDocketNumber;
   });
-  petitionsClerkBlocksCase(cerebralTest, trialLocation, {
-    docketNumberSuffix: 'S',
-  });
+  petitionsClerkBlocksCase(cerebralTest, trialLocation);
   it('should verify blocked case has inLeadCase flag, inConsolidatedGroup flag and "Lead case" tool tip', () => {
     const { blockedCasesFormatted } = runCompute(
       blockedCasesReportHelperComputed,
@@ -90,9 +88,7 @@ describe('Manually block consolidated cases', () => {
   it('should set case docket number to memberCaseDocketNumber', () => {
     cerebralTest.docketNumber = memberCaseDocketNumber;
   });
-  petitionsClerkBlocksCase(cerebralTest, trialLocation, {
-    docketNumberSuffix: 'S',
-  });
+  petitionsClerkBlocksCase(cerebralTest, trialLocation);
   it('should verify blocked case does NOT have inLeadCase flag, but has inConsolidatedGroup flag and "Consolidated case" tool tip', () => {
     const { blockedCasesFormatted } = runCompute(
       blockedCasesReportHelperComputed,


### PR DESCRIPTION
Don't override the docket number suffix because `petitionsClerkBlocksCase` no longer forces a suffix of `S`.