### PR TITLE
9740 tcrp story feedback

### DIFF
--- a/shared/src/business/entities/EntityConstants.js
+++ b/shared/src/business/entities/EntityConstants.js
@@ -608,6 +608,7 @@ const EVENT_CODES_VISIBLE_TO_PUBLIC = [
   'ODL',
   'SPTN',
   'OCS',
+  'TCRP',
 ];
 
 const SYSTEM_GENERATED_DOCUMENT_TYPES = {

--- a/shared/src/tools/courtIssuedEventCodes.json
+++ b/shared/src/tools/courtIssuedEventCodes.json
@@ -42,7 +42,7 @@
   {
     "eventCode": "TCRP",
     "documentType": "Tax Court Report Pamphlet",
-    "documentTitle": "Tax Court Report Pamphlet [Anything]",
+    "documentTitle": "[Anything]",
     "scenario": "Type A",
     "isUnservable": true
   },


### PR DESCRIPTION
addressing these 2 feedback items:

1. The Filings & Proceedings column on the docket display should have whatever the description entered during docketing is - no need to prepend "Tax Court Report Pamphlet" before the description
2. General public does not have visibility to the TCRP, they should be able to open/view the doc