### PR TITLE
increase parallelism for test stability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
           discovery.type: single-node
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
     resource_class: large
-    parallelism: 8
+    parallelism: 16
     steps:
       - git-shallow-clone/checkout
       - npm-install


### PR DESCRIPTION
we've seen a number of tests failing after reducing this value this morning. 

* https://app.circleci.com/pipelines/github/ustaxcourt/ef-cms/4127/workflows/d7623ee2-6d66-4dbf-9b48-c54b432f6654
* https://app.circleci.com/pipelines/github/ustaxcourt/ef-cms/4131/workflows/2b42513c-1066-4daa-88f8-090c21db2086
* https://app.circleci.com/pipelines/github/ustaxcourt/ef-cms/4132/workflows/53c86215-0f60-4714-9b06-a843ac47b862
* https://app.circleci.com/pipelines/github/ustaxcourt/ef-cms/4132/workflows/130cc208-f45c-44e0-816e-03bafb16d8ef
* https://app.circleci.com/pipelines/github/ustaxcourt/ef-cms/4132/workflows/7d371f73-de5c-4434-9c85-c84a238b47f0

reverting to 16 for now...