### PR TITLE
devex-1074: removing description properties from terraform resources

### DIFF
--- a/web-api/terraform/api/api-public.tf
+++ b/web-api/terraform/api/api-public.tf
@@ -113,7 +113,6 @@ resource "aws_api_gateway_deployment" "api_public_deployment" {
 resource "aws_api_gateway_stage" "api_public_stage" {
   rest_api_id   = aws_api_gateway_rest_api.gateway_for_api_public.id
   stage_name    = var.environment
-  description   = "Deployed at ${timestamp()}"
   deployment_id = aws_api_gateway_deployment.api_public_deployment.id
 
   access_log_settings {

--- a/web-api/terraform/api/api.tf
+++ b/web-api/terraform/api/api.tf
@@ -276,7 +276,6 @@ resource "aws_api_gateway_deployment" "api_deployment" {
 resource "aws_api_gateway_stage" "api_stage" {
   rest_api_id   = aws_api_gateway_rest_api.gateway_for_api.id
   stage_name    = var.environment
-  description   = "Deployed at ${timestamp()}"
   deployment_id = aws_api_gateway_deployment.api_deployment.id
 
   access_log_settings {


### PR DESCRIPTION
Let's see if we deploy less (or none!) of the current color's resources when the description doesn't have to change.

Note: we won't know if this is successful until after the second deployment that includes this change.