### PR TITLE
9559 alternate trial clerk

### DIFF
--- a/shared/src/business/entities/trialSessions/NewTrialSession.js
+++ b/shared/src/business/entities/trialSessions/NewTrialSession.js
@@ -20,17 +20,25 @@ NewTrialSession.prototype.init = function init(
   rawSession,
   { applicationContext },
 ) {
+  this.trialClerkId = rawSession.trialClerkId;
   TrialSession.prototype.init.call(this, rawSession, { applicationContext });
 };
 
 NewTrialSession.VALIDATION_ERROR_MESSAGES = {
   ...TrialSession.VALIDATION_ERROR_MESSAGES,
+  alternateTrialClerkName:
+    'A valid Alternate Trial Clerk name must be provided if "Other*" is selected',
 };
 
 joiValidationDecorator(
   NewTrialSession,
   joi.object().keys({
     ...TrialSession.validationRules.COMMON,
+    alternateTrialClerkName: joi.when('trialClerkId', {
+      is: 'Other',
+      otherwise: joi.optional(),
+      then: JoiValidationConstants.STRING.max(100).required(),
+    }),
     startDate: JoiValidationConstants.ISO_DATE.min('now').required(),
   }),
   NewTrialSession.VALIDATION_ERROR_MESSAGES,

--- a/shared/src/business/entities/trialSessions/NewTrialSession.test.js
+++ b/shared/src/business/entities/trialSessions/NewTrialSession.test.js
@@ -74,5 +74,19 @@ describe('NewTrialSession entity', () => {
       }
       expect(error).toBeDefined();
     });
+
+    it('should throw an error on when a valid alternateTrialClerkName is not provided and only when "Other" is selected', () => {
+      let error;
+      try {
+        const trialSession = new NewTrialSession(
+          { ...VALID_TRIAL_SESSION, trialClerkId: 'Other' },
+          { applicationContext },
+        );
+        trialSession.validate();
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toBeDefined();
+    });
   });
 });

--- a/shared/src/business/entities/trialSessions/TrialSession.js
+++ b/shared/src/business/entities/trialSessions/TrialSession.js
@@ -53,6 +53,7 @@ TrialSession.prototype.init = function (rawSession, { applicationContext }) {
   this.estimatedEndDate = rawSession.estimatedEndDate || null;
   this.irsCalendarAdministrator = rawSession.irsCalendarAdministrator;
   this.isCalendared = rawSession.isCalendared || false;
+  this.isClosed = rawSession.isClosed || false;
   this.joinPhoneNumber = rawSession.joinPhoneNumber;
   this.maxCases = rawSession.maxCases;
   this.meetingId = rawSession.meetingId;
@@ -63,7 +64,6 @@ TrialSession.prototype.init = function (rawSession, { applicationContext }) {
   this.sessionScope =
     rawSession.sessionScope || TRIAL_SESSION_SCOPE_TYPES.locationBased;
   this.sessionType = rawSession.sessionType;
-  this.isClosed = rawSession.isClosed || false;
   this.startDate = rawSession.startDate;
   if (isStandaloneRemoteSession(rawSession.sessionScope)) {
     this.startTime = '13:00';
@@ -172,9 +172,11 @@ TrialSession.validationRules = {
   COMMON: {
     address1: JoiValidationConstants.STRING.max(100).allow('').optional(),
     address2: JoiValidationConstants.STRING.max(100).allow('').optional(),
-    alternateTrialClerkName: JoiValidationConstants.STRING.max(100)
-      .allow('')
-      .optional(),
+    alternateTrialClerkName: joi.when('trialClerk', {
+      is: joi.exist(),
+      otherwise: JoiValidationConstants.STRING.max(100).allow('').optional(),
+      then: joi.any().forbidden(),
+    }),
     chambersPhoneNumber: stringRequiredForRemoteProceedings,
     city: JoiValidationConstants.STRING.max(100).allow('').optional(),
     courtReporter: JoiValidationConstants.STRING.max(100).optional(),

--- a/shared/src/business/entities/trialSessions/TrialSession.js
+++ b/shared/src/business/entities/trialSessions/TrialSession.js
@@ -35,6 +35,7 @@ TrialSession.prototype.init = function (rawSession, { applicationContext }) {
 
   this.address1 = rawSession.address1;
   this.address2 = rawSession.address2;
+  this.alternateTrialClerkName = rawSession.alternateTrialClerkName;
   this.caseOrder = (rawSession.caseOrder || []).map(caseOrder => ({
     addedToSessionAt: caseOrder.addedToSessionAt,
     calendarNotes: caseOrder.calendarNotes,
@@ -171,6 +172,9 @@ TrialSession.validationRules = {
   COMMON: {
     address1: JoiValidationConstants.STRING.max(100).allow('').optional(),
     address2: JoiValidationConstants.STRING.max(100).allow('').optional(),
+    alternateTrialClerkName: JoiValidationConstants.STRING.max(100)
+      .allow('')
+      .optional(),
     chambersPhoneNumber: stringRequiredForRemoteProceedings,
     city: JoiValidationConstants.STRING.max(100).allow('').optional(),
     courtReporter: JoiValidationConstants.STRING.max(100).optional(),

--- a/shared/src/business/useCases/trialSessions/updateTrialSessionInteractor.js
+++ b/shared/src/business/useCases/trialSessions/updateTrialSessionInteractor.js
@@ -169,6 +169,7 @@ exports.updateTrialSessionInteractor = async (
   const editableFields = {
     address1: trialSession.address1,
     address2: trialSession.address2,
+    alternateTrialClerkName: trialSession.alternateTrialClerkName,
     chambersPhoneNumber: trialSession.chambersPhoneNumber,
     city: trialSession.city,
     courtReporter: trialSession.courtReporter,

--- a/shared/src/business/useCases/trialSessions/updateTrialSessionInteractor.test.js
+++ b/shared/src/business/useCases/trialSessions/updateTrialSessionInteractor.test.js
@@ -289,6 +289,7 @@ describe('updateTrialSessionInteractor', () => {
     const updatedFields = {
       address1: '123 Main St',
       address2: 'Apt 234',
+      alternateTrialClerkName: 'Some OtherClerk',
       chambersPhoneNumber: '111111',
       city: 'Somewhere',
       courtReporter: 'Someone Reporter',

--- a/shared/src/business/useCases/trialSessions/updateTrialSessionInteractor.test.js
+++ b/shared/src/business/useCases/trialSessions/updateTrialSessionInteractor.test.js
@@ -289,7 +289,6 @@ describe('updateTrialSessionInteractor', () => {
     const updatedFields = {
       address1: '123 Main St',
       address2: 'Apt 234',
-      alternateTrialClerkName: 'Some OtherClerk',
       chambersPhoneNumber: '111111',
       city: 'Somewhere',
       courtReporter: 'Someone Reporter',
@@ -320,6 +319,31 @@ describe('updateTrialSessionInteractor', () => {
         userId: '200d96ac-7edc-407d-a3a7-a3e7db78b881',
       },
       trialLocation: 'Boise, Idaho',
+    };
+
+    applicationContext
+      .getPersistenceGateway()
+      .getTrialSessionById.mockReturnValue(MOCK_TRIAL_INPERSON);
+
+    await updateTrialSessionInteractor(applicationContext, {
+      trialSession: {
+        ...MOCK_TRIAL_INPERSON,
+        ...updatedFields,
+      },
+    });
+
+    expect(
+      applicationContext.getPersistenceGateway().updateTrialSession.mock
+        .calls[0][0].trialSessionToUpdate,
+    ).toMatchObject({
+      ...MOCK_TRIAL_INPERSON,
+      ...updatedFields,
+    });
+  });
+
+  it('should update the trial session when an alternateTrialClerkName is added and no trial clerk', async () => {
+    const updatedFields = {
+      alternateTrialClerkName: 'Incredible Hulk',
     };
 
     applicationContext

--- a/shared/src/business/utilities/getFormattedTrialSessionDetails.compareCasesByDocketNumber.test.js
+++ b/shared/src/business/utilities/getFormattedTrialSessionDetails.compareCasesByDocketNumber.test.js
@@ -1,0 +1,113 @@
+import { compareTrialSessionEligibleCases } from './getFormattedTrialSessionDetails';
+
+describe('formattedTrialSessionDetails', () => {
+  describe('comparing eligible cases', () => {
+    it('prioritizes L and P', () => {
+      const result = compareTrialSessionEligibleCases(
+        {
+          docketNumber: '101-19',
+          docketNumberSuffix: '',
+          docketNumberWithSuffix: '101-19',
+          isDocketSuffixHighPriority: false,
+        },
+        {
+          docketNumber: '101-19',
+          docketNumberSuffix: 'P',
+          docketNumberWithSuffix: '101-19P',
+          isDocketSuffixHighPriority: true,
+        },
+      );
+      expect(result).toBe(1);
+    });
+
+    it('compares eligible trial session cases sorting lien/levy and passport first', () => {
+      const formattedEligibleCases = [
+        {
+          docketNumber: '101-19',
+          docketNumberSuffix: '',
+          docketNumberWithSuffix: '101-19',
+        },
+        {
+          docketNumber: '101-19',
+          docketNumberSuffix: 'P',
+          docketNumberWithSuffix: '101-19P',
+          isDocketSuffixHighPriority: true,
+        },
+      ];
+      const result = formattedEligibleCases.sort(
+        compareTrialSessionEligibleCases,
+      );
+      expect(result).toMatchObject([
+        {
+          docketNumber: '101-19',
+          docketNumberSuffix: 'P',
+          docketNumberWithSuffix: '101-19P',
+          isDocketSuffixHighPriority: true,
+        },
+        {
+          docketNumber: '101-19',
+          docketNumberSuffix: '',
+          docketNumberWithSuffix: '101-19',
+        },
+      ]);
+    });
+
+    it('compares eligible trial session cases sorting manually added cases first', () => {
+      const formattedEligibleCases = [
+        {
+          // should be last
+          docketNumber: '105-19',
+          docketNumberSuffix: '',
+          docketNumberWithSuffix: '105-19',
+        },
+        {
+          // should be 3rd
+          docketNumber: '101-19',
+          docketNumberSuffix: 'L',
+          docketNumberWithSuffix: '101-19L',
+        },
+        {
+          // should be 1st
+          docketNumber: '103-19',
+          docketNumberSuffix: 'P',
+          docketNumberWithSuffix: '103-19P',
+          isManuallyAdded: true,
+        },
+        {
+          // should be 2nd
+          docketNumber: '104-19',
+          docketNumberSuffix: '',
+          docketNumberWithSuffix: '104-19',
+          highPriority: true,
+        },
+      ];
+      const result = formattedEligibleCases.sort(
+        compareTrialSessionEligibleCases,
+      );
+      expect(result).toMatchObject([
+        {
+          docketNumber: '103-19',
+          docketNumberSuffix: 'P',
+          docketNumberWithSuffix: '103-19P',
+          isManuallyAdded: true,
+        },
+        {
+          docketNumber: '104-19',
+          docketNumberSuffix: '',
+          docketNumberWithSuffix: '104-19',
+          highPriority: true,
+        },
+        {
+          docketNumber: '101-19',
+          docketNumberSuffix: 'L',
+          docketNumberWithSuffix: '101-19L',
+        },
+        {
+          docketNumber: '105-19',
+          docketNumberSuffix: '',
+          docketNumberWithSuffix: '105-19',
+        },
+      ]);
+    });
+  });
+});

--- a/shared/src/business/utilities/getFormattedTrialSessionDetails.js
+++ b/shared/src/business/utilities/getFormattedTrialSessionDetails.js
@@ -165,7 +165,9 @@ exports.formattedTrialSessionDetails = ({
   trialSession.formattedJudge =
     (trialSession.judge && trialSession.judge.name) || 'Not assigned';
   trialSession.formattedTrialClerk =
-    (trialSession.trialClerk && trialSession.trialClerk.name) || 'Not assigned';
+    (trialSession.trialClerk && trialSession.trialClerk.name) ||
+    trialSession.alternateTrialClerkName ||
+    'Not assigned';
   trialSession.formattedCourtReporter =
     trialSession.courtReporter || 'Not assigned';
   trialSession.formattedIrsCalendarAdministrator =

--- a/shared/src/business/utilities/getFormattedTrialSessionDetails.setPretrialMemorandumFilter.test.js
+++ b/shared/src/business/utilities/getFormattedTrialSessionDetails.setPretrialMemorandumFilter.test.js
@@ -1,0 +1,174 @@
+import { MOCK_CASE } from '../../test/mockCase';
+import { PARTIES_CODES } from '../entities/EntityConstants';
+const { applicationContext } = require('../test/createTestApplicationContext');
+import { setPretrialMemorandumFiler } from './getFormattedTrialSessionDetails';
+
+describe('formattedTrialSessionDetails', () => {
+  describe('setPretrialMemorandumFiler', () => {
+    const mockPretrialMemorandumDocketEntry = {
+      createdAt: '2018-11-21T20:49:28.192Z',
+      docketEntryId: '9de27a7d-7c6b-434b-803b-7655f82d5e07',
+      docketNumber: '101-18',
+      documentTitle: 'Pretrial Memorandum',
+      documentType: 'Pretrial Memorandum',
+      eventCode: 'PMT',
+      filedBy: 'Test Petitioner',
+      filers: [MOCK_CASE.petitioners[0].contactId],
+      filingDate: '2018-03-01T05:00:00.000Z',
+      index: 5,
+      isFileAttached: true,
+      isOnDocketRecord: true,
+      isStricken: false,
+      partyIrsPractitioner: false,
+      processingStatus: 'complete',
+      receivedAt: '2018-03-01T05:00:00.000Z',
+      userId: '7805d1ab-18d0-43ec-bafb-654e83405416',
+    };
+
+    let mockCase;
+
+    beforeEach(() => {
+      applicationContext
+        .getPersistenceGateway()
+        .getCaseByDocketNumber.mockImplementation(() => mockCase);
+    });
+
+    it('should set the pretrialMemorandumStatus to "P" when the filer is the petitioner', () => {
+      mockCase = {
+        ...MOCK_CASE,
+        docketEntries: [mockPretrialMemorandumDocketEntry],
+        irsPractitioners: [],
+      };
+
+      const result = setPretrialMemorandumFiler({
+        applicationContext,
+        caseItem: mockCase,
+      });
+
+      expect(result).toEqual(PARTIES_CODES.PETITIONER);
+    });
+
+    it('should set the pretrialMemorandumStatus to "R" when the filer is the respondent', () => {
+      mockCase = {
+        ...MOCK_CASE,
+        docketEntries: [
+          {
+            ...mockPretrialMemorandumDocketEntry,
+            filers: [],
+            partyIrsPractitioner: true,
+          },
+        ],
+      };
+
+      const result = setPretrialMemorandumFiler({
+        applicationContext,
+        caseItem: mockCase,
+      });
+
+      expect(result).toEqual(PARTIES_CODES.RESPONDENT);
+    });
+
+    it('should set the pretrialMemorandumStatus to "B" when the filers are both petitioner and respondent', () => {
+      mockCase = {
+        ...MOCK_CASE,
+        docketEntries: [
+          {
+            ...mockPretrialMemorandumDocketEntry,
+            filers: [MOCK_CASE.petitioners[0].contactId],
+            partyIrsPractitioner: true,
+          },
+        ],
+      };
+
+      const result = setPretrialMemorandumFiler({
+        applicationContext,
+        caseItem: mockCase,
+      });
+
+      expect(result).toEqual(PARTIES_CODES.BOTH);
+    });
+
+    it('should set the pretrialMemorandumStatus to "B" when there are 2 PMTs, one filed by petitioner and one filed by respondent', () => {
+      mockCase = {
+        ...MOCK_CASE,
+        docketEntries: [
+          {
+            ...mockPretrialMemorandumDocketEntry,
+            filers: [MOCK_CASE.petitioners[0].contactId],
+            partyIrsPractitioner: false,
+          },
+          {
+            ...mockPretrialMemorandumDocketEntry,
+            filers: [],
+            partyIrsPractitioner: true,
+          },
+        ],
+      };
+
+      const result = setPretrialMemorandumFiler({
+        applicationContext,
+        caseItem: mockCase,
+      });
+
+      expect(result).toEqual(PARTIES_CODES.BOTH);
+    });
+
+    it('should set the pretrialMemorandumStatus to "R" when there are 2 PMTs, one stricken and filed by petitioner and one filed by respondent', () => {
+      mockCase = {
+        ...MOCK_CASE,
+        docketEntries: [
+          {
+            ...mockPretrialMemorandumDocketEntry,
+            filers: [MOCK_CASE.petitioners[0].contactId],
+            isStricken: true,
+            partyIrsPractitioner: false,
+          },
+          {
+            ...mockPretrialMemorandumDocketEntry,
+            filers: [],
+            partyIrsPractitioner: true,
+          },
+        ],
+      };
+
+      const result = setPretrialMemorandumFiler({
+        applicationContext,
+        caseItem: mockCase,
+      });
+
+      expect(result).toEqual(PARTIES_CODES.RESPONDENT);
+    });
+
+    it('should set the pretrialMemorandumStatus to undefined when there is no pretrial memorandum on the case', () => {
+      applicationContext
+        .getPersistenceGateway()
+        .getCaseByDocketNumber.mockReturnValue(MOCK_CASE);
+
+      const result = setPretrialMemorandumFiler({
+        applicationContext,
+        caseItem: MOCK_CASE,
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should set the pretrialMemorandumStatus to undefined when there is a pretrial memorandum on the case but it is stricken', () => {
+      mockCase = {
+        ...MOCK_CASE,
+        docketEntries: [
+          {
+            ...mockPretrialMemorandumDocketEntry,
+            isStricken: true,
+          },
+        ],
+      };
+
+      const result = setPretrialMemorandumFiler({
+        applicationContext,
+        caseItem: MOCK_CASE,
+      });
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/shared/src/business/utilities/getFormattedTrialSessionDetails.test.js
+++ b/shared/src/business/utilities/getFormattedTrialSessionDetails.test.js
@@ -117,9 +117,10 @@ describe('formattedTrialSessionDetails', () => {
   });
 
   it('formats trial session when trial clerk is empty and alternate trial clerk name is populated', () => {
-    let testTrialSession = {
+    const alternateTrialClerkName = 'Incredible Hulk';
+    const testTrialSession = {
       ...TRIAL_SESSION,
-      alternateTrialClerkName: 'Some OtherClerk',
+      alternateTrialClerkName,
       trialClerk: {},
     };
     const result = formattedTrialSessionDetails({
@@ -127,7 +128,7 @@ describe('formattedTrialSessionDetails', () => {
       trialSession: testTrialSession,
     });
     expect(result).toMatchObject({
-      formattedTrialClerk: 'Some OtherClerk',
+      formattedTrialClerk: alternateTrialClerkName,
     });
   });
 

--- a/shared/src/business/utilities/getFormattedTrialSessionDetails.test.js
+++ b/shared/src/business/utilities/getFormattedTrialSessionDetails.test.js
@@ -116,6 +116,19 @@ describe('formattedTrialSessionDetails', () => {
     });
   });
 
+  it('formats trial session when trial clerk is empty and alternate trial clerk name is populated', () => {
+    let testTrialSession = { ...TRIAL_SESSION };
+    testTrialSession.trialClerk = {};
+    testTrialSession.alternateTrialClerkName = 'Some OtherClerk';
+    const result = formattedTrialSessionDetails({
+      applicationContext,
+      trialSession: testTrialSession,
+    });
+    expect(result).toMatchObject({
+      formattedTrialClerk: 'Some OtherClerk',
+    });
+  });
+
   describe('formats trial session start times', () => {
     it('formats trial session start time', () => {
       const result = formattedTrialSessionDetails({

--- a/shared/src/business/utilities/getFormattedTrialSessionDetails.test.js
+++ b/shared/src/business/utilities/getFormattedTrialSessionDetails.test.js
@@ -5,7 +5,6 @@ import {
 import { MOCK_CASE } from '../../../../shared/src/test/mockCase';
 import { applicationContext } from '../test/createTestApplicationContext';
 import {
-  compareTrialSessionEligibleCases,
   formatCase,
   formattedTrialSessionDetails,
 } from './getFormattedTrialSessionDetails';
@@ -243,116 +242,6 @@ describe('formattedTrialSessionDetails', () => {
     expect(
       applicationContext.getUtilities().setConsolidationFlagsForDisplay,
     ).toHaveBeenCalledTimes(4);
-  });
-
-  describe('comparing eligible cases', () => {
-    it('prioritizes L and P', () => {
-      const result = compareTrialSessionEligibleCases(
-        {
-          docketNumber: '101-19',
-          docketNumberSuffix: '',
-          docketNumberWithSuffix: '101-19',
-          isDocketSuffixHighPriority: false,
-        },
-        {
-          docketNumber: '101-19',
-          docketNumberSuffix: 'P',
-          docketNumberWithSuffix: '101-19P',
-          isDocketSuffixHighPriority: true,
-        },
-      );
-      expect(result).toBe(1);
-    });
-
-    it('compares eligible trial session cases sorting lien/levy and passport first', () => {
-      const formattedEligibleCases = [
-        {
-          docketNumber: '101-19',
-          docketNumberSuffix: '',
-          docketNumberWithSuffix: '101-19',
-        },
-        {
-          docketNumber: '101-19',
-          docketNumberSuffix: 'P',
-          docketNumberWithSuffix: '101-19P',
-          isDocketSuffixHighPriority: true,
-        },
-      ];
-      const result = formattedEligibleCases.sort(
-        compareTrialSessionEligibleCases,
-      );
-      expect(result).toMatchObject([
-        {
-          docketNumber: '101-19',
-          docketNumberSuffix: 'P',
-          docketNumberWithSuffix: '101-19P',
-          isDocketSuffixHighPriority: true,
-        },
-        {
-          docketNumber: '101-19',
-          docketNumberSuffix: '',
-          docketNumberWithSuffix: '101-19',
-        },
-      ]);
-    });
-
-    it('compares eligible trial session cases sorting manually added cases first', () => {
-      const formattedEligibleCases = [
-        {
-          // should be last
-          docketNumber: '105-19',
-          docketNumberSuffix: '',
-          docketNumberWithSuffix: '105-19',
-        },
-        {
-          // should be 3rd
-          docketNumber: '101-19',
-          docketNumberSuffix: 'L',
-          docketNumberWithSuffix: '101-19L',
-        },
-        {
-          // should be 1st
-          docketNumber: '103-19',
-          docketNumberSuffix: 'P',
-          docketNumberWithSuffix: '103-19P',
-          isManuallyAdded: true,
-        },
-        {
-          // should be 2nd
-          docketNumber: '104-19',
-          docketNumberSuffix: '',
-          docketNumberWithSuffix: '104-19',
-          highPriority: true,
-        },
-      ];
-      const result = formattedEligibleCases.sort(
-        compareTrialSessionEligibleCases,
-      );
-      expect(result).toMatchObject([
-        {
-          docketNumber: '103-19',
-          docketNumberSuffix: 'P',
-          docketNumberWithSuffix: '103-19P',
-          isManuallyAdded: true,
-        },
-        {
-          docketNumber: '104-19',
-          docketNumberSuffix: '',
-          docketNumberWithSuffix: '104-19',
-          highPriority: true,
-        },
-        {
-          docketNumber: '101-19',
-          docketNumberSuffix: 'L',
-          docketNumberWithSuffix: '101-19L',
-        },
-        {
-          docketNumber: '105-19',
-          docketNumberSuffix: '',
-          docketNumberWithSuffix: '105-19',
-        },
-      ]);
-    });
   });
 
   it('formats docket numbers with suffixes and case caption names without postfix on eligible cases', () => {

--- a/shared/src/business/utilities/getFormattedTrialSessionDetails.test.js
+++ b/shared/src/business/utilities/getFormattedTrialSessionDetails.test.js
@@ -117,9 +117,11 @@ describe('formattedTrialSessionDetails', () => {
   });
 
   it('formats trial session when trial clerk is empty and alternate trial clerk name is populated', () => {
-    let testTrialSession = { ...TRIAL_SESSION };
-    testTrialSession.trialClerk = {};
-    testTrialSession.alternateTrialClerkName = 'Some OtherClerk';
+    let testTrialSession = {
+      ...TRIAL_SESSION,
+      alternateTrialClerkName: 'Some OtherClerk',
+      trialClerk: {},
+    };
     const result = formattedTrialSessionDetails({
       applicationContext,
       trialSession: testTrialSession,

--- a/web-client/integration-tests/docketClerkEditsACalendaredTrialSession.test.js
+++ b/web-client/integration-tests/docketClerkEditsACalendaredTrialSession.test.js
@@ -7,13 +7,27 @@ import { docketClerkEditsTrialSession } from './journey/docketClerkEditsTrialSes
 import { docketClerkUpdatesCaseStatusToClosed } from './journey/docketClerkUpdatesCaseStatusToClosed';
 import { docketClerkVerifiesCaseStatusIsUnchanged } from './journey/docketClerkVerifiesCaseStatusIsUnchanged';
 import { docketClerkViewsTrialSessionList } from './journey/docketClerkViewsTrialSessionList';
-import { loginAs, setupTest, uploadPetition } from './helpers';
+import { formattedTrialSessionDetails as formattedTrialSessionDetailsComputed } from '../src/presenter/computeds/formattedTrialSessionDetails';
+import {
+  loginAs,
+  setupTest,
+  uploadPetition,
+  waitForExpectedItem,
+  waitForLoadingComponentToHide,
+} from './helpers';
 import { markAllCasesAsQCed } from './journey/markAllCasesAsQCed';
 import { petitionsClerkManuallyAddsCaseToTrial } from './journey/petitionsClerkManuallyAddsCaseToTrial';
 import { petitionsClerkSetsATrialSessionsSchedule } from './journey/petitionsClerkSetsATrialSessionsSchedule';
+import { runCompute } from 'cerebral/test';
+import { withAppContextDecorator } from '../src/withAppContext';
+
+const formattedTrialSessionDetails = withAppContextDecorator(
+  formattedTrialSessionDetailsComputed,
+);
 
 describe('Docket Clerk edits a calendared trial session', () => {
   const cerebralTest = setupTest();
+  let overrides = {};
 
   beforeEach(() => {
     jest.setTimeout(30000);
@@ -73,7 +87,7 @@ describe('Docket Clerk edits a calendared trial session', () => {
   loginAs(cerebralTest, 'docketclerk@example.com');
   docketClerkUpdatesCaseStatusToClosed(cerebralTest);
 
-  const overrides = {
+  overrides = {
     fieldToUpdate: 'judge',
     valueToUpdate: {
       name: 'Gustafson',
@@ -88,6 +102,90 @@ describe('Docket Clerk edits a calendared trial session', () => {
     });
 
     expect(cerebralTest.getState('trialSession.caseOrder').length).toBe(3);
+  });
+
+  it('should throw validation error when "Other" is selected and no alternateTrialClerkName provided', async () => {
+    await cerebralTest.runSequence('gotoEditTrialSessionSequence', {
+      trialSessionId: cerebralTest.trialSessionId,
+    });
+
+    expect(cerebralTest.getState('currentPage')).toEqual('EditTrialSession');
+
+    await cerebralTest.runSequence('updateTrialSessionFormDataSequence', {
+      key: 'trialClerkId',
+      value: {
+        name: 'Other*',
+        userId: 'Other',
+      },
+    });
+    await cerebralTest.runSequence('updateTrialSessionSequence');
+
+    expect(cerebralTest.getState('validationErrors')).toEqual({
+      alternateTrialClerkName:
+        'A valid Alternate Trial Clerk name must be provided if "Other*" is selected',
+    });
+  });
+
+  it('should set the alternateTrialClerkName', async () => {
+    const alternateTrialClerkName = 'Incredible Hulk';
+    await cerebralTest.runSequence('updateTrialSessionFormDataSequence', {
+      key: 'alternateTrialClerkName',
+      value: alternateTrialClerkName,
+    });
+    await cerebralTest.runSequence('updateTrialSessionSequence');
+
+    expect(cerebralTest.getState('validationErrors')).toEqual({});
+
+    await waitForLoadingComponentToHide({ cerebralTest });
+    await waitForExpectedItem({
+      cerebralTest,
+      currentItem: 'currentPage',
+      expectedItem: 'PrintPaperTrialNotices',
+    });
+    expect(cerebralTest.getState('currentPage')).toEqual('TrialSessionDetail');
+
+    const formatted = runCompute(formattedTrialSessionDetails, {
+      state: cerebralTest.getState(),
+    });
+
+    expect(formatted.formattedTrialClerk).toEqual(alternateTrialClerkName);
+  });
+
+  it('should unset the alternateTrialClerkName by setting trial clerk name', async () => {
+    const testClerkName = 'Test Clerk';
+    await cerebralTest.runSequence('gotoEditTrialSessionSequence', {
+      trialSessionId: cerebralTest.trialSessionId,
+    });
+    expect(cerebralTest.getState('currentPage')).toEqual('EditTrialSession');
+
+    await cerebralTest.runSequence('updateTrialSessionFormDataSequence', {
+      key: 'trialClerkId',
+      value: {
+        name: testClerkName,
+        userId: 'dabbad05-18d0-43ec-bafb-654e83405415',
+      },
+    });
+
+    await cerebralTest.runSequence('updateTrialSessionSequence');
+
+    expect(cerebralTest.getState('validationErrors')).toEqual({});
+
+    await waitForLoadingComponentToHide({ cerebralTest });
+    await waitForExpectedItem({
+      cerebralTest,
+      currentItem: 'currentPage',
+      expectedItem: 'PrintPaperTrialNotices',
+    });
+    expect(cerebralTest.getState('currentPage')).toEqual('TrialSessionDetail');
+
+    const formatted = runCompute(formattedTrialSessionDetails, {
+      state: cerebralTest.getState(),
+    });
+
+    expect(formatted.formattedTrialClerk).toEqual(testClerkName);
+    expect(
+      cerebralTest.getState('trialSession.alternateTrialClerkName'),
+    ).toEqual(undefined);
   });
 
   it('verify that a Notice of Change of Trial Judge was generated for each open case', async () => {

--- a/web-client/src/presenter/actions/TrialSession/computeSubmitTrialSessionDataAction.js
+++ b/web-client/src/presenter/actions/TrialSession/computeSubmitTrialSessionDataAction.js
@@ -1,0 +1,38 @@
+import {
+  compute24HrTimeAndUpdateState,
+  computeTermAndUpdateState,
+} from './computeTrialSessionFormDataAction';
+import { state } from 'cerebral';
+
+/**
+ * computes the trial session data based on user input for submission
+ *
+ * @param {object} providers the providers object
+ * @param {object} providers.get the cerebral get function
+ * @param {object} providers.store the cerebral store function
+ */
+export const computeSubmitTrialSessionDataAction = ({ get, store }) => {
+  const form = get(state.form);
+
+  computeTermAndUpdateState(
+    {
+      month: form.startDateMonth,
+      year: form.startDateYear,
+    },
+    store,
+  );
+
+  compute24HrTimeAndUpdateState(
+    {
+      extension: form.startTimeExtension,
+      hours: form.startTimeHours,
+      minutes: form.startTimeMinutes,
+    },
+    store,
+  );
+
+  if (form.alternateTrialClerkName) {
+    store.set(state.form.trialClerkId, undefined);
+    store.set(state.form.trialClerk, undefined);
+  }
+};

--- a/web-client/src/presenter/actions/TrialSession/computeSubmitTrialSessionFormDataAction.test.js
+++ b/web-client/src/presenter/actions/TrialSession/computeSubmitTrialSessionFormDataAction.test.js
@@ -1,0 +1,61 @@
+import * as computeFile from './computeTrialSessionFormDataAction';
+import { computeSubmitTrialSessionDataAction } from './computeSubmitTrialSessionDataAction';
+import { runAction } from 'cerebral/test';
+
+describe('computeSubmitTrialSessionDataAction', () => {
+  let form = {};
+  const trialClerk = { name: 'Test Clerk', userId: '321' };
+  let spyCompute24HrTimeAndUpdateState, spyComputeTermAndUpdateState;
+
+  beforeAll(() => {
+    spyCompute24HrTimeAndUpdateState = jest.spyOn(
+      computeFile,
+      'compute24HrTimeAndUpdateState',
+    );
+    spyComputeTermAndUpdateState = jest.spyOn(
+      computeFile,
+      'computeTermAndUpdateState',
+    );
+  });
+
+  it('should call computeTermAndUpdateState', async () => {
+    runAction(computeSubmitTrialSessionDataAction, {
+      state: { form },
+    });
+    expect(spyCompute24HrTimeAndUpdateState).toHaveBeenCalled();
+    expect(spyComputeTermAndUpdateState).toHaveBeenCalled();
+  });
+
+  it('should clear trialClerkId and trialClerk when alternateTrialClerkName is present', async () => {
+    const alternateTrialClerkName = 'Wonder Woman';
+    const result = await runAction(computeSubmitTrialSessionDataAction, {
+      state: {
+        form: {
+          ...form,
+          alternateTrialClerkName,
+          trialClerk,
+          trialClerkId: 'Other',
+        },
+      },
+    });
+    expect(result.state.form.trialClerkId).toEqual(undefined);
+    expect(result.state.form.trialClerk).toEqual(undefined);
+    expect(result.state.form.alternateTrialClerkName).toEqual(
+      alternateTrialClerkName,
+    );
+  });
+
+  it('should NOT clear trialClerkId and trialClerk when alternateTrialClerkName is not present', async () => {
+    const result = await runAction(computeSubmitTrialSessionDataAction, {
+      state: {
+        form: {
+          ...form,
+          trialClerk,
+          trialClerkId: '12',
+        },
+      },
+    });
+    expect(result.state.form.trialClerkId).toEqual('12');
+    expect(result.state.form.trialClerk).toEqual(trialClerk);
+  });
+});

--- a/web-client/src/presenter/actions/TrialSession/computeTrialSessionFormDataAction.js
+++ b/web-client/src/presenter/actions/TrialSession/computeTrialSessionFormDataAction.js
@@ -86,11 +86,17 @@ export const computeTrialSessionFormDataAction = ({ get, props, store }) => {
   }
 
   if (props.key === 'trialClerkId') {
-    if (props.value.userId !== ('Other' || undefined)) {
+    if (!props.value) {
       store.set(state.form.alternateTrialClerkName, undefined);
+      store.set(state.form.trialClerk, undefined);
+      store.set(state.form.trialClerkId, undefined);
+    } else if (props.value.userId !== 'Other') {
+      store.set(state.form.alternateTrialClerkName, undefined);
+      store.set(state.form.trialClerk, props.value);
+      store.set(state.form.trialClerkId, props.value.userId);
+    } else {
+      store.set(state.form.trialClerkId, props.value.userId);
     }
-    store.set(state.form.trialClerkId, props.value.userId);
-    store.set(state.form.trialClerk, props.value);
   }
 };
 

--- a/web-client/src/presenter/actions/TrialSession/computeTrialSessionFormDataAction.js
+++ b/web-client/src/presenter/actions/TrialSession/computeTrialSessionFormDataAction.js
@@ -86,16 +86,16 @@ export const computeTrialSessionFormDataAction = ({ get, props, store }) => {
   }
 
   if (props.key === 'trialClerkId') {
-    if (!props.value) {
+    if (props.value) {
+      store.set(state.form.trialClerkId, props.value.userId);
+      if (props.value.userId !== 'Other') {
+        store.set(state.form.trialClerk, props.value);
+        store.set(state.form.alternateTrialClerkName, undefined);
+      }
+    } else {
       store.set(state.form.alternateTrialClerkName, undefined);
       store.set(state.form.trialClerk, undefined);
       store.set(state.form.trialClerkId, undefined);
-    } else if (props.value.userId !== 'Other') {
-      store.set(state.form.alternateTrialClerkName, undefined);
-      store.set(state.form.trialClerk, props.value);
-      store.set(state.form.trialClerkId, props.value.userId);
-    } else {
-      store.set(state.form.trialClerkId, props.value.userId);
     }
   }
 };

--- a/web-client/src/presenter/actions/TrialSession/computeTrialSessionFormDataAction.js
+++ b/web-client/src/presenter/actions/TrialSession/computeTrialSessionFormDataAction.js
@@ -1,6 +1,6 @@
 import { state } from 'cerebral';
 
-const computeTerm = ({ month, year }) => {
+export const computeTermAndUpdateState = ({ month, year }, store) => {
   const selectedMonth = +month;
   let term, termYear;
 
@@ -22,12 +22,15 @@ const computeTerm = ({ month, year }) => {
     } else if (termsByMonth.fall.includes(selectedMonth)) {
       term = 'Fall';
     }
+    store.set(state.form.term, term);
+    store.set(state.form.termYear, termYear);
   }
-
-  return { term, termYear };
 };
 
-const compute24HrTime = ({ extension, hours, minutes }) => {
+export const compute24HrTimeAndUpdateState = (
+  { extension, hours, minutes },
+  store,
+) => {
   if (!hours && !minutes) return undefined;
   const TIME_INVALID = '99:99'; // force time validation error
 
@@ -54,7 +57,7 @@ const compute24HrTime = ({ extension, hours, minutes }) => {
     }
   }
 
-  return `${hours}:${minutes}`;
+  store.set(state.form.startTime, `${hours}:${minutes}`);
 };
 
 /**
@@ -67,19 +70,23 @@ const compute24HrTime = ({ extension, hours, minutes }) => {
 export const computeTrialSessionFormDataAction = ({ get, props, store }) => {
   const form = get(state.form);
 
-  const { term, termYear } = computeTerm({
-    month: form.startDateMonth,
-    year: form.startDateYear,
-  });
-  store.set(state.form.term, term);
-  store.set(state.form.termYear, termYear);
+  computeTermAndUpdateState(
+    {
+      month: form.startDateMonth,
+      year: form.startDateYear,
+    },
+    store,
+  );
 
-  const startTime = compute24HrTime({
-    extension: form.startTimeExtension,
-    hours: form.startTimeHours,
-    minutes: form.startTimeMinutes,
-  });
-  store.set(state.form.startTime, startTime);
+  compute24HrTimeAndUpdateState(
+    {
+      extension: form.startTimeExtension,
+      hours: form.startTimeHours,
+      minutes: form.startTimeMinutes,
+    },
+    store,
+  );
+
   if (props.key === 'judgeId') {
     store.set(state.form.judgeId, props.value.userId);
     store.set(state.form.judge, props.value);
@@ -97,35 +104,5 @@ export const computeTrialSessionFormDataAction = ({ get, props, store }) => {
       store.set(state.form.trialClerk, undefined);
       store.set(state.form.trialClerkId, undefined);
     }
-  }
-};
-
-/**
- * computes the trial session data based on user input for submission
- *
- * @param {object} providers the providers object
- * @param {object} providers.get the cerebral get function
- * @param {object} providers.store the cerebral store function
- */
-export const computeSubmitTrialSessionDataAction = ({ get, store }) => {
-  const form = get(state.form);
-
-  const { term, termYear } = computeTerm({
-    month: form.startDateMonth,
-    year: form.startDateYear,
-  });
-  store.set(state.form.term, term);
-  store.set(state.form.termYear, termYear);
-
-  const startTime = compute24HrTime({
-    extension: form.startTimeExtension,
-    hours: form.startTimeHours,
-    minutes: form.startTimeMinutes,
-  });
-  store.set(state.form.startTime, startTime);
-
-  if (form.alternateTrialClerkName) {
-    store.set(state.form.trialClerkId, undefined);
-    store.set(state.form.trialClerk, undefined);
   }
 };

--- a/web-client/src/presenter/actions/TrialSession/computeTrialSessionFormDataAction.js
+++ b/web-client/src/presenter/actions/TrialSession/computeTrialSessionFormDataAction.js
@@ -22,9 +22,9 @@ export const computeTermAndUpdateState = ({ month, year }, store) => {
     } else if (termsByMonth.fall.includes(selectedMonth)) {
       term = 'Fall';
     }
-    store.set(state.form.term, term);
-    store.set(state.form.termYear, termYear);
   }
+  store.set(state.form.term, term);
+  store.set(state.form.termYear, termYear);
 };
 
 export const compute24HrTimeAndUpdateState = (
@@ -42,14 +42,15 @@ export const compute24HrTimeAndUpdateState = (
     !VALID_MINUTE_RE.test(minutes) ||
     !['am', 'pm'].includes(extension)
   ) {
-    return TIME_INVALID;
+    store.set(state.form.startTime, TIME_INVALID);
+    return;
   }
 
   if (extension === 'pm') {
     if (+hours <= 11) {
       hours = `${+hours + 12}`;
     }
-  } else if (extension === 'am') {
+  } else {
     if (+hours === 12) {
       hours = '00';
     } else {

--- a/web-client/src/presenter/actions/TrialSession/computeTrialSessionFormDataAction.js
+++ b/web-client/src/presenter/actions/TrialSession/computeTrialSessionFormDataAction.js
@@ -98,12 +98,12 @@ export const computeTrialSessionFormDataAction = ({ get, props, store }) => {
       store.set(state.form.trialClerkId, props.value.userId);
       if (props.value.userId !== 'Other') {
         store.set(state.form.trialClerk, props.value);
-        store.set(state.form.alternateTrialClerkName, undefined);
+        store.unset(state.form.alternateTrialClerkName);
       }
     } else {
-      store.set(state.form.alternateTrialClerkName, undefined);
-      store.set(state.form.trialClerk, undefined);
-      store.set(state.form.trialClerkId, undefined);
+      store.unset(state.form.alternateTrialClerkName);
+      store.unset(state.form.trialClerk);
+      store.unset(state.form.trialClerkId);
     }
   }
 };

--- a/web-client/src/presenter/actions/TrialSession/computeTrialSessionFormDataAction.js
+++ b/web-client/src/presenter/actions/TrialSession/computeTrialSessionFormDataAction.js
@@ -86,7 +86,40 @@ export const computeTrialSessionFormDataAction = ({ get, props, store }) => {
   }
 
   if (props.key === 'trialClerkId') {
+    if (props.value.userId !== ('Other' || undefined)) {
+      store.set(state.form.alternateTrialClerkName, undefined);
+    }
     store.set(state.form.trialClerkId, props.value.userId);
     store.set(state.form.trialClerk, props.value);
+  }
+};
+
+/**
+ * computes the trial session data based on user input for submission
+ *
+ * @param {object} providers the providers object
+ * @param {object} providers.get the cerebral get function
+ * @param {object} providers.store the cerebral store function
+ */
+export const computeSubmitTrialSessionDataAction = ({ get, store }) => {
+  const form = get(state.form);
+
+  const { term, termYear } = computeTerm({
+    month: form.startDateMonth,
+    year: form.startDateYear,
+  });
+  store.set(state.form.term, term);
+  store.set(state.form.termYear, termYear);
+
+  const startTime = compute24HrTime({
+    extension: form.startTimeExtension,
+    hours: form.startTimeHours,
+    minutes: form.startTimeMinutes,
+  });
+  store.set(state.form.startTime, startTime);
+
+  if (form.alternateTrialClerkName) {
+    store.set(state.form.trialClerkId, undefined);
+    store.set(state.form.trialClerk, undefined);
   }
 };

--- a/web-client/src/presenter/actions/TrialSession/computeTrialSessionFormDataAction.test.js
+++ b/web-client/src/presenter/actions/TrialSession/computeTrialSessionFormDataAction.test.js
@@ -269,5 +269,51 @@ describe('computeTrialSessionFormDataAction', () => {
       name: 'Test Clerk',
       userId: '321',
     });
+    expect(result.state.form.alternateTrialClerkName).toEqual(undefined);
+  });
+
+  it('should correctly store the trialClerkId to "Other" on the form when "Other" is selected in drop down', async () => {
+    const result = await runAction(computeTrialSessionFormDataAction, {
+      props: {
+        key: 'trialClerkId',
+        value: { name: 'Other*', userId: 'Other' },
+      },
+      state: { form },
+    });
+    expect(result.state.form.trialClerkId).toEqual('Other');
+    expect(result.state.form.trialClerk).toEqual(undefined);
+  });
+
+  it('should clear the trial clerk input when "Select" is selected in drop down', async () => {
+    let result = await runAction(computeTrialSessionFormDataAction, {
+      props: {
+        key: 'trialClerkId',
+        value: undefined,
+      },
+      state: {
+        form: {
+          ...form,
+          trialClerk: { name: 'trial clerk', userId: '78' },
+          trialClerkId: '9',
+        },
+      },
+    });
+    expect(result.state.form.trialClerkId).toEqual(undefined);
+    expect(result.state.form.trialClerk).toEqual(undefined);
+    result = await runAction(computeTrialSessionFormDataAction, {
+      props: {
+        key: 'trialClerkId',
+        value: undefined,
+      },
+      state: {
+        form: {
+          ...form,
+          trialClerk: { name: 'Other*', userId: 'Other' },
+          trialClerkId: 'Other',
+        },
+      },
+    });
+    expect(result.state.form.trialClerkId).toEqual(undefined);
+    expect(result.state.form.alternateTrialClerkName).toEqual(undefined);
   });
 });

--- a/web-client/src/presenter/actions/TrialSession/setTrialSessionDetailsOnFormAction.js
+++ b/web-client/src/presenter/actions/TrialSession/setTrialSessionDetailsOnFormAction.js
@@ -36,6 +36,7 @@ export const setTrialSessionDetailsOnFormAction = ({
     },
     judgeId: props.trialSession.judge && props.trialSession.judge.userId,
     trialClerkId:
-      props.trialSession.trialClerk && props.trialSession.trialClerk.userId,
+      (props.trialSession.trialClerk && props.trialSession.trialClerk.userId) ||
+      (props.trialSession.alternateTrialClerkName && 'Other'),
   });
 };

--- a/web-client/src/presenter/actions/TrialSession/setTrialSessionDetailsOnFormAction.test.js
+++ b/web-client/src/presenter/actions/TrialSession/setTrialSessionDetailsOnFormAction.test.js
@@ -77,4 +77,39 @@ describe('setTrialSessionDetailsOnFormAction', () => {
       trialSessionId: '123',
     });
   });
+
+  it('sets the props.trialSession on state.form to include setting trialClerkId to "Other", when alternateTrialClerkName is given', async () => {
+    const result = await runAction(setTrialSessionDetailsOnFormAction, {
+      modules: {
+        presenter,
+      },
+      props: {
+        trialSession: {
+          alternateTrialClerkName: 'Iron Man',
+          estimatedEndDate: '2019-05-01T21:40:46.415Z',
+          judge: { userId: '456' },
+          sessionType: 'Regular',
+          startDate: '2019-03-01T21:40:46.415Z',
+          trialSessionId: '123',
+        },
+      },
+      state: { form: {} },
+    });
+    expect(result.state.form).toEqual({
+      alternateTrialClerkName: 'Iron Man',
+      estimatedEndDate: '2019-05-01T21:40:46.415Z',
+      estimatedEndDateDay: '1',
+      estimatedEndDateMonth: '5',
+      estimatedEndDateYear: '2019',
+      judge: { userId: '456' },
+      judgeId: '456',
+      sessionType: 'Regular',
+      startDate: '2019-03-01T21:40:46.415Z',
+      startDateDay: '1',
+      startDateMonth: '3',
+      startDateYear: '2019',
+      trialClerkId: 'Other',
+      trialSessionId: '123',
+    });
+  });
 });

--- a/web-client/src/presenter/actions/TrialSession/validateTrialSessionAction.js
+++ b/web-client/src/presenter/actions/TrialSession/validateTrialSessionAction.js
@@ -60,6 +60,7 @@ export const validateTrialSessionAction = ({
       'maxCases',
       'trialLocation',
       'postalCode',
+      'alternateTrialClerkName',
     ];
     return path.error({
       alertError: {

--- a/web-client/src/presenter/computeds/sessionAssignmentHelper.js
+++ b/web-client/src/presenter/computeds/sessionAssignmentHelper.js
@@ -7,8 +7,7 @@ export const sessionAssignmentHelper = get => {
     ...formattedTrialClerks,
   ];
 
-  let showAlternateTrialClerkField =
-    get(state.form.trialClerk.userId) === 'Other';
+  let showAlternateTrialClerkField = get(state.form.trialClerkId) === 'Other';
 
   return { formattedTrialClerks, showAlternateTrialClerkField };
 };

--- a/web-client/src/presenter/computeds/sessionAssignmentHelper.js
+++ b/web-client/src/presenter/computeds/sessionAssignmentHelper.js
@@ -6,6 +6,9 @@ export const sessionAssignmentHelper = get => {
     { name: 'Other*', userId: 'Other' },
     ...formattedTrialClerks,
   ];
-  let showAlternateTrialClerkField = true;
+
+  let showAlternateTrialClerkField =
+    get(state.form.trialClerk.userId) === 'Other';
+
   return { formattedTrialClerks, showAlternateTrialClerkField };
 };

--- a/web-client/src/presenter/computeds/sessionAssignmentHelper.js
+++ b/web-client/src/presenter/computeds/sessionAssignmentHelper.js
@@ -1,0 +1,11 @@
+import { state } from 'cerebral';
+
+export const sessionAssignmentHelper = get => {
+  let formattedTrialClerks = get(state.trialClerks);
+  formattedTrialClerks = [
+    { name: 'Other*', userId: 'Other' },
+    ...formattedTrialClerks,
+  ];
+  let showAlternateTrialClerkField = true;
+  return { formattedTrialClerks, showAlternateTrialClerkField };
+};

--- a/web-client/src/presenter/computeds/sessionAssignmentHelper.test.js
+++ b/web-client/src/presenter/computeds/sessionAssignmentHelper.test.js
@@ -1,0 +1,34 @@
+import { runCompute } from 'cerebral/test';
+import { sessionAssignmentHelper } from './sessionAssignmentHelper';
+
+const trialClerks = [
+  { name: 'Ed the Horse', userId: 12345 },
+  { name: 'He-man', userId: 67890 },
+];
+
+describe('sessionAssignmentHelper', () => {
+  it('should add alternateTrialClerk of "Other" to formattedTrialClerks', () => {
+    const result = runCompute(sessionAssignmentHelper, {
+      state: { trialClerks },
+    });
+    expect(result.formattedTrialClerks[0]).toEqual({
+      name: 'Other*',
+      userId: 'Other',
+    });
+    expect(result.showAlternateTrialClerkField).toEqual(false);
+  });
+
+  it('should set showAlternateTrialClerkField to true when "Other" is selected', () => {
+    const result = runCompute(sessionAssignmentHelper, {
+      state: { form: { trialClerkId: 'Other' }, trialClerks },
+    });
+    expect(result.showAlternateTrialClerkField).toEqual(true);
+  });
+
+  it('should set showAlternateTrialClerkField to false when "Other" is NOT selected', () => {
+    const result = runCompute(sessionAssignmentHelper, {
+      state: { form: { trialClerkId: 's0m3th1ng' }, trialClerks },
+    });
+    expect(result.showAlternateTrialClerkField).toEqual(false);
+  });
+});

--- a/web-client/src/presenter/sequences/submitTrialSessionSequence.js
+++ b/web-client/src/presenter/sequences/submitTrialSessionSequence.js
@@ -1,5 +1,5 @@
 import { clearAlertsAction } from '../actions/clearAlertsAction';
-import { computeSubmitTrialSessionDataAction } from '../actions/TrialSession/computeTrialSessionFormDataAction';
+import { computeSubmitTrialSessionDataAction } from '../actions/TrialSession/computeSubmitTrialSessionDataAction';
 import { createTrialSessionAction } from '../actions/TrialSession/createTrialSessionAction';
 import { getComputedFormDateFactoryAction } from '../actions/getComputedFormDateFactoryAction';
 import { getCreateTrialSessionAlertSuccessAction } from '../actions/TrialSession/getCreateTrialSessionAlertSuccessAction';

--- a/web-client/src/presenter/sequences/submitTrialSessionSequence.js
+++ b/web-client/src/presenter/sequences/submitTrialSessionSequence.js
@@ -1,5 +1,5 @@
 import { clearAlertsAction } from '../actions/clearAlertsAction';
-import { computeTrialSessionFormDataAction } from '../actions/TrialSession/computeTrialSessionFormDataAction';
+import { computeSubmitTrialSessionDataAction } from '../actions/TrialSession/computeTrialSessionFormDataAction';
 import { createTrialSessionAction } from '../actions/TrialSession/createTrialSessionAction';
 import { getComputedFormDateFactoryAction } from '../actions/getComputedFormDateFactoryAction';
 import { getCreateTrialSessionAlertSuccessAction } from '../actions/TrialSession/getCreateTrialSessionAlertSuccessAction';
@@ -23,7 +23,7 @@ export const submitTrialSessionSequence = [
     null,
     'computedEstimatedEndDate',
   ),
-  computeTrialSessionFormDataAction,
+  computeSubmitTrialSessionDataAction,
   validateTrialSessionAction,
   {
     error: [

--- a/web-client/src/presenter/sequences/updateTrialSessionSequence.js
+++ b/web-client/src/presenter/sequences/updateTrialSessionSequence.js
@@ -1,6 +1,6 @@
 import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearPdfPreviewUrlAction } from '../actions/CourtIssuedOrder/clearPdfPreviewUrlAction';
-import { computeSubmitTrialSessionDataAction } from '../actions/TrialSession/computeTrialSessionFormDataAction';
+import { computeSubmitTrialSessionDataAction } from '../actions/TrialSession/computeSubmitTrialSessionDataAction';
 import { getComputedFormDateFactoryAction } from '../actions/getComputedFormDateFactoryAction';
 import { setAlertErrorAction } from '../actions/setAlertErrorAction';
 import { setValidationAlertErrorsAction } from '../actions/setValidationAlertErrorsAction';

--- a/web-client/src/presenter/sequences/updateTrialSessionSequence.js
+++ b/web-client/src/presenter/sequences/updateTrialSessionSequence.js
@@ -1,6 +1,6 @@
 import { clearAlertsAction } from '../actions/clearAlertsAction';
 import { clearPdfPreviewUrlAction } from '../actions/CourtIssuedOrder/clearPdfPreviewUrlAction';
-import { computeTrialSessionFormDataAction } from '../actions/TrialSession/computeTrialSessionFormDataAction';
+import { computeSubmitTrialSessionDataAction } from '../actions/TrialSession/computeTrialSessionFormDataAction';
 import { getComputedFormDateFactoryAction } from '../actions/getComputedFormDateFactoryAction';
 import { setAlertErrorAction } from '../actions/setAlertErrorAction';
 import { setValidationAlertErrorsAction } from '../actions/setValidationAlertErrorsAction';
@@ -21,7 +21,7 @@ export const updateTrialSessionSequence = [
     null,
     'computedEstimatedEndDate',
   ),
-  computeTrialSessionFormDataAction,
+  computeSubmitTrialSessionDataAction,
   validateTrialSessionAction,
   {
     error: [

--- a/web-client/src/presenter/state.js
+++ b/web-client/src/presenter/state.js
@@ -86,6 +86,7 @@ import { reviewSavedPetitionHelper } from './computeds/reviewSavedPetitionHelper
 import { scanBatchPreviewerHelper } from './computeds/scanBatchPreviewerHelper';
 import { scanHelper } from './computeds/scanHelper';
 import { sealedCaseDetailHelper } from './computeds/sealedCaseDetailHelper';
+import { sessionAssignmentHelper } from './computeds/sessionAssignmentHelper';
 import { setForHearingModalHelper } from './computeds/setForHearingModalHelper';
 import { showAppTimeoutModalHelper } from './computeds/showAppTimeoutModalHelper';
 import { showSortableHeaders } from './computeds/showSortableHeaders';
@@ -198,6 +199,7 @@ const helpers = {
   scanBatchPreviewerHelper,
   scanHelper,
   sealedCaseDetailHelper,
+  sessionAssignmentHelper,
   setForHearingModalHelper,
   showAppTimeoutModalHelper,
   showSortableHeaders,

--- a/web-client/src/styles/forms.scss
+++ b/web-client/src/styles/forms.scss
@@ -582,3 +582,9 @@ label.ustc-upload {
   color: gray;
   opacity: 1; /* Firefox */
 }
+
+.grid-row {
+  .no-shrink {
+    min-width: 480px;
+  }
+}

--- a/web-client/src/views/TrialSessions/SessionAssignmentsForm.jsx
+++ b/web-client/src/views/TrialSessions/SessionAssignmentsForm.jsx
@@ -8,15 +8,15 @@ export const SessionAssignmentsForm = connect(
       state.constants.TRIAL_SESSION_PROCEEDING_TYPES,
     form: state.form,
     judges: state.judges,
-    trialClerks: state.trialClerks,
+    sessionAssignmentHelper: state.sessionAssignmentHelper,
     updateTrialSessionFormDataSequence:
       sequences.updateTrialSessionFormDataSequence,
   },
   function SessionAssignmentsForm({
     form,
     judges,
+    sessionAssignmentHelper,
     TRIAL_SESSION_PROCEEDING_TYPES,
-    trialClerks,
     updateTrialSessionFormDataSequence,
   }) {
     return (
@@ -71,39 +71,64 @@ export const SessionAssignmentsForm = connect(
               />
             </div>
           )}
-
-          <div className="usa-form-group">
-            <label
-              className="usa-label"
-              htmlFor="trial-clerk"
-              id="trial-clerk-label"
-            >
-              Trial clerk <span className="usa-hint">(optional)</span>
-            </label>
-            <select
-              aria-describedby="trial-clerk-label"
-              className="usa-select"
-              id="trial-clerk"
-              name="trialClerkId"
-              value={form.trialClerkId || ''}
-              onChange={e => {
-                updateTrialSessionFormDataSequence({
-                  key: e.target.name,
-                  value: trialClerks.find(
-                    trialClerk => trialClerk.userId === e.target.value,
+          <div className="grid-row">
+            <div className="usa-form-group desktop:grid-col-6 desktop:margin-right-3 no-shrink">
+              <label
+                className="usa-label"
+                htmlFor="trial-clerk"
+                id="trial-clerk-label"
+              >
+                Trial clerk <span className="usa-hint">(optional)</span>
+              </label>
+              <select
+                aria-describedby="trial-clerk-label"
+                className="usa-select"
+                id="trial-clerk"
+                name="trialClerkId"
+                value={form.trialClerkId || ''}
+                onChange={e => {
+                  updateTrialSessionFormDataSequence({
+                    key: e.target.name,
+                    value: sessionAssignmentHelper.formattedTrialClerks.find(
+                      trialClerk => trialClerk.userId === e.target.value,
+                    ),
+                  });
+                }}
+              >
+                <option value="">- Select -</option>
+                {sessionAssignmentHelper.formattedTrialClerks.map(
+                  trialClerk => (
+                    <option key={trialClerk.userId} value={trialClerk.userId}>
+                      {trialClerk.name}
+                    </option>
                   ),
-                });
-              }}
-            >
-              <option value="">- Select -</option>
-              {trialClerks.map(trialClerk => (
-                <option key={trialClerk.userId} value={trialClerk.userId}>
-                  {trialClerk.name}
-                </option>
-              ))}
-            </select>
-          </div>
+                )}
+              </select>
+            </div>
 
+            <div
+              className="usa-form-group desktop:grid-col-6 no-shrink"
+              hidden={!sessionAssignmentHelper.showAlternateTrialClerkField}
+            >
+              <label className="usa-label" htmlFor="alternate-trial-clerk-name">
+                Alternate Trial Clerk Name{' '}
+              </label>
+              <input
+                autoCapitalize="none"
+                className="usa-input"
+                id="alternate-trial-clerk-name"
+                name="alternateTrialClerkName"
+                type="text"
+                value={form.alternateTrialClerkName || ''}
+                onChange={e => {
+                  updateTrialSessionFormDataSequence({
+                    key: e.target.name,
+                    value: e.target.value,
+                  });
+                }}
+              />
+            </div>
+          </div>
           <div className="usa-form-group">
             <label className="usa-label" htmlFor="court-reporter">
               Court reporter <span className="usa-hint">(optional)</span>


### PR DESCRIPTION
This PR addresses [Story 9559](https://github.com/flexion/ef-cms/issues/9559). An alternate trial clerk field has been added when "Other" is selected in the Trial Clerk drop down for Session Assignments in Trial Sessions.

<img width="1462" alt="Screen Shot 2022-09-02 at 1 22 56 PM" src="https://user-images.githubusercontent.com/66225176/188214978-faed07e0-b3f0-4bf8-9bc9-4dab46d5d73b.png">
