### PR TITLE
9715 Bug Fix

### DIFF
--- a/web-client/src/presenter/actions/openPractitionerDocumentDownloadUrlAction.js
+++ b/web-client/src/presenter/actions/openPractitionerDocumentDownloadUrlAction.js
@@ -2,14 +2,14 @@ export const openUrlInNewTab = async getUrlCb => {
   let url;
 
   try {
+    const openFileViewerWindow = window.open();
+    openFileViewerWindow.document.write('Loading your document...');
+
     ({ url } = await getUrlCb());
+    openFileViewerWindow.location.href = url;
   } catch (err) {
     throw new Error(`Unable to get document download url. ${err.message}`);
   }
-
-  const openFileViewerWindow = window.open();
-  openFileViewerWindow.document.write('Loading your document...');
-  openFileViewerWindow.location.href = url;
 };
 
 /**

--- a/web-client/src/presenter/actions/openPractitionerDocumentDownloadUrlAction.js
+++ b/web-client/src/presenter/actions/openPractitionerDocumentDownloadUrlAction.js
@@ -1,15 +1,16 @@
 export const openUrlInNewTab = async getUrlCb => {
   let url;
 
-  try {
-    const openFileViewerWindow = window.open();
-    openFileViewerWindow.document.write('Loading your document...');
+  const openFileViewerWindow = window.open();
 
+  try {
     ({ url } = await getUrlCb());
-    openFileViewerWindow.location.href = url;
   } catch (err) {
     throw new Error(`Unable to get document download url. ${err.message}`);
   }
+
+  openFileViewerWindow.document.write('Loading your document...');
+  openFileViewerWindow.location.href = url;
 };
 
 /**

--- a/web-client/src/presenter/actions/openPractitionerDocumentDownloadUrlAction.test.js
+++ b/web-client/src/presenter/actions/openPractitionerDocumentDownloadUrlAction.test.js
@@ -7,19 +7,15 @@ import { presenter } from '../presenter-mock';
 import { runAction } from 'cerebral/test';
 
 describe('openPractitionerDocumentDownloadUrlAction', () => {
-  const closeSpy = jest.fn();
   const writeSpy = jest.fn();
 
   beforeEach(() => {
     window.open = jest.fn().mockReturnValue({
-      close: closeSpy,
       document: {
         write: writeSpy,
       },
       location: { href: '' },
     });
-    delete window.location;
-    window.location = { href: '' };
 
     presenter.providers.applicationContext = applicationContext;
 
@@ -41,6 +37,31 @@ describe('openPractitionerDocumentDownloadUrlAction', () => {
     });
 
     expect(window.open().location.href).toEqual('http://example.com');
+  });
+});
+
+describe('openUrlInNewTab', () => {
+  const closeSpy = jest.fn();
+  const writeSpy = jest.fn();
+
+  beforeEach(() => {
+    window.open = jest.fn().mockReturnValue({
+      close: closeSpy,
+      document: {
+        write: writeSpy,
+      },
+      location: { href: '' },
+    });
+  });
+
+  it('should open a new tab before fetching the url to open', async () => {
+    try {
+      await openUrlInNewTab(() => {
+        throw new Error();
+      });
+    } catch (e) {
+      expect(window.open).toHaveBeenCalled();
+    }
   });
 
   it('should throw an error if url is invalid', async () => {


### PR DESCRIPTION
This bug occurred because Safari treats the window.open() method as an async call but doesn't mark it as async. When it was moved to be called after the async call that retrieves the URL to load, the window.open() method had not yet "resolved" so it was attempting to set the URL on an undefined object. This only applies to Safari browser as far as we can tell (see links below for more information). 

Mozilla docs explaining this behavior:
`When window.open() returns, the window always contains about:blank. The actual fetching of the URL is deferred and starts after the current script block finishes executing. The window creation and the loading of the referenced resource are done asynchronously.` 

https://stackoverflow.com/questions/20696041/window-openurl-blank-not-working-on-imac-safari
https://stackoverflow.com/questions/40362093/safari-window-open-doesnt-work
https://developer.mozilla.org/en-US/docs/Web/API/Window/open#:~:text=Note%20that%20remote,are%20done%20asynchronously