### PR TITLE
9870 BUG: Incorrect Error message appears if a Petitions Clerk clicks create case before all required fields have been completed.

### DIFF
--- a/web-client/src/presenter/actions/chooseStatisticValidationStrategyAction.test.ts
+++ b/web-client/src/presenter/actions/chooseStatisticValidationStrategyAction.test.ts
@@ -36,4 +36,16 @@ describe('chooseStatisticValidationStrategyAction', () => {
     expect(addEditStatisticMock).not.toHaveBeenCalled();
     expect(startCaseMock).toHaveBeenCalled();
   });
+
+  it('should call path.startCase when statisticIndex is 0', async () => {
+    await runAction(chooseStatisticValidationStrategyAction, {
+      modules: { presenter },
+      state: {
+        modal: { statisticIndex: 0 },
+      },
+    });
+
+    expect(addEditStatisticMock).not.toHaveBeenCalled();
+    expect(startCaseMock).toHaveBeenCalled();
+  });
 });

--- a/web-client/src/presenter/actions/chooseStatisticValidationStrategyAction.ts
+++ b/web-client/src/presenter/actions/chooseStatisticValidationStrategyAction.ts
@@ -8,7 +8,7 @@ import { state } from 'cerebral';
  * @returns {object} next path based on if modal has statistic index
  */
 export const chooseStatisticValidationStrategyAction = ({ get, path }) => {
-  return get(state.modal.statisticIndex)
+  return get(state.modal.statisticIndex) >= 0
     ? path.startCase()
     : path.addEditStatistic();
 };

--- a/web-client/src/presenter/sequences/calculatePenaltiesSequence.ts
+++ b/web-client/src/presenter/sequences/calculatePenaltiesSequence.ts
@@ -14,12 +14,12 @@ export const calculatePenaltiesSequence = [
     error: [setModalErrorAction],
     success: [
       setTotalPenaltiesAmountForStatisticAction,
-      clearModalStateAction,
       chooseStatisticValidationStrategyAction,
       {
-        addEditStatistic: [validateAddDeficiencyStatisticsSequence],
-        startCase: [validatePetitionFromPaperSequence],
+        addEditStatistic: validateAddDeficiencyStatisticsSequence,
+        startCase: validatePetitionFromPaperSequence,
       },
+      clearModalStateAction,
     ],
   },
 ];


### PR DESCRIPTION
The source of this bug was that `clearModalStateAction` was called prior to `chooseStatisticValidationStrategyAction`, which was using the modal's properties to determine how to validate the statistic. That mean the sequence was always choosing the same path, `addEditStatistic`, even when the sequence was triggered from the starting a petition from paper. `chooseStatisticValidationStrategyAction` also needed to check that the `statisticIndex` value was >= 0 since it could possibly be 0, resulting in a falsey return value, again only returning the `addEditStatistic` path.

flexion#9870