### PR TITLE
9559 UX Feedback: Remove asterisk appended to 'Other' in trial clerk dropdown

### DIFF
--- a/shared/src/business/entities/trialSessions/NewTrialSession.js
+++ b/shared/src/business/entities/trialSessions/NewTrialSession.js
@@ -27,7 +27,7 @@ NewTrialSession.prototype.init = function init(
 NewTrialSession.VALIDATION_ERROR_MESSAGES = {
   ...TrialSession.VALIDATION_ERROR_MESSAGES,
   alternateTrialClerkName:
-    'A valid Alternate Trial Clerk name must be provided if "Other" is selected',
+    'A valid alternate trial clerk name must be provided if "Other" is selected',
 };
 
 joiValidationDecorator(

--- a/shared/src/business/entities/trialSessions/NewTrialSession.js
+++ b/shared/src/business/entities/trialSessions/NewTrialSession.js
@@ -27,7 +27,7 @@ NewTrialSession.prototype.init = function init(
 NewTrialSession.VALIDATION_ERROR_MESSAGES = {
   ...TrialSession.VALIDATION_ERROR_MESSAGES,
   alternateTrialClerkName:
-    'A valid Alternate Trial Clerk name must be provided if "Other*" is selected',
+    'A valid Alternate Trial Clerk name must be provided if "Other" is selected',
 };
 
 joiValidationDecorator(

--- a/web-client/integration-tests/docketClerkEditsACalendaredTrialSession.test.js
+++ b/web-client/integration-tests/docketClerkEditsACalendaredTrialSession.test.js
@@ -114,7 +114,7 @@ describe('Docket Clerk edits a calendared trial session', () => {
     await cerebralTest.runSequence('updateTrialSessionFormDataSequence', {
       key: 'trialClerkId',
       value: {
-        name: 'Other*',
+        name: 'Other',
         userId: 'Other',
       },
     });
@@ -122,7 +122,7 @@ describe('Docket Clerk edits a calendared trial session', () => {
 
     expect(cerebralTest.getState('validationErrors')).toEqual({
       alternateTrialClerkName:
-        'A valid Alternate Trial Clerk name must be provided if "Other*" is selected',
+        'A valid Alternate Trial Clerk name must be provided if "Other" is selected',
     });
   });
 

--- a/web-client/integration-tests/docketClerkEditsACalendaredTrialSession.test.js
+++ b/web-client/integration-tests/docketClerkEditsACalendaredTrialSession.test.js
@@ -122,7 +122,7 @@ describe('Docket Clerk edits a calendared trial session', () => {
 
     expect(cerebralTest.getState('validationErrors')).toEqual({
       alternateTrialClerkName:
-        'A valid Alternate Trial Clerk name must be provided if "Other" is selected',
+        'A valid alternate trial clerk name must be provided if "Other" is selected',
     });
   });
 

--- a/web-client/src/presenter/actions/TrialSession/computeTrialSessionFormDataAction.test.js
+++ b/web-client/src/presenter/actions/TrialSession/computeTrialSessionFormDataAction.test.js
@@ -276,7 +276,7 @@ describe('computeTrialSessionFormDataAction', () => {
     const result = await runAction(computeTrialSessionFormDataAction, {
       props: {
         key: 'trialClerkId',
-        value: { name: 'Other*', userId: 'Other' },
+        value: { name: 'Other', userId: 'Other' },
       },
       state: { form },
     });
@@ -308,7 +308,7 @@ describe('computeTrialSessionFormDataAction', () => {
       state: {
         form: {
           ...form,
-          trialClerk: { name: 'Other*', userId: 'Other' },
+          trialClerk: { name: 'Other', userId: 'Other' },
           trialClerkId: 'Other',
         },
       },

--- a/web-client/src/presenter/computeds/sessionAssignmentHelper.js
+++ b/web-client/src/presenter/computeds/sessionAssignmentHelper.js
@@ -3,7 +3,7 @@ import { state } from 'cerebral';
 export const sessionAssignmentHelper = get => {
   let formattedTrialClerks = get(state.trialClerks);
   formattedTrialClerks = [
-    { name: 'Other*', userId: 'Other' },
+    { name: 'Other', userId: 'Other' },
     ...formattedTrialClerks,
   ];
 

--- a/web-client/src/presenter/computeds/sessionAssignmentHelper.test.js
+++ b/web-client/src/presenter/computeds/sessionAssignmentHelper.test.js
@@ -12,7 +12,7 @@ describe('sessionAssignmentHelper', () => {
       state: { trialClerks },
     });
     expect(result.formattedTrialClerks[0]).toEqual({
-      name: 'Other*',
+      name: 'Other',
       userId: 'Other',
     });
     expect(result.showAlternateTrialClerkField).toEqual(false);

--- a/web-client/src/views/TrialSessions/SessionAssignmentsForm.jsx
+++ b/web-client/src/views/TrialSessions/SessionAssignmentsForm.jsx
@@ -111,7 +111,7 @@ export const SessionAssignmentsForm = connect(
               hidden={!sessionAssignmentHelper.showAlternateTrialClerkField}
             >
               <label className="usa-label" htmlFor="alternate-trial-clerk-name">
-                Alternate Trial Clerk Name{' '}
+                Alternate trial clerk name{' '}
               </label>
               <input
                 autoCapitalize="none"


### PR DESCRIPTION
"Other" no longer has a an asterisk:

<img width="1410" alt="Screen Shot 2022-09-06 at 2 50 27 PM" src="https://user-images.githubusercontent.com/66225176/188725937-b4305c23-88c1-458c-8c94-a8af9a1f9373.png">
