### PR TITLE
fix display issue for irs practitioners

### DIFF
--- a/web-client/src/presenter/computeds/caseDetailHeaderHelper.ts
+++ b/web-client/src/presenter/computeds/caseDetailHeaderHelper.ts
@@ -53,8 +53,9 @@ export const caseDetailHeaderHelper = (get, applicationContext) => {
     } else if (user.role === USER_ROLES.irsPractitioner) {
       // can remove  !!caseDetail.hasIrsPractitioner once CONSOLIDATED_CASES_GROUP_ACCESS_PETITIONER / consolidated-cases-group-access-petitioner has been removed
 
-      const caseHasRespondent =
-        !!caseDetail.hasIrsPractitioner || caseDetail.irsPractitioners?.length;
+      const caseHasRespondent = !!(
+        !!caseDetail.hasIrsPractitioner || caseDetail.irsPractitioners?.length
+      );
 
       showFileFirstDocumentButton = !caseHasRespondent && !isCaseSealed;
 


### PR DESCRIPTION
This logic check ensures the value is a boolean and not a false-y value that ended up getting outputted only for IRS Practitioners.

<img width="1496" alt="Screenshot 2023-02-24 at 3 19 17 PM" src="https://user-images.githubusercontent.com/5023502/221282911-592be9f9-7f39-4e22-8646-c1e21e1d21ce.png">

this length of `0` had been getting picked up by 

```
      showRequestAccessToCaseButton =
        caseHasRespondent && // processing stops here as this is 0, and is assigned to `showRequestAccessToCaseButton`
        !isRequestAccessForm &&
        !isCaseSealed &&
        !isCurrentPageFilePetitionSuccess;
```

... then it was being outputted in the `CaseDetailHeader.tsx:41` 

```
          {caseDetailHeaderHelper.showRequestAccessToCaseButton && ( // `showRequestAccessToCaseButton` gets printed as `0`
            <Button
              secondary
```
