### PR TITLE
devex: Make typescript error count log be accurate.

### DIFF
--- a/scripts/compareTypescriptErrors.ts
+++ b/scripts/compareTypescriptErrors.ts
@@ -65,7 +65,7 @@ const stagingCypressErrorCount = countTypescriptErrors(
 const stagingTotalErrors: number =
   stagingProjectErrorCount + stagingCypressErrorCount;
 
-console.log('Staging errors: ', stagingProjectErrorCount);
+console.log('Staging errors: ', stagingTotalErrors);
 console.log('Your branch errors: ', compareBranchTotalErrors);
 if (compareBranchTotalErrors > stagingTotalErrors) {
   console.log(


### PR DESCRIPTION
When console logging robocop was outputting only a subsection of the errors. 

The logic was always working well, just logging incorrectly.