### PR TITLE
Update terraform-provider-aws to 3.76.0 

### DIFF
--- a/iam/terraform/account-specific/main/main.tf
+++ b/iam/terraform/account-specific/main/main.tf
@@ -17,6 +17,6 @@ terraform {
   }
 
   required_providers {
-    aws = "3.75.2"
+    aws = "3.76.0"
   }
 }

--- a/iam/terraform/environment-specific/main/main.tf
+++ b/iam/terraform/environment-specific/main/main.tf
@@ -7,6 +7,6 @@ terraform {
   }
 
   required_providers {
-    aws = "3.75.2"
+    aws = "3.76.0"
   }
 }

--- a/shared/admin-tools/glue/glue_migrations/main.tf
+++ b/shared/admin-tools/glue/glue_migrations/main.tf
@@ -7,7 +7,7 @@ terraform {
   }
 
   required_providers {
-    aws = "3.75.2"
+    aws = "3.76.0"
   }
 }
 

--- a/shared/admin-tools/glue/remote_role/main.tf
+++ b/shared/admin-tools/glue/remote_role/main.tf
@@ -7,7 +7,7 @@ terraform {
   }
 
   required_providers {
-    aws = "3.75.2"
+    aws = "3.76.0"
   }
 }
 

--- a/web-api/migration-cron-terraform/main/main.tf
+++ b/web-api/migration-cron-terraform/main/main.tf
@@ -7,7 +7,7 @@ terraform {
   }
 
   required_providers {
-    aws = "3.75.2"
+    aws = "3.76.0"
   }
 }
 

--- a/web-api/migration-terraform/main/main.tf
+++ b/web-api/migration-terraform/main/main.tf
@@ -7,7 +7,7 @@ terraform {
   }
 
   required_providers {
-    aws = "3.75.2"
+    aws = "3.76.0"
   }
 }
 

--- a/web-api/switch-colors-cron-terraform/main/main.tf
+++ b/web-api/switch-colors-cron-terraform/main/main.tf
@@ -7,7 +7,7 @@ terraform {
   }
 
   required_providers {
-    aws = "3.75.2"
+    aws = "3.76.0"
   }
 }
 

--- a/web-api/terraform/main/main.tf
+++ b/web-api/terraform/main/main.tf
@@ -17,7 +17,7 @@ terraform {
   }
 
   required_providers {
-    aws = "3.75.2"
+    aws = "3.76.0"
   }
 }
 

--- a/web-client/terraform/main/main.tf
+++ b/web-client/terraform/main/main.tf
@@ -7,7 +7,7 @@ terraform {
   }
 
   required_providers {
-    aws = "3.75.2"
+    aws = "3.76.0"
   }
 }
 


### PR DESCRIPTION
Updating terraform-provider-aws to this [version](https://github.com/hashicorp/terraform-provider-aws/releases?page=2) provides support for node18, which then sets us up to update the lambdas to be able to use node 18, which would then allow us to use [v3 of aws-sdk on lambdas](https://github.com/hashicorp/terraform-provider-aws/releases?page=2) by default without having to finagle a bunch of stuff together. 🕸️ 

Deployment to an experimental https://app.circleci.com/pipelines/github/flexion/ef-cms/41425/workflows/ba5bc788-7802-4a32-b26a-d73b470ceaba

This came about in relation to https://trello.com/c/AJwYBIpd/1138-update-aws-sdk-to-v3