### PR TITLE
9610 hybrid case type counts to test

### DIFF
--- a/web-client/src/presenter/computeds/formattedTrialSessionDetails.js
+++ b/web-client/src/presenter/computeds/formattedTrialSessionDetails.js
@@ -9,7 +9,6 @@ export const formattedTrialSessionDetails = (get, applicationContext) => {
       applicationContext,
       trialSession: get(state.trialSession),
     });
-  const permissions = get(state.permissions);
 
   if (formattedTrialSession) {
     const { DATE_FORMATS, SESSION_STATUS_GROUPS, TRIAL_SESSION_SCOPE_TYPES } =
@@ -31,10 +30,6 @@ export const formattedTrialSessionDetails = (get, applicationContext) => {
 
     formattedTrialSession.disableHybridFilter =
       formattedTrialSession.formattedEligibleCases.length === 0;
-
-    formattedTrialSession.showSmallAndRegularQcComplete =
-      formattedTrialSession.isHybridSession &&
-      permissions.TRIAL_SESSION_QC_COMPLETE;
 
     if (formattedTrialSession.startDate) {
       const trialDateFormatted = applicationContext

--- a/web-client/src/presenter/computeds/formattedTrialSessionDetails.js
+++ b/web-client/src/presenter/computeds/formattedTrialSessionDetails.js
@@ -9,6 +9,7 @@ export const formattedTrialSessionDetails = (get, applicationContext) => {
       applicationContext,
       trialSession: get(state.trialSession),
     });
+  const permissions = get(state.permissions);
 
   if (formattedTrialSession) {
     const { DATE_FORMATS, SESSION_STATUS_GROUPS, TRIAL_SESSION_SCOPE_TYPES } =
@@ -30,6 +31,10 @@ export const formattedTrialSessionDetails = (get, applicationContext) => {
 
     formattedTrialSession.disableHybridFilter =
       formattedTrialSession.formattedEligibleCases.length === 0;
+
+    formattedTrialSession.showSmallAndRegularQcComplete =
+      formattedTrialSession.isHybridSession &&
+      permissions.TRIAL_SESSION_QC_COMPLETE;
 
     if (formattedTrialSession.startDate) {
       const trialDateFormatted = applicationContext

--- a/web-client/src/presenter/computeds/formattedTrialSessionDetails.test.js
+++ b/web-client/src/presenter/computeds/formattedTrialSessionDetails.test.js
@@ -70,6 +70,51 @@ describe('formattedTrialSessionDetails', () => {
     expect(result).toMatchObject({ isHybridSession: false });
   });
 
+  it('should return false for showSmallAndRegularQcComplete when sessionType is set to Hybrid and does not have permission to QC trial session', () => {
+    mockTrialSession = {
+      ...TRIAL_SESSION,
+      sessionType: HYBRID_SESSION_TYPE,
+    };
+    const result = runCompute(formattedTrialSessionDetails, {
+      state: {
+        permissions: { TRIAL_SESSION_QC_COMPLETE: false },
+        trialSession: {},
+      },
+    });
+
+    expect(result).toMatchObject({ showSmallAndRegularQcComplete: false });
+  });
+
+  it('should return true for showSmallAndRegularQcComplete when sessionType is set to Hybrid and has permission to QC trial session', () => {
+    mockTrialSession = {
+      ...TRIAL_SESSION,
+      sessionType: HYBRID_SESSION_TYPE,
+    };
+    const result = runCompute(formattedTrialSessionDetails, {
+      state: {
+        permissions: { TRIAL_SESSION_QC_COMPLETE: true },
+        trialSession: {},
+      },
+    });
+
+    expect(result).toMatchObject({ showSmallAndRegularQcComplete: true });
+  });
+
+  it('should return false for showSmallAndRegularQcComplete when sessionType is set to Regular and has permission to QC trial session', () => {
+    mockTrialSession = {
+      ...TRIAL_SESSION,
+      sessionType: REGULAR_SESSION_TYPE,
+    };
+    const result = runCompute(formattedTrialSessionDetails, {
+      state: {
+        permissions: { TRIAL_SESSION_QC_COMPLETE: true },
+        trialSession: {},
+      },
+    });
+
+    expect(result).toMatchObject({ showSmallAndRegularQcComplete: false });
+  });
+
   it('should be true for isHybridSession when sessionType is set to Hybrid', () => {
     mockTrialSession = {
       ...TRIAL_SESSION,
@@ -77,6 +122,7 @@ describe('formattedTrialSessionDetails', () => {
     };
     const result = runCompute(formattedTrialSessionDetails, {
       state: {
+        permissions: { TRIAL_SESSION_QC_COMPLETE: true },
         trialSession: {},
       },
     });
@@ -108,6 +154,7 @@ describe('formattedTrialSessionDetails', () => {
     };
     const result = runCompute(formattedTrialSessionDetails, {
       state: {
+        permissions: { TRIAL_SESSION_QC_COMPLETE: true },
         trialSession: {},
       },
     });
@@ -122,6 +169,7 @@ describe('formattedTrialSessionDetails', () => {
     };
     const result = runCompute(formattedTrialSessionDetails, {
       state: {
+        permissions: { TRIAL_SESSION_QC_COMPLETE: true },
         trialSession: {},
       },
     });

--- a/web-client/src/presenter/computeds/formattedTrialSessionDetails.test.js
+++ b/web-client/src/presenter/computeds/formattedTrialSessionDetails.test.js
@@ -77,7 +77,6 @@ describe('formattedTrialSessionDetails', () => {
     };
     const result = runCompute(formattedTrialSessionDetails, {
       state: {
-        permissions: { TRIAL_SESSION_QC_COMPLETE: true },
         trialSession: {},
       },
     });
@@ -109,7 +108,6 @@ describe('formattedTrialSessionDetails', () => {
     };
     const result = runCompute(formattedTrialSessionDetails, {
       state: {
-        permissions: { TRIAL_SESSION_QC_COMPLETE: true },
         trialSession: {},
       },
     });
@@ -124,7 +122,6 @@ describe('formattedTrialSessionDetails', () => {
     };
     const result = runCompute(formattedTrialSessionDetails, {
       state: {
-        permissions: { TRIAL_SESSION_QC_COMPLETE: true },
         trialSession: {},
       },
     });

--- a/web-client/src/presenter/computeds/formattedTrialSessionDetails.test.js
+++ b/web-client/src/presenter/computeds/formattedTrialSessionDetails.test.js
@@ -70,51 +70,6 @@ describe('formattedTrialSessionDetails', () => {
     expect(result).toMatchObject({ isHybridSession: false });
   });
 
-  it('should return false for showSmallAndRegularQcComplete when sessionType is set to Hybrid and does not have permission to QC trial session', () => {
-    mockTrialSession = {
-      ...TRIAL_SESSION,
-      sessionType: HYBRID_SESSION_TYPE,
-    };
-    const result = runCompute(formattedTrialSessionDetails, {
-      state: {
-        permissions: { TRIAL_SESSION_QC_COMPLETE: false },
-        trialSession: {},
-      },
-    });
-
-    expect(result).toMatchObject({ showSmallAndRegularQcComplete: false });
-  });
-
-  it('should return true for showSmallAndRegularQcComplete when sessionType is set to Hybrid and has permission to QC trial session', () => {
-    mockTrialSession = {
-      ...TRIAL_SESSION,
-      sessionType: HYBRID_SESSION_TYPE,
-    };
-    const result = runCompute(formattedTrialSessionDetails, {
-      state: {
-        permissions: { TRIAL_SESSION_QC_COMPLETE: true },
-        trialSession: {},
-      },
-    });
-
-    expect(result).toMatchObject({ showSmallAndRegularQcComplete: true });
-  });
-
-  it('should return false for showSmallAndRegularQcComplete when sessionType is set to Regular and has permission to QC trial session', () => {
-    mockTrialSession = {
-      ...TRIAL_SESSION,
-      sessionType: REGULAR_SESSION_TYPE,
-    };
-    const result = runCompute(formattedTrialSessionDetails, {
-      state: {
-        permissions: { TRIAL_SESSION_QC_COMPLETE: true },
-        trialSession: {},
-      },
-    });
-
-    expect(result).toMatchObject({ showSmallAndRegularQcComplete: false });
-  });
-
   it('should be true for isHybridSession when sessionType is set to Hybrid', () => {
     mockTrialSession = {
       ...TRIAL_SESSION,

--- a/web-client/src/presenter/computeds/trialSessionDetailsHelper.js
+++ b/web-client/src/presenter/computeds/trialSessionDetailsHelper.js
@@ -1,9 +1,16 @@
-import { DOCKET_NUMBER_SUFFIXES } from '../../../../shared/src/business/entities/EntityConstants';
+import {
+  DOCKET_NUMBER_SUFFIXES,
+  SESSION_TYPES,
+} from '../../../../shared/src/business/entities/EntityConstants';
 import { state } from 'cerebral';
 
 export const trialSessionDetailsHelper = get => {
-  const { eligibleCases, trialSessionId } = get(state.trialSession);
+  const { eligibleCases, sessionType, trialSessionId } = get(
+    state.trialSession,
+  );
   const permissions = get(state.permissions);
+
+  console.log(get(state.trialSession));
 
   const eligibleTotalCaseQcCompleteCount = (eligibleCases || []).filter(
     eligibleCase => eligibleCase.qcCompleteForTrial?.[trialSessionId],
@@ -27,6 +34,8 @@ export const trialSessionDetailsHelper = get => {
   ).length;
 
   const showQcComplete = permissions.TRIAL_SESSION_QC_COMPLETE;
+  const showSmallAndRegularQcComplete =
+    sessionType === SESSION_TYPES.hybrid && showQcComplete;
 
   return {
     eligibleRegularCaseQcTotalCompleteCount,
@@ -34,5 +43,6 @@ export const trialSessionDetailsHelper = get => {
     eligibleTotalCaseQcCompleteCount,
     showQcComplete,
     showSetCalendarButton: permissions.SET_TRIAL_SESSION_CALENDAR,
+    showSmallAndRegularQcComplete,
   };
 };

--- a/web-client/src/presenter/computeds/trialSessionDetailsHelper.js
+++ b/web-client/src/presenter/computeds/trialSessionDetailsHelper.js
@@ -10,8 +10,6 @@ export const trialSessionDetailsHelper = get => {
   );
   const permissions = get(state.permissions);
 
-  console.log(get(state.trialSession));
-
   const eligibleTotalCaseQcCompleteCount = (eligibleCases || []).filter(
     eligibleCase => eligibleCase.qcCompleteForTrial?.[trialSessionId],
   ).length;

--- a/web-client/src/presenter/computeds/trialSessionDetailsHelper.js
+++ b/web-client/src/presenter/computeds/trialSessionDetailsHelper.js
@@ -8,6 +8,7 @@ export const trialSessionDetailsHelper = get => {
   const eligibleTotalCaseQcCompleteCount = (eligibleCases || []).filter(
     eligibleCase => eligibleCase.qcCompleteForTrial?.[trialSessionId],
   ).length;
+
   const eligibleSmallCaseQcTotalCompleteCount = (eligibleCases || []).filter(
     eligibleCase =>
       eligibleCase.qcCompleteForTrial?.[trialSessionId] &&
@@ -15,6 +16,7 @@ export const trialSessionDetailsHelper = get => {
         eligibleCase.docketNumberSuffix ===
           DOCKET_NUMBER_SUFFIXES.SMALL_LIEN_LEVY),
   ).length;
+
   const eligibleRegularCaseQcTotalCompleteCount = (eligibleCases || []).filter(
     eligibleCase =>
       eligibleCase.qcCompleteForTrial?.[trialSessionId] &&
@@ -23,6 +25,7 @@ export const trialSessionDetailsHelper = get => {
           eligibleCase.docketNumberSuffix !==
             DOCKET_NUMBER_SUFFIXES.SMALL_LIEN_LEVY)),
   ).length;
+
   const showQcComplete = permissions.TRIAL_SESSION_QC_COMPLETE;
 
   return {

--- a/web-client/src/presenter/computeds/trialSessionDetailsHelper.js
+++ b/web-client/src/presenter/computeds/trialSessionDetailsHelper.js
@@ -6,22 +6,18 @@ export const trialSessionDetailsHelper = get => {
   const permissions = get(state.permissions);
 
   const eligibleTotalCaseQcCompleteCount = (eligibleCases || []).filter(
-    eligibleCase =>
-      eligibleCase.qcCompleteForTrial &&
-      eligibleCase.qcCompleteForTrial[trialSessionId],
+    eligibleCase => eligibleCase.qcCompleteForTrial?.[trialSessionId],
   ).length;
   const eligibleSmallCaseQcTotalCompleteCount = (eligibleCases || []).filter(
     eligibleCase =>
-      eligibleCase.qcCompleteForTrial &&
-      eligibleCase.qcCompleteForTrial[trialSessionId] &&
+      eligibleCase.qcCompleteForTrial?.[trialSessionId] &&
       (eligibleCase.docketNumberSuffix === DOCKET_NUMBER_SUFFIXES.SMALL ||
         eligibleCase.docketNumberSuffix ===
           DOCKET_NUMBER_SUFFIXES.SMALL_LIEN_LEVY),
   ).length;
   const eligibleRegularCaseQcTotalCompleteCount = (eligibleCases || []).filter(
     eligibleCase =>
-      eligibleCase.qcCompleteForTrial &&
-      eligibleCase.qcCompleteForTrial[trialSessionId] &&
+      eligibleCase.qcCompleteForTrial?.[trialSessionId] &&
       (eligibleCase.docketNumberSuffix === null ||
         (eligibleCase.docketNumberSuffix !== DOCKET_NUMBER_SUFFIXES.SMALL &&
           eligibleCase.docketNumberSuffix !==

--- a/web-client/src/presenter/computeds/trialSessionDetailsHelper.test.js
+++ b/web-client/src/presenter/computeds/trialSessionDetailsHelper.test.js
@@ -1,4 +1,5 @@
 import { MOCK_CASE } from '../../../../shared/src/test/mockCase';
+import { SESSION_TYPES } from '../../../../shared/src/business/entities/EntityConstants';
 import { applicationContextForClient as applicationContext } from '../../../../shared/src/business/test/createTestApplicationContext';
 import { runCompute } from 'cerebral/test';
 import { trialSessionDetailsHelper } from './trialSessionDetailsHelper';
@@ -129,5 +130,47 @@ describe('trialSessionDetailsHelper', () => {
       },
     });
     expect(result.showQcComplete).toEqual(false);
+  });
+
+  it('returns showSmallAndRegularQcComplete true if the user has TRIAL_SESSION_QC_COMPLETE permission and sessionType is Hybrid', () => {
+    const result = runCompute(trialSessionDetailsHelper, {
+      state: {
+        permissions: { TRIAL_SESSION_QC_COMPLETE: true },
+        trialSession: {
+          ...TRIAL_SESSION,
+          eligibleCases: [],
+          sessionType: SESSION_TYPES.hybrid,
+        },
+      },
+    });
+    expect(result.showSmallAndRegularQcComplete).toEqual(true);
+  });
+
+  it('returns showSmallAndRegularQcComplete false if the user does not have TRIAL_SESSION_QC_COMPLETE permission and sessionType is Hybrid', () => {
+    const result = runCompute(trialSessionDetailsHelper, {
+      state: {
+        permissions: { TRIAL_SESSION_QC_COMPLETE: false },
+        trialSession: {
+          ...TRIAL_SESSION,
+          eligibleCases: [],
+          sessionType: SESSION_TYPES.hybrid,
+        },
+      },
+    });
+    expect(result.showSmallAndRegularQcComplete).toEqual(false);
+  });
+
+  it('returns showSmallAndRegularQcComplete false if the user has TRIAL_SESSION_QC_COMPLETE permission and sessionType is Regular', () => {
+    const result = runCompute(trialSessionDetailsHelper, {
+      state: {
+        permissions: { TRIAL_SESSION_QC_COMPLETE: true },
+        trialSession: {
+          ...TRIAL_SESSION,
+          eligibleCases: [],
+          sessionType: SESSION_TYPES.regular,
+        },
+      },
+    });
+    expect(result.showSmallAndRegularQcComplete).toEqual(false);
   });
 });

--- a/web-client/src/views/TrialSessionDetail/EligibleCases.jsx
+++ b/web-client/src/views/TrialSessionDetail/EligibleCases.jsx
@@ -25,7 +25,7 @@ export const EligibleCases = connect(
     return (
       <React.Fragment>
         <div className="grid-row float-right text-semibold margin-bottom-2">
-          {formattedTrialSessionDetails.isHybridSession && (
+          {formattedTrialSessionDetails.showSmallAndRegularQcComplete && (
             <div className="grid-row">
               <div className="margin-right-50 margin-right-mobile">
                 Regular:{' '}

--- a/web-client/src/views/TrialSessionDetail/EligibleCases.jsx
+++ b/web-client/src/views/TrialSessionDetail/EligibleCases.jsx
@@ -17,7 +17,6 @@ export const EligibleCases = connect(
   },
   function EligibleCases({
     formattedEligibleCases,
-    formattedTrialSessionDetails,
     trialSessionDetailsHelper,
     trialSessionId,
     updateQcCompleteForTrialSequence,
@@ -25,7 +24,7 @@ export const EligibleCases = connect(
     return (
       <React.Fragment>
         <div className="grid-row float-right text-semibold margin-bottom-2">
-          {formattedTrialSessionDetails.showSmallAndRegularQcComplete && (
+          {trialSessionDetailsHelper.showSmallAndRegularQcComplete && (
             <div className="grid-row">
               <div className="margin-right-50 margin-right-mobile">
                 Regular:{' '}

--- a/web-client/src/views/TrialSessionDetail/EligibleCases.jsx
+++ b/web-client/src/views/TrialSessionDetail/EligibleCases.jsx
@@ -24,7 +24,7 @@ export const EligibleCases = connect(
   }) {
     return (
       <React.Fragment>
-        <div className="grid-row float-right text-semibold margin-top-neg-3">
+        <div className="grid-row float-right text-semibold margin-bottom-2">
           {formattedTrialSessionDetails.isHybridSession && (
             <div className="grid-row">
               <div className="margin-right-50 margin-right-mobile">

--- a/web-client/src/views/TrialSessionDetail/TrialSessionDetail.jsx
+++ b/web-client/src/views/TrialSessionDetail/TrialSessionDetail.jsx
@@ -62,7 +62,7 @@ export const TrialSessionDetail = connect(
               >
                 {formattedTrialSessionDetails.isHybridSession && (
                   <div className="grid-container padding-0">
-                    <div className="grid-row hide-on-mobile margin-bottom-105">
+                    <div className="grid-row hide-on-mobile margin-2">
                       <label
                         className="dropdown-label-serif margin-right-3 padding-top-05"
                         htmlFor="hybrid-session-filter"

--- a/web-client/src/views/TrialSessionDetail/TrialSessionDetail.jsx
+++ b/web-client/src/views/TrialSessionDetail/TrialSessionDetail.jsx
@@ -62,7 +62,7 @@ export const TrialSessionDetail = connect(
               >
                 {formattedTrialSessionDetails.isHybridSession && (
                   <div className="grid-container padding-0">
-                    <div className="grid-row hide-on-mobile margin-2">
+                    <div className="grid-row hide-on-mobile margin-bottom-neg-205">
                       <label
                         className="dropdown-label-serif margin-right-3 padding-top-05"
                         htmlFor="hybrid-session-filter"


### PR DESCRIPTION
This addresses an issue of when a user does not have TRIAL_SESSION_QC_COMPLETE permission, do not show the counts of regular and small cases. The `showSmallAndRegularQcComplete` flag in `trialSessionDetailsHelper.js` was created to fix this.  The `cypress-integration/support/pages/create-paper-petition.js` and `web-client/src/ustc-ui/DollarsInput/DollarsInput.jsx' are not part of this story.