### PR TITLE
9845: fix live migration

### DIFF
--- a/web-api/migration-terraform/main/lambdas/migration.js
+++ b/web-api/migration-terraform/main/lambdas/migration.js
@@ -1,4 +1,6 @@
 const AWS = require('aws-sdk');
+const createApplicationContext = require('../../../src/applicationContext');
+const { createLogger } = require('../../../src/createLogger');
 const { migrateRecords: migrations } = require('./migration-segments');
 
 const dynamodb = new AWS.DynamoDB({
@@ -12,10 +14,13 @@ const docClient = new AWS.DynamoDB.DocumentClient({
   service: dynamodb,
 });
 
-const processItems = async ({ documentClient, items, migrateRecords }) => {
+const processItems = async (
+  applicationContext,
+  { documentClient, items, migrateRecords },
+) => {
   const promises = [];
 
-  items = await migrateRecords({ documentClient, items });
+  items = await migrateRecords(applicationContext, { documentClient, items });
 
   for (const item of items) {
     promises.push(
@@ -46,9 +51,22 @@ const getRemoveEvents = event => {
 
 exports.getFilteredGlobalEvents = getFilteredGlobalEvents;
 exports.processItems = processItems;
-exports.handler = async event => {
+exports.handler = async (event, context) => {
+  const applicationContext = createApplicationContext(
+    {},
+    createLogger({
+      defaultMeta: {
+        environment: {
+          stage: process.env.STAGE || 'local',
+        },
+        requestId: {
+          lambda: context.awsRequestId,
+        },
+      },
+    }),
+  );
   const items = getFilteredGlobalEvents(event);
-  await processItems({
+  await processItems(applicationContext, {
     documentClient: docClient,
     items,
     migrateRecords: migrations,

--- a/web-api/migration-terraform/main/lambdas/migration.test.js
+++ b/web-api/migration-terraform/main/lambdas/migration.test.js
@@ -17,7 +17,8 @@ describe('migration', () => {
         }),
       };
       const mockMigrateRecords = jest.fn().mockReturnValue(mockItems);
-      await processItems({
+      const applicationContext = jest.fn();
+      await processItems(applicationContext, {
         documentClient: mockDocumentClient,
         items: mockItems,
         migrateRecords: mockMigrateRecords,


### PR DESCRIPTION
[flexion#9854 ](https://github.com/flexion/ef-cms/issues/9845)

Recent work (#3057) to introduce logging required in `migrateRecords(...)` required `applicationContext`.

![Screenshot 2023-02-23 at 9 36 53 AM](https://user-images.githubusercontent.com/5023502/220937891-1bcf4c79-40b0-4317-b31f-a5282c38b7f7.png)
