### PR TITLE
Fix public integration tests

### DIFF
--- a/web-client/integration-tests-public/journey/unauthedUserSearchesForSealedCaseByName.ts
+++ b/web-client/integration-tests-public/journey/unauthedUserSearchesForSealedCaseByName.ts
@@ -6,7 +6,7 @@ export const unauthedUserSearchesForSealedCaseByName = cerebralTest => {
     await refreshElasticsearchIndex(3000);
 
     const queryParams = {
-      petitionerName: 'NOTAREALNAMEFORTESTINGPUBLIC',
+      petitionerName: 'Roland the Headless Thompson Gunner',
     };
 
     cerebralTest.setState('advancedSearchForm.caseSearchByName', queryParams);

--- a/web-client/integration-tests-public/unauthedUserSearchesForSealedCase.test.ts
+++ b/web-client/integration-tests-public/unauthedUserSearchesForSealedCase.test.ts
@@ -33,7 +33,7 @@ describe('unauthed user searches for sealed case', () => {
           address1: '734 Cowley Parkway',
           city: 'Somewhere',
           countryType: COUNTRY_TYPES.DOMESTIC,
-          name: 'NOTAREALNAMEFORTESTINGPUBLIC',
+          name: 'Roland the Headless Thompson Gunner',
           phone: '+1 (884) 358-9729',
           postalCode: '77546',
           state: 'CT',


### PR DESCRIPTION
~~With the recent changes to typescript, the `--runInBand` flag was dropped from integration tests running in CI, which now causes the tests to run concurrently instead of sequentially. This sometimes causes collisions in testing when some test data share the same petitioner name.~~

We fixed this by changing one of the test petitioner's names.