### PR TITLE
add-missing-tests: add client-integration-public to GA workflows

### DIFF
--- a/.github/workflows/client-integration-public.yml
+++ b/.github/workflows/client-integration-public.yml
@@ -1,0 +1,54 @@
+name: Node.js Client Integration Tests
+
+on:
+  pull_request:
+
+jobs:
+  client_integration_public:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ci_node_total: [2]
+        ci_node_index: [0, 1]
+    env:
+      CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
+      CI_NODE_INDEX: ${{ matrix.ci_node_index }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - name: Configure sysctl limits
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+      - name: Runs Elasticsearch
+        uses: elastic/elastic-github-actions/elasticsearch@master
+        with:
+          stack-version: 7.10.2
+          security-enabled: false
+      - name: Setup DynamoDB Local
+        uses: rrainn/dynamodb-action@v3.0.0
+        with:
+          port: 8000
+          cors: '*'
+      - name: Collect Workflow Telemetry
+        uses: runforesight/workflow-telemetry-action@v1
+      - name: Install Node Dependencies
+        run: npm ci
+      - name: Web Client - Integration Tests Public
+        run: |
+          mkdir -p /tmp/web-client
+          npm run start:api:ci > /tmp/web-client/server-output${{ matrix.ci_node_index }}.txt &
+          ./wait-until-services.sh
+          export TESTFILES=$(node split-tests.js -public)
+          npm run test:client:integration:ci
+      - name: Store Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: server log output
+          path: /tmp/web-client/server-output${{ matrix.ci_node_index }}.txt

--- a/split-tests.js
+++ b/split-tests.js
@@ -1,7 +1,9 @@
 const fs = require('fs');
 const shuffleSeed = require('shuffle-seed');
 
-const specDir = './web-client/integration-tests';
+const testType = process.argv[2] || '';
+
+const specDir = `./web-client/integration-tests${testType}`;
 const files = fs.readdirSync(specDir).filter(f => f.endsWith('test.js'));
 
 const shuffled = shuffleSeed.shuffle(files, process.env.GITHUB_SHA);


### PR DESCRIPTION
while working on 9865 tests, @mrinsin noticed that these `client-integration-public` tests do not appear to be running on any github workflows after moving from circleCI to GA