### PR TITLE
9627: Adding a STIN from the Review Petition page creates a Docket Index number for the STIN

### DIFF
--- a/shared/src/business/entities/cases/Case.addDocketEntry.test.js
+++ b/shared/src/business/entities/cases/Case.addDocketEntry.test.js
@@ -4,6 +4,24 @@ const {
 const { Case } = require('./Case');
 
 describe('addDocketEntry', () => {
+  it('should throw when docket entry is a STIN', () => {
+    const caseToVerify = new Case(
+      { docketNumber: '123-45' },
+      {
+        applicationContext,
+      },
+    );
+    expect(() => {
+      caseToVerify.addDocketEntry({
+        docketEntryId: '123',
+        documentType: 'Statement of Taxpayer Identification',
+        eventCode: 'STIN',
+        isOnDocketRecord: true,
+        userId: 'petitionsClerk',
+      });
+    }).toThrow('STIN documents should not be on the docket record.');
+  });
+
   it('should attach the docket entry to the case', () => {
     const caseToVerify = new Case(
       { docketNumber: '123-45' },
@@ -36,7 +54,7 @@ describe('addDocketEntry', () => {
       docketEntryId: '123',
       documentType: 'Statement of Taxpayer Identification',
       eventCode: 'STIN',
-      isOnDocketRecord: true,
+      isOnDocketRecord: false,
       userId: 'petitionsClerk',
     });
     expect(caseToVerify.docketEntries.length).toEqual(1);

--- a/shared/src/business/entities/cases/Case.addDocketEntry.test.js
+++ b/shared/src/business/entities/cases/Case.addDocketEntry.test.js
@@ -4,7 +4,7 @@ const {
 const { Case } = require('./Case');
 
 describe('addDocketEntry', () => {
-  it('attaches the docket entry to the case', () => {
+  it('should attach the docket entry to the case', () => {
     const caseToVerify = new Case(
       { docketNumber: '123-45' },
       {
@@ -22,6 +22,31 @@ describe('addDocketEntry', () => {
       docketNumber: '123-45',
       documentType: 'Answer',
       userId: 'irsPractitioner',
+    });
+  });
+
+  it("should assign docket entry index of '0' to the STIN", () => {
+    const caseToVerify = new Case(
+      { docketNumber: '123-45' },
+      {
+        applicationContext,
+      },
+    );
+    caseToVerify.addDocketEntry({
+      docketEntryId: '123',
+      documentType: 'Statement of Taxpayer Identification',
+      eventCode: 'STIN',
+      isOnDocketRecord: true,
+      userId: 'petitionsClerk',
+    });
+    expect(caseToVerify.docketEntries.length).toEqual(1);
+    expect(caseToVerify.docketEntries[0]).toMatchObject({
+      docketEntryId: '123',
+      docketNumber: '123-45',
+      documentType: 'Statement of Taxpayer Identification',
+      eventCode: 'STIN',
+      index: 0,
+      userId: 'petitionsClerk',
     });
   });
 });

--- a/shared/src/business/entities/cases/Case.js
+++ b/shared/src/business/entities/cases/Case.js
@@ -1018,6 +1018,10 @@ Case.prototype.addDocketEntry = function (docketEntryEntity) {
 
     if (updateIndex) {
       docketEntryEntity.index = this.generateNextDocketRecordIndex();
+    } else if (
+      docketEntryEntity.eventCode === INITIAL_DOCUMENT_TYPES.stin.eventCode
+    ) {
+      docketEntryEntity.index = 0;
     }
   }
 

--- a/shared/src/business/entities/cases/Case.js
+++ b/shared/src/business/entities/cases/Case.js
@@ -1021,8 +1021,12 @@ Case.prototype.addDocketEntry = function (docketEntryEntity) {
     } else if (
       docketEntryEntity.eventCode === INITIAL_DOCUMENT_TYPES.stin.eventCode
     ) {
-      docketEntryEntity.index = 0;
+      throw new Error('STIN documents should not be on the docket record.');
     }
+  } else if (
+    docketEntryEntity.eventCode === INITIAL_DOCUMENT_TYPES.stin.eventCode
+  ) {
+    docketEntryEntity.index = 0;
   }
 
   this.docketEntries = [...this.docketEntries, docketEntryEntity];

--- a/shared/src/business/useCaseHelper/initialFilingDocuments/updateInitialFilingDocuments.js
+++ b/shared/src/business/useCaseHelper/initialFilingDocuments/updateInitialFilingDocuments.js
@@ -39,7 +39,7 @@ const addNewInitialFilingToCase = ({
       filers,
       filingDate: caseEntity.receivedAt,
       isFileAttached: true,
-      isOnDocketRecord: true,
+      isOnDocketRecord: eventCode !== INITIAL_DOCUMENT_TYPES.stin.eventCode,
       isPaper: true,
       mailingDate: caseEntity.mailingDate,
       receivedAt: caseEntity.receivedAt,
@@ -92,9 +92,10 @@ exports.updateInitialFilingDocuments = async ({
   caseEntity,
   caseToUpdate,
 }) => {
+  const PETITION_KEY = 'petitionFile';
   const initialDocumentTypesWithoutPetition = omit(
     INITIAL_DOCUMENT_TYPES_MAP,
-    'petitionFile',
+    PETITION_KEY,
   );
 
   for (const key of Object.keys(initialDocumentTypesWithoutPetition)) {

--- a/shared/src/business/useCaseHelper/initialFilingDocuments/updateInitialFilingDocuments.test.js
+++ b/shared/src/business/useCaseHelper/initialFilingDocuments/updateInitialFilingDocuments.test.js
@@ -23,6 +23,13 @@ describe('addNewInitialFilingToCase', () => {
     isOnDocketRecord: true,
     userId: '50c62fa0-dd90-4244-b7c7-9cb2302d7688',
   };
+  const mockSTIN = {
+    docketEntryId: 'b6b81f4d-1e47-423a-8caf-6d2fdc3d3850',
+    documentType: 'Statement of Taxpayer Identification',
+    eventCode: 'STIN',
+    filedBy: 'Test Petitioner',
+    userId: '50c62fa0-dd90-4244-b7c7-9cb2302d7688',
+  };
   const mockPetition = MOCK_DOCUMENTS.find(
     mockDocument =>
       mockDocument.documentType ===
@@ -59,10 +66,35 @@ describe('addNewInitialFilingToCase', () => {
     });
 
     const rqtFile = mockOriginalCase.docketEntries.find(
-      d => d.docketEntryId === mockRQT.docketEntryId,
+      d => d.documentType === mockRQT.documentType,
     );
     expect(rqtFile).toBeDefined();
     expect(rqtFile.index).toBeDefined();
+  });
+
+  it('should add a new STIN to the case when one does not exist on the original case', async () => {
+    mockOriginalCase = new Case(
+      { ...MOCK_CASE, docketEntries: [mockPetition] },
+      { applicationContext },
+    );
+
+    mockCaseToUpdate = {
+      ...MOCK_CASE,
+      docketEntries: [...MOCK_CASE.docketEntries, mockSTIN],
+    };
+
+    await updateInitialFilingDocuments({
+      applicationContext,
+      authorizedUser: petitionsClerkUser,
+      caseEntity: mockOriginalCase,
+      caseToUpdate: mockCaseToUpdate,
+    });
+
+    const stinFile = mockOriginalCase.docketEntries.find(
+      d => d.eventCode === INITIAL_DOCUMENT_TYPES.stin.eventCode,
+    );
+    expect(stinFile).toBeDefined();
+    expect(stinFile.index).toEqual(0);
   });
 
   it('should set isFileAttached and isPaper to true', async () => {

--- a/shared/src/business/utilities/shouldGenerateDocketRecordIndex.js
+++ b/shared/src/business/utilities/shouldGenerateDocketRecordIndex.js
@@ -51,6 +51,10 @@ const shouldGenerateDocketRecordIndex = ({ caseDetail, docketEntry }) => {
     return false;
   }
 
+  if (docketEntry.eventCode === INITIAL_DOCUMENT_TYPES.stin.eventCode) {
+    return false;
+  }
+
   if (!docketEntry.isPaper && !isCourtIssued) {
     return true;
   }

--- a/shared/src/business/utilities/shouldGenerateDocketRecordIndex.test.js
+++ b/shared/src/business/utilities/shouldGenerateDocketRecordIndex.test.js
@@ -100,7 +100,36 @@ describe('shouldGenerateDocketRecordIndex', () => {
     expect(result).toEqual(true);
   });
 
-  it('returns true for initial document types filed along with the petition', () => {
+  it('returns false for STIN', () => {
+    const caseDetail = {
+      docketEntries: [
+        {
+          createdAt: '2019-03-01T21:40:46.415Z',
+          docketEntryId: '012',
+          eventCode: 'P',
+          isPaper: true,
+        },
+        {
+          docketEntryId: '123',
+          isPaper: true,
+        },
+      ],
+    };
+    const docketEntry = {
+      docketEntryId: '123',
+      documentType: 'Statement of Taxpayer Identification',
+      eventCode: 'STIN',
+      filingDate: '2019-03-01T21:40:56.415Z', // 10 seconds
+    };
+    const result = shouldGenerateDocketRecordIndex({
+      caseDetail,
+      docketEntry,
+    });
+
+    expect(result).toEqual(false);
+  });
+
+  it('returns true for non-STIN initial document types filed along with the petition', () => {
     const caseDetail = {
       docketEntries: [
         {

--- a/shared/src/business/utilities/shouldGenerateDocketRecordIndex.test.js
+++ b/shared/src/business/utilities/shouldGenerateDocketRecordIndex.test.js
@@ -100,7 +100,7 @@ describe('shouldGenerateDocketRecordIndex', () => {
     expect(result).toEqual(true);
   });
 
-  it('returns false for STIN', () => {
+  it('should return false for STIN', () => {
     const caseDetail = {
       docketEntries: [
         {
@@ -120,6 +120,7 @@ describe('shouldGenerateDocketRecordIndex', () => {
       documentType: 'Statement of Taxpayer Identification',
       eventCode: 'STIN',
       filingDate: '2019-03-01T21:40:56.415Z', // 10 seconds
+      isPaper: true,
     };
     const result = shouldGenerateDocketRecordIndex({
       caseDetail,
@@ -129,7 +130,7 @@ describe('shouldGenerateDocketRecordIndex', () => {
     expect(result).toEqual(false);
   });
 
-  it('returns true for non-STIN initial document types filed along with the petition', () => {
+  it('should return true for non-STIN initial document types filed along with the petition', () => {
     const caseDetail = {
       docketEntries: [
         {


### PR DESCRIPTION
# [9627](https://github.com/flexion/ef-cms/issues/9627)

When adding the STIN on the wizard initially, we set the index to 0. When adding initial documents we were generating the next index number when we should not assign a real index number.