### PR TITLE
9600 (and 9569) - Address UX Feedback #2

### DIFF
--- a/web-client/src/styles/custom.scss
+++ b/web-client/src/styles/custom.scss
@@ -2024,6 +2024,6 @@ button.change-scanner-button {
   width: 180px;
 }
 
-.align-center {
-  align-items: center;
+.align-items-baseline {
+  align-items: baseline;
 }

--- a/web-client/src/views/CaseDetail/CaseInformation/ConsolidatedCases.jsx
+++ b/web-client/src/views/CaseDetail/CaseInformation/ConsolidatedCases.jsx
@@ -16,7 +16,7 @@ export const ConsolidatedCases = connect(
         <div className="grid-container padding-left-0 margin-bottom-2">
           {caseDetail.consolidatedCases.map(consolidatedCase => (
             <div
-              className="grid-row margin-top-3 align-center"
+              className="grid-row margin-top-3 align-items-baseline"
               key={consolidatedCase.docketNumber}
             >
               <NonMobile>


### PR DESCRIPTION
### Changes

- Text within rows in the Consolidated Cases Card are now aligned to baseline across mobile, tablet, and desktop views.

### iPhone SE View (375 x 667)
![DAD5AEF1-7EDA-47B3-957F-120EA8E457C4](https://user-images.githubusercontent.com/93543562/195882026-86011ce3-219b-4093-97a2-97a1d51f13fe.jpeg)

### Surface Pro 7 View (912 x 1368)
![B8A49999-C0F6-4D6B-A436-F2DE08ADA421](https://user-images.githubusercontent.com/93543562/195882202-57e077b3-a11f-44b9-87e0-f8afc95cc9d1.jpeg)

### iPad Air View (820 x 1180)
![07D29C0B-15D8-4263-A45C-19C4BC1D32A9](https://user-images.githubusercontent.com/93543562/195882323-220fb538-e508-4489-9d86-6192d260219d.jpeg)

### Standard Card View on Desktop (1920 x 1080)
![67D432EB-8A31-4A71-8419-1F5841717936_4_5005_c](https://user-images.githubusercontent.com/93543562/195884050-e1548579-0c07-41ce-b300-79e41de3f6f7.jpeg)



