### PR TITLE
DevEx: env switcher - fixing broken ES endpoint environment variable

### DIFF
--- a/scripts/env/environments/00-common
+++ b/scripts/env/environments/00-common
@@ -9,7 +9,7 @@ SOURCE_TABLE_VERSION="${SOURCE_TABLE//efcms-${ENV}-/}"
 
 # region hard-coded; all ES domains and Cognito user pools are in us-east-1
 ELASTICSEARCH_ENDPOINT=$(aws es describe-elasticsearch-domain \
-  --domain-name "efcms-search-${ENV}-${SOURCE_TABLE}" \
+  --domain-name "efcms-search-${ENV}-${SOURCE_TABLE_VERSION}" \
   --region "us-east-1" \
   --query 'DomainStatus.Endpoint' \
   --output text)


### PR DESCRIPTION
Recently I updated the environment switcher to set `SOURCE_TABLE` and `SOURCE_TABLE_VERSION` separately, which caused this bug where the environment variable for the Elasticsearch endpoint URL is not being set correctly.