### PR TITLE
fix github actions for e2e-cypress

### DIFF
--- a/.github/workflows/e2e-cypress.yml
+++ b/.github/workflows/e2e-cypress.yml
@@ -21,6 +21,9 @@ jobs:
       AWS_SECRET_ACCESS_KEY: S3RVER
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
       - name: Run E2E Cypress
         run: |
           npm ci


### PR DESCRIPTION
We found that `macos-latest` was upgraded to using node v18. Our npm prohibits that, and so Github actions was erroring out immediately. We're now trying to configure it to use node v16.