### PR TITLE
Devex: silence the env switcher

### DIFF
--- a/scripts/env/set-env.zsh
+++ b/scripts/env/set-env.zsh
@@ -41,13 +41,16 @@ if [[ ! -f "./scripts/env/environments/${environment}.env" ]]; then
   return 1
 fi
 
+# quiet can potentially be overwritten
+sshhh=${quiet}
+
 # shellcheck disable=SC1090
 source "./scripts/env/environments/${environment}.env"
 
 if [[ $environment != "local" ]]; then
   source "./scripts/env/environments/00-common"
 
-  if [[ $quiet -ne 0 ]] && [[ -n "$CURRENT_COLOR" ]]; then
+  if [[ $sshhh -eq 0 ]] && [[ -n "$CURRENT_COLOR" ]]; then
     echo "  ___   ___      _____  ___  _  _ ";
     echo " |   \ /_\ \    / / __|/ _ \| \| |";
     echo " | |) / _ \ \/\/ /\__ \ (_) | .\` |";


### PR DESCRIPTION
A while back I added a `--quiet` flag to `load-environment-from-secrets`, `check-env-variables`, and `set-env` that can be passed in to prevent those scripts from outputting anything.

Because the `set-env` script is sourced it has to in turn source the others, which can result in the --quiet flag being overwritten if:

- `set-env` is called without the `--quiet` flag but an environment config calls `load-environment-from-secrets` with the `--quiet` flag
- `set-env` is called with the `--quiet` flag but an environment config calls `load-environment-from-secrets` without the `--quiet` flag

This PR fixes that.