### PR TITLE
9739 approach to fix update case and assocations

### DIFF
--- a/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.ts
+++ b/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.ts
@@ -60,8 +60,6 @@ export const updateDocketEntryMetaInteractor = async (
       docketNumber,
     });
 
-  await new Promise(resolve => setTimeout(resolve, 10000));
-
   if (!caseToUpdate) {
     throw new NotFoundError(`Case ${docketNumber} was not found.`);
   }

--- a/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.ts
+++ b/shared/src/business/useCases/docketEntry/updateDocketEntryMetaInteractor.ts
@@ -60,6 +60,8 @@ export const updateDocketEntryMetaInteractor = async (
       docketNumber,
     });
 
+  await new Promise(resolve => setTimeout(resolve, 10000));
+
   if (!caseToUpdate) {
     throw new NotFoundError(`Case ${docketNumber} was not found.`);
   }
@@ -212,6 +214,7 @@ export const updateDocketEntryMetaInteractor = async (
     .updateCaseAndAssociations({
       applicationContext,
       caseToUpdate: caseEntity,
+      changedDocketEntryIds: [docketEntryEntity.docketEntryId], // we only want to modify this single docket entry
     });
 
   return new Case(result, { applicationContext }).validate().toRawObject();


### PR DESCRIPTION
Right now, updateCaseAndAssociations has no clue which sub records on the case it actually needs to update.  For example, if we update a docket entry on a case that has 3 docket entries, it doesn't know which one we updated so it tries to just update every docket entry regardless if the interactor made changes or not.  This prototype instead allows the interactor to pass in an array of ids which it knows it's changed so that persistence doesn't overwrite existing sub records with old values.