### PR TITLE
devex: `is-migration-needed` check always returns true

### DIFF
--- a/web-api/is-migration-needed.js
+++ b/web-api/is-migration-needed.js
@@ -16,7 +16,10 @@ const docClient = new AWS.DynamoDB.DocumentClient({
 const getFilesInDirectory = dir => {
   const files = fs.readdirSync(dir);
   return files.filter(
-    file => !file.endsWith('.test.js') && !file.startsWith('0000'),
+    file =>
+      !file.endsWith('.test.js') &&
+      !file.endsWith('.test.ts') &&
+      !file.startsWith('0000'),
   );
 };
 

--- a/web-api/track-successful-migrations.js
+++ b/web-api/track-successful-migrations.js
@@ -16,7 +16,10 @@ const docClient = new AWS.DynamoDB.DocumentClient({
 const getFilesInDirectory = dir => {
   const files = fs.readdirSync(dir);
   return files.filter(
-    file => !file.endsWith('.test.js') && !file.startsWith('0000'),
+    file =>
+      !file.endsWith('.test.js') &&
+      !file.endsWith('.test.ts') &&
+      !file.startsWith('0000'),
   );
 };
 


### PR DESCRIPTION
Now that some of the migration files are typescript, the `is-migration-needed` check is always returning true.

This PR addresses this.