### PR TITLE
BUG 9648: When a Lead case is removed from a trial, member cases no longer display on the Session Copy Page

### DIFF
--- a/web-client/src/presenter/computeds/trialSessionWorkingCopyHelper.caseNotes.test.js
+++ b/web-client/src/presenter/computeds/trialSessionWorkingCopyHelper.caseNotes.test.js
@@ -1,0 +1,131 @@
+import { MOCK_CASE } from '../../../../shared/src/test/mockCase';
+import {
+  STATUS_TYPES,
+  TRIAL_STATUS_TYPES,
+} from '../../../../shared/src/business/entities/EntityConstants';
+import { applicationContext } from '../../applicationContext';
+import { runCompute } from 'cerebral/test';
+import { trialSessionWorkingCopyHelper as trialSessionWorkingCopyHelperComputed } from './trialSessionWorkingCopyHelper';
+import { withAppContextDecorator } from '../../withAppContext';
+describe('trial session working copy computed', () => {
+  const trialSessionWorkingCopyHelper = withAppContextDecorator(
+    trialSessionWorkingCopyHelperComputed,
+    applicationContext,
+  );
+
+  const MOCK_TRIAL_SESSION = {
+    city: 'Hartford',
+    courtReporter: 'Test Court Reporter',
+    irsCalendarAdministrator: 'Test Calendar Admin',
+    judge: { name: 'Test Judge' },
+    postalCode: '12345',
+    startDate: '2019-11-25T15:00:00.000Z',
+    startTime: '10:00',
+    state: 'CT',
+    term: 'Fall',
+    termYear: '2019',
+    trialClerk: { name: 'Test Trial Clerk' },
+    trialLocation: 'Hartford, Connecticut',
+  };
+
+  it('should set calendarNotes on cases that have them', () => {
+    const mockCaseWithCalendarNotes = '102-19';
+    const mockCaseWithoutCalendarNotes = '5000-17';
+    const mockCaseWithCalendarNotesNotInSelectedTrialSession = '999-99';
+    const mockCalendarNote = 'this is a test note';
+
+    const { formattedCases } = runCompute(trialSessionWorkingCopyHelper, {
+      state: {
+        constants: {
+          STATUS_TYPES,
+          TRIAL_STATUS_TYPES,
+        },
+        trialSession: {
+          ...MOCK_TRIAL_SESSION,
+          calendaredCases: [
+            MOCK_CASE,
+            { ...MOCK_CASE, docketNumber: mockCaseWithCalendarNotes },
+            { ...MOCK_CASE, docketNumber: mockCaseWithoutCalendarNotes },
+          ],
+          caseOrder: [
+            {
+              calendarNotes: mockCalendarNote,
+              docketNumber: mockCaseWithCalendarNotes,
+            },
+            {
+              calendarNotes: mockCalendarNote,
+              docketNumber: mockCaseWithCalendarNotesNotInSelectedTrialSession,
+            },
+          ],
+        },
+        trialSessionWorkingCopy: {
+          caseMetadata: {},
+          filters: { statusUnassigned: true },
+          sort: 'docket',
+          sortOrder: 'asc',
+          userNotes: {},
+        },
+      },
+    });
+
+    expect(
+      formattedCases.find(
+        ({ docketNumber }) => docketNumber === mockCaseWithCalendarNotes,
+      ).calendarNotes,
+    ).toEqual(mockCalendarNote);
+    expect(
+      formattedCases.find(
+        ({ docketNumber }) => docketNumber === mockCaseWithoutCalendarNotes,
+      ).calendarNotes,
+    ).toBeUndefined();
+  });
+
+  it('should set userNotes on cases that are calendared on the trial session when they have them', () => {
+    const mockCaseWithUserNotes = '102-19';
+    const mockCaseWithoutUserNotes = '90-07';
+    const mockCaseWithUserNotesNotInSelectedTrialSession = '999-99';
+    const mockUserNote = 'this is a test note';
+
+    const { formattedCases } = runCompute(trialSessionWorkingCopyHelper, {
+      state: {
+        constants: {
+          STATUS_TYPES,
+          TRIAL_STATUS_TYPES,
+        },
+        trialSession: {
+          ...MOCK_TRIAL_SESSION,
+          calendaredCases: [
+            { ...MOCK_CASE, docketNumber: mockCaseWithUserNotes },
+            { ...MOCK_CASE, docketNumber: mockCaseWithoutUserNotes },
+          ],
+          caseOrder: [
+            {
+              docketNumber: mockCaseWithUserNotes,
+            },
+          ],
+        },
+        trialSessionWorkingCopy: {
+          caseMetadata: {},
+          filters: { statusUnassigned: true },
+          sort: 'docket',
+          sortOrder: 'asc',
+          userNotes: {
+            [mockCaseWithUserNotes]: { notes: mockUserNote },
+            [mockCaseWithUserNotesNotInSelectedTrialSession]: { notes: 'blah' },
+          },
+        },
+      },
+    });
+
+    expect(
+      formattedCases.find(
+        ({ docketNumber }) => docketNumber === mockCaseWithUserNotes,
+      ).userNotes,
+    ).toEqual(mockUserNote);
+    expect(
+      formattedCases.find(
+        ({ docketNumber }) => docketNumber === mockCaseWithoutUserNotes,
+      ).userNotes,
+    ).toBeUndefined();
+  });
+});

--- a/web-client/src/presenter/computeds/trialSessionWorkingCopyHelper.test.js
+++ b/web-client/src/presenter/computeds/trialSessionWorkingCopyHelper.test.js
@@ -374,6 +374,42 @@ describe('trial session working copy computed', () => {
     expect(casesShownCount).toEqual(7);
   });
 
+  it('should return a member case (without a lead case on the trial session) and unconsolidated cases', () => {
+    const { formattedCases } = runCompute(trialSessionWorkingCopyHelper, {
+      state: {
+        trialSession: {
+          ...MOCK_TRIAL_SESSION,
+          calendaredCases: [
+            {
+              ...MOCK_CASE,
+              docketNumber: '102-19',
+              leadDocketNumber: '500-17',
+              privatePractitioners: [],
+            },
+            {
+              ...MOCK_CASE,
+              docketNumber: '115-20',
+              privatePractitioners: [],
+            },
+          ],
+          caseOrder: [],
+        },
+        trialSessionWorkingCopy: {
+          caseMetadata: {},
+          filters: { statusUnassigned: true },
+          sort: 'docket',
+          sortOrder: 'asc',
+          userNotes: {},
+        },
+      },
+    });
+
+    expect(formattedCases).toMatchObject([
+      { docketNumber: '102-19' },
+      { docketNumber: '115-20' },
+    ]);
+  });
+
   it('should assign consolidated member cases to the correct lead case and sort them correctly', () => {
     const { casesShownCount, formattedCases } = runCompute(
       trialSessionWorkingCopyHelper,

--- a/web-client/src/presenter/computeds/trialSessionWorkingCopyHelper.test.js
+++ b/web-client/src/presenter/computeds/trialSessionWorkingCopyHelper.test.js
@@ -410,6 +410,59 @@ describe('trial session working copy computed', () => {
     ]);
   });
 
+  it('should return a member case (without a lead case on the trial session), a lead case, and unconsolidated cases sorted in ascending order', () => {
+    const { formattedCases } = runCompute(trialSessionWorkingCopyHelper, {
+      state: {
+        trialSession: {
+          ...MOCK_TRIAL_SESSION,
+          calendaredCases: [
+            {
+              ...MOCK_CASE,
+              docketNumber: '102-19',
+              leadDocketNumber: '500-17',
+              privatePractitioners: [],
+            },
+            {
+              ...MOCK_CASE,
+              docketNumber: '111-17',
+              leadDocketNumber: '111-17',
+              privatePractitioners: [],
+            },
+            {
+              ...MOCK_CASE,
+              docketNumber: '122-17',
+              leadDocketNumber: '111-17',
+              privatePractitioners: [],
+            },
+            {
+              ...MOCK_CASE,
+              docketNumber: '115-20',
+              privatePractitioners: [],
+            },
+          ],
+          caseOrder: [],
+        },
+        trialSessionWorkingCopy: {
+          caseMetadata: {},
+          filters: { statusUnassigned: true },
+          sort: 'docket',
+          sortOrder: 'asc',
+          userNotes: {},
+        },
+      },
+    });
+
+    expect(formattedCases).toMatchObject([
+      { docketNumber: '111-17' },
+      { docketNumber: '102-19' },
+      { docketNumber: '115-20' },
+    ]);
+
+    expect(formattedCases[0].consolidatedCases).toMatchObject([
+      { docketNumber: '122-17' },
+    ]);
+  });
+
   it('should assign consolidated member cases to the correct lead case and sort them correctly', () => {
     const { casesShownCount, formattedCases } = runCompute(
       trialSessionWorkingCopyHelper,


### PR DESCRIPTION
<img width="1439" alt="Screen Shot 2022-10-24 at 2 54 16 PM" src="https://user-images.githubusercontent.com/16403861/197637038-283253c6-273a-41b3-96ca-44795a159f6e.png">

addresses flexion#9648