### PR TITLE
Fix the timing for switch-colors cron for dst

### DIFF
--- a/web-api/switch-colors-cron-terraform/main/switch-colors.tf
+++ b/web-api/switch-colors-cron-terraform/main/switch-colors.tf
@@ -29,7 +29,7 @@ resource "aws_lambda_function" "switch_colors_status_lambda" {
 
 resource "aws_cloudwatch_event_rule" "check_switch_colors_status_cron_rule-sunday" {
   name                = "check_switch_colors_status_cron_${var.environment}"
-  schedule_expression = "cron(* 4,5 ? * SUN *)"
+  schedule_expression = "cron(* 5,6 ? * SUN *)"
   is_enabled          = "true"
 }
 


### PR DESCRIPTION
Now that daylight's savings time has ended, we need to adjust the timing for deployments to midnight Eastern on Saturday night. 