### PR TITLE
9758 - New endpoint to only fetch judge sessions

### DIFF
--- a/shared/src/business/useCases/trialSessions/getTrialSessionsForJudgeInteractor.test.ts
+++ b/shared/src/business/useCases/trialSessions/getTrialSessionsForJudgeInteractor.test.ts
@@ -1,0 +1,54 @@
+import { ROLES } from '../../entities/EntityConstants';
+import { applicationContext } from '../../test/createTestApplicationContext';
+import { getTrialSessionsForJudgeInteractor } from './getTrialSessionsForJudgeInteractor';
+
+const MOCK_TRIAL_SESSION = {
+  maxCases: 100,
+  proceedingType: 'Remote',
+  sessionType: 'Regular',
+  startDate: '3000-03-01T00:00:00.000Z',
+  term: 'Fall',
+  termYear: '2009',
+  trialLocation: 'Birmingham, Alabama',
+};
+
+const JUDGE_ID = 'abc';
+
+describe('getTrialSessionsForJudgeInteractor', () => {
+  it('throws error if user is unauthorized', async () => {
+    applicationContext.getUniqueId.mockReturnValue(
+      'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+    );
+
+    await expect(
+      getTrialSessionsForJudgeInteractor(applicationContext, JUDGE_ID),
+    ).rejects.toThrow();
+  });
+
+  it('should only return trial sessions associated with the judgeId', async () => {
+    applicationContext.getCurrentUser.mockImplementation(() => {
+      return {
+        role: ROLES.petitionsClerk,
+        userId: 'petitionsclerk',
+      };
+    });
+    applicationContext
+      .getPersistenceGateway()
+      .getTrialSessions.mockResolvedValue([
+        MOCK_TRIAL_SESSION,
+        {
+          ...MOCK_TRIAL_SESSION,
+          judge: {
+            userId: JUDGE_ID,
+          },
+        },
+      ]);
+
+    const trialSessions = await getTrialSessionsForJudgeInteractor(
+      applicationContext,
+      JUDGE_ID,
+    );
+
+    expect(trialSessions.length).toEqual(1);
+  });
+});

--- a/shared/src/business/useCases/trialSessions/getTrialSessionsForJudgeInteractor.ts
+++ b/shared/src/business/useCases/trialSessions/getTrialSessionsForJudgeInteractor.ts
@@ -1,0 +1,37 @@
+import {
+  ROLE_PERMISSIONS,
+  isAuthorized,
+} from '../../../authorization/authorizationClientService';
+import { TrialSession } from '../../entities/trialSessions/TrialSession';
+import { UnauthorizedError } from '../../../errors/errors';
+
+/**
+ * getTrialSessionsForJudgeInteractor
+ *
+ * @param {object} applicationContext the application context
+ * @returns {Array<TrialSession>} the trial sessions returned from persistence
+ */
+export const getTrialSessionsForJudgeInteractor = async (
+  applicationContext: IApplicationContext,
+  judgeId: string,
+) => {
+  const user = applicationContext.getCurrentUser();
+
+  if (!isAuthorized(user, ROLE_PERMISSIONS.TRIAL_SESSIONS)) {
+    throw new UnauthorizedError('Unauthorized');
+  }
+
+  const trialSessions = await applicationContext
+    .getPersistenceGateway()
+    .getTrialSessions({
+      applicationContext,
+    });
+
+  const judgeSessions = trialSessions.filter(
+    session => session.judge?.userId === judgeId,
+  );
+
+  return TrialSession.validateRawCollection(judgeSessions, {
+    applicationContext,
+  });
+};

--- a/shared/src/proxies/trialSessions/getTrialSessionsForJudgeProxy.js
+++ b/shared/src/proxies/trialSessions/getTrialSessionsForJudgeProxy.js
@@ -1,0 +1,14 @@
+const { get } = require('../requests');
+
+/**
+ * getTrialSessionsForJudgeInteractor
+ *
+ * @param {object} applicationContext the application context
+ * @returns {Promise<*>} the promise of the api call
+ */
+exports.getTrialSessionsForJudgeInteractor = (applicationContext, judgeId) => {
+  return get({
+    applicationContext,
+    endpoint: `/judges/${judgeId}/trial-sessions`,
+  });
+};

--- a/web-api/src/app.js
+++ b/web-api/src/app.js
@@ -297,6 +297,9 @@ const {
   getTrialSessionDetailsLambda,
 } = require('./trialSessions/getTrialSessionDetailsLambda');
 const {
+  getTrialSessionsForJudgeLambda,
+} = require('./trialSessions/getTrialSessionsForJudgeLambda');
+const {
   getTrialSessionsLambda,
 } = require('./trialSessions/getTrialSessionsLambda');
 const {
@@ -1083,6 +1086,10 @@ app.get('/sections/:section/judge', lambdaWrapper(getJudgeInSectionLambda));
   app.post(
     '/trial-sessions/:trialSessionId/close',
     lambdaWrapper(closeTrialSessionLambda),
+  );
+  app.get(
+    '/judges/:judgeId/trial-sessions',
+    lambdaWrapper(getTrialSessionsForJudgeLambda),
   );
 }
 

--- a/web-api/src/getUseCases.ts
+++ b/web-api/src/getUseCases.ts
@@ -337,6 +337,9 @@ const {
   getTrialSessionDetailsInteractor,
 } = require('../../shared/src/business/useCases/trialSessions/getTrialSessionDetailsInteractor');
 const {
+  getTrialSessionsForJudgeInteractor,
+} = require('../../shared/src/business/useCases/trialSessions/getTrialSessionsForJudgeInteractor');
+const {
   getTrialSessionsInteractor,
 } = require('../../shared/src/business/useCases/trialSessions/getTrialSessionsInteractor');
 const {
@@ -691,6 +694,7 @@ const useCases = {
   getTodaysOrdersInteractor,
   getTrialSessionDetailsInteractor,
   getTrialSessionWorkingCopyInteractor,
+  getTrialSessionsForJudgeInteractor,
   getTrialSessionsInteractor,
   getUploadPolicyInteractor,
   getUserByIdInteractor,

--- a/web-api/src/trialSessions/getTrialSessionsForJudgeLambda.js
+++ b/web-api/src/trialSessions/getTrialSessionsForJudgeLambda.js
@@ -1,0 +1,17 @@
+const { genericHandler } = require('../genericHandler');
+
+/**
+ * gets all trial sessions for a judge
+ *
+ * @param {object} event the AWS event object
+ * @returns {Promise<*|undefined>} the api gateway response object containing the statusCode, body, and headers
+ */
+exports.getTrialSessionsForJudgeLambda = event =>
+  genericHandler(event, async ({ applicationContext }) => {
+    return await applicationContext
+      .getUseCases()
+      .getTrialSessionsForJudgeInteractor(
+        applicationContext,
+        event.pathParameters.judgeId,
+      );
+  });

--- a/web-api/swagger.json
+++ b/web-api/swagger.json
@@ -4763,6 +4763,14 @@
       }
     },
     "/judges/{judgeId}/trial-sessions": {
+      "parameters": [
+        {
+          "name": "judgeId",
+          "in": "path",
+          "required": true,
+          "type": "string"
+        }
+      ],
       "get": {
         "tags": ["trialsessions"],
         "summary": "gets all trial sessions for a judge",

--- a/web-api/swagger.json
+++ b/web-api/swagger.json
@@ -4762,6 +4762,27 @@
         }
       }
     },
+    "/judges/{judgeId}/trial-sessions": {
+      "get": {
+        "tags": ["trialsessions"],
+        "summary": "gets all trial sessions for a judge",
+        "description": "gets all trial sessions for a judge.\n",
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "schema": {
+              "$ref": "#/definitions/trialSession"
+            }
+          }
+        },
+        "security": [
+          {
+            "CognitoUserPool": []
+          }
+        ]
+      }
+    },
     "/trial-sessions": {
       "get": {
         "tags": ["trialsessions"],

--- a/web-client/src/applicationContext.js
+++ b/web-client/src/applicationContext.js
@@ -211,6 +211,7 @@ import { getSealedDocketEntryTooltip } from '../../shared/src/business/utilities
 import { getStatusOfVirusScanInteractor } from '../../shared/src/proxies/documents/getStatusOfVirusScanProxy';
 import { getTrialSessionDetailsInteractor } from '../../shared/src/proxies/trialSessions/getTrialSessionDetailsProxy';
 import { getTrialSessionWorkingCopyInteractor } from '../../shared/src/proxies/trialSessions/getTrialSessionWorkingCopyProxy';
+import { getTrialSessionsForJudgeInteractor } from '../../shared/src/proxies/trialSessions/getTrialSessionsForJudgeProxy';
 import { getTrialSessionsInteractor } from '../../shared/src/proxies/trialSessions/getTrialSessionsProxy';
 import { getUserByIdInteractor } from '../../shared/src/proxies/users/getUserByIdProxy';
 import { getUserCaseNoteForCasesInteractor } from '../../shared/src/proxies/caseNote/getUserCaseNoteForCasesProxy';
@@ -465,6 +466,7 @@ const allUseCases = {
       : getStatusOfVirusScanInteractor(applicationContext, args),
   getTrialSessionDetailsInteractor,
   getTrialSessionWorkingCopyInteractor,
+  getTrialSessionsForJudgeInteractor,
   getTrialSessionsInteractor,
   getUserByIdInteractor,
   getUserCaseNoteForCasesInteractor,
@@ -692,6 +694,7 @@ const applicationContext = {
       process.env.SCANNER_RESOURCE_URI || 'http://localhost:10000/Resources'
     );
   },
+  getTrialSessionsForJudgeInteractor,
   getUniqueId,
   getUseCases: () => allUseCases,
   getUserPermissions,

--- a/web-client/src/presenter/actions/TrialSession/getTrialSessionsForJudgeAction.js
+++ b/web-client/src/presenter/actions/TrialSession/getTrialSessionsForJudgeAction.js
@@ -1,0 +1,26 @@
+import { state } from 'cerebral';
+
+/**
+ * Fetches the trial sessions for a judge user id
+ *
+ * @param {object} providers the providers object
+ * @param {object} providers.applicationContext needed for getting the getCase use case
+ * @returns {object} contains the trial sessions returned from the use case
+ */
+export const getTrialSessionsForJudgeAction = async ({
+  applicationContext,
+  get,
+}) => {
+  const { role, userId } = applicationContext.getCurrentUser();
+  const { USER_ROLES } = applicationContext.getConstants();
+  const chambersJudgeUser = get(state.judgeUser);
+  const isChambersUser = role === USER_ROLES.chambers;
+  const judgeUserId =
+    isChambersUser && chambersJudgeUser ? chambersJudgeUser.userId : userId;
+
+  const trialSessions = await applicationContext
+    .getUseCases()
+    .getTrialSessionsForJudgeInteractor(applicationContext, judgeUserId);
+
+  return { trialSessions };
+};

--- a/web-client/src/presenter/actions/TrialSession/getTrialSessionsForJudgeAction.test.js
+++ b/web-client/src/presenter/actions/TrialSession/getTrialSessionsForJudgeAction.test.js
@@ -1,0 +1,68 @@
+import { applicationContextForClient as applicationContext } from '../../../../../shared/src/business/test/createTestApplicationContext';
+import { getTrialSessionsForJudgeAction } from './getTrialSessionsForJudgeAction';
+import { presenter } from '../../presenter-mock';
+import { runAction } from 'cerebral/test';
+
+describe('getTrialSessionsForJudgeAction', () => {
+  beforeAll(() => {
+    presenter.providers.applicationContext = applicationContext;
+  });
+
+  it('should invoke the interactor with the expected judge id when calling this action as a judge user', async () => {
+    applicationContext.getCurrentUser.mockReturnValue({
+      role: 'judge',
+      userId: '123',
+    });
+    applicationContext
+      .getUseCases()
+      .getTrialSessionsForJudgeInteractor.mockResolvedValue([
+        {
+          trialSessionId: 'abc',
+        },
+      ]);
+
+    const result = await runAction(getTrialSessionsForJudgeAction, {
+      modules: {
+        presenter,
+      },
+      props: {},
+      state: {},
+    });
+
+    expect(
+      applicationContext.getUseCases().getTrialSessionsForJudgeInteractor,
+    ).toHaveBeenCalledWith(expect.anything(), '123');
+    expect(result.output.trialSessions.length).toEqual(1);
+  });
+
+  it('should invoke the interactor with the expected judge id when calling this action as a chambers user', async () => {
+    applicationContext.getCurrentUser.mockReturnValue({
+      role: 'chambers',
+    });
+    applicationContext
+      .getUseCases()
+      .getTrialSessionsForJudgeInteractor.mockResolvedValue([
+        {
+          trialSessionId: 'abc',
+        },
+      ]);
+
+    const result = await runAction(getTrialSessionsForJudgeAction, {
+      modules: {
+        presenter,
+      },
+      props: {},
+      state: {
+        judgeUser: {
+          role: 'judge',
+          userId: '123',
+        },
+      },
+    });
+
+    expect(
+      applicationContext.getUseCases().getTrialSessionsForJudgeInteractor,
+    ).toHaveBeenCalledWith(expect.anything(), '123');
+    expect(result.output.trialSessions.length).toEqual(1);
+  });
+});

--- a/web-client/src/presenter/sequences/gotoDashboardSequence.js
+++ b/web-client/src/presenter/sequences/gotoDashboardSequence.js
@@ -6,7 +6,7 @@ import { getInboxMessagesForUserAction } from '../actions/getInboxMessagesForUse
 import { getJudgeForCurrentUserAction } from '../actions/getJudgeForCurrentUserAction';
 import { getMaintenanceModeAction } from '../actions/getMaintenanceModeAction';
 import { getOpenAndClosedCasesForUserAction } from '../actions/Dashboard/getOpenAndClosedCasesForUserAction';
-import { getTrialSessionsAction } from '../actions/TrialSession/getTrialSessionsAction';
+import { getTrialSessionsForJudgeAction } from '../actions/TrialSession/getTrialSessionsForJudgeAction';
 import { getUserAction } from '../actions/getUserAction';
 import { gotoMaintenanceSequence } from './gotoMaintenanceSequence';
 import { isLoggedInAction } from '../actions/isLoggedInAction';
@@ -70,7 +70,7 @@ const goToDashboard = [
                   getMessages,
                   getJudgeForCurrentUserAction,
                   setJudgeUserAction,
-                  getTrialSessionsAction,
+                  getTrialSessionsForJudgeAction,
                   setTrialSessionsAction,
                   setCurrentPageAction('DashboardChambers'),
                 ],
@@ -88,7 +88,7 @@ const goToDashboard = [
                 judge: [
                   setMessageInboxPropsAction,
                   getMessages,
-                  getTrialSessionsAction,
+                  getTrialSessionsForJudgeAction,
                   setTrialSessionsAction,
                   setCurrentPageAction('DashboardJudge'),
                 ],


### PR DESCRIPTION
Adding a new endpoint for fetching just the sessions associated with a judge instead of returning every single trial session.