### PR TITLE
reduce deploy resource_class to medium+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -417,7 +417,7 @@ jobs:
         aws_auth:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
-    resource_class: xlarge # this should be temporary until we improve memory usage of 'Deploy - Web Client - S3'
+    resource_class: medium+
     steps:
       - git-shallow-clone/checkout
       - npm-install


### PR DESCRIPTION
![Screen Shot 2022-09-23 at 8 36 01 AM](https://user-images.githubusercontent.com/16403861/192001100-4fd0aeee-09de-41a6-b336-8d770fce600a.png)

Since Monday this week, CircleCI has automatically been reducing this docker resource to medium since xlarge is unavailable and resource usage seem to be low enough for the circle workflows to be functional, so going to try to reduce to medium+ which matches most of our other circleci jobs.
