### PR TITLE
Devex: Remove unnecessary timeouts

### DIFF
--- a/web-client/integration-tests-public/unauthedUserCaseSearchExactMatch.test.js
+++ b/web-client/integration-tests-public/unauthedUserCaseSearchExactMatch.test.js
@@ -46,10 +46,6 @@ primaryContactNames.forEach(createCaseUsingPrimaryContactName);
  */
 function createCaseUsingPrimaryContactName(name) {
   describe(`Create and serve a case for ${name}`, () => {
-    beforeAll(() => {
-      jest.setTimeout(30000);
-    });
-
     afterAll(() => {
       testClient.closeSocket();
     });

--- a/web-client/integration-tests-public/unauthedUserCaseSearchExactMatchCaseCaption.test.js
+++ b/web-client/integration-tests-public/unauthedUserCaseSearchExactMatchCaseCaption.test.js
@@ -53,10 +53,6 @@ caseCaptionNames.forEach(createCaseWithCaption);
  */
 function createCaseWithCaption(captionString) {
   describe(`Create and serve a case with "${captionString}" in the case caption`, () => {
-    beforeAll(() => {
-      jest.setTimeout(30000);
-    });
-
     afterAll(() => {
       testClient.closeSocket();
     });

--- a/web-client/integration-tests-public/unauthedUserCaseSearchExactMatchMultipleFields.test.js
+++ b/web-client/integration-tests-public/unauthedUserCaseSearchExactMatchMultipleFields.test.js
@@ -64,10 +64,6 @@ const updateCaseCaption = (docketNumber, caseCaption) => {
 };
 
 describe('Create and serve a case to test contactPrimary.name', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
-
   afterAll(() => {
     testClient.closeSocket();
   });
@@ -99,10 +95,6 @@ describe('Create and serve a case to test contactPrimary.name', () => {
 });
 
 describe('Create and serve a case to test contactPrimary.secondaryName', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
-
   afterAll(() => {
     testClient.closeSocket();
   });
@@ -135,10 +127,6 @@ describe('Create and serve a case to test contactPrimary.secondaryName', () => {
 });
 
 describe('Create and serve a case to test contactSecondary.name', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
-
   afterAll(() => {
     testClient.closeSocket();
   });
@@ -171,10 +159,6 @@ describe('Create and serve a case to test contactSecondary.name', () => {
 });
 
 describe('Create and serve a case to test caseCaption', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
-
   afterAll(() => {
     testClient.closeSocket();
   });
@@ -202,10 +186,6 @@ describe('Create and serve a case to test caseCaption', () => {
 });
 
 describe('Create and serve a case to test contactPrimary.name with terms out of order that shows last in search results', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
-
   afterAll(() => {
     testClient.closeSocket();
   });

--- a/web-client/integration-tests-public/unauthedUserCaseSearchExactMatchPrimaryAndSecondaryContactName.test.js
+++ b/web-client/integration-tests-public/unauthedUserCaseSearchExactMatchPrimaryAndSecondaryContactName.test.js
@@ -1,8 +1,8 @@
 import {
   ADVANCED_SEARCH_TABS,
+  COUNTRY_TYPES,
   PARTY_TYPES,
 } from '../../shared/src/business/entities/EntityConstants';
-import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
 import {
   loginAs,
   setupTest as setupTestClient,
@@ -15,7 +15,6 @@ const { faker } = require('@faker-js/faker');
 
 const cerebralTest = setupTest();
 const testClient = setupTestClient();
-const { COUNTRY_TYPES } = applicationContext.getConstants();
 
 testClient.draftOrders = [];
 
@@ -39,10 +38,6 @@ const searchTerm = firstName;
  * add a case with the contactSecondary.name provided
  */
 describe(`Petitioner creates cases with name ${firstName}`, () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
-
   afterAll(() => {
     testClient.closeSocket();
   });

--- a/web-client/integration-tests-public/unauthedUserCaseSearchExactMatchSecondaryContactName.test.js
+++ b/web-client/integration-tests-public/unauthedUserCaseSearchExactMatchSecondaryContactName.test.js
@@ -1,5 +1,7 @@
-import { ADVANCED_SEARCH_TABS } from '../../shared/src/business/entities/EntityConstants';
-import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
+import {
+  ADVANCED_SEARCH_TABS,
+  COUNTRY_TYPES,
+} from '../../shared/src/business/entities/EntityConstants';
 import {
   loginAs,
   setupTest as setupTestClient,
@@ -12,7 +14,6 @@ const { faker } = require('@faker-js/faker');
 
 const cerebralTest = setupTest();
 const testClient = setupTestClient();
-const { COUNTRY_TYPES } = applicationContext.getConstants();
 
 testClient.draftOrders = [];
 
@@ -44,10 +45,6 @@ secondaryNames.forEach(createCaseWithSecondaryName);
  */
 function createCaseWithSecondaryName(name) {
   describe(`Create and serve a case for ${name}`, () => {
-    beforeAll(() => {
-      jest.setTimeout(30000);
-    });
-
     afterAll(() => {
       testClient.closeSocket();
     });

--- a/web-client/integration-tests-public/unauthedUserCaseSearchPartialMatchContactPrimaryName.test.js
+++ b/web-client/integration-tests-public/unauthedUserCaseSearchPartialMatchContactPrimaryName.test.js
@@ -1,5 +1,7 @@
-import { ADVANCED_SEARCH_TABS } from '../../shared/src/business/entities/EntityConstants';
-import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
+import {
+  ADVANCED_SEARCH_TABS,
+  COUNTRY_TYPES,
+} from '../../shared/src/business/entities/EntityConstants';
 import {
   loginAs,
   setupTest as setupTestClient,
@@ -12,7 +14,6 @@ const { faker } = require('@faker-js/faker');
 
 const cerebralTest = setupTest();
 const testClient = setupTestClient();
-const { COUNTRY_TYPES } = applicationContext.getConstants();
 
 testClient.draftOrders = [];
 
@@ -52,10 +53,6 @@ caseNamesToCreate.forEach(createCase);
  */
 function createCase(name) {
   describe(`Create and serve a case for ${name}`, () => {
-    beforeAll(() => {
-      jest.setTimeout(30000);
-    });
-
     afterAll(() => {
       testClient.closeSocket();
     });

--- a/web-client/integration-tests-public/unauthedUserOrderSearchExactMatchDocumentTitle.test.js
+++ b/web-client/integration-tests-public/unauthedUserOrderSearchExactMatchDocumentTitle.test.js
@@ -24,10 +24,6 @@ const documentTitleKeyword = `Sunglasses_${new Date().getTime()}`;
 const nonExactDocumentTitleKeyword = `${documentTitleKeyword}y`;
 
 describe(`Create and serve a case with an order with exact keyword (${documentTitleKeyword})`, () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
-
   afterAll(() => {
     testClient.closeSocket();
   });

--- a/web-client/integration-tests-public/unauthedUserSearchesForCase.test.js
+++ b/web-client/integration-tests-public/unauthedUserSearchesForCase.test.js
@@ -1,5 +1,7 @@
-import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
-
+import {
+  COUNTRY_TYPES,
+  PARTY_TYPES,
+} from '../../shared/src/business/entities/EntityConstants';
 import { docketClerkAddsDocketEntryFromOrderOfDismissal } from '../integration-tests/journey/docketClerkAddsDocketEntryFromOrderOfDismissal';
 import { docketClerkAddsStipulatedDecisionDocketEntryFromOrder } from '../integration-tests/journey/docketClerkAddsStipulatedDecisionDocketEntryFromOrder';
 import { docketClerkAddsTranscriptDocketEntryFromOrder } from '../integration-tests/journey/docketClerkAddsTranscriptDocketEntryFromOrder';
@@ -20,16 +22,11 @@ import { unauthedUserViewsCaseDetail } from './journey/unauthedUserViewsCaseDeta
 import { unauthedUserViewsFilteredDocketRecord } from './journey/unauthedUserViewsFilteredDocketRecord';
 import { unauthedUserViewsPrintableDocketRecord } from './journey/unauthedUserViewsPrintableDocketRecord';
 
-const cerebralTest = setupTest();
-const testClient = setupTestClient();
-const { COUNTRY_TYPES, PARTY_TYPES } = applicationContext.getConstants();
-
-testClient.draftOrders = [];
-
 describe('unauthed user searches for case', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
+  const testClient = setupTestClient();
+
+  testClient.draftOrders = [];
 
   afterAll(() => {
     testClient.closeSocket();
@@ -108,13 +105,13 @@ describe('unauthed user searches for case', () => {
     docketClerkAddsStipulatedDecisionDocketEntryFromOrder(testClient, 3);
     docketClerkServesDocument(testClient, 3);
   });
-});
 
-describe('Unauthed user searches for a case and views a case detail page', () => {
-  unauthedUserNavigatesToPublicSite(cerebralTest);
-  unauthedUserSearchesByMeta(cerebralTest);
-  unauthedUserSearchesByDocketNumber(cerebralTest, testClient);
-  unauthedUserViewsCaseDetail(cerebralTest);
-  unauthedUserViewsFilteredDocketRecord(cerebralTest);
-  unauthedUserViewsPrintableDocketRecord(cerebralTest);
+  describe('Unauthed user searches for a case and views a case detail page', () => {
+    unauthedUserNavigatesToPublicSite(cerebralTest);
+    unauthedUserSearchesByMeta(cerebralTest);
+    unauthedUserSearchesByDocketNumber(cerebralTest, testClient);
+    unauthedUserViewsCaseDetail(cerebralTest);
+    unauthedUserViewsFilteredDocketRecord(cerebralTest);
+    unauthedUserViewsPrintableDocketRecord(cerebralTest);
+  });
 });

--- a/web-client/integration-tests-public/unauthedUserSearchesForOrder.test.js
+++ b/web-client/integration-tests-public/unauthedUserSearchesForOrder.test.js
@@ -1,5 +1,8 @@
-import { ADVANCED_SEARCH_TABS } from '../../shared/src/business/entities/EntityConstants';
-import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
+import {
+  ADVANCED_SEARCH_TABS,
+  COUNTRY_TYPES,
+  PARTY_TYPES,
+} from '../../shared/src/business/entities/EntityConstants';
 import { docketClerkAddsDocketEntryFromOrder } from '../integration-tests/journey/docketClerkAddsDocketEntryFromOrder';
 import { docketClerkAddsDocketEntryFromOrderOfDismissal } from '../integration-tests/journey/docketClerkAddsDocketEntryFromOrderOfDismissal';
 import { docketClerkCreatesAnOrder } from '../integration-tests/journey/docketClerkCreatesAnOrder';
@@ -21,13 +24,9 @@ import { unauthedUserSearchesForSealedCaseOrderByKeyword } from './journey/unaut
 
 const cerebralTest = setupTest();
 const testClient = setupTestClient();
-testClient.draftOrders = [];
-const { COUNTRY_TYPES, PARTY_TYPES } = applicationContext.getConstants();
 
 describe('Petitioner creates case', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  testClient.draftOrders = [];
 
   afterAll(() => {
     testClient.closeSocket();

--- a/web-client/integration-tests-public/unauthedUserSearchesForSealedCase.test.js
+++ b/web-client/integration-tests-public/unauthedUserSearchesForSealedCase.test.js
@@ -1,4 +1,7 @@
-import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
+import {
+  COUNTRY_TYPES,
+  PARTY_TYPES,
+} from '../../shared/src/business/entities/EntityConstants';
 import { docketClerkSealsCase } from '../integration-tests/journey/docketClerkSealsCase';
 import {
   loginAs,
@@ -13,14 +16,9 @@ import { unauthedUserSearchesForSealedCasesByDocketNumber } from './journey/unau
 import { unauthedUserViewsCaseDetailForSealedCase } from './journey/unauthedUserViewsCaseDetailForSealedCase';
 import { unauthedUserViewsPrintableDocketRecordForSealedCase } from './journey/unauthedUserViewsPrintableDocketRecordForSealedCase';
 
-const cerebralTest = setupTest();
-const testClient = setupTestClient();
-const { COUNTRY_TYPES, PARTY_TYPES } = applicationContext.getConstants();
-
 describe('unauthed user searches for sealed case', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
+  const testClient = setupTestClient();
 
   afterAll(() => {
     testClient.closeSocket();
@@ -57,21 +55,21 @@ describe('unauthed user searches for sealed case', () => {
     loginAs(testClient, 'docketclerk@example.com');
     docketClerkSealsCase(testClient);
   });
-});
 
-describe('Unauthed user searches for a sealed case by docket number', () => {
-  unauthedUserNavigatesToPublicSite(cerebralTest);
-  unauthedUserViewsCaseDetailForSealedCase(cerebralTest);
-  unauthedUserViewsPrintableDocketRecordForSealedCase(cerebralTest);
-});
+  describe('Unauthed user searches for a sealed case by docket number', () => {
+    unauthedUserNavigatesToPublicSite(cerebralTest);
+    unauthedUserViewsCaseDetailForSealedCase(cerebralTest);
+    unauthedUserViewsPrintableDocketRecordForSealedCase(cerebralTest);
+  });
 
-describe('Unauthed user searches for a sealed case by name', () => {
-  unauthedUserNavigatesToPublicSite(cerebralTest);
-  unauthedUserSearchesForSealedCaseByName(cerebralTest);
-  unauthedUserViewsPrintableDocketRecordForSealedCase(cerebralTest);
-});
+  describe('Unauthed user searches for a sealed case by name', () => {
+    unauthedUserNavigatesToPublicSite(cerebralTest);
+    unauthedUserSearchesForSealedCaseByName(cerebralTest);
+    unauthedUserViewsPrintableDocketRecordForSealedCase(cerebralTest);
+  });
 
-describe('Unauthed user searches for a sealed case and does not route to the case detail page', () => {
-  unauthedUserNavigatesToPublicSite(cerebralTest);
-  unauthedUserSearchesForSealedCasesByDocketNumber(cerebralTest);
+  describe('Unauthed user searches for a sealed case and does not route to the case detail page', () => {
+    unauthedUserNavigatesToPublicSite(cerebralTest);
+    unauthedUserSearchesForSealedCasesByDocketNumber(cerebralTest);
+  });
 });

--- a/web-client/integration-tests-public/unauthedUserSearchesForUnsealedCase.test.js
+++ b/web-client/integration-tests-public/unauthedUserSearchesForUnsealedCase.test.js
@@ -27,10 +27,6 @@ describe('Unauthed user sees unsealed case', () => {
   testClient.draftOrders = [];
 
   describe('Petitioner creates case', () => {
-    beforeAll(() => {
-      jest.setTimeout(30000);
-    });
-
     afterAll(() => {
       testClient.closeSocket();
     });

--- a/web-client/integration-tests-public/unauthedUserSeesStrickenDocketEntry.test.js
+++ b/web-client/integration-tests-public/unauthedUserSeesStrickenDocketEntry.test.js
@@ -26,10 +26,6 @@ describe('unauthed user sees stricken docket entry', () => {
   const cerebralTest = setupTest();
   const testClient = setupTestClient();
 
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
-
   afterAll(() => {
     testClient.closeSocket();
     testClient.draftOrders = [];

--- a/web-client/integration-tests-public/unauthedUserViewsHealthCheck.test.js
+++ b/web-client/integration-tests-public/unauthedUserViewsHealthCheck.test.js
@@ -1,12 +1,8 @@
 import { setupTest } from './helpers';
 import { unauthedUserViewsHealthCheck } from './journey/unauthedUserViewsHealthCheck';
 
-const cerebralTest = setupTest();
-
 describe('Unauthed user views health check', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
 
   unauthedUserViewsHealthCheck(cerebralTest);
 });

--- a/web-client/integration-tests-public/unauthedUserViewsTodaysOpinions.test.js
+++ b/web-client/integration-tests-public/unauthedUserViewsTodaysOpinions.test.js
@@ -19,10 +19,6 @@ describe('Unauthed user views todays opinions', () => {
   const cerebralTest = setupTest();
   const testClient = setupTestClient();
 
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
-
   afterAll(() => {
     testClient.closeSocket();
     testClient.draftOrders = [];

--- a/web-client/integration-tests-public/unauthedUserViewsTodaysOrders.test.js
+++ b/web-client/integration-tests-public/unauthedUserViewsTodaysOrders.test.js
@@ -18,13 +18,11 @@ describe('Unauthed user views todays orders', () => {
   const testClient = setupTestClient();
 
   beforeAll(() => {
-    jest.setTimeout(30000);
     cerebralTest.draftOrders = [];
   });
 
   afterAll(() => {
     testClient.closeSocket();
-    testClient.draftOrders = [];
   });
 
   loginAs(testClient, 'petitioner@example.com');

--- a/web-client/integration-tests-public/userTriesToViewUnsealedCaseWithSealedDocketEntry.test.js
+++ b/web-client/integration-tests-public/userTriesToViewUnsealedCaseWithSealedDocketEntry.test.js
@@ -26,10 +26,6 @@ describe('Unauthed user views todays orders', () => {
   const privateTestClient = privateSetupTest();
   const publicTestClient = publicSetupTest();
 
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
-
   afterAll(() => {
     privateTestClient.closeSocket();
     privateTestClient.draftOrders = [];

--- a/web-client/integration-tests/petitionsClerkBlockConsolidatedCasesJourney.test.js
+++ b/web-client/integration-tests/petitionsClerkBlockConsolidatedCasesJourney.test.js
@@ -10,26 +10,22 @@ import { petitionsClerkCreatesNewCase } from './journey/petitionsClerkCreatesNew
 import { runCompute } from 'cerebral/test';
 import { withAppContextDecorator } from '../src/withAppContext';
 
-const blockedCasesReportHelperComputed = withAppContextDecorator(
-  blockedCasesReportHelper,
-  applicationContext,
-);
-
-let leadDocketNumber;
-let memberCaseDocketNumber;
-
 describe('Manually block consolidated cases', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
+
+  const trialLocation = `Charleston, West Virginia, ${Date.now()}`;
+
+  let leadDocketNumber;
+  let memberCaseDocketNumber;
+
+  const blockedCasesReportHelperComputed = withAppContextDecorator(
+    blockedCasesReportHelper,
+    applicationContext,
+  );
 
   afterAll(() => {
     cerebralTest.closeSocket();
   });
-
-  const cerebralTest = setupTest();
-
-  const trialLocation = `Charleston, West Virginia, ${Date.now()}`;
 
   loginAs(cerebralTest, 'petitionsclerk@example.com');
   petitionsClerkCreatesNewCase(cerebralTest, fakeFile, trialLocation, true, {

--- a/web-client/integration-tests/petitionsClerkCaseAdvancedSearch.test.js
+++ b/web-client/integration-tests/petitionsClerkCaseAdvancedSearch.test.js
@@ -2,12 +2,8 @@ import { fakeFile, loginAs, setupTest } from './helpers';
 import { petitionsClerkAdvancedSearchForCase } from './journey/petitionsClerkAdvancedSearchForCase';
 import { petitionsClerkCreatesNewCase } from './journey/petitionsClerkCreatesNewCase';
 
-const cerebralTest = setupTest();
-
 describe('petitions clerk case advanced search', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
 
   afterAll(() => {
     cerebralTest.closeSocket();

--- a/web-client/integration-tests/petitionsClerkCaseNotesJourney.test.js
+++ b/web-client/integration-tests/petitionsClerkCaseNotesJourney.test.js
@@ -2,12 +2,8 @@ import { loginAs, setupTest, uploadPetition } from './helpers';
 import { petitionsClerkAddsCaseNote } from './journey/petitionsClerkAddsCaseNote';
 import { petitionsClerkDeletesCaseNote } from './journey/petitionsClerkDeletesCaseNote';
 
-const cerebralTest = setupTest();
-
 describe('petitions clerk case notes journey', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
 
   afterAll(() => {
     cerebralTest.closeSocket();

--- a/web-client/integration-tests/petitionsClerkCounselAssociationJourney.test.js
+++ b/web-client/integration-tests/petitionsClerkCounselAssociationJourney.test.js
@@ -1,4 +1,7 @@
-import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
+import {
+  COUNTRY_TYPES,
+  PARTY_TYPES,
+} from '../../shared/src/business/entities/EntityConstants';
 import { loginAs, setupTest, uploadPetition } from './helpers';
 import { petitionsClerkAddsPractitionersToCase } from './journey/petitionsClerkAddsPractitionersToCase';
 import { petitionsClerkAddsRespondentsToCase } from './journey/petitionsClerkAddsRespondentsToCase';
@@ -7,13 +10,8 @@ import { petitionsClerkRemovesPractitionerFromCase } from './journey/petitionsCl
 import { petitionsClerkRemovesRespondentFromCase } from './journey/petitionsClerkRemovesRespondentFromCase';
 import { petitionsClerkViewsCaseDetail } from './journey/petitionsClerkViewsCaseDetail';
 
-const cerebralTest = setupTest();
-const { COUNTRY_TYPES, PARTY_TYPES } = applicationContext.getConstants();
-
 describe('Petitions Clerk Counsel Association Journey', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
 
   afterAll(() => {
     cerebralTest.closeSocket();

--- a/web-client/integration-tests/petitionsClerkCreateNoticeJourney.test.js
+++ b/web-client/integration-tests/petitionsClerkCreateNoticeJourney.test.js
@@ -5,11 +5,8 @@ import { petitionsClerkViewsCaseDetail } from './journey/petitionsClerkViewsCase
 import { petitionsClerkViewsCaseDetailAfterAddingNotice } from './journey/petitionsClerkViewsCaseDetailAfterAddingNotice';
 import { petitionsClerkViewsDraftDocumentsForNotice } from './journey/petitionsClerkViewsDraftDocumentsForNotice';
 
-const cerebralTest = setupTest();
 describe('Petitions Clerk Create Notice Journey', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
 
   afterAll(() => {
     cerebralTest.closeSocket();

--- a/web-client/integration-tests/petitionsClerkCreateOrderJourney.test.js
+++ b/web-client/integration-tests/petitionsClerkCreateOrderJourney.test.js
@@ -13,12 +13,8 @@ import { petitionsClerkViewsCaseDetailAfterAddingOrder } from './journey/petitio
 import { petitionsClerkViewsDraftDocuments } from './journey/petitionsClerkViewsDraftDocuments';
 import { petitionsDeletesOrderFromCase } from './journey/petitionsDeletesOrderFromCase';
 
-const cerebralTest = setupTest();
-
 describe('Petitions Clerk Create Order Journey', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
 
   afterAll(() => {
     cerebralTest.closeSocket();

--- a/web-client/integration-tests/petitionsClerkCreatesEstateCaseWithLongAdditionalName.test.js
+++ b/web-client/integration-tests/petitionsClerkCreatesEstateCaseWithLongAdditionalName.test.js
@@ -7,12 +7,8 @@ import {
 import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
 import { fakeFile, loginAs, setupTest } from './helpers';
 
-const cerebralTest = setupTest();
-
 describe('Petitions clerk creates Estate case with long additionalName', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
 
   afterAll(() => {
     cerebralTest.closeSocket();

--- a/web-client/integration-tests/petitionsClerkDocumentQCJourney.test.js
+++ b/web-client/integration-tests/petitionsClerkDocumentQCJourney.test.js
@@ -11,20 +11,15 @@ import { petitionsClerkVerifiesAssignedWorkItem } from './journey/petitionsClerk
 import { petitionsClerkViewsMyDocumentQC } from './journey/petitionsClerkViewsMyDocumentQC';
 import { petitionsClerkViewsSectionDocumentQC } from './journey/petitionsClerkViewsSectionDocumentQC';
 
-const cerebralTest = setupTest();
-
 describe('Petitions Clerk Document QC Journey', () => {
-  beforeEach(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
+
+  const createdCases = [];
+  const caseCreationCount = 3;
 
   afterAll(() => {
     cerebralTest.closeSocket();
   });
-
-  const createdCases = [];
-
-  const caseCreationCount = 3;
 
   loginAs(cerebralTest, 'petitionsclerk@example.com');
   petitionsClerkViewsSectionDocumentQC(cerebralTest, true);

--- a/web-client/integration-tests/petitionsClerkEditsPetitionPaymentFee.test.js
+++ b/web-client/integration-tests/petitionsClerkEditsPetitionPaymentFee.test.js
@@ -5,18 +5,14 @@ import {
 } from '../../shared/src/business/entities/EntityConstants';
 import { loginAs, setupTest, uploadPetition } from './helpers';
 
-const cerebralTest = setupTest();
-
 describe('petitions clerk edits a petition payment fee', () => {
-  beforeEach(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
+
+  let caseDetail;
 
   afterAll(() => {
     cerebralTest.closeSocket();
   });
-
-  let caseDetail;
 
   loginAs(cerebralTest, 'petitioner@example.com');
 

--- a/web-client/integration-tests/petitionsClerkPrioritizesCase.test.js
+++ b/web-client/integration-tests/petitionsClerkPrioritizesCase.test.js
@@ -5,12 +5,8 @@ import { petitionsClerkUnprioritizesCase } from './journey/petitionsClerkUnprior
 import { petitionsClerkVerifyEligibleCase } from './journey/petitionsClerkVerifyEligibleCase';
 import { petitionsClerkVerifyNotEligibleCase } from './journey/petitionsClerkVerifyNotEligibleCase';
 
-const cerebralTest = setupTest();
-
 describe('Prioritize a Case', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
 
   afterAll(() => {
     cerebralTest.closeSocket();

--- a/web-client/integration-tests/petitionsClerkQCPetitionStatistics.test.js
+++ b/web-client/integration-tests/petitionsClerkQCPetitionStatistics.test.js
@@ -6,12 +6,8 @@ import { petitionsClerkSelectsFirstPetitionOnMyDocumentQC } from './journey/peti
 import { petitionsClerkViewsMyDocumentQC } from './journey/petitionsClerkViewsMyDocumentQC';
 import { petitionsClerkViewsSectionDocumentQC } from './journey/petitionsClerkViewsSectionDocumentQC';
 
-const cerebralTest = setupTest();
-
 describe('Entry of Statistics in Petition QC', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
 
   afterAll(() => {
     cerebralTest.closeSocket();

--- a/web-client/integration-tests/petitionsClerkRemovesPetitionerDuringPetitionQc.test.js
+++ b/web-client/integration-tests/petitionsClerkRemovesPetitionerDuringPetitionQc.test.js
@@ -7,12 +7,8 @@ import { loginAs, setupTest, uploadPetition } from './helpers';
 import { petitionsClerkEditsPetitionInQCPartyType } from './journey/petitionsClerkEditsPetitionInQCPartyType';
 import { petitionsClerkServesElectronicCaseToIrs } from './journey/petitionsClerkServesElectronicCaseToIrs';
 
-const cerebralTest = setupTest();
-
 describe('petitions clerk removes petitioner during petition QC', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
 
   afterAll(() => {
     cerebralTest.closeSocket();

--- a/web-client/integration-tests/petitionsClerkSavesDocumentQCForLater.test.js
+++ b/web-client/integration-tests/petitionsClerkSavesDocumentQCForLater.test.js
@@ -1,4 +1,7 @@
-import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
+import {
+  COUNTRY_TYPES,
+  PARTY_TYPES,
+} from '../../shared/src/business/entities/EntityConstants';
 import {
   loginAs,
   refreshElasticsearchIndex,
@@ -9,14 +12,8 @@ import { petitionsClerkReviewsPetitionAndSavesForLater } from './journey/petitio
 import { petitionsClerkServesPetitionFromDocumentView } from './journey/petitionsClerkServesPetitionFromDocumentView';
 import { petitionsClerkViewsSectionInProgress } from './journey/petitionsClerkViewsSectionInProgress';
 
-const cerebralTest = setupTest();
-
 describe('Petitions Clerk Saves Document QC for Later', () => {
-  const { COUNTRY_TYPES, PARTY_TYPES } = applicationContext.getConstants();
-
-  beforeEach(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
 
   afterAll(() => {
     cerebralTest.closeSocket();

--- a/web-client/integration-tests/petitionsClerkServesOrder.test.js
+++ b/web-client/integration-tests/petitionsClerkServesOrder.test.js
@@ -4,13 +4,10 @@ import { petitionsClerkCreateOrder } from './journey/petitionsClerkCreateOrder';
 import { petitionsClerkServesOrder } from './journey/petitionsClerkServesOrder';
 import { petitionsClerkSignsOrder } from './journey/petitionsClerkSignsOrder';
 
-const cerebralTest = setupTest();
-cerebralTest.draftOrders = [];
-
 describe('Docket Clerk Adds Court-Issued Order to Docket Record', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
+
+  cerebralTest.draftOrders = [];
 
   afterAll(() => {
     cerebralTest.closeSocket();

--- a/web-client/integration-tests/petitionsClerkSetsRemoteTrialSessionCalendar.test.js
+++ b/web-client/integration-tests/petitionsClerkSetsRemoteTrialSessionCalendar.test.js
@@ -1,4 +1,4 @@
-import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
+import { CASE_TYPES_MAP } from '../../shared/src/business/entities/EntityConstants';
 import { docketClerkCreatesARemoteTrialSession } from './journey/docketClerkCreatesARemoteTrialSession';
 import { docketClerkSetsCaseReadyForTrial } from './journey/docketClerkSetsCaseReadyForTrial';
 import { docketClerkViewsTrialSessionList } from './journey/docketClerkViewsTrialSessionList';
@@ -11,10 +11,9 @@ import { petitionsClerkViewsOpenTrialSession } from './journey/petitionsClerkVie
 import { runCompute } from 'cerebral/test';
 import { withAppContextDecorator } from '../src/withAppContext';
 
-const cerebralTest = setupTest();
-
 describe('petitions clerk sets a remote trial session calendar', () => {
-  const { CASE_TYPES_MAP } = applicationContext.getConstants();
+  const cerebralTest = setupTest();
+
   const trialLocation = `Denver, Colorado, ${Date.now()}`;
   const overrides = {
     maxCases: 2,
@@ -22,10 +21,6 @@ describe('petitions clerk sets a remote trial session calendar', () => {
     sessionType: 'Small',
     trialLocation,
   };
-
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
 
   afterAll(() => {
     cerebralTest.closeSocket();

--- a/web-client/integration-tests/petitionsClerkSetsTrialSessionCalendar.test.js
+++ b/web-client/integration-tests/petitionsClerkSetsTrialSessionCalendar.test.js
@@ -1,4 +1,4 @@
-import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
+import { CASE_TYPES_MAP } from '../../shared/src/business/entities/EntityConstants';
 import { docketClerkCreatesATrialSession } from './journey/docketClerkCreatesATrialSession';
 import { docketClerkSetsCaseReadyForTrial } from './journey/docketClerkSetsCaseReadyForTrial';
 import { docketClerkViewsNewTrialSession } from './journey/docketClerkViewsNewTrialSession';
@@ -14,10 +14,9 @@ import { petitionsClerkViewsNewTrialSession } from './journey/petitionsClerkView
 import { runCompute } from 'cerebral/test';
 import { withAppContextDecorator } from '../src/withAppContext';
 
-const cerebralTest = setupTest();
-
 describe('petitions clerk sets a trial session calendar', () => {
-  const { CASE_TYPES_MAP } = applicationContext.getConstants();
+  const cerebralTest = setupTest();
+
   const trialLocation = `Denver, Colorado, ${Date.now()}`;
   const overrides = {
     maxCases: 2,
@@ -25,10 +24,6 @@ describe('petitions clerk sets a trial session calendar', () => {
     sessionType: 'Small',
     trialLocation,
   };
-
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
 
   afterAll(() => {
     cerebralTest.closeSocket();

--- a/web-client/integration-tests/petitionsClerkSignsDocumentJourney.test.js
+++ b/web-client/integration-tests/petitionsClerkSignsDocumentJourney.test.js
@@ -10,12 +10,8 @@ import { petitionsClerkViewsCaseDetailAfterAddingOrder } from './journey/petitio
 import { petitionsClerkViewsDraftDocuments } from './journey/petitionsClerkViewsDraftDocuments';
 import { petitionsClerkViewsSignDraftDocument } from './journey/petitionsClerkViewsSignDraftDocument';
 
-const cerebralTest = setupTest();
-
 describe('Petitions Clerk Create Order Journey', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
 
   afterAll(() => {
     cerebralTest.closeSocket();

--- a/web-client/integration-tests/petitionsClerkVerifiesOffboardedJudgeJourney.test.js
+++ b/web-client/integration-tests/petitionsClerkVerifiesOffboardedJudgeJourney.test.js
@@ -7,18 +7,14 @@ import { runCompute } from 'cerebral/test';
 import { withAppContextDecorator } from '../src/withAppContext';
 import { workQueueSectionHelper as workQueueSectionHelperComputed } from '../src/presenter/computeds/workQueueSectionHelper';
 
-const cerebralTest = setupTest();
-
 describe('Petitions clerk verifies offboarded judge journey', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
+
+  const OFFBOARDED_JUDGE_NAMES = ['Guy'];
 
   afterAll(() => {
     cerebralTest.closeSocket();
   });
-
-  const OFFBOARDED_JUDGE_NAMES = ['Guy'];
 
   loginAs(cerebralTest, 'petitionsclerk@example.com');
   for (const judgeName of OFFBOARDED_JUDGE_NAMES) {

--- a/web-client/integration-tests/petitionsClerkViewsDraftDocuments.test.js
+++ b/web-client/integration-tests/petitionsClerkViewsDraftDocuments.test.js
@@ -6,16 +6,12 @@ import { petitionsClerkViewsDraftDocuments } from './journey/petitionsClerkViews
 import { runCompute } from 'cerebral/test';
 import { withAppContextDecorator } from '../src/withAppContext';
 
-const formattedCaseDetail = withAppContextDecorator(
-  formattedCaseDetailComputed,
-);
-
-const cerebralTest = setupTest();
-
 describe('Petitions Clerk Views Draft Documents', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
+
+  const formattedCaseDetail = withAppContextDecorator(
+    formattedCaseDetailComputed,
+  );
 
   afterAll(() => {
     cerebralTest.closeSocket();

--- a/web-client/integration-tests/practitionerCaseJourney.test.js
+++ b/web-client/integration-tests/practitionerCaseJourney.test.js
@@ -40,10 +40,6 @@ import { withAppContextDecorator } from '../src/withAppContext';
 describe('Practitioner requests access to case', () => {
   const cerebralTest = setupTest();
 
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
-
   afterAll(() => {
     cerebralTest.closeSocket();
   });

--- a/web-client/integration-tests/practitionerDocumentationJourney.test.js
+++ b/web-client/integration-tests/practitionerDocumentationJourney.test.js
@@ -5,16 +5,14 @@ import {
 import { fakeFile, loginAs, setupTest, waitForExpectedItem } from './helpers';
 
 describe('Practitioner documentation journey', () => {
-  const barNumber = 'PT1234';
   const cerebralTest = setupTest();
 
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const barNumber = 'PT1234';
 
   afterAll(() => {
     cerebralTest.closeSocket();
   });
+
   describe('Admissions Clerk uploads a practitioner document', () => {
     loginAs(cerebralTest, 'admissionsclerk@example.com');
 

--- a/web-client/integration-tests/privatePractitionerConsolidatedCasesWithStatisticsJourney.test.js
+++ b/web-client/integration-tests/privatePractitionerConsolidatedCasesWithStatisticsJourney.test.js
@@ -8,18 +8,14 @@ import { petitionsClerkEditsPetitionInQCIRSNotice } from './journey/petitionsCle
 import { petitionsClerkServesElectronicCaseToIrs } from './journey/petitionsClerkServesElectronicCaseToIrs';
 import { privatePractitionerViewsOpenConsolidatedCases } from './journey/privatePractitionerViewsOpenConsolidatedCases';
 
-const cerebralTest = setupTest();
-
 describe('private practitioner views consolidated cases with statistics (cerebralTest for bug 8473)', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
+
+  const createdDocketNumbers = [];
 
   afterAll(() => {
     cerebralTest.closeSocket();
   });
-
-  const createdDocketNumbers = [];
 
   for (let i = 0; i < 2; i++) {
     loginAs(cerebralTest, 'privatePractitioner@example.com');

--- a/web-client/integration-tests/privatePractitionerViewsPendingEmailJourney.test.js
+++ b/web-client/integration-tests/privatePractitionerViewsPendingEmailJourney.test.js
@@ -12,12 +12,8 @@ import { practitionerRequestsAccessToCase } from './journey/practitionerRequests
 import { runCompute } from 'cerebral/test';
 import { withAppContextDecorator } from '../src/withAppContext';
 
-const cerebralTest = setupTest();
-
 describe('private practitioner views pending email journey', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
 
   afterAll(() => {
     cerebralTest.closeSocket();

--- a/web-client/integration-tests/respondentCaseJourney.test.js
+++ b/web-client/integration-tests/respondentCaseJourney.test.js
@@ -1,4 +1,7 @@
-import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
+import {
+  COUNTRY_TYPES,
+  PARTY_TYPES,
+} from '../../shared/src/business/entities/EntityConstants';
 import { fakeFile, loginAs, setupTest, uploadPetition } from './helpers';
 import { practitionerSearchesForUnassociatedSealedCase } from './journey/practitionerSearchesForUnassociatedSealedCase';
 import { respondent1ViewsCaseDetailOfAssociatedCase } from './journey/respondent1ViewsCaseDetailOfAssociatedCase';
@@ -12,14 +15,8 @@ import { respondentViewsCaseDetailOfAssociatedCase } from './journey/respondentV
 import { respondentViewsCaseDetailOfUnassociatedCase } from './journey/respondentViewsCaseDetailOfUnassociatedCase';
 import { respondentViewsDashboard } from './journey/respondentViewsDashboard';
 
-const cerebralTest = setupTest();
-
 describe('Respondent requests access to a case', () => {
-  const { COUNTRY_TYPES, PARTY_TYPES } = applicationContext.getConstants();
-
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
 
   afterAll(() => {
     cerebralTest.closeSocket();

--- a/web-client/integration-tests/scheduleATrialSession.test.js
+++ b/web-client/integration-tests/scheduleATrialSession.test.js
@@ -13,16 +13,10 @@ import { petitionsClerkViewsACalendaredTrialSession } from './journey/petitionsC
 import { petitionsClerkViewsATrialSessionsEligibleCases } from './journey/petitionsClerkViewsATrialSessionsEligibleCases';
 import { petitionsClerkViewsATrialSessionsEligibleCasesWithManuallyAddedCase } from './journey/petitionsClerkViewsATrialSessionsEligibleCasesWithManuallyAddedCase';
 
-const cerebralTest = setupTest();
-
 describe('Schedule A Trial Session', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
 
-  afterAll(() => {
-    cerebralTest.closeSocket();
-  });
+  cerebralTest.casesReadyForTrial = [];
 
   const caseCount = 2;
   const trialLocation = `Albuquerque, New Mexico, ${Date.now()}`;
@@ -36,10 +30,11 @@ describe('Schedule A Trial Session', () => {
     preferredTrialCity: trialLocation2,
     trialLocation: trialLocation2,
   };
-
-  cerebralTest.casesReadyForTrial = [];
-
   const createdDocketNumbers = [];
+
+  afterAll(() => {
+    cerebralTest.closeSocket();
+  });
 
   const makeCaseReadyForTrial = (testSession, id, caseOverrides) => {
     loginAs(testSession, 'petitioner@example.com');

--- a/web-client/integration-tests/sentWorkItemsExpireAfterNDays.test.js
+++ b/web-client/integration-tests/sentWorkItemsExpireAfterNDays.test.js
@@ -11,9 +11,9 @@ import {
 } from './helpers';
 import applicationContextFactory from '../../web-api/src/applicationContext';
 
-const cerebralTest = setupTest();
-
 describe('verify old sent work items do not show up in the outbox', () => {
+  const cerebralTest = setupTest();
+
   let workItemNMinus1Days;
   let workItemNDays;
   let workItemNPlus1Days;
@@ -22,16 +22,11 @@ describe('verify old sent work items do not show up in the outbox', () => {
   let workItemIdNPlus1;
   let caseDetail;
 
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
-
   afterAll(() => {
     cerebralTest.closeSocket();
   });
 
   loginAs(cerebralTest, 'petitioner@example.com');
-
   it('creates the case', async () => {
     caseDetail = await uploadPetition(cerebralTest);
     expect(caseDetail.docketNumber).toBeDefined();

--- a/web-client/integration-tests/signAndServeStipulatedDecision.test.js
+++ b/web-client/integration-tests/signAndServeStipulatedDecision.test.js
@@ -7,19 +7,15 @@ import { loginAs, setupTest, uploadPetition } from './helpers';
 import { petitionsClerkServesPetitionFromDocumentView } from './journey/petitionsClerkServesPetitionFromDocumentView';
 import { respondentUploadsProposedStipulatedDecision } from './journey/respondentUploadsProposedStipulatedDecision';
 
-const cerebralTest = setupTest({
-  useCases: {
-    loadPDFForSigningInteractor: () => {
-      return new Promise(resolve => {
-        resolve(null);
-      });
-    },
-  },
-});
-
 describe('a user signs and serves a stipulated decision', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
+  const cerebralTest = setupTest({
+    useCases: {
+      loadPDFForSigningInteractor: () => {
+        return new Promise(resolve => {
+          resolve(null);
+        });
+      },
+    },
   });
 
   afterAll(() => {

--- a/web-client/integration-tests/stampDispositionClerkOfTheCourtJourney.test.js
+++ b/web-client/integration-tests/stampDispositionClerkOfTheCourtJourney.test.js
@@ -19,10 +19,6 @@ describe('Stamp disposition clerk of the court journey test', () => {
   const grantedMotionDocketEntryTitle = 'Motion GRANTED';
   const signedJudgeName = 'Maurice B. Foley';
 
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
-
   afterAll(() => {
     cerebralTest.closeSocket();
   });
@@ -242,7 +238,7 @@ describe('Stamp disposition clerk of the court journey test', () => {
     expect(cerebralTest.getState('validationErrors')).toEqual({});
   });
 
-  it('verify the second auto-generated draft stamp order', async () => {
+  it('verify the second auto-generated draft stamp order', () => {
     expect(cerebralTest.getState('currentPage')).toBe('MessageDetail');
 
     const docketEntries = cerebralTest.getState('caseDetail.docketEntries');

--- a/web-client/integration-tests/stampDispositionJudgeJourney.test.js
+++ b/web-client/integration-tests/stampDispositionJudgeJourney.test.js
@@ -23,10 +23,6 @@ describe('Stamp disposition judge journey test', () => {
   const grantedMotionDocketEntryTitle = 'Motion GRANTED';
   const signedJudgeName = 'Mary Ann Cohen';
 
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
-
   afterAll(() => {
     cerebralTest.closeSocket();
   });

--- a/web-client/integration-tests/trialClerkWorkingCopy.test.js
+++ b/web-client/integration-tests/trialClerkWorkingCopy.test.js
@@ -1,4 +1,4 @@
-import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
+import { CASE_TYPES_MAP } from '../../shared/src/business/entities/EntityConstants';
 import { docketClerkCreatesATrialSession } from './journey/docketClerkCreatesATrialSession';
 import { docketClerkSetsCaseReadyForTrial } from './journey/docketClerkSetsCaseReadyForTrial';
 import { docketClerkViewsNewTrialSession } from './journey/docketClerkViewsNewTrialSession';
@@ -12,13 +12,8 @@ import { trialClerkViewsNotesFromCaseDetail } from './journey/trialClerkViewsNot
 import { trialClerkViewsTrialSessionWorkingCopy } from './journey/trialClerkViewsTrialSessionWorkingCopy';
 import { trialClerkViewsTrialSessionWorkingCopyWithNotes } from './journey/trialClerkViewsTrialSessionWorkingCopyWithNotes';
 
-const cerebralTest = setupTest();
-const { CASE_TYPES_MAP } = applicationContext.getConstants();
-
 describe('Trial Clerk Views Trial Session Working Copy', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
 
   afterAll(() => {
     cerebralTest.closeSocket();

--- a/web-client/integration-tests/trialHearingsJourney.test.js
+++ b/web-client/integration-tests/trialHearingsJourney.test.js
@@ -6,21 +6,15 @@ import { docketClerkRemovesCaseFromHearing } from './journey/docketClerkRemovesC
 import { docketClerkViewsNewTrialSession } from './journey/docketClerkViewsNewTrialSession';
 import { docketClerkViewsTrialSessionList } from './journey/docketClerkViewsTrialSessionList';
 import { judgeViewsTrialSessionWorkingCopy } from './journey/judgeViewsTrialSessionWorkingCopy';
+import { loginAs, setupTest, uploadPetition } from './helpers';
 import { petitionsClerkBlocksCase } from './journey/petitionsClerkBlocksCase';
 import { petitionsClerkPrioritizesCase } from './journey/petitionsClerkPrioritizesCase';
 
-import { loginAs, setupTest, uploadPetition } from './helpers';
-
-const cerebralTest = setupTest();
-
 describe('trial hearings journey', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
 
-  afterAll(() => {
-    cerebralTest.closeSocket();
-  });
+  cerebralTest.createdTrialSessions = [];
+  cerebralTest.createdCases = [];
 
   const trialLocation1 = `Denver, Colorado, ${Date.now()}`;
   const overrides1 = {
@@ -36,8 +30,10 @@ describe('trial hearings journey', () => {
     sessionType: 'Small',
     trialLocation: trialLocation2,
   };
-  cerebralTest.createdTrialSessions = [];
-  cerebralTest.createdCases = [];
+
+  afterAll(() => {
+    cerebralTest.closeSocket();
+  });
 
   loginAs(cerebralTest, 'docketclerk@example.com');
   docketClerkCreatesATrialSession(cerebralTest, overrides1);

--- a/web-client/integration-tests/trialSessionChangeToInPersonProceedingJourney.test.js
+++ b/web-client/integration-tests/trialSessionChangeToInPersonProceedingJourney.test.js
@@ -28,10 +28,6 @@ describe('petitions clerk sets a remote trial session calendar', () => {
     trialLocation,
   };
 
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
-
   afterAll(() => {
     cerebralTest.closeSocket();
   });

--- a/web-client/integration-tests/trialSessionEligibleCasesJourney.test.js
+++ b/web-client/integration-tests/trialSessionEligibleCasesJourney.test.js
@@ -1,4 +1,8 @@
-import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
+import {
+  CASE_STATUS_TYPES,
+  CASE_TYPES_MAP,
+  CHIEF_JUDGE,
+} from '../../shared/src/business/entities/EntityConstants';
 import { docketClerkCreatesATrialSession } from './journey/docketClerkCreatesATrialSession';
 import { docketClerkSetsCaseReadyForTrial } from './journey/docketClerkSetsCaseReadyForTrial';
 import { docketClerkViewsNewTrialSession } from './journey/docketClerkViewsNewTrialSession';
@@ -8,18 +12,8 @@ import { markAllCasesAsQCed } from './journey/markAllCasesAsQCed';
 import { petitionsClerkSetsATrialSessionsSchedule } from './journey/petitionsClerkSetsATrialSessionsSchedule';
 import { petitionsClerkSubmitsCaseToIrs } from './journey/petitionsClerkSubmitsCaseToIrs';
 
-const cerebralTest = setupTest();
-const { CASE_TYPES_MAP, CHIEF_JUDGE, STATUS_TYPES } =
-  applicationContext.getConstants();
-
 describe('Trial Session Eligible Cases Journey', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
-
-  afterAll(() => {
-    cerebralTest.closeSocket();
-  });
+  const cerebralTest = setupTest();
 
   const trialLocation = `Madison, Wisconsin, ${Date.now()}`;
   const overrides = {
@@ -29,6 +23,10 @@ describe('Trial Session Eligible Cases Journey', () => {
     trialLocation,
   };
   const createdDocketNumbers = [];
+
+  afterAll(() => {
+    cerebralTest.closeSocket();
+  });
 
   describe(`Create trial session with Small session type for '${trialLocation}' with max case count = 1`, () => {
     loginAs(cerebralTest, 'docketclerk@example.com');
@@ -174,7 +172,7 @@ describe('Trial Session Eligible Cases Journey', () => {
         docketNumber: createdDocketNumbers[1],
       });
       expect(cerebralTest.getState('caseDetail.status')).not.toEqual(
-        STATUS_TYPES.calendared,
+        CASE_STATUS_TYPES.calendared,
       );
       expect(cerebralTest.getState('caseDetail').highPriority).toBeFalsy();
 
@@ -214,7 +212,7 @@ describe('Trial Session Eligible Cases Journey', () => {
         docketNumber: createdDocketNumbers[1],
       });
       expect(cerebralTest.getState('caseDetail.status')).not.toEqual(
-        STATUS_TYPES.calendared,
+        CASE_STATUS_TYPES.calendared,
       );
       expect(cerebralTest.getState('caseDetail').highPriority).toBeTruthy();
 
@@ -285,7 +283,7 @@ describe('Trial Session Eligible Cases Journey', () => {
         docketNumber: createdDocketNumbers[0],
       });
       expect(cerebralTest.getState('caseDetail.status')).toEqual(
-        STATUS_TYPES.calendared,
+        CASE_STATUS_TYPES.calendared,
       );
       expect(cerebralTest.getState('caseDetail.trialLocation')).toEqual(
         trialLocation,
@@ -302,7 +300,7 @@ describe('Trial Session Eligible Cases Journey', () => {
         docketNumber: createdDocketNumbers[1],
       });
       expect(cerebralTest.getState('caseDetail.status')).not.toEqual(
-        STATUS_TYPES.calendared,
+        CASE_STATUS_TYPES.calendared,
       );
       expect(cerebralTest.getState('caseDetail.trialLocation')).toBeUndefined();
       expect(cerebralTest.getState('caseDetail.trialDate')).toBeUndefined();
@@ -315,7 +313,7 @@ describe('Trial Session Eligible Cases Journey', () => {
         docketNumber: createdDocketNumbers[2],
       });
       expect(cerebralTest.getState('caseDetail.status')).not.toEqual(
-        STATUS_TYPES.calendared,
+        CASE_STATUS_TYPES.calendared,
       );
 
       //Case #4 - assigned
@@ -323,7 +321,7 @@ describe('Trial Session Eligible Cases Journey', () => {
         docketNumber: createdDocketNumbers[3],
       });
       expect(cerebralTest.getState('caseDetail.status')).toEqual(
-        STATUS_TYPES.calendared,
+        CASE_STATUS_TYPES.calendared,
       );
 
       //Case #5 - assigned
@@ -331,7 +329,7 @@ describe('Trial Session Eligible Cases Journey', () => {
         docketNumber: createdDocketNumbers[4],
       });
       expect(cerebralTest.getState('caseDetail.status')).toEqual(
-        STATUS_TYPES.calendared,
+        CASE_STATUS_TYPES.calendared,
       );
     });
 
@@ -367,7 +365,7 @@ describe('Trial Session Eligible Cases Journey', () => {
         docketNumber: createdDocketNumbers[0],
       });
       expect(cerebralTest.getState('caseDetail.status')).not.toEqual(
-        STATUS_TYPES.calendared,
+        CASE_STATUS_TYPES.calendared,
       );
 
       await cerebralTest.runSequence('gotoTrialSessionDetailSequence', {
@@ -386,7 +384,7 @@ describe('Trial Session Eligible Cases Journey', () => {
         docketNumber: createdDocketNumbers[0],
       });
       expect(cerebralTest.getState('caseDetail.status')).not.toEqual(
-        STATUS_TYPES.calendared,
+        CASE_STATUS_TYPES.calendared,
       );
 
       await cerebralTest.runSequence('openAddToTrialModalSequence');
@@ -412,7 +410,7 @@ describe('Trial Session Eligible Cases Journey', () => {
         docketNumber: createdDocketNumbers[0],
       });
       expect(cerebralTest.getState('caseDetail.status')).toEqual(
-        STATUS_TYPES.calendared,
+        CASE_STATUS_TYPES.calendared,
       );
 
       await cerebralTest.runSequence('gotoTrialSessionDetailSequence', {

--- a/web-client/integration-tests/trialSessionMigrations.test.js
+++ b/web-client/integration-tests/trialSessionMigrations.test.js
@@ -1,4 +1,7 @@
-import { applicationContextForClient as applicationContext } from '../../shared/src/business/test/createTestApplicationContext';
+import {
+  COUNTRY_TYPES,
+  PARTY_TYPES,
+} from '../../shared/src/business/entities/EntityConstants';
 import { docketClerkSetsCaseReadyForTrial } from './journey/docketClerkSetsCaseReadyForTrial';
 import {
   loginAs,
@@ -9,18 +12,12 @@ import {
 import { petitionsClerkManuallyAddsCaseToCalendaredTrialSession } from './journey/petitionsClerkManuallyAddsCaseToCalendaredTrialSession';
 import { petitionsClerkSubmitsCaseToIrs } from './journey/petitionsClerkSubmitsCaseToIrs';
 
-const cerebralTest = setupTest();
-
-let caseDetail;
-
 describe('Trial session migration journey', () => {
-  const { COUNTRY_TYPES, PARTY_TYPES } = applicationContext.getConstants();
+  const cerebralTest = setupTest();
 
   const trialLocation = 'Memphis, Tennessee';
 
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  let caseDetail;
 
   beforeEach(async () => {
     await refreshElasticsearchIndex();

--- a/web-client/integration-tests/v1ApiJourney.test.js
+++ b/web-client/integration-tests/v1ApiJourney.test.js
@@ -5,13 +5,12 @@ import { userMap } from '../../shared/src/test/mockUserTokenMap';
 import axios from 'axios';
 import jwt from 'jsonwebtoken';
 
-const cerebralTest = setupTest();
-let userToken;
-
 describe('View and manage the deadlines of a case', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
+  const cerebralTest = setupTest();
 
+  let userToken;
+
+  beforeAll(() => {
     const loginUsername = 'irsSuperuser@example.com';
     if (!userMap[loginUsername]) {
       throw new Error(`Unable to log into test as ${loginUsername}`);

--- a/web-client/integration-tests/v2ApiJourney.test.js
+++ b/web-client/integration-tests/v2ApiJourney.test.js
@@ -5,13 +5,10 @@ import { userMap } from '../../shared/src/test/mockUserTokenMap';
 import axios from 'axios';
 import jwt from 'jsonwebtoken';
 
-const cerebralTest = setupTest();
-let userToken;
-
 describe('View and manage the deadlines of a case', () => {
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
+  const cerebralTest = setupTest();
+
+  let userToken;
 
   afterAll(() => {
     cerebralTest.closeSocket();

--- a/web-client/integration-tests/verifyCheckReadyForTrial.test.js
+++ b/web-client/integration-tests/verifyCheckReadyForTrial.test.js
@@ -13,10 +13,6 @@ import axios from 'axios';
 describe('Invoke checkForReadyForTrialCasesLambda via http request', () => {
   const cerebralTest = setupTest();
 
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
-
   afterAll(() => {
     cerebralTest.closeSocket();
   });

--- a/web-client/integration-tests/viewManageDeadlinesOfCase.test.js
+++ b/web-client/integration-tests/viewManageDeadlinesOfCase.test.js
@@ -12,17 +12,16 @@ import { petitionsClerkViewCaseDeadline } from './journey/petitionsClerkViewCase
 import { petitionsClerkViewsCaseWithNoDeadlines } from './journey/petitionsClerkViewsCaseWithNoDeadlines';
 import { petitionsClerkViewsDeadlineReportForSingleCase } from './journey/petitionsClerkViewsDeadlineReportForSingleCase';
 
-const cerebralTest = setupTest({
-  constantsOverrides: {
-    DEADLINE_REPORT_PAGE_SIZE: 1,
-  },
-});
-
 describe('View and manage the deadlines of a case', () => {
+  const cerebralTest = setupTest({
+    constantsOverrides: {
+      DEADLINE_REPORT_PAGE_SIZE: 1,
+    },
+  });
+
   const randomDay = `0${Math.floor(Math.random() * 9) + 1}`;
   const randomMonth = `0${Math.floor(Math.random() * 9) + 1}`;
   const randomYear = `200${Math.floor(Math.random() * 9) + 1}`;
-
   const overrides = {
     day: randomDay,
     month: randomMonth,
@@ -30,7 +29,6 @@ describe('View and manage the deadlines of a case', () => {
   };
 
   beforeAll(() => {
-    jest.setTimeout(30000);
     jest.spyOn(
       cerebralTest.applicationContext.getUseCases(),
       'createMessageInteractor',


### PR DESCRIPTION
Remove setting timeout in tests if the old timeout value being set was 30 seconds, that is already defaulted in the jest config file for integration tests, also cleanup test files