### PR TITLE
Devex update cypress to es6

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,13 +26,9 @@ module.exports = {
   ignorePatterns: '**/*_.js',
   overrides: [
     {
-      files: [
-        'cypress-integration/**/*.js',
-        'cypress-smoketests/**/*.js',
-        'cypress-readonly/**/*.js',
-        'cypress/**/*.ts',
-      ],
+      files: ['cypress/**/*.ts'],
       rules: {
+        'cypress/unsafe-to-chain-command': 'warn',
         'jest/expect-expect': 'off',
         'jest/valid-expect': 'off',
         'jest/valid-expect-in-promise': 'off',

--- a/cypress/cypress-integration/integration/assign-a-work-item-to-self.cy.ts
+++ b/cypress/cypress-integration/integration/assign-a-work-item-to-self.cy.ts
@@ -1,10 +1,10 @@
-const {
+import {
   getWorkItemCheckboxLabel,
   getWorkItemRow,
-  navigateTo: navigateToDashboard,
+  navigateTo as navigateToDashboard,
   selectAssignee,
   viewDocumentQCSectionInbox,
-} = require('../support/pages/dashboard');
+} from '../support/pages/dashboard';
 
 describe('Assign a work item', () => {
   it('views the section inbox', () => {

--- a/cypress/cypress-integration/integration/chambers-user-clicks-document-qc-link.cy.ts
+++ b/cypress/cypress-integration/integration/chambers-user-clicks-document-qc-link.cy.ts
@@ -1,6 +1,4 @@
-const {
-  navigateTo: navigateToDashboard,
-} = require('../support/pages/dashboard');
+import { navigateTo as navigateToDashboard } from '../support/pages/dashboard';
 
 describe('A Colvins chambers user has the correct flow for QC documents', function () {
   it('should log in as chambers user', () => {

--- a/cypress/cypress-integration/integration/consolidated-case.cy.ts
+++ b/cypress/cypress-integration/integration/consolidated-case.cy.ts
@@ -1,4 +1,4 @@
-const { getCaseDetailTab } = require('../support/pages/case-detail');
+import { getCaseDetailTab } from '../support/pages/case-detail';
 
 describe('Docket clerk views consolidated case', function () {
   describe('case detail header', () => {

--- a/cypress/cypress-integration/integration/docket-clerk-edits-court-issued-document.cy.ts
+++ b/cypress/cypress-integration/integration/docket-clerk-edits-court-issued-document.cy.ts
@@ -1,6 +1,4 @@
-const {
-  navigateTo: navigateToDashboard,
-} = require('../support/pages/dashboard');
+import { navigateTo as navigateToDashboard } from '../support/pages/dashboard';
 import { uploadCourtIssuedDocumentAndEditViaDocumentQC } from '../support/pages/document-qc';
 
 describe('Docket clerk edits a court issued document', function () {

--- a/cypress/cypress-integration/integration/edit-a-trial-session.cy.ts
+++ b/cypress/cypress-integration/integration/edit-a-trial-session.cy.ts
@@ -1,11 +1,8 @@
-const {
+import {
   getCancelButton,
-  navigateTo: navigateToTrialSessionDetail,
-} = require('../support/pages/edit-trial-session');
-
-const {
-  getCancelModalTitle,
-} = require('../support/pages/form-cancel-modal-dialog');
+  navigateTo as navigateToTrialSessionDetail,
+} from '../support/pages/edit-trial-session';
+import { getCancelModalTitle } from '../support/pages/form-cancel-modal-dialog';
 
 describe('Edit a trial session', () => {
   it('should display a modal to confirm discarding changes when cancel is clicked', () => {

--- a/cypress/cypress-integration/integration/edit-case-caption-via-case-detail-header.cy.ts
+++ b/cypress/cypress-integration/integration/edit-case-caption-via-case-detail-header.cy.ts
@@ -1,11 +1,11 @@
-const {
+import {
   getButton,
   getCaptionTextArea,
   getCaseDetailTab,
   getCaseTitleContaining,
   getEditCaseCaptionButton,
-  navigateTo: navigateToCaseDetail,
-} = require('../support/pages/case-detail');
+  navigateTo as navigateToCaseDetail,
+} from '../support/pages/case-detail';
 
 describe('Edit a case caption from case detail header', function () {
   it('should changes the title of the case', () => {

--- a/cypress/cypress-integration/integration/edit-case-caption-via-petition-qc.cy.ts
+++ b/cypress/cypress-integration/integration/edit-case-caption-via-petition-qc.cy.ts
@@ -1,4 +1,4 @@
-const {
+import {
   getCaseInfoTab,
   getCaseTitleContaining,
   getCaseTitleTextArea,
@@ -6,9 +6,9 @@ const {
   getIrsNoticeTab,
   getReviewPetitionButton,
   getSaveForLaterButton,
-  navigateTo: navigateToPetitionQc,
   navigateToCase,
-} = require('../support/pages/petition-qc');
+  navigateTo as navigateToPetitionQc,
+} from '../support/pages/petition-qc';
 
 describe('change the case caption via the petition qc page', () => {
   it('updates the case title header', () => {

--- a/cypress/cypress-integration/integration/file-an-answer.cy.ts
+++ b/cypress/cypress-integration/integration/file-an-answer.cy.ts
@@ -1,6 +1,4 @@
-const {
-  navigateTo: navigateToDashboard,
-} = require('../support/pages/dashboard');
+import { navigateTo as navigateToDashboard } from '../support/pages/dashboard';
 
 describe('Filing an Answer', function () {
   it('should have a file first IRS document button', () => {

--- a/cypress/cypress-integration/integration/maintenance.cy.ts
+++ b/cypress/cypress-integration/integration/maintenance.cy.ts
@@ -1,4 +1,4 @@
-const {
+import {
   disengageMaintenance,
   engageMaintenance,
   getCancelButton,
@@ -6,8 +6,8 @@ const {
   getLogoutButton,
   getMaintenanceModal,
   getMaintenancePageContent,
-  navigateTo: loginAs,
-} = require('../support/pages/maintenance');
+  navigateTo as loginAs,
+} from '../support/pages/maintenance';
 
 describe('Maintenance mode', () => {
   after(() => {

--- a/cypress/cypress-integration/integration/messages.cy.ts
+++ b/cypress/cypress-integration/integration/messages.cy.ts
@@ -1,4 +1,4 @@
-const {
+import {
   createMessage,
   enterSubject,
   fillOutMessageField,
@@ -8,12 +8,13 @@ const {
   selectRecipient,
   selectSection,
   sendMessage,
-} = require('../support/pages/document-qc');
-const {
+} from '../support/pages/document-qc';
+
+import {
   getCaseStatusFilter,
   messagesShouldBeFiltered,
   selectsCaseStatusFilterNew,
-} = require('../support/pages/dashboard');
+} from '../support/pages/dashboard';
 
 describe('Messages', () => {
   describe('Docket clerk completes qc and sends a message', () => {

--- a/cypress/cypress-integration/integration/petition-clerk-verifies-auto-generated-nane.cy.ts
+++ b/cypress/cypress-integration/integration/petition-clerk-verifies-auto-generated-nane.cy.ts
@@ -1,15 +1,9 @@
-const {
+import { SYSTEM_GENERATED_DOCUMENT_TYPES } from '../../../shared/src/business/entities/EntityConstants';
+import { fillInCreateCaseFromPaperForm } from '../support/pages/create-paper-petition';
+import {
   getCreateACaseButton,
-  navigateTo: navigateToDocumentQC,
-} = require('../support/pages/document-qc');
-
-const {
-  fillInCreateCaseFromPaperForm,
-} = require('../support/pages/create-paper-petition');
-
-const {
-  SYSTEM_GENERATED_DOCUMENT_TYPES,
-} = require('../../../shared/src/business/entities/EntityConstants');
+  navigateTo as navigateToDocumentQC,
+} from '../support/pages/document-qc';
 
 const { noticeOfAttachmentsInNatureOfEvidence } =
   SYSTEM_GENERATED_DOCUMENT_TYPES;

--- a/cypress/cypress-integration/integration/petitioner-updates-email.cy.ts
+++ b/cypress/cypress-integration/integration/petitioner-updates-email.cy.ts
@@ -1,14 +1,13 @@
-const {
+import {
   changeEmailTo,
   clickChangeEmail,
   clickConfirmModal,
   confirmEmailPendingAlert,
   goToMyAccount,
-} = require('../support/pages/my-account');
-const {
-  confirmEmailVerificationSuccessful,
-} = require('../support/pages/public/email-verification');
-const { navigateTo: loginAs } = require('../support/pages/maintenance');
+} from '../support/pages/my-account';
+
+import { confirmEmailVerificationSuccessful } from '../support/pages/public/email-verification';
+import { navigateTo as loginAs } from '../support/pages/maintenance';
 
 describe('Petitioner updates and verifies their email', () => {
   it('petitioner should be able to change their email', () => {

--- a/cypress/cypress-integration/integration/petitions-clerk-creates-a-case.cy.ts
+++ b/cypress/cypress-integration/integration/petitions-clerk-creates-a-case.cy.ts
@@ -1,14 +1,9 @@
-const {
+import { fillInCreateCaseFromPaperForm } from '../support/pages/create-paper-petition';
+import {
   getCreateACaseButton,
-  navigateTo: navigateToDocumentQC,
-} = require('../support/pages/document-qc');
-
-const {
-  fillInCreateCaseFromPaperForm,
-} = require('../support/pages/create-paper-petition');
-const {
-  unchecksOrdersAndNoticesBoxesInCase,
-} = require('../support/pages/unchecks-orders-and-notices-boxes-in-case');
+  navigateTo as navigateToDocumentQC,
+} from '../support/pages/document-qc';
+import { unchecksOrdersAndNoticesBoxesInCase } from '../support/pages/unchecks-orders-and-notices-boxes-in-case';
 
 describe('Create case and submit to IRS', function () {
   it('should display parties tab when user navigates to create a case', () => {

--- a/cypress/cypress-integration/integration/public/advanced-search.cy.ts
+++ b/cypress/cypress-integration/integration/public/advanced-search.cy.ts
@@ -1,11 +1,11 @@
-const {
+import {
   clickOnSearchTab,
   docketRecordTable,
   enterDocumentDocketNumber,
   enterDocumentKeywordForAdvancedSearch,
   enterPetitionerName,
   firstSearchResultJudgeField,
-  navigateTo: navigateToDashboard,
+  navigateTo as navigateToDashboard,
   noSearchResultsContainer,
   searchForCaseByDocketNumber,
   searchForCaseByPetitionerInformation,
@@ -13,7 +13,7 @@ const {
   searchForOrderByJudge,
   searchResultsTable,
   unselectOpinionTypesExceptBench,
-} = require('../../support/pages/public/advanced-search');
+} from '../../support/pages/public/advanced-search';
 
 describe('Advanced search', () => {
   describe('case - by name', () => {

--- a/cypress/cypress-integration/integration/public/check-seamless-deploys.cy.ts
+++ b/cypress/cypress-integration/integration/public/check-seamless-deploys.cy.ts
@@ -1,4 +1,4 @@
-const {
+import {
   enterCaseTitleOrPetitionerName,
   enterDocumentDocketNumber,
   enterDocumentKeywordForAdvancedSearch,
@@ -7,7 +7,7 @@ const {
   getDocketNumberInput,
   getKeywordInput,
   getPetitionerNameInput,
-} = require('../../support/pages/public/advanced-search');
+} from '../../support/pages/public/advanced-search';
 
 describe('Public user experiences seamless reload after deployment', function () {
   it('should reload the page after deploy', () => {

--- a/cypress/cypress-integration/integration/public/maintenance-public.cy.ts
+++ b/cypress/cypress-integration/integration/public/maintenance-public.cy.ts
@@ -1,9 +1,9 @@
-const {
+import {
   disengageMaintenance,
   engageMaintenance,
   getMaintenancePageContent,
   navigateToDashboard,
-} = require('../../support/pages/maintenance');
+} from '../../support/pages/maintenance';
 
 describe('Maintenance mode public view', () => {
   before(() => {

--- a/cypress/cypress-integration/integration/public/terminal-user.cy.ts
+++ b/cypress/cypress-integration/integration/public/terminal-user.cy.ts
@@ -1,9 +1,9 @@
-const {
-  navigateTo: navigateToDashboard,
+import {
+  navigateTo as navigateToDashboard,
   petitionHyperlink,
   publicHeader,
   searchForCaseByDocketNumber,
-} = require('../../support/pages/public/advanced-search');
+} from '../../support/pages/public/advanced-search';
 
 describe('Terminal user', () => {
   after(() => {

--- a/cypress/cypress-integration/integration/start-a-case-practitioner.cy.ts
+++ b/cypress/cypress-integration/integration/start-a-case-practitioner.cy.ts
@@ -1,10 +1,9 @@
-const {
+import { fillInAndSubmitForm } from '../support/pages/start-a-case';
+import {
   getCaseList,
   getStartCaseButton,
-  navigateTo: navigateToDashboard,
-} = require('../support/pages/dashboard-practitioner');
-
-const { fillInAndSubmitForm } = require('../support/pages/start-a-case');
+  navigateTo as navigateToDashboard,
+} from '../support/pages/dashboard-practitioner';
 
 describe('Start a case as a practitioner', () => {
   it('go to the practitioner dashboard and expect that a case list table is displayed with eight cases', () => {

--- a/cypress/cypress-integration/integration/trial-session-working-copy.cy.ts
+++ b/cypress/cypress-integration/integration/trial-session-working-copy.cy.ts
@@ -1,4 +1,4 @@
-const {
+import {
   addCaseNote,
   changeCaseTrialStatus,
   createTrialSession,
@@ -6,8 +6,9 @@ const {
   goToTrialSession,
   markCaseAsQcCompleteForTrial,
   setTrialSessionAsCalendared,
-} = require('../../cypress-smoketests/support/pages/trial-sessions');
-const {
+} from '../../cypress-smoketests/support/pages/trial-sessions';
+
+import {
   completeWizardStep1,
   completeWizardStep2,
   completeWizardStep3,
@@ -22,12 +23,13 @@ const {
   goToWizardStep5,
   hasIrsNotice,
   submitPetition,
-} = require('../../cypress-smoketests/support/pages/create-electronic-petition');
-const {
+} from '../../cypress-smoketests/support/pages/create-electronic-petition';
+
+import { faker } from '@faker-js/faker';
+import {
   goToCaseOverview,
   manuallyAddCaseToNewTrialSession,
-} = require('../../cypress-smoketests/support/pages/case-detail');
-const { faker } = require('@faker-js/faker');
+} from '../../cypress-smoketests/support/pages/case-detail';
 
 faker.seed(faker.datatype.number());
 
@@ -96,8 +98,6 @@ describe.skip('Petitioner', () => {
   });
 });
 
-// eslint-disable-next-line no-unused-vars
-let judgeUserId;
 describe.skip('Petitions Clerk', () => {
   describe('should create and set a trial session', () => {
     beforeEach(() => {

--- a/cypress/cypress-integration/support/database.ts
+++ b/cypress/cypress-integration/support/database.ts
@@ -1,12 +1,10 @@
-const AWS = require('aws-sdk');
-const { chunk } = require('lodash');
+import { chunk } from 'lodash';
+import AWS from 'aws-sdk';
 
 AWS.config = new AWS.Config();
 AWS.config.region = 'us-east-1';
 
-const {
-  seedLocalDatabase,
-} = require('../../../web-api/storage/scripts/seedLocalDatabase');
+import { seedLocalDatabase } from '../../../web-api/storage/scripts/seedLocalDatabase';
 
 const documentClient = new AWS.DynamoDB.DocumentClient({
   credentials: {
@@ -63,7 +61,7 @@ const clearDatabase = async () => {
   }
 };
 
-module.exports.getEmailVerificationToken = async ({ userId }) => {
+export const getEmailVerificationToken = async ({ userId }) => {
   return await documentClient
     .get({
       Key: {
@@ -78,7 +76,7 @@ module.exports.getEmailVerificationToken = async ({ userId }) => {
     });
 };
 
-module.exports.setAllowedTerminalIpAddresses = async ipAddresses => {
+export const setAllowedTerminalIpAddresses = async ipAddresses => {
   return await documentClient
     .put({
       Item: {
@@ -91,7 +89,7 @@ module.exports.setAllowedTerminalIpAddresses = async ipAddresses => {
     .promise();
 };
 
-module.exports.reseedDatabase = async () => {
+export const reseedDatabase = async () => {
   await clearDatabase();
   await seedLocalDatabase();
   return null;

--- a/cypress/cypress-integration/support/pages/case-detail.ts
+++ b/cypress/cypress-integration/support/pages/case-detail.ts
@@ -1,33 +1,33 @@
-exports.navigateTo = (username, docketNumber) => {
+export const navigateTo = (username, docketNumber) => {
   cy.login(username, `/case-detail/${docketNumber}`);
 };
 
-exports.getActionMenuButton = () => {
+export const getActionMenuButton = () => {
   return cy.get('button.case-detail-menu__button');
 };
 
-exports.getEditCaseCaptionButton = () => {
+export const getEditCaseCaptionButton = () => {
   return cy.get('button#menu-edit-case-context-button');
 };
 
-exports.getCaptionTextArea = () => {
+export const getCaptionTextArea = () => {
   return cy.get('textarea.caption');
 };
 
-exports.getButton = buttonText => {
+export const getButton = buttonText => {
   return cy.contains('button', buttonText);
 };
 
-exports.getCaseTitleContaining = text => {
+export const getCaseTitleContaining = text => {
   return cy.contains('p#case-title', text);
 };
 
-exports.getCaseDetailTab = tabName => {
+export const getCaseDetailTab = tabName => {
   // tabName can be: docket-record, tracked-items, drafts, correspondence, case-information, case-messages, notes
   return cy.get(`button#tab-${tabName}`);
 };
 
-exports.createOrder = docketNumber => {
+export const createOrder = docketNumber => {
   cy.goToRoute(
     `/case-detail/${docketNumber}/create-order?documentTitle=Order to Show Cause&documentType=Order to Show Cause&eventCode=OSC`,
   );

--- a/cypress/cypress-integration/support/pages/create-paper-petition.ts
+++ b/cypress/cypress-integration/support/pages/create-paper-petition.ts
@@ -1,6 +1,6 @@
-const { faker } = require('@faker-js/faker');
+import { faker } from '@faker-js/faker';
 
-exports.fillInCreateCaseFromPaperForm = testData => {
+export const fillInCreateCaseFromPaperForm = testData => {
   const petitionerName = `${faker.name.firstName()} ${faker.name.lastName()}`;
   cy.get('#party-type').select('Petitioner');
   cy.get('#name').type(petitionerName);

--- a/cypress/cypress-integration/support/pages/dashboard-practitioner.ts
+++ b/cypress/cypress-integration/support/pages/dashboard-practitioner.ts
@@ -1,11 +1,11 @@
-exports.navigateTo = username => {
+export const navigateTo = username => {
   cy.login(username, '/');
 };
 
-exports.getStartCaseButton = () => {
+export const getStartCaseButton = () => {
   return cy.get('a#file-a-petition');
 };
 
-exports.getCaseList = () => {
+export const getCaseList = () => {
   return cy.get('#case-list tbody tr');
 };

--- a/cypress/cypress-integration/support/pages/dashboard.ts
+++ b/cypress/cypress-integration/support/pages/dashboard.ts
@@ -1,58 +1,58 @@
-exports.navigateTo = username => {
+export const navigateTo = username => {
   cy.login(username, '/');
 };
 
-exports.viewMyOutbox = () => {
+export const viewMyOutbox = () => {
   cy.get('button#individual-sent-tab').click();
 };
 
-exports.viewSectionOutbox = () => {
+export const viewSectionOutbox = () => {
   cy.get('button.button-switch-box').click();
   cy.get('button#section-sent-tab').click();
 };
 
-exports.viewDocumentQCSectionInbox = () => {
+export const viewDocumentQCSectionInbox = () => {
   cy.visit('/document-qc/section/inbox');
 };
 
-exports.getWorkItemContaining = text => {
+export const getWorkItemContaining = text => {
   return cy.contains(text);
 };
 
-exports.getTableRows = () => {
+export const getTableRows = () => {
   return cy.get('tbody');
 };
 
-exports.getWorkItemCheckboxLabel = workItemId => {
+export const getWorkItemCheckboxLabel = workItemId => {
   return cy.get(`label#label-${workItemId}`);
 };
 
-exports.getSectionUsersSelect = () => {
+export const getSectionUsersSelect = () => {
   return cy.get('select#options');
 };
 
-exports.selectAssignee = user => {
+export const selectAssignee = user => {
   cy.intercept('PUT', '/work-items').as('assignWorkItem');
-  exports.getSectionUsersSelect().select(user);
+  getSectionUsersSelect().select(user);
   cy.wait('@assignWorkItem');
 };
 
-exports.getWorkItemRow = docketNumber => {
+export const getWorkItemRow = docketNumber => {
   return cy.contains('tr', docketNumber);
 };
 
-exports.getSendButton = () => {
+export const getSendButton = () => {
   return cy.contains('button', 'Send');
 };
 
-exports.getCaseStatusFilter = () => {
+export const getCaseStatusFilter = () => {
   return cy.get('select#caseStatusFilter');
 };
 
-exports.selectsCaseStatusFilterNew = () => {
-  exports.getCaseStatusFilter().select('New');
+export const selectsCaseStatusFilterNew = () => {
+  getCaseStatusFilter().select('New');
 };
 
-exports.messagesShouldBeFiltered = () => {
+export const messagesShouldBeFiltered = () => {
   return cy.get('table').contains('td', 'Calendared').should('not.exist');
 };

--- a/cypress/cypress-integration/support/pages/document-detail.ts
+++ b/cypress/cypress-integration/support/pages/document-detail.ts
@@ -1,39 +1,39 @@
-exports.navigateTo = (username, docketNumber, docketEntryId) => {
+export const navigateTo = (username, docketNumber, docketEntryId) => {
   cy.login(username, `/case-detail/${docketNumber}/documents/${docketEntryId}`);
 };
 
-exports.getMessagesTab = () => {
+export const getMessagesTab = () => {
   return cy.get('button#tab-pending-messages');
 };
 
-exports.getInProgressTab = () => {
+export const getInProgressTab = () => {
   return cy.get('button#tab-messages-in-progress');
 };
 
-exports.getCreateMessageButton = () => {
+export const getCreateMessageButton = () => {
   return cy.get('button#create-message-button');
 };
 
-exports.getSectionSelect = () => {
+export const getSectionSelect = () => {
   return cy.get('select#section');
 };
 
-exports.getAssigneeIdSelect = () => {
+export const getAssigneeIdSelect = () => {
   return cy.get('select#assigneeId');
 };
 
-exports.getMessageTextArea = () => {
+export const getMessageTextArea = () => {
   return cy.get('textarea#message');
 };
 
-exports.getSendMessageButton = () => {
+export const getSendMessageButton = () => {
   return cy.get('.modal-dialog').contains('Send');
 };
 
-exports.getCardContaining = text => {
+export const getCardContaining = text => {
   return cy.get('.card').contains(text);
 };
 
-exports.getModal = () => {
+export const getModal = () => {
   return cy.get('.modal-dialog');
 };

--- a/cypress/cypress-integration/support/pages/document-qc.ts
+++ b/cypress/cypress-integration/support/pages/document-qc.ts
@@ -1,49 +1,49 @@
-exports.navigateTo = username => {
+export const navigateTo = username => {
   cy.login(username, '/document-qc');
 };
 
-exports.getCreateACaseButton = () => {
+export const getCreateACaseButton = () => {
   return cy.get('a#file-a-petition');
 };
 
-exports.goToDocumentNeedingQC = () => {
+export const goToDocumentNeedingQC = () => {
   cy.get('a.case-link').first().click();
 };
 
-exports.createMessage = () => {
+export const createMessage = () => {
   cy.get('#case-detail-menu-button').click();
   cy.get('#menu-button-add-new-message').click();
 };
 
-exports.openCompleteAndSendMessageDialog = () => {
+export const openCompleteAndSendMessageDialog = () => {
   cy.get('button#save-and-add-supporting').click();
 };
 
-exports.selectSection = section => {
+export const selectSection = section => {
   cy.get('#toSection').scrollIntoView().select(section);
 };
 
-exports.selectRecipient = recipient => {
+export const selectRecipient = recipient => {
   cy.get('#toUserId').scrollIntoView().select(recipient);
 };
 
-exports.fillOutMessageField = () => {
+export const fillOutMessageField = () => {
   cy.get('#message').clear().type("I don't appreciate your lack of sarcasm.");
 };
 
-exports.enterSubject = () => {
+export const enterSubject = () => {
   cy.get('#subject').clear().type('Demeanor');
 };
 
-exports.sendMessage = () => {
+export const sendMessage = () => {
   cy.get('#confirm').click();
 };
 
-exports.progressIndicatorDoesNotExist = () => {
+export const progressIndicatorDoesNotExist = () => {
   cy.get('.progress-indicator').should('not.exist');
 };
 
-exports.uploadCourtIssuedDocumentAndEditViaDocumentQC = attempt => {
+export const uploadCourtIssuedDocumentAndEditViaDocumentQC = attempt => {
   cy.visit('case-detail/104-20/upload-court-issued');
   const freeText = `court document ${attempt}`;
   cy.get('#upload-description').clear().type(freeText);

--- a/cypress/cypress-integration/support/pages/edit-trial-session.ts
+++ b/cypress/cypress-integration/support/pages/edit-trial-session.ts
@@ -1,7 +1,7 @@
-exports.navigateTo = (username, trialSessionId) => {
+export const navigateTo = (username, trialSessionId) => {
   cy.login(username, `/edit-trial-session/${trialSessionId}`);
 };
 
-exports.getCancelButton = () => {
+export const getCancelButton = () => {
   return cy.contains('Cancel');
 };

--- a/cypress/cypress-integration/support/pages/form-cancel-modal-dialog.ts
+++ b/cypress/cypress-integration/support/pages/form-cancel-modal-dialog.ts
@@ -1,3 +1,3 @@
-exports.getCancelModalTitle = () => {
+export const getCancelModalTitle = () => {
   return cy.get('h3.modal-header__title');
 };

--- a/cypress/cypress-integration/support/pages/maintenance.ts
+++ b/cypress/cypress-integration/support/pages/maintenance.ts
@@ -1,35 +1,35 @@
-exports.navigateTo = username => {
+export const navigateTo = username => {
   cy.login(username, '/');
 };
 
-exports.navigateToDashboard = () => {
+export const navigateToDashboard = () => {
   cy.visit('/');
 };
 
-exports.engageMaintenance = () => {
+export const engageMaintenance = () => {
   cy.exec('npm run maintenance:engage:local');
 };
 
-exports.disengageMaintenance = () => {
+export const disengageMaintenance = () => {
   cy.exec('npm run maintenance:disengage:local');
 };
 
-exports.getMaintenanceModal = () => {
+export const getMaintenanceModal = () => {
   return cy.get('.app-maintenance-modal');
 };
 
-exports.getLogoutButton = () => {
+export const getLogoutButton = () => {
   return cy.get('#maintenance-logout-btn');
 };
 
-exports.getCancelButton = () => {
+export const getCancelButton = () => {
   return cy.get('#maintenance-cancel-btn');
 };
 
-exports.getLoginHeader = () => {
+export const getLoginHeader = () => {
   return cy.get('h1').contains('Log in');
 };
 
-exports.getMaintenancePageContent = () => {
+export const getMaintenancePageContent = () => {
   return cy.get('.maintenance-content');
 };

--- a/cypress/cypress-integration/support/pages/my-account.ts
+++ b/cypress/cypress-integration/support/pages/my-account.ts
@@ -1,39 +1,39 @@
-const { faker } = require('@faker-js/faker');
+import { faker } from '@faker-js/faker';
 
-exports.goToMyAccount = () => {
+export const goToMyAccount = () => {
   cy.get('svg.account-menu-icon').parent().parent().click();
   cy.get('button#my-account').click();
 };
 
-exports.clickChangeEmail = () => {
+export const clickChangeEmail = () => {
   cy.get('button').contains('Change Email').click();
 };
 
-exports.changeEmailTo = newEmail => {
+export const changeEmailTo = newEmail => {
   cy.get('input[name="email"]').type(newEmail);
   cy.get('input[name="confirmEmail"]').type(newEmail);
   cy.get('button').contains('Save').click();
 };
 
-exports.clickConfirmModal = () => {
+export const clickConfirmModal = () => {
   cy.get('button.modal-button-confirm').click();
 };
 
-exports.confirmEmailPendingAlert = () => {
+export const confirmEmailPendingAlert = () => {
   cy.get('.verify-email-notification').should('exist');
 };
 
-exports.goToEditContactInformation = () => {
+export const goToEditContactInformation = () => {
   cy.get('button.ustc-button--unstyled').contains('Edit').click();
 };
 
-exports.updateAddress1 = () => {
+export const updateAddress1 = () => {
   cy.get('input[id=contact\\.address1]')
     .clear()
     .type(faker.address.streetAddress());
 };
 
-exports.saveContactInformation = () => {
+export const saveContactInformation = () => {
   cy.get('button.usa-button').contains('Save').click();
 
   cy.get('.progress-indicator').should('not.exist');

--- a/cypress/cypress-integration/support/pages/petition-qc.ts
+++ b/cypress/cypress-integration/support/pages/petition-qc.ts
@@ -1,35 +1,35 @@
-exports.navigateTo = (username, docketNumber) => {
+export const navigateTo = (username, docketNumber) => {
   cy.login(username, `/case-detail/${docketNumber}/petition-qc`);
 };
 
-exports.navigateToCase = (username, docketNumber) => {
+export const navigateToCase = (username, docketNumber) => {
   cy.login(username, `/case-detail/${docketNumber}`);
 };
 
-exports.getCaseInfoTab = () => {
+export const getCaseInfoTab = () => {
   return cy.get('button#tab-case-info');
 };
 
-exports.getCaseTitleTextArea = () => {
+export const getCaseTitleTextArea = () => {
   return cy.get('textarea#case-caption');
 };
 
-exports.getCaseTitleContaining = text => {
+export const getCaseTitleContaining = text => {
   return cy.contains('p#case-title', text);
 };
 
-exports.getIrsNoticeTab = () => {
+export const getIrsNoticeTab = () => {
   return cy.get('button#tab-irs-notice');
 };
 
-exports.getHasIrsNoticeYesRadioButton = () => {
+export const getHasIrsNoticeYesRadioButton = () => {
   return cy.get('#has-irs-verified-notice-yes');
 };
 
-exports.getReviewPetitionButton = () => {
+export const getReviewPetitionButton = () => {
   return cy.contains('button', 'Review Petition');
 };
 
-exports.getSaveForLaterButton = () => {
+export const getSaveForLaterButton = () => {
   return cy.contains('button', 'Save for Later');
 };

--- a/cypress/cypress-integration/support/pages/public/advanced-search.ts
+++ b/cypress/cypress-integration/support/pages/public/advanced-search.ts
@@ -1,53 +1,51 @@
-const {
-  ADVANCED_SEARCH_OPINION_TYPES,
-} = require('../../../../../shared/src/business/entities/EntityConstants');
+import { ADVANCED_SEARCH_OPINION_TYPES } from '../../../../../shared/src/business/entities/EntityConstants';
 
-exports.navigateTo = () => {
+export const navigateTo = () => {
   cy.visit('/');
 };
 
-exports.clickOnSearchTab = tabName => {
+export const clickOnSearchTab = tabName => {
   cy.get(`button#tab-${tabName}`).click();
 };
 
-exports.searchForCaseByDocketNumber = docketNumber => {
+export const searchForCaseByDocketNumber = docketNumber => {
   cy.get('input#docket-number').type(docketNumber);
   cy.get('button#docket-search-button').click();
 };
 
-exports.enterPetitionerName = name => {
+export const enterPetitionerName = name => {
   cy.get('input#petitioner-name').type(name);
 };
 
-exports.getPetitionerNameInput = () => {
+export const getPetitionerNameInput = () => {
   return cy.get('input#petitioner-name');
 };
 
-exports.enterCaseTitleOrPetitionerName = name => {
+export const enterCaseTitleOrPetitionerName = name => {
   cy.get('input#title-or-name').type(name);
 };
 
-exports.getCaseTitleOrPetitionerNameInput = () => {
+export const getCaseTitleOrPetitionerNameInput = () => {
   return cy.get('input#title-or-name');
 };
 
-exports.enterDocumentKeywordForAdvancedSearch = keyword => {
+export const enterDocumentKeywordForAdvancedSearch = keyword => {
   cy.get('input#keyword-search').type(keyword);
 };
 
-exports.getKeywordInput = () => {
+export const getKeywordInput = () => {
   return cy.get('input#keyword-search');
 };
 
-exports.enterDocumentDocketNumber = docketNumber => {
+export const enterDocumentDocketNumber = docketNumber => {
   cy.get('input#docket-number').type(docketNumber);
 };
 
-exports.getDocketNumberInput = () => {
+export const getDocketNumberInput = () => {
   return cy.get('input#docket-number');
 };
 
-exports.unselectOpinionTypesExceptBench = () => {
+export const unselectOpinionTypesExceptBench = () => {
   let opinionTypes = Object.keys(ADVANCED_SEARCH_OPINION_TYPES).filter(
     type => type !== 'Bench',
   );
@@ -57,38 +55,38 @@ exports.unselectOpinionTypesExceptBench = () => {
   });
 };
 
-exports.searchForCaseByPetitionerInformation = () => {
+export const searchForCaseByPetitionerInformation = () => {
   cy.get('button#advanced-search-button').click();
 };
 
-exports.searchForDocuments = () => {
+export const searchForDocuments = () => {
   cy.get('button#advanced-search-button').click();
 };
 
-exports.noSearchResultsContainer = () => {
+export const noSearchResultsContainer = () => {
   return cy.get('div#no-search-results');
 };
 
-exports.searchResultsTable = () => {
+export const searchResultsTable = () => {
   return cy.get('table.search-results');
 };
 
-exports.firstSearchResultJudgeField = () => {
+export const firstSearchResultJudgeField = () => {
   return cy.contains('td', 'Foley');
 };
 
-exports.docketRecordTable = () => {
+export const docketRecordTable = () => {
   return cy.get('table#docket-record-table');
 };
 
-exports.searchForOrderByJudge = judge => {
+export const searchForOrderByJudge = judge => {
   return cy.get('#order-judge').select(judge);
 };
 
-exports.publicHeader = () => {
+export const publicHeader = () => {
   return cy.get('h1.header-welcome-public');
 };
 
-exports.petitionHyperlink = () => {
+export const petitionHyperlink = () => {
   return cy.get('button.view-pdf-link').contains('Petition');
 };

--- a/cypress/cypress-integration/support/pages/public/email-verification.ts
+++ b/cypress/cypress-integration/support/pages/public/email-verification.ts
@@ -1,4 +1,4 @@
-exports.confirmEmailVerificationSuccessful = () => {
+export const confirmEmailVerificationSuccessful = () => {
   cy.get('h1')
     .contains('You Must Be Logged In to Verify Email')
     .should('not.exist');

--- a/cypress/cypress-integration/support/pages/start-a-case.ts
+++ b/cypress/cypress-integration/support/pages/start-a-case.ts
@@ -1,8 +1,8 @@
-exports.navigateTo = username => {
+export const navigateTo = username => {
   cy.login(username, '/file-a-petition/step-1');
 };
 
-exports.fillInAndSubmitForm = () => {
+export const fillInAndSubmitForm = () => {
   //wizard step 1
   cy.get('input#stin-file').attachFile('../fixtures/w3-dummy.pdf');
 

--- a/cypress/cypress-integration/support/pages/unchecks-orders-and-notices-boxes-in-case.ts
+++ b/cypress/cypress-integration/support/pages/unchecks-orders-and-notices-boxes-in-case.ts
@@ -1,4 +1,4 @@
-exports.unchecksOrdersAndNoticesBoxesInCase = () => {
+export const unchecksOrdersAndNoticesBoxesInCase = () => {
   cy.get('label[for="notice-of-attachments"]').scrollIntoView().click();
   cy.get('label[for="order-for-ratification"]').scrollIntoView().click();
 };

--- a/cypress/cypress-readonly/integration/document-qc.cy.ts
+++ b/cypress/cypress-readonly/integration/document-qc.cy.ts
@@ -1,7 +1,5 @@
-const {
-  getEnvironmentSpecificFunctions,
-} = require('../support/pages/environment-specific-factory');
-const { isValidRequest } = require('../support/helpers');
+import { getEnvironmentSpecificFunctions } from '../support/pages/environment-specific-factory';
+import { isValidRequest } from '../support/helpers';
 
 const DEFAULT_ACCOUNT_PASS = Cypress.env('DEFAULT_ACCOUNT_PASS');
 const EFCMS_DOMAIN = Cypress.env('EFCMS_DOMAIN');

--- a/cypress/cypress-readonly/integration/messages.cy.ts
+++ b/cypress/cypress-readonly/integration/messages.cy.ts
@@ -1,7 +1,5 @@
-const {
-  getEnvironmentSpecificFunctions,
-} = require('../support/pages/environment-specific-factory');
-const { isValidRequest } = require('../support/helpers');
+import { getEnvironmentSpecificFunctions } from '../support/pages/environment-specific-factory';
+import { isValidRequest } from '../support/helpers';
 
 const DEFAULT_ACCOUNT_PASS = Cypress.env('DEFAULT_ACCOUNT_PASS');
 const EFCMS_DOMAIN = Cypress.env('EFCMS_DOMAIN');

--- a/cypress/cypress-readonly/integration/practitioner-search.cy.ts
+++ b/cypress/cypress-readonly/integration/practitioner-search.cy.ts
@@ -1,7 +1,5 @@
-const {
-  getEnvironmentSpecificFunctions,
-} = require('../support/pages/environment-specific-factory');
-const { isValidRequest } = require('../support/helpers');
+import { getEnvironmentSpecificFunctions } from '../support/pages/environment-specific-factory';
+import { isValidRequest } from '../support/helpers';
 
 const DEFAULT_ACCOUNT_PASS = Cypress.env('DEFAULT_ACCOUNT_PASS');
 const EFCMS_DOMAIN = Cypress.env('EFCMS_DOMAIN');

--- a/cypress/cypress-readonly/integration/public/advanced-search.cy.ts
+++ b/cypress/cypress-readonly/integration/public/advanced-search.cy.ts
@@ -1,11 +1,12 @@
-const {
+import {
   docketRecordTable,
   enterPetitionerName,
-  navigateTo: navigateToDashboard,
+  navigateTo as navigateToDashboard,
   noSearchResultsContainer,
   searchForCaseByDocketNumber,
-} = require('../../support/pages/public/advanced-search');
-const { isValidRequest } = require('../../support/helpers');
+} from '../../support/pages/public/advanced-search';
+
+import { isValidRequest } from '../../support/helpers';
 
 const EFCMS_DOMAIN = Cypress.env('EFCMS_DOMAIN');
 const DEPLOYING_COLOR = Cypress.env('DEPLOYING_COLOR');

--- a/cypress/cypress-readonly/integration/public/todays-opinions.cy.ts
+++ b/cypress/cypress-readonly/integration/public/todays-opinions.cy.ts
@@ -1,4 +1,4 @@
-const { isValidRequest } = require('../../support/helpers');
+import { isValidRequest } from '../../support/helpers';
 
 const EFCMS_DOMAIN = Cypress.env('EFCMS_DOMAIN');
 const DEPLOYING_COLOR = Cypress.env('DEPLOYING_COLOR');

--- a/cypress/cypress-readonly/integration/public/todays-orders.cy.ts
+++ b/cypress/cypress-readonly/integration/public/todays-orders.cy.ts
@@ -1,4 +1,4 @@
-const { isValidRequest } = require('../../support/helpers');
+import { isValidRequest } from '../../support/helpers';
 
 const EFCMS_DOMAIN = Cypress.env('EFCMS_DOMAIN');
 const DEPLOYING_COLOR = Cypress.env('DEPLOYING_COLOR');

--- a/cypress/cypress-readonly/integration/trial-sessions.cy.ts
+++ b/cypress/cypress-readonly/integration/trial-sessions.cy.ts
@@ -1,7 +1,5 @@
-const {
-  getEnvironmentSpecificFunctions,
-} = require('../support/pages/environment-specific-factory');
-const { isValidRequest } = require('../support/helpers');
+import { getEnvironmentSpecificFunctions } from '../support/pages/environment-specific-factory';
+import { isValidRequest } from '../support/helpers';
 
 const DEFAULT_ACCOUNT_PASS = Cypress.env('DEFAULT_ACCOUNT_PASS');
 const EFCMS_DOMAIN = Cypress.env('EFCMS_DOMAIN');

--- a/cypress/cypress-readonly/support/helpers.ts
+++ b/cypress/cypress-readonly/support/helpers.ts
@@ -1,4 +1,4 @@
-exports.isValidRequest = ({ response }) => {
+export const isValidRequest = ({ response }) => {
   expect(response.statusCode).to.eq(200);
   expect(response.headers['content-type']).to.contain('application/json');
 };

--- a/cypress/cypress-readonly/support/pages/environment-specific-factory.ts
+++ b/cypress/cypress-readonly/support/pages/environment-specific-factory.ts
@@ -1,10 +1,10 @@
-const {
-  getRestApi: getRestApiDeployed,
-  getUserToken: getUserTokenDeployed,
-  login: loginDeployed,
-} = require('./login');
+import {
+  getRestApi as getRestApiDeployed,
+  getUserToken as getUserTokenDeployed,
+  login as loginDeployed,
+} from './login';
 
-exports.getEnvironmentSpecificFunctions = () => {
+export const getEnvironmentSpecificFunctions = () => {
   return {
     getRestApi: getRestApiDeployed,
     getUserToken: getUserTokenDeployed,

--- a/cypress/cypress-readonly/support/pages/login.ts
+++ b/cypress/cypress-readonly/support/pages/login.ts
@@ -1,4 +1,4 @@
-const AWS = require('aws-sdk');
+import AWS from 'aws-sdk';
 
 const awsRegion = 'us-east-1';
 
@@ -37,7 +37,7 @@ const getUserPoolId = async () => {
   return userPoolId;
 };
 
-exports.getUserToken = async (username, password) => {
+export const getUserToken = async (username, password) => {
   const userPoolId = await getUserPoolId();
   const clientId = await getClientId(userPoolId);
 
@@ -54,7 +54,7 @@ exports.getUserToken = async (username, password) => {
     .promise();
 };
 
-exports.login = token => {
+export const login = token => {
   cy.visit(`/log-in?token=${token}`);
   cy.get('.progress-indicator').should('not.exist');
   cy.get('.big-blue-header').should('exist');

--- a/cypress/cypress-readonly/support/pages/public/advanced-search.ts
+++ b/cypress/cypress-readonly/support/pages/public/advanced-search.ts
@@ -1,24 +1,24 @@
-exports.navigateTo = () => {
+export const navigateTo = () => {
   cy.visit('/');
 };
 
-exports.searchForCaseByDocketNumber = docketNumber => {
+export const searchForCaseByDocketNumber = docketNumber => {
   cy.get('input#docket-number').type(docketNumber);
   cy.get('button#docket-search-button').click();
 };
 
-exports.enterPetitionerName = name => {
+export const enterPetitionerName = name => {
   cy.get('input#petitioner-name').type(name);
 };
 
-exports.noSearchResultsContainer = () => {
+export const noSearchResultsContainer = () => {
   return cy.get('div#no-search-results');
 };
 
-exports.searchResultsTable = () => {
+export const searchResultsTable = () => {
   return cy.get('table.search-results');
 };
 
-exports.docketRecordTable = () => {
+export const docketRecordTable = () => {
   return cy.get('table#docket-record-table');
 };

--- a/cypress/cypress-smoketests/integration/case-creation.cy.ts
+++ b/cypress/cypress-smoketests/integration/case-creation.cy.ts
@@ -1,4 +1,4 @@
-const {
+import {
   completeWizardStep1,
   completeWizardStep2,
   completeWizardStep3,
@@ -13,21 +13,18 @@ const {
   goToWizardStep5,
   hasIrsNotice,
   submitPetition,
-} = require('../support/pages/create-electronic-petition');
-const {
-  fillInCreateCaseFromPaperForm,
-} = require('../../cypress-integration/support/pages/create-paper-petition');
-const {
-  getEnvironmentSpecificFunctions,
-} = require('../support/pages/environment-specific-factory');
-const {
+} from '../support/pages/create-electronic-petition';
+
+import { faker } from '@faker-js/faker';
+import { fillInCreateCaseFromPaperForm } from '../../cypress-integration/support/pages/create-paper-petition';
+import { getEnvironmentSpecificFunctions } from '../support/pages/environment-specific-factory';
+import {
   goToCreateCase,
   goToReviewCase,
   saveCaseForLater,
   serveCaseToIrs,
-} = require('../support/pages/create-paper-case');
-const { faker } = require('@faker-js/faker');
-const { goToMyDocumentQC } = require('../support/pages/document-qc');
+} from '../support/pages/create-paper-case';
+import { goToMyDocumentQC } from '../support/pages/document-qc';
 
 const DEFAULT_ACCOUNT_PASS = Cypress.env('DEFAULT_ACCOUNT_PASS');
 

--- a/cypress/cypress-smoketests/integration/change-address.cy.ts
+++ b/cypress/cypress-smoketests/integration/change-address.cy.ts
@@ -1,12 +1,12 @@
-const {
-  getEnvironmentSpecificFunctions,
-} = require('../support/pages/environment-specific-factory');
-const {
+import { getEnvironmentSpecificFunctions } from '../support/pages/environment-specific-factory';
+
+import {
   goToEditContactInformation,
   goToMyAccount,
   saveContactInformation,
   updateAddress1,
-} = require('../support/pages/my-account');
+} from '../support/pages/my-account';
+
 const { getUserToken, login } = getEnvironmentSpecificFunctions();
 
 const DEFAULT_ACCOUNT_PASS = Cypress.env('DEFAULT_ACCOUNT_PASS');

--- a/cypress/cypress-smoketests/integration/court-issued-documents.cy.ts
+++ b/cypress/cypress-smoketests/integration/court-issued-documents.cy.ts
@@ -1,4 +1,4 @@
-const {
+import {
   addDocketEntryForOrderAndSaveForLater,
   addDocketEntryForOrderAndServePaper,
   addDocketEntryForUploadedPdfAndServe,
@@ -10,8 +10,9 @@ const {
   reviewAndServePetition,
   serveCourtIssuedDocketEntry,
   uploadCourtIssuedDocPdf,
-} = require('../support/pages/case-detail');
-const {
+} from '../support/pages/case-detail';
+
+import {
   completeWizardStep1,
   completeWizardStep2,
   completeWizardStep3,
@@ -26,20 +27,17 @@ const {
   goToWizardStep5,
   hasIrsNotice,
   submitPetition,
-} = require('../support/pages/create-electronic-petition');
-const {
-  fillInCreateCaseFromPaperForm,
-} = require('../../cypress-integration/support/pages/create-paper-petition');
-const {
-  getEnvironmentSpecificFunctions,
-} = require('../support/pages/environment-specific-factory');
-const {
+} from '../support/pages/create-electronic-petition';
+
+import { faker } from '@faker-js/faker';
+import { fillInCreateCaseFromPaperForm } from '../../cypress-integration/support/pages/create-paper-petition';
+import { getEnvironmentSpecificFunctions } from '../support/pages/environment-specific-factory';
+import {
   goToCreateCase,
   goToReviewCase,
   serveCaseToIrs,
-} = require('../support/pages/create-paper-case');
-const { faker } = require('@faker-js/faker');
-const { goToMyDocumentQC } = require('../support/pages/document-qc');
+} from '../support/pages/create-paper-case';
+import { goToMyDocumentQC } from '../support/pages/document-qc';
 
 let token = null;
 const testData = {};

--- a/cypress/cypress-smoketests/integration/create-trial-session.cy.ts
+++ b/cypress/cypress-smoketests/integration/create-trial-session.cy.ts
@@ -42,6 +42,7 @@ import {
   runTrialSessionPlanningReport,
   viewBlockedCaseOnBlockedReport,
 } from '../support/pages/reports';
+import { waitForElasticsearch } from '../support/helpers';
 
 const DEFAULT_ACCOUNT_PASS = Cypress.env('DEFAULT_ACCOUNT_PASS');
 
@@ -221,7 +222,7 @@ describe('Petitions Clerk', () => {
       // enough time has elapsed since we blocked second case. look for it on blocked cases report
       // warning: if there are elasticsearch delays, this test might be brittle...
       // view blocked report
-      cy.waitForElasticsearch();
+      waitForElasticsearch();
       viewBlockedCaseOnBlockedReport({
         ...testData,
         docketNumber: secondDocketNumber,

--- a/cypress/cypress-smoketests/integration/create-trial-session.cy.ts
+++ b/cypress/cypress-smoketests/integration/create-trial-session.cy.ts
@@ -1,4 +1,4 @@
-const {
+import {
   blockCaseFromTrial,
   goToCaseOverview,
   manuallyAddCaseToCalendaredTrialSession,
@@ -7,8 +7,9 @@ const {
   setCaseAsHighPriority,
   setCaseAsReadyForTrial,
   unblockCaseFromTrial,
-} = require('../support/pages/case-detail');
-const {
+} from '../support/pages/case-detail';
+
+import {
   completeWizardStep1,
   completeWizardStep2,
   completeWizardStep3,
@@ -23,8 +24,9 @@ const {
   goToWizardStep5,
   hasIrsNotice,
   submitPetition,
-} = require('../support/pages/create-electronic-petition');
-const {
+} from '../support/pages/create-electronic-petition';
+
+import {
   createTrialSession,
   goToCreateTrialSession,
   goToTrialSession,
@@ -32,15 +34,14 @@ const {
   markCaseAsQcCompleteForTrial,
   setTrialSessionAsCalendared,
   verifyOpenCaseOnTrialSession,
-} = require('../support/pages/trial-sessions');
-const {
-  getEnvironmentSpecificFunctions,
-} = require('../support/pages/environment-specific-factory');
-const {
+} from '../support/pages/trial-sessions';
+
+import { faker } from '@faker-js/faker';
+import { getEnvironmentSpecificFunctions } from '../support/pages/environment-specific-factory';
+import {
   runTrialSessionPlanningReport,
   viewBlockedCaseOnBlockedReport,
-} = require('../support/pages/reports');
-const { faker } = require('@faker-js/faker');
+} from '../support/pages/reports';
 
 const DEFAULT_ACCOUNT_PASS = Cypress.env('DEFAULT_ACCOUNT_PASS');
 

--- a/cypress/cypress-smoketests/integration/search.cy.ts
+++ b/cypress/cypress-smoketests/integration/search.cy.ts
@@ -20,6 +20,7 @@ import {
   serveCaseToIrs,
 } from '../support/pages/create-paper-case';
 import { goToMyDocumentQC } from '../support/pages/document-qc';
+import { waitForElasticsearch } from '../support/helpers';
 
 const barNumberToSearchBy = 'PT1234';
 let testData = {};
@@ -49,7 +50,7 @@ describe('Create and serve a case to search for', () => {
     fillInCreateCaseFromPaperForm(testData);
     goToReviewCase(testData);
     serveCaseToIrs();
-    cy.waitForElasticsearch();
+    waitForElasticsearch();
   });
 });
 
@@ -118,7 +119,7 @@ describe('Opinion Search', () => {
     goToCaseDetail(testData.createdPaperDocketNumber);
     createOpinion();
     addDocketEntryAndServeOpinion(testData);
-    cy.waitForElasticsearch();
+    waitForElasticsearch();
   });
 
   it('should be able to search for an opinion by keyword', () => {

--- a/cypress/cypress-smoketests/integration/search.cy.ts
+++ b/cypress/cypress-smoketests/integration/search.cy.ts
@@ -1,28 +1,25 @@
-const {
+import {
   addDocketEntryAndServeOpinion,
   createOpinion,
+  goToOpinionSearch,
   gotoAdvancedPractitionerSearch,
   gotoAdvancedSearch,
-  goToOpinionSearch,
   searchByDocketNumber,
   searchByPetitionerName,
-  searchByPractitionerbarNumber,
   searchByPractitionerName,
+  searchByPractitionerbarNumber,
   searchOpinionByKeyword,
-} = require('../support/pages/advanced-search');
-const {
-  fillInCreateCaseFromPaperForm,
-} = require('../../cypress-integration/support/pages/create-paper-petition');
-const {
-  getEnvironmentSpecificFunctions,
-} = require('../support/pages/environment-specific-factory');
-const {
+} from '../support/pages/advanced-search';
+
+import { fillInCreateCaseFromPaperForm } from '../../cypress-integration/support/pages/create-paper-petition';
+import { getEnvironmentSpecificFunctions } from '../support/pages/environment-specific-factory';
+import { goToCaseDetail } from '../support/pages/case-detail';
+import {
   goToCreateCase,
   goToReviewCase,
   serveCaseToIrs,
-} = require('../support/pages/create-paper-case');
-const { goToCaseDetail } = require('../support/pages/case-detail');
-const { goToMyDocumentQC } = require('../support/pages/document-qc');
+} from '../support/pages/create-paper-case';
+import { goToMyDocumentQC } from '../support/pages/document-qc';
 
 const barNumberToSearchBy = 'PT1234';
 let testData = {};

--- a/cypress/cypress-smoketests/support/commands.ts
+++ b/cypress/cypress-smoketests/support/commands.ts
@@ -8,12 +8,6 @@ Cypress.Commands.add('goToRoute', (...args) => {
   });
 });
 
-Cypress.Commands.add('waitForElasticsearch', () => {
-  const ES_WAIT_TIME = 5000;
-  /* eslint-disable cypress/no-unnecessary-waiting */
-  return cy.wait(ES_WAIT_TIME);
-});
-
 Cypress.Commands.add('waitUntilSettled', (maxTries = 20) => {
   let didDOMChange = false;
   let consecutiveIdleCallbacksWithUnchangedDOM = 0;

--- a/cypress/cypress-smoketests/support/helpers.ts
+++ b/cypress/cypress-smoketests/support/helpers.ts
@@ -1,0 +1,5 @@
+export const waitForElasticsearch = () => {
+  const ES_WAIT_TIME = 5000;
+  /* eslint-disable cypress/no-unnecessary-waiting */
+  return cy.wait(ES_WAIT_TIME);
+};

--- a/cypress/cypress-smoketests/support/pages/advanced-search.ts
+++ b/cypress/cypress-smoketests/support/pages/advanced-search.ts
@@ -1,63 +1,63 @@
-const { faker } = require('@faker-js/faker');
+import { faker } from '@faker-js/faker';
 
 faker.seed(faker.datatype.number());
 
-exports.gotoAdvancedSearch = () => {
+export const gotoAdvancedSearch = () => {
   cy.get('a.advanced').click();
 };
 
-exports.gotoAdvancedPractitionerSearch = () => {
+export const gotoAdvancedPractitionerSearch = () => {
   cy.get('a.advanced').click();
   cy.get('button#tab-practitioner').click();
 };
 
-exports.goToOrderSearch = () => {
+export const goToOrderSearch = () => {
   cy.get('a.advanced').click();
   cy.get('button#tab-order').click();
 };
 
-exports.goToOpinionSearch = () => {
+export const goToOpinionSearch = () => {
   cy.get('a.advanced').click();
   cy.get('button#tab-opinion').click();
 };
 
-exports.searchByPetitionerName = petitionerName => {
+export const searchByPetitionerName = petitionerName => {
   cy.get('input#petitioner-name').clear().type(petitionerName);
   cy.get('button#advanced-search-button').click();
   cy.get('table.search-results').should('exist');
 };
 
-exports.searchByDocketNumber = docketNumber => {
+export const searchByDocketNumber = docketNumber => {
   cy.get('input#docket-number').clear().type(docketNumber);
   cy.get('button#docket-search-button').click();
   cy.url().should('contain', docketNumber);
 };
 
-exports.searchByPractitionerName = () => {
+export const searchByPractitionerName = () => {
   cy.get('input#practitioner-name').clear().type('test');
   cy.get('button#practitioner-search-by-name-button').click();
   cy.get('table.search-results').should('exist');
 };
 
-exports.searchByPractitionerbarNumber = barNumber => {
+export const searchByPractitionerbarNumber = barNumber => {
   cy.get('input#bar-number').clear().type(barNumber);
   cy.get('button.advanced-search__button').eq(1).click();
   cy.url().should('contain', barNumber);
 };
 
-exports.searchOrderByKeyword = keyword => {
+export const searchOrderByKeyword = keyword => {
   cy.get('input#keyword-search').clear().type(keyword);
   cy.get('button#advanced-search-button').click();
   cy.get('table.search-results').should('exist');
 };
 
-exports.searchOpinionByKeyword = keyword => {
+export const searchOpinionByKeyword = keyword => {
   cy.get('input#keyword-search').clear().type(keyword);
   cy.get('button#advanced-search-button').click();
   cy.get('table.search-results').should('exist');
 };
 
-exports.createOpinion = () => {
+export const createOpinion = () => {
   cy.get('#case-detail-menu-button').click();
   cy.get('#menu-button-upload-pdf').click();
   cy.get('#upload-description').type('A Smoketest Opinion');
@@ -65,7 +65,7 @@ exports.createOpinion = () => {
   cy.get('#save-uploaded-pdf-button').scrollIntoView().click();
 };
 
-exports.addDocketEntryAndServeOpinion = testData => {
+export const addDocketEntryAndServeOpinion = testData => {
   cy.get('div.document-viewer--documents-list:last-child').click();
   cy.get('#add-court-issued-docket-entry-button').click();
   cy.url().should('contain', '/add-court-issued-docket-entry');

--- a/cypress/cypress-smoketests/support/pages/case-detail.ts
+++ b/cypress/cypress-smoketests/support/pages/case-detail.ts
@@ -1,20 +1,18 @@
-const {
-  CASE_STATUS_TYPES,
-} = require('../../../../shared/src/business/entities/EntityConstants');
-const { faker } = require('@faker-js/faker');
+import { CASE_STATUS_TYPES } from '../../../../shared/src/business/entities/EntityConstants';
+import { faker } from '@faker-js/faker';
 
 faker.seed(faker.datatype.number());
 
 const EFCMS_DOMAIN = Cypress.env('EFCMS_DOMAIN');
 const DEPLOYING_COLOR = Cypress.env('DEPLOYING_COLOR');
 
-exports.goToCaseDetail = docketNumber => {
+export const goToCaseDetail = docketNumber => {
   cy.get('#search-field').clear().type(docketNumber);
   cy.get('.ustc-search-button').click();
   cy.get(`.big-blue-header h1 a:contains("${docketNumber}")`).should('exist');
 };
 
-exports.goToCaseOverview = docketNumber => {
+export const goToCaseOverview = docketNumber => {
   // first visit / because if this step fails and has to be rerun, cerebral will
   // not see it as a new page visit when routing to the same route again and the page
   // will not reload
@@ -29,7 +27,7 @@ exports.goToCaseOverview = docketNumber => {
   cy.get('.internal-information').should('exist');
 };
 
-exports.createOrder = docketNumber => {
+export const createOrder = docketNumber => {
   cy.goToRoute(
     `/case-detail/${docketNumber}/create-order?documentTitle=Order to Show Cause&documentType=Order to Show Cause&eventCode=OSC`,
   );
@@ -41,7 +39,7 @@ exports.createOrder = docketNumber => {
   cy.url().should('not.contain', '/sign');
 };
 
-exports.editAndSignOrder = () => {
+export const editAndSignOrder = () => {
   cy.get('#draft-edit-button-not-signed').click();
   cy.url().should('contain', '/edit-order');
   cy.get('.ql-editor').type('edited');
@@ -52,7 +50,7 @@ exports.editAndSignOrder = () => {
   cy.url().should('not.contain', '/sign');
 };
 
-exports.addDocketEntryForOrderAndSaveForLater = attempt => {
+export const addDocketEntryForOrderAndSaveForLater = attempt => {
   cy.get('#add-court-issued-docket-entry-button').click();
   cy.url().should('contain', '/add-court-issued-docket-entry');
   cy.get('#free-text').clear().type(` ${attempt}`);
@@ -63,14 +61,14 @@ exports.addDocketEntryForOrderAndSaveForLater = attempt => {
   cy.get('span:contains("Not served")').should('exist');
 };
 
-exports.serveCourtIssuedDocketEntry = () => {
+export const serveCourtIssuedDocketEntry = () => {
   cy.get('button:contains("Serve")').click();
   cy.get('.modal-button-confirm').click();
   cy.get('h3:contains("Order to Show Cause")').should('exist');
   cy.get('div:contains("Served")').should('exist');
 };
 
-exports.addDocketEntryForOrderAndServePaper = () => {
+export const addDocketEntryForOrderAndServePaper = () => {
   cy.get('#add-court-issued-docket-entry-button').click();
   cy.url().should('contain', '/add-court-issued-docket-entry');
   cy.get('#serve-to-parties-btn').click();
@@ -83,7 +81,7 @@ exports.addDocketEntryForOrderAndServePaper = () => {
   cy.get('div:contains("Served")').should('exist');
 };
 
-exports.addDocketEntryForUploadedPdfAndServe = () => {
+export const addDocketEntryForUploadedPdfAndServe = () => {
   cy.get('#add-court-issued-docket-entry-button').click();
   cy.url().should('contain', '/add-court-issued-docket-entry');
   cy.get('div#document-type').type('Miscellaneous{enter}');
@@ -95,7 +93,7 @@ exports.addDocketEntryForUploadedPdfAndServe = () => {
   cy.get('div:contains("Served")').should('exist');
 };
 
-exports.addDocketEntryForUploadedPdfAndServePaper = () => {
+export const addDocketEntryForUploadedPdfAndServePaper = () => {
   cy.get('#add-court-issued-docket-entry-button').click();
   cy.url().should('contain', '/add-court-issued-docket-entry');
   cy.get('div#document-type').type('Miscellaneous{enter}');
@@ -110,7 +108,7 @@ exports.addDocketEntryForUploadedPdfAndServePaper = () => {
   cy.get('div:contains("Served")').should('exist');
 };
 
-exports.uploadCourtIssuedDocPdf = () => {
+export const uploadCourtIssuedDocPdf = () => {
   cy.get('#case-detail-menu-button').click();
   cy.get('#menu-button-upload-pdf').click();
   cy.url().should('contain', '/upload-court-issued');
@@ -118,7 +116,7 @@ exports.uploadCourtIssuedDocPdf = () => {
   cy.get('input#primary-document-file').attachFile('../fixtures/w3-dummy.pdf');
 };
 
-exports.reviewAndServePetition = () => {
+export const reviewAndServePetition = () => {
   cy.get('#tab-document-view').click();
   cy.get('a:contains("Review and Serve Petition")').click();
   cy.get('button#tab-irs-notice').click();
@@ -129,13 +127,13 @@ exports.reviewAndServePetition = () => {
   cy.get('.usa-alert:contains("Petition served")').should('exist');
 };
 
-exports.clickSaveUploadedPdfButton = () => {
+export const clickSaveUploadedPdfButton = () => {
   cy.get('#save-uploaded-pdf-button').click();
   cy.get('h1:contains("Drafts")').should('exist');
   cy.get('h3:contains("An Uploaded PDF")').should('exist');
 };
 
-exports.manuallyAddCaseToNewTrialSession = trialSessionId => {
+export const manuallyAddCaseToNewTrialSession = trialSessionId => {
   cy.get('#add-to-trial-session-btn').should('exist').click();
   cy.get('label[for="show-all-locations-true"]').click();
   cy.get('select#trial-session')
@@ -146,7 +144,7 @@ exports.manuallyAddCaseToNewTrialSession = trialSessionId => {
   cy.get('h3:contains("Trial - Scheduled")').should('exist');
 };
 
-exports.manuallyAddCaseToCalendaredTrialSession = trialSessionId => {
+export const manuallyAddCaseToCalendaredTrialSession = trialSessionId => {
   cy.get('#add-to-trial-session-btn').should('exist').click();
   cy.get('label[for="show-all-locations-true"]').click();
   cy.get('select#trial-session')
@@ -156,7 +154,7 @@ exports.manuallyAddCaseToCalendaredTrialSession = trialSessionId => {
   cy.get('.usa-alert--success').should('contain', 'Case set for trial.');
 };
 
-exports.removeCaseFromTrialSession = () => {
+export const removeCaseFromTrialSession = () => {
   cy.get('#edit-case-trial-information-btn').should('exist').click();
   cy.get('#remove-from-trial-session-btn').should('exist').click();
   cy.get('#disposition').type(faker.company.catchPhrase());
@@ -165,20 +163,20 @@ exports.removeCaseFromTrialSession = () => {
   cy.get('.usa-alert--success').should('contain', 'Case removed from trial.');
 };
 
-exports.blockCaseFromTrial = () => {
+export const blockCaseFromTrial = () => {
   cy.get('#tabContent-overview .block-from-trial-btn').click();
   cy.get('.modal-dialog #reason').type(faker.company.catchPhrase());
   cy.get('.modal-dialog .modal-button-confirm').click();
   cy.contains('Blocked From Trial').should('exist');
 };
 
-exports.unblockCaseFromTrial = () => {
+export const unblockCaseFromTrial = () => {
   cy.get('#remove-block').click();
   cy.get('.modal-button-confirm').click();
   cy.contains('Block removed.').should('exist');
 };
 
-exports.setCaseAsHighPriority = () => {
+export const setCaseAsHighPriority = () => {
   cy.get('.high-priority-btn').click();
   cy.get('#reason').type(faker.company.catchPhrase());
   cy.get('.modal-button-confirm').click();
@@ -186,7 +184,7 @@ exports.setCaseAsHighPriority = () => {
   cy.contains('High Priority').should('exist');
 };
 
-exports.setCaseAsReadyForTrial = () => {
+export const setCaseAsReadyForTrial = () => {
   cy.get('#menu-edit-case-context-button').click();
   cy.get('#caseStatus').select(CASE_STATUS_TYPES.generalDocketReadyForTrial);
   cy.get('.modal-button-confirm').click();
@@ -194,7 +192,7 @@ exports.setCaseAsReadyForTrial = () => {
   cy.contains(CASE_STATUS_TYPES.generalDocketReadyForTrial).should('exist');
 };
 
-exports.viewPrintableDocketRecord = () => {
+export const viewPrintableDocketRecord = () => {
   cy.get('button#printable-docket-record-button').click();
 
   cy.get('a.modal-button-confirm')

--- a/cypress/cypress-smoketests/support/pages/create-electronic-petition.ts
+++ b/cypress/cypress-smoketests/support/pages/create-electronic-petition.ts
@@ -1,47 +1,47 @@
-const { faker } = require('@faker-js/faker');
+import { faker } from '@faker-js/faker';
 
-exports.hasIrsNotice = {
+export const hasIrsNotice = {
   NO: 1,
   YES: 0,
 };
 
-exports.filingTypes = {
+export const filingTypes = {
   BUSINESS: 2,
   INDIVIDUAL: 0,
   OTHER: 3,
   PETITIONER_AND_SPOUSE: 1,
 };
 
-exports.goToStartCreatePetition = () => {
+export const goToStartCreatePetition = () => {
   cy.get('a#file-a-petition').click();
 };
 
-exports.goToWizardStep1 = () => {
+export const goToWizardStep1 = () => {
   cy.get('a[href*="file-a-petition/step-1"]').click();
   cy.url().should('contain', '/file-a-petition/step-1');
 };
 
-exports.goToWizardStep2 = () => {
+export const goToWizardStep2 = () => {
   cy.get('button#submit-case').click();
   cy.url().should('contain', '/file-a-petition/step-2');
 };
 
-exports.goToWizardStep3 = () => {
+export const goToWizardStep3 = () => {
   cy.get('button#submit-case').click();
   cy.url().should('contain', '/file-a-petition/step-3');
 };
 
-exports.goToWizardStep4 = () => {
+export const goToWizardStep4 = () => {
   cy.get('button#submit-case').click();
   cy.url().should('contain', '/file-a-petition/step-4');
 };
 
-exports.goToWizardStep5 = () => {
+export const goToWizardStep5 = () => {
   cy.get('button#submit-case').click();
   cy.url().should('contain', '/file-a-petition/step-5');
 };
 
-exports.submitPetition = testData => {
+export const submitPetition = testData => {
   cy.get('button#submit-case').scrollIntoView().click();
 
   cy.intercept('POST', '**/cases').as('postCase');
@@ -58,23 +58,23 @@ exports.submitPetition = testData => {
   cy.url().should('include', 'file-a-petition/success');
 };
 
-exports.goToDashboard = () => {
+export const goToDashboard = () => {
   cy.get('a#button-back-to-dashboard').click();
 };
 
-exports.completeWizardStep1 = () => {
+export const completeWizardStep1 = () => {
   cy.get('input#stin-file').attachFile('../fixtures/w3-dummy.pdf');
 };
 
-exports.completeWizardStep2 = (hasIrsNotice, caseType) => {
+export const completeWizardStep2 = (hasIrsNoticeInput, caseType) => {
   cy.screenshot();
   cy.get('input#petition-file').attachFile('../fixtures/w3-dummy.pdf');
   cy.get('#irs-notice-radios').scrollIntoView();
-  cy.get(`label#hasIrsNotice-${hasIrsNotice}`).click();
+  cy.get(`label#hasIrsNotice-${hasIrsNoticeInput}`).click();
   cy.get('#case-type').scrollIntoView().select(caseType);
 };
 
-exports.completeWizardStep3 = (filingType, petitionerName) => {
+export const completeWizardStep3 = (filingType, petitionerName) => {
   cy.get(`label#filing-type-${filingType}`).scrollIntoView().click();
 
   if (filingType === exports.filingTypes.PETITIONER_AND_SPOUSE) {
@@ -107,7 +107,7 @@ exports.completeWizardStep3 = (filingType, petitionerName) => {
   cy.get('input#phone').scrollIntoView().type(faker.phone.number());
 };
 
-exports.completeWizardStep4 = () => {
+export const completeWizardStep4 = () => {
   cy.get('label#procedure-type-0').scrollIntoView().click();
   cy.get('#preferred-trial-city').scrollIntoView().select('Mobile, Alabama');
 };

--- a/cypress/cypress-smoketests/support/pages/create-paper-case-local.ts
+++ b/cypress/cypress-smoketests/support/pages/create-paper-case-local.ts
@@ -1,1 +1,1 @@
-exports.closeScannerSetupDialog = () => {};
+export const closeScannerSetupDialog = () => {};

--- a/cypress/cypress-smoketests/support/pages/create-paper-case.ts
+++ b/cypress/cypress-smoketests/support/pages/create-paper-case.ts
@@ -1,9 +1,9 @@
-exports.goToCreateCase = () => {
+export const goToCreateCase = () => {
   cy.get('a#file-a-petition').click();
   cy.get('.big-blue-header').should('exist');
 };
 
-exports.goToReviewCase = testData => {
+export const goToReviewCase = testData => {
   cy.intercept('POST', '**/paper').as('postPaperCase');
   cy.get('button#submit-case').scrollIntoView().click();
   cy.wait('@postPaperCase').then(({ response }) => {
@@ -15,18 +15,18 @@ exports.goToReviewCase = testData => {
   cy.get('.big-blue-header').should('exist');
 };
 
-exports.saveCaseForLater = () => {
+export const saveCaseForLater = () => {
   cy.get('button:contains("Save for Later")').click();
 };
 
-exports.serveCaseToIrs = () => {
+export const serveCaseToIrs = () => {
   cy.get('#ustc-start-a-case-form button#submit-case').scrollIntoView().click();
   cy.get('button#confirm').scrollIntoView().click();
   cy.get('.progress-indicator').should('not.exist');
   cy.get('.big-blue-header').should('exist');
 };
 
-exports.closeScannerSetupDialog = () => {
+export const closeScannerSetupDialog = () => {
   cy.intercept('dynamsoft.webtwain.install.js?t=*').as('getDynamsoft');
   cy.wait('@getDynamsoft');
   // the dynamsoft popup doesn't show immediately after the last script has been downloaded

--- a/cypress/cypress-smoketests/support/pages/document-qc.ts
+++ b/cypress/cypress-smoketests/support/pages/document-qc.ts
@@ -1,17 +1,17 @@
-exports.goToMyDocumentQC = () => {
+export const goToMyDocumentQC = () => {
   cy.get('a[href*="document-qc/my/inbox"]').click();
   cy.get('.big-blue-header').should('exist');
 };
 
-exports.goToSectionDocumentQC = () => {
+export const goToSectionDocumentQC = () => {
   cy.get('button:contains("Switch to Section Document QC")').click();
 };
 
-exports.goToPetitionNeedingQC = () => {
+export const goToPetitionNeedingQC = () => {
   cy.get('a[href*="petition-qc"]').first().click();
 };
 
-exports.goToPetitionNeedingQCByCaseTitle = caseTitle => {
+export const goToPetitionNeedingQCByCaseTitle = caseTitle => {
   cy.get(`td:contains(${caseTitle})`)
     .first()
     .parent()
@@ -19,35 +19,35 @@ exports.goToPetitionNeedingQCByCaseTitle = caseTitle => {
     .click();
 };
 
-exports.goToReviewPetition = () => {
+export const goToReviewPetition = () => {
   cy.get('button#submit-case').click();
 };
 
-exports.savePetitionForLater = () => {
+export const savePetitionForLater = () => {
   cy.get('button:contains("Save for Later")').click();
 
   cy.get('div.usa-alert--success').should('exist');
 };
 
-exports.selectTab = tabName => {
+export const selectTab = tabName => {
   cy.get(`button#tab-${tabName}`).click();
 };
 
-exports.selectCaseType = caseType => {
+export const selectCaseType = caseType => {
   cy.get('#case-type').scrollIntoView().select(caseType);
 };
 
-exports.addStatistic = (year, deficiencyAmount, totalPenalties) => {
+export const addStatistic = (year, deficiencyAmount, totalPenalties) => {
   cy.get('input[id^=year-]').last().type(year);
   cy.get('input[id^=deficiency-amount-]').last().type(deficiencyAmount);
   cy.get('input[id^=total-penalties-]').last().type(totalPenalties);
 };
 
-exports.servePetition = () => {
+export const servePetition = () => {
   cy.get('#ustc-start-a-case-form button#submit-case').scrollIntoView().click();
 };
 
-exports.confirmServePetition = () => {
+export const confirmServePetition = () => {
   cy.get('button#confirm').click();
 
   cy.get('div.usa-alert--success').should('exist');

--- a/cypress/cypress-smoketests/support/pages/environment-specific-factory.ts
+++ b/cypress/cypress-smoketests/support/pages/environment-specific-factory.ts
@@ -1,23 +1,21 @@
-const {
-  closeScannerSetupDialog: closeScannerSetupDialogDeployed,
-} = require('./create-paper-case');
-const {
-  closeScannerSetupDialog: closeScannerSetupDialogLocal,
-} = require('./create-paper-case-local');
-const {
-  getRestApi: getRestApiDeployed,
-  getUserToken: getUserTokenDeployed,
-  login: loginDeployed,
-} = require('./login');
-const {
-  getRestApi: getRestApiLocal,
-  getUserToken: getUserTokenLocal,
-  login: loginLocal,
-} = require('./local-login');
+import { closeScannerSetupDialog as closeScannerSetupDialogDeployed } from './create-paper-case';
+import { closeScannerSetupDialog as closeScannerSetupDialogLocal } from './create-paper-case-local';
+
+import {
+  getRestApi as getRestApiDeployed,
+  getUserToken as getUserTokenDeployed,
+  login as loginDeployed,
+} from './login';
+
+import {
+  getRestApi as getRestApiLocal,
+  getUserToken as getUserTokenLocal,
+  login as loginLocal,
+} from './local-login';
 
 const SMOKETESTS_LOCAL = Cypress.env('SMOKETESTS_LOCAL');
 
-exports.getEnvironmentSpecificFunctions = () => {
+export const getEnvironmentSpecificFunctions = () => {
   if (SMOKETESTS_LOCAL) {
     return {
       closeScannerSetupDialog: closeScannerSetupDialogLocal,

--- a/cypress/cypress-smoketests/support/pages/local-login.ts
+++ b/cypress/cypress-smoketests/support/pages/local-login.ts
@@ -1,4 +1,4 @@
-exports.getUserToken = async username => {
+export const getUserToken = async username => {
   if (username === 'migrator@example.com') {
     username =
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImFkbWluIiwibmFtZSI6IlRlc3QgQWRtaW4iLCJyb2xlIjoiYWRtaW4iLCJ1c2VySWQiOiI4NmMzZjg3Yi0zNTBiLTQ3N2QtOTJjMy00M2JkMDk1Y2IwMDYiLCJjdXN0b206cm9sZSI6ImFkbWluIiwic3ViIjoiODZjM2Y4N2ItMzUwYi00NzdkLTkyYzMtNDNiZDA5NWNiMDA2IiwiaWF0IjoxNTgyOTIxMTI1fQ.PBmSyb6_E_53FNG0GiEpAFqTNmooSh4rI0ApUQt3UH8';
@@ -10,12 +10,12 @@ exports.getUserToken = async username => {
   };
 };
 
-exports.login = email => {
+export const login = email => {
   cy.visit(`/log-in?code=${email}`);
   cy.get('.progress-indicator').should('not.exist');
   cy.get('.big-blue-header').should('exist');
 };
 
-exports.getRestApi = async () => {
+export const getRestApi = async () => {
   return 'localhost:4000';
 };

--- a/cypress/cypress-smoketests/support/pages/login.ts
+++ b/cypress/cypress-smoketests/support/pages/login.ts
@@ -1,4 +1,4 @@
-const AWS = require('aws-sdk');
+import AWS from 'aws-sdk';
 
 const awsRegion = 'us-east-1';
 
@@ -16,7 +16,7 @@ const cognito = new AWS.CognitoIdentityServiceProvider({
   region: 'us-east-1',
 });
 
-exports.confirmUser = async ({ email }) => {
+export const confirmUser = async ({ email }) => {
   const userPoolId = await getUserPoolId();
   const clientId = await getClientId(userPoolId);
 
@@ -71,7 +71,7 @@ const getUserPoolId = async () => {
   return userPoolId;
 };
 
-exports.getUserToken = async (username, password) => {
+export const getUserToken = async (username, password) => {
   const userPoolId = await getUserPoolId();
   const clientId = await getClientId(userPoolId);
 
@@ -88,7 +88,7 @@ exports.getUserToken = async (username, password) => {
     .promise();
 };
 
-exports.login = token => {
+export const login = token => {
   cy.visit(`/log-in?token=${token}`);
 
   cy.waitUntilSettled(50);
@@ -96,7 +96,7 @@ exports.login = token => {
   cy.get('.progress-indicator').should('not.exist');
 };
 
-exports.getRestApi = async () => {
+export const getRestApi = async () => {
   let apigateway = new AWS.APIGateway({
     region: awsRegion,
   });

--- a/cypress/cypress-smoketests/support/pages/my-account.ts
+++ b/cypress/cypress-smoketests/support/pages/my-account.ts
@@ -1,15 +1,15 @@
-const { faker } = require('@faker-js/faker');
+import { faker } from '@faker-js/faker';
 
-exports.goToMyAccount = () => {
+export const goToMyAccount = () => {
   cy.get('svg.account-menu-icon').parent().parent().click();
   cy.get('button#my-account').click();
 };
 
-exports.goToEditContactInformation = () => {
+export const goToEditContactInformation = () => {
   cy.get('button.ustc-button--unstyled').contains('Edit').click();
 };
 
-exports.updateAddress1 = () => {
+export const updateAddress1 = () => {
   cy.get('.progress-indicator').should('not.exist');
   cy.contains('Edit Contact Information').should('exist');
 
@@ -18,7 +18,7 @@ exports.updateAddress1 = () => {
     .type(faker.address.streetAddress());
 };
 
-exports.saveContactInformation = () => {
+export const saveContactInformation = () => {
   cy.get('button.usa-button').contains('Save').click();
   cy.get('.progress-indicator').should('not.exist');
   cy.get('.progress-user-contact-edit').should('not.exist');

--- a/cypress/cypress-smoketests/support/pages/petitioner-dashboard.ts
+++ b/cypress/cypress-smoketests/support/pages/petitioner-dashboard.ts
@@ -1,4 +1,4 @@
-exports.goToCaseDetail = caseTitle => {
+export const goToCaseDetail = caseTitle => {
   cy.get(`td:contains(${caseTitle})`)
     .first()
     .parent()
@@ -7,24 +7,25 @@ exports.goToCaseDetail = caseTitle => {
     .click();
 };
 
-exports.goToFileADocument = () => {
+export const goToFileADocument = () => {
   cy.get('a#button-file-document').click();
 };
 
-exports.goToSelectDocumentType = () => {
+export const goToSelectDocumentType = () => {
   cy.get('a[href*="/file-a-document"]').scrollIntoView().click();
 };
 
-exports.goToFileYourDocument = () => {
+export const goToFileYourDocument = () => {
   cy.get('button#submit-document').click();
 };
-exports.goToReviewDocument = exports.goToFileYourDocument;
 
-exports.uploadDocumentFile = () => {
+export const goToReviewDocument = exports.goToFileYourDocument;
+
+export const uploadDocumentFile = () => {
   cy.get('#primary-document').attachFile('../fixtures/w3-dummy.pdf');
 };
 
-exports.submitDocument = () => {
+export const submitDocument = () => {
   cy.get('button#submit-document').click();
 
   cy.get('div.usa-alert--success').should('exist');

--- a/cypress/cypress-smoketests/support/pages/reports.ts
+++ b/cypress/cypress-smoketests/support/pages/reports.ts
@@ -1,11 +1,11 @@
-exports.viewBlockedCaseOnBlockedReport = testData => {
+export const viewBlockedCaseOnBlockedReport = testData => {
   cy.get('#reports-btn').click();
   cy.get('#all-blocked-cases').click();
   cy.get('#trial-location').select(testData.preferredTrialCity);
   cy.get(`a[href="/case-detail/${testData.docketNumber}"]`).should('exist');
 };
 
-exports.runTrialSessionPlanningReport = () => {
+export const runTrialSessionPlanningReport = () => {
   // eslint-disable-next-line @miovision/disallow-date/no-new-date
   const nextYear = new Date().getUTCFullYear() + 1;
   cy.get('#reports-btn').click();

--- a/cypress/cypress-smoketests/support/pages/trial-sessions.ts
+++ b/cypress/cypress-smoketests/support/pages/trial-sessions.ts
@@ -1,21 +1,21 @@
-const { faker } = require('@faker-js/faker');
+import { faker } from '@faker-js/faker';
 
 faker.seed(faker.datatype.number());
 
-exports.goToTrialSessions = () => {
+export const goToTrialSessions = () => {
   cy.get('a[href="/trial-sessions"]').click();
   cy.waitUntilSettled(50);
   cy.get('h1').contains('Trial Sessions').should('exist');
 };
 
-exports.goToCreateTrialSession = () => {
+export const goToCreateTrialSession = () => {
   cy.get('a[href="/add-a-trial-session"]').click();
   cy.waitUntilSettled(50);
   cy.get('h1').contains('Create Trial Session').should('exist');
   cy.waitUntilSettled(50);
 };
 
-exports.createTrialSession = (testData, overrides = {}) => {
+export const createTrialSession = (testData, overrides = {}) => {
   const createFutureDate = () => {
     const month = faker.datatype.number({ max: 12, min: 1 });
     const day = faker.datatype.number({ max: 28, min: 1 });
@@ -70,12 +70,12 @@ exports.createTrialSession = (testData, overrides = {}) => {
   });
 };
 
-exports.goToTrialSession = trialSessionId => {
+export const goToTrialSession = trialSessionId => {
   cy.goToRoute(`/trial-session-detail/${trialSessionId}`);
   cy.get('.big-blue-header').should('exist');
 };
 
-exports.setTrialSessionAsCalendared = trialSessionId => {
+export const setTrialSessionAsCalendared = trialSessionId => {
   cy.goToRoute(`/trial-session-detail/${trialSessionId}`);
   cy.get('#set-calendar-button').should('exist').click();
   cy.get('#modal-root .modal-button-confirm').click();
@@ -83,17 +83,17 @@ exports.setTrialSessionAsCalendared = trialSessionId => {
   cy.get('.progress-indicator').should('not.exist');
 };
 
-exports.markCaseAsQcCompleteForTrial = docketNumber => {
+export const markCaseAsQcCompleteForTrial = docketNumber => {
   cy.get(`#upcoming-sessions label[for="${docketNumber}-complete"]`).click();
 };
 
-exports.verifyOpenCaseOnTrialSession = docketNumber => {
+export const verifyOpenCaseOnTrialSession = docketNumber => {
   cy.get(
     `#open-cases-tab-content a[href="/case-detail/${docketNumber}"]`,
   ).should('exist');
 };
 
-exports.goToTrialSessionWorkingCopy = ({
+export const goToTrialSessionWorkingCopy = ({
   docketNumbers,
   judgeName,
   trialSessionId,
@@ -105,16 +105,19 @@ exports.goToTrialSessionWorkingCopy = ({
   });
 };
 
-exports.changeCaseTrialStatus = (docketNumber, status = 'Set for Trial') => {
+export const changeCaseTrialStatus = (
+  docketNumber,
+  status = 'Set for Trial',
+) => {
   cy.get(`#trialSessionWorkingCopy-${docketNumber}`).select(status);
 };
 
-exports.checkShowAllFilterOnWorkingCopy = trialSessionId => {
+export const checkShowAllFilterOnWorkingCopy = trialSessionId => {
   cy.goToRoute(`/trial-session-working-copy/${trialSessionId}`);
   cy.get('label[for="filters.showAll"]').click();
 };
 
-exports.filterWorkingCopyByStatus = ({
+export const filterWorkingCopyByStatus = ({
   docketNumberShouldExist,
   docketNumberShouldNotExist,
   status,
@@ -126,7 +129,7 @@ exports.filterWorkingCopyByStatus = ({
   );
 };
 
-exports.addCaseNote = (docketNumber, note) => {
+export const addCaseNote = (docketNumber, note) => {
   cy.get('.no-wrap button:contains("Add Note")').click(); //TODO #add-note-${docketNumber}
   cy.get(`h5:contains("Docket ${docketNumber}")`).should('exist');
   cy.get('#case-notes').type(note);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
     "./web-api/src/**/*",
     "./shared/src/**/*",
     "./web-client/src/**/*",
-    "./web-client/integration-tests/fixtures/consolidated-cases.ts"
+    "./web-client/integration-tests/fixtures/consolidated-cases.ts",
+    "./cypress/**/*.ts"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Move all cypress tests to es6 from commonjs. No functional changes.

Before this change we were not counting errors in the ./cypress folder for Typescript. Now we are. This will increase our type errors by an additional 1000 errors and cause robocop to fail :(. This will need to be merged to staging with failing robocop so we can start tracking typescript errors in cypress.