### PR TITLE
devex: js files that import utils.ts need to run in ts-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,10 +82,10 @@
     "winston": "^3.8.2"
   },
   "scripts": {
-    "admin:create-user": "node shared/admin-tools/user/add-user.js",
-    "admin:become-user": "node shared/admin-tools/glue/become-user.js",
-    "admin:lookup-user": "node shared/admin-tools/glue/lookup-user.js",
-    "admin:resend-service-email-to-irs-superuser": "node shared/admin-tools/email/resend-service-email-to-irs-superuser.js",
+    "admin:create-user": "npx ts-node --transpile-only shared/admin-tools/user/add-user.js",
+    "admin:become-user": "npx ts-node --transpile-only shared/admin-tools/glue/become-user.js",
+    "admin:lookup-user": "npx ts-node --transpile-only shared/admin-tools/glue/lookup-user.js",
+    "admin:resend-service-email-to-irs-superuser": "npx ts-node --transpile-only shared/admin-tools/email/resend-service-email-to-irs-superuser.js",
     "backup:dynamo-table": "./scripts/dynamo/backup-dynamo-table.sh",
     "build:all": "npm run clean && npm run build:assets && npm run build:client",
     "build:assets": "node shared/createModule.js",
@@ -137,7 +137,7 @@
     "docs": "npx docsify-cli serve ./docs",
     "dynamo:admin": "AWS_ACCESS_KEY_ID=S3RVER AWS_SECRET_ACCESS_KEY=S3RVER DYNAMO_ENDPOINT=http://localhost:8000 dynamodb-admin",
     "dynamo:export": "AWS_ACCESS_KEY_ID=S3RVER AWS_SECRET_ACCESS_KEY=S3RVER SLS_DEPLOYMENT_BUCKET=noop ts-node --transpile-only web-api/dynamo-export.js > ./web-api/storage/fixtures/efcms-export.json",
-    "dynamo:import": "node ./web-api/create-dynamo-tables.js && ts-node ./web-api/seed-dynamo.ts ./storage/fixtures/efcms-export.json",
+    "dynamo:import": "npx ts-node --transpile-only ./web-api/create-dynamo-tables.js && npx ts-node --transpile-only ./web-api/seed-dynamo.ts ./storage/fixtures/efcms-export.json",
     "init:api": "cd web-api/terraform/main && ../bin/deploy-init.sh",
     "init:ui": "cd web-client/terraform/main && ../bin/deploy-init.sh",
     "lint:css:fix": "npm run lint:css -- --fix",


### PR DESCRIPTION
Scripts in `package.json` that depend directly or transitively on `utils` need to be called with `npx ts-node` now that `utils` has been converted to typescript. This PR addresses that, as well as fixes a typo/bug in the `dynamo:import` script.