### PR TITLE
Provide full URL for GitHub Pages link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Documentation
 
-**To get a better understanding of Dawson, head over to the [main documentation page](ustaxcourt.github.io/ef-cms/).**
+**To get a better understanding of Dawson, head over to the [main documentation page](https://ustaxcourt.github.io/ef-cms/#/).**
 Our documentation should help give you a better understanding of what Dawson is and how you can contribute.
 
 ### Project status


### PR DESCRIPTION
# The Problem

The `main documentation page` link in README.md did not properly navigate to the Docsify hosted by GitHub Pages.

# The Solution

Provide the full URL. This was tested on my fork on the `test-link` branch, which can be found [here](https://github.com/jamesobrooks/ef-cms/tree/test-link#documentation).