### PR TITLE
9628: alternate way for bug fix, update how showBlockedTag is displayed

### DIFF
--- a/web-client/integration-tests/docketClerkAddsAutomaticBlockCaseToTrial.test.js
+++ b/web-client/integration-tests/docketClerkAddsAutomaticBlockCaseToTrial.test.js
@@ -56,7 +56,8 @@ describe('Adds automatic block case to trial', () => {
       state: cerebralTest.getState(),
     });
 
-    expect(headerHelper.showBlockedTag).toBeTruthy();
+    // blocked tag doesn't display when the case has a trial date
+    expect(headerHelper.showBlockedTag).toBeFalsy();
     expect(formattedCase.automaticBlocked).toBeTruthy();
   });
 });

--- a/web-client/src/presenter/computeds/caseDetailHeaderHelper.js
+++ b/web-client/src/presenter/computeds/caseDetailHeaderHelper.js
@@ -1,7 +1,7 @@
 import { state } from 'cerebral';
 
 export const caseDetailHeaderHelper = (get, applicationContext) => {
-  const { STATUS_TYPES, USER_ROLES } = applicationContext.getConstants();
+  const { USER_ROLES } = applicationContext.getConstants();
 
   const user = applicationContext.getCurrentUser();
   const isExternalUser = applicationContext
@@ -65,8 +65,7 @@ export const caseDetailHeaderHelper = (get, applicationContext) => {
 
   const showBlockedTag =
     caseDetail.blocked ||
-    (caseDetail.automaticBlocked &&
-      caseDetail.status !== STATUS_TYPES.calendared);
+    (caseDetail.automaticBlocked && !caseDetail.trialDate);
 
   return {
     hidePublicCaseInformation: !isExternalUser,

--- a/web-client/src/presenter/computeds/caseDetailHeaderHelper.test.js
+++ b/web-client/src/presenter/computeds/caseDetailHeaderHelper.test.js
@@ -82,7 +82,7 @@ describe('caseDetailHeaderHelper', () => {
       expect(result.showBlockedTag).toBeTruthy();
     });
 
-    it('should be true when blocked is false, automaticBlocked is true, and case status is NOT calendared', () => {
+    it('should be false when blocked is false, automaticBlocked is true, and the case has a trial date', () => {
       const result = runCompute(caseDetailHeaderHelper, {
         state: {
           ...getBaseState(docketClerkUser),
@@ -90,15 +90,15 @@ describe('caseDetailHeaderHelper', () => {
             ...getBaseState(docketClerkUser).caseDetail,
             automaticBlocked: true,
             blocked: false,
-            status: CASE_STATUS_TYPES.new,
+            trialDate: '2020-03-01T00:00:00.000Z',
           },
         },
       });
 
-      expect(result.showBlockedTag).toBeTruthy();
+      expect(result.showBlockedTag).toBeFalsy();
     });
 
-    it('should be false when blocked is false, automaticBlocked is true, and case status is calendared', () => {
+    it('should be true when blocked is false, automaticBlocked is true, and the case has no trial date', () => {
       const result = runCompute(caseDetailHeaderHelper, {
         state: {
           ...getBaseState(docketClerkUser),
@@ -111,7 +111,7 @@ describe('caseDetailHeaderHelper', () => {
         },
       });
 
-      expect(result.showBlockedTag).toBeFalsy();
+      expect(result.showBlockedTag).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
This solution only focuses on updating how the `showBlockedTag` shows up in the UI. Instead of checking if the case is automatic blocked and NOT calendared, it checks if the case is automatic blocked and does NOT have a trial date to determine showing the blocked tag. Since SDEC (stipulated decisions) is one of the ENTERED_AND_SERVED_EVENT_CODES, on service, it closes the case and trial session, then updates the case status from `Calendared` to `Closed`, therefore improperly displaying the blocked tag.

This is an alternate fix to [this PR](https://github.com/ustaxcourt/ef-cms/pull/2815). The original solution actually updated the `automaticBlocked` property values when removing tracked items with existing trial session and included a migration to update all matching data that fell into this scenario. Although updating the `automaticBlocked` property's values is actually more accurate to what is happening with the caseEntity, there is a far increased complexity and impact to implementing this solution. There could be a decently sized refactoring done around how we are implementing the blocking logic.

Deployed to [exp3](https://app.exp3.ustc-case-mgmt.flexion.us/case-detail/338-22)

<img width="1192" alt="image" src="https://user-images.githubusercontent.com/16403861/202284274-df92e508-06c6-406f-8e4a-d04b562fec6f.png">
<img width="1006" alt="image" src="https://user-images.githubusercontent.com/16403861/202284301-3cd215c3-9978-46bc-a499-38d2c1c5b704.png">