### PR TITLE
Fix esbuild crashing when attempting to hot reload with an error

### DIFF
--- a/.github/workflows/e2e-cypress-public.yml
+++ b/.github/workflows/e2e-cypress-public.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   e2e_cypress_public:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     env:
       CI: true
       SKIP_CACHE_INVALIDATION: true
@@ -19,6 +19,7 @@ jobs:
       MASTER_DYNAMODB_ENDPOINT: http://localhost:8000
       AWS_ACCESS_KEY_ID: S3RVER
       AWS_SECRET_ACCESS_KEY: S3RVER
+      CHECK_DEPLOY_DATE_INTERVAL: 5000
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/e2e-cypress-public.yml
+++ b/.github/workflows/e2e-cypress-public.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   e2e_cypress_public:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     env:
       CI: true
       SKIP_CACHE_INVALIDATION: true

--- a/.github/workflows/e2e-cypress-public.yml
+++ b/.github/workflows/e2e-cypress-public.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   e2e_cypress_public:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     env:
       CI: true
       SKIP_CACHE_INVALIDATION: true
@@ -19,29 +19,11 @@ jobs:
       MASTER_DYNAMODB_ENDPOINT: http://localhost:8000
       AWS_ACCESS_KEY_ID: S3RVER
       AWS_SECRET_ACCESS_KEY: S3RVER
-      CHECK_DEPLOY_DATE_INTERVAL: 5000
-      CIRCLECI: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
-      - name: Configure sysctl limits
-        run: |
-          sudo swapoff -a
-          sudo sysctl -w vm.swappiness=1
-          sudo sysctl -w fs.file-max=262144
-          sudo sysctl -w vm.max_map_count=262144
-      - name: Runs Elasticsearch
-        uses: elastic/elastic-github-actions/elasticsearch@master
-        with:
-          stack-version: 7.10.2
-          security-enabled: false
-      - name: Setup DynamoDB Local
-        uses: rrainn/dynamodb-action@v2.0.1
-        with:
-          port: 8000
-          cors: '*'
       - name: Run E2E Cypress
         run: |
           npm ci
@@ -51,13 +33,3 @@ jobs:
           URL=http://localhost:4000/api/swagger ./wait-until.sh
           sleep 5
           npm run cypress:integration:public
-      - name: Store Video Artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: cypress-videos
-          path: ${{ github.workspace }}/cypress-integration/videos/public
-      - name: Store Logs
-        uses: actions/upload-artifact@v3
-        with:
-          name: cypress-logs
-          path: /tmp/cypress

--- a/esbuildHelper.mjs
+++ b/esbuildHelper.mjs
@@ -174,6 +174,7 @@ export default function ({
                 return;
               }
               replaceHtmlFile();
+
               clients.forEach(res => res.write('data: update\n\n'));
               clients.length = 0;
             },

--- a/esbuildHelper.mjs
+++ b/esbuildHelper.mjs
@@ -168,16 +168,14 @@ export default function ({
       splitting: true,
       watch: watch
         ? {
-            onRebuild(error, result) {
+            onRebuild(error) {
+              if (error) {
+                console.error(error);
+                return;
+              }
               replaceHtmlFile();
               clients.forEach(res => res.write('data: update\n\n'));
               clients.length = 0;
-              error && console.error(error);
-
-              fs.writeFileSync(
-                'metadata.json',
-                JSON.stringify(result.metafile, null, 2),
-              );
             },
           }
         : false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13791,7 +13791,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/english-ordinals/-/english-ordinals-2.4.0.tgz",
       "integrity": "sha512-FR/uCrgzpqvRfJeGJY2VvcqnYw54USEzV0SavktmAzIg8ZSVoe5ikV5ahzZ1BdxTmKfzdJjf2DNwQVuI0T6ELQ==",
-      "dev": true,
       "dependencies": {
         "rosaenlg-n2words": "2.4.0"
       }
@@ -40775,7 +40774,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/english-ordinals/-/english-ordinals-2.4.0.tgz",
       "integrity": "sha512-FR/uCrgzpqvRfJeGJY2VvcqnYw54USEzV0SavktmAzIg8ZSVoe5ikV5ahzZ1BdxTmKfzdJjf2DNwQVuI0T6ELQ==",
-      "dev": true,
       "requires": {
         "rosaenlg-n2words": "2.4.0"
       }
@@ -49928,8 +49926,7 @@
     "rosaenlg-n2words": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/rosaenlg-n2words/-/rosaenlg-n2words-2.4.0.tgz",
-      "integrity": "sha512-VoqGmwvnuJj1GdK3yVWhdkItI0Z401TWhVg92pr6QwFPICZ0Y9VZfnJzGexS9JUWuj7Fq0LGbZaeXUXXjAzNUA==",
-      "dev": true
+      "integrity": "sha512-VoqGmwvnuJj1GdK3yVWhdkItI0Z401TWhVg92pr6QwFPICZ0Y9VZfnJzGexS9JUWuj7Fq0LGbZaeXUXXjAzNUA=="
     },
     "rrweb-cssom": {
       "version": "0.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13791,6 +13791,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/english-ordinals/-/english-ordinals-2.4.0.tgz",
       "integrity": "sha512-FR/uCrgzpqvRfJeGJY2VvcqnYw54USEzV0SavktmAzIg8ZSVoe5ikV5ahzZ1BdxTmKfzdJjf2DNwQVuI0T6ELQ==",
+      "dev": true,
       "dependencies": {
         "rosaenlg-n2words": "2.4.0"
       }
@@ -40774,6 +40775,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/english-ordinals/-/english-ordinals-2.4.0.tgz",
       "integrity": "sha512-FR/uCrgzpqvRfJeGJY2VvcqnYw54USEzV0SavktmAzIg8ZSVoe5ikV5ahzZ1BdxTmKfzdJjf2DNwQVuI0T6ELQ==",
+      "dev": true,
       "requires": {
         "rosaenlg-n2words": "2.4.0"
       }
@@ -49926,7 +49928,8 @@
     "rosaenlg-n2words": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/rosaenlg-n2words/-/rosaenlg-n2words-2.4.0.tgz",
-      "integrity": "sha512-VoqGmwvnuJj1GdK3yVWhdkItI0Z401TWhVg92pr6QwFPICZ0Y9VZfnJzGexS9JUWuj7Fq0LGbZaeXUXXjAzNUA=="
+      "integrity": "sha512-VoqGmwvnuJj1GdK3yVWhdkItI0Z401TWhVg92pr6QwFPICZ0Y9VZfnJzGexS9JUWuj7Fq0LGbZaeXUXXjAzNUA==",
+      "dev": true
     },
     "rrweb-cssom": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "start:madge": "node ./graph-generators/index.js",
     "start:migration": "node ./web-api/send-migration-segment-messages.js",
     "start:public:ci": "npm run clean:public && CI=true npm run start:public",
-    "start:public": "WATCH=true USTC_ENV=dev IS_LOCAL=true PDF_EXPRESS_LICENSE_KEY=OjkUB41bl1hJg6jvUEfn node esbuild.public.config.mjs",
+    "start:public": "CHECK_DEPLOY_DATE_INTERVAL=5000 WATCH=true USTC_ENV=dev IS_LOCAL=true PDF_EXPRESS_LICENSE_KEY=OjkUB41bl1hJg6jvUEfn node esbuild.public.config.mjs",
     "start:s3rver": "s3rver -d web-api/storage/s3 -a 0.0.0.0 -p 9000 --configure-bucket $DOCUMENTS_BUCKET_NAME web-api/cors-policy.xml --configure-bucket $TEMP_DOCUMENTS_BUCKET_NAME web-api/cors-policy.xml",
     "switch-colors": "./web-client/switch-colors.sh",
     "test:_client:parallel": "NO_SCANNER=true SKIP_VIRUS_SCAN=true AWS_ACCESS_KEY_ID=S3RVER AWS_SECRET_ACCESS_KEY=S3RVER FILE_UPLOAD_MODAL_TIMEOUT=1 jest --maxWorkers=50% --config web-client/jest-unit.config.js",


### PR DESCRIPTION
Previously, esbuild would crash when trying to hot reload when: 
1) the front-end is running
2) there is a javascript error (syntax, compile, yadda yadda)

now it doesn't

edit:
also included in this PR is a fix for `e2e-cypress-public` tests failing by switching the runner from ubuntu to macos, and also fixed a failing test due to erroneously-set timeouts in the same test suite.