### PR TITLE
switch-colors-cron node18

### DIFF
--- a/web-api/workflow-terraform/switch-colors-cron/main/main.tf
+++ b/web-api/workflow-terraform/switch-colors-cron/main/main.tf
@@ -7,7 +7,7 @@ terraform {
   }
 
   required_providers {
-    aws = "3.75.2"
+    aws = "3.76.0"
   }
 }
 


### PR DESCRIPTION
bump aws terraform provider version to 3.76.0 for the switch-colors-cron terraform so the lambda can use node 18