### PR TITLE
9868: jumpy checkboxes alternative

### DIFF
--- a/web-client/src/styles/overrides.scss
+++ b/web-client/src/styles/overrides.scss
@@ -223,7 +223,7 @@ option:first-child {
 }
 
 .usa-checkbox__input {
-  display: none;
+  position: fixed;
 }
 
 .no-bottom-margin {


### PR DESCRIPTION
Since completely hiding the input removes it from the tab order, overriding the `position: absolute` is the simplest solution