### PR TITLE
9785 add consolidation icons to deadlines report intermediate to test

### DIFF
--- a/shared/src/business/entities/CaseDeadline.test.ts
+++ b/shared/src/business/entities/CaseDeadline.test.ts
@@ -24,6 +24,20 @@ describe('CaseDeadline', () => {
           deadlineDate: '2019-03-01T21:42:29.073Z',
           description: 'One small step',
           docketNumber: DOCKET_NUMBER,
+          leadDocketNumber: DOCKET_NUMBER,
+        },
+        { applicationContext },
+      );
+      expect(caseDeadline.getFormattedValidationErrors()).toEqual(null);
+    });
+
+    it('should be valid when all fields are present except for leadDocketNumber', () => {
+      const caseDeadline = new CaseDeadline(
+        {
+          associatedJudge: 'Judge Buch',
+          deadlineDate: '2019-03-01T21:42:29.073Z',
+          description: 'One small step',
+          docketNumber: DOCKET_NUMBER,
         },
         { applicationContext },
       );

--- a/shared/src/business/entities/CaseDeadline.ts
+++ b/shared/src/business/entities/CaseDeadline.ts
@@ -13,6 +13,7 @@ export class CaseDeadline extends JoiValidationEntity {
   public docketNumber: string;
   public sortableDocketNumber: string;
   public entityName: string;
+  public leadDocketNumber?: string;
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   constructor(rawProps, { applicationContext }) {
@@ -29,6 +30,7 @@ export class CaseDeadline extends JoiValidationEntity {
     this.deadlineDate = rawProps.deadlineDate;
     this.description = rawProps.description;
     this.docketNumber = rawProps.docketNumber;
+    this.leadDocketNumber = rawProps.leadDocketNumber;
     // TODO: why is this if statement here
     if (this.docketNumber) {
       this.sortableDocketNumber = Case.getSortableDocketNumber(
@@ -81,6 +83,7 @@ export class CaseDeadline extends JoiValidationEntity {
       ),
       entityName:
         JoiValidationConstants.STRING.valid('CaseDeadline').required(),
+      leadDocketNumber: JoiValidationConstants.DOCKET_NUMBER.optional(),
       sortableDocketNumber: joi
         .number()
         .required()

--- a/shared/src/business/useCases/caseDeadline/createCaseDeadlineInteractor.ts
+++ b/shared/src/business/useCases/caseDeadline/createCaseDeadlineInteractor.ts
@@ -6,14 +6,6 @@ import {
 } from '../../../authorization/authorizationClientService';
 import { UnauthorizedError } from '../../../errors/errors';
 
-/**
- * createCaseDeadlineInteractor
- *
- * @param {object} applicationContext the application context
- * @param {object} providers the providers object
- * @param {object} providers.caseDeadline the case deadline data
- * @returns {CaseDeadline} the created case deadline
- */
 export const createCaseDeadlineInteractor = async (
   applicationContext: IApplicationContext,
   { caseDeadline }: { caseDeadline: CaseDeadline },

--- a/shared/src/business/useCases/getCaseDeadlinesInteractor.ts
+++ b/shared/src/business/useCases/getCaseDeadlinesInteractor.ts
@@ -7,18 +7,6 @@ import {
 import { UnauthorizedError } from '../../errors/errors';
 import { pick } from 'lodash';
 
-/**
- * getCaseDeadlinesInteractor
- *
- * @param {object} applicationContext the application context
- * @param {object} providers the providers object
- * @param {string} providers.endDate the end date
- * @param {string} providers.startDate the start date
- * @param {number} providers.from the index to start from
- * @param {string} providers.judge the judge
- * @param {number} providers.pageSize the page size
- * @returns {Promise} the promise of the getCaseDeadlinesByDateRange call
- */
 export const getCaseDeadlinesInteractor = async (
   applicationContext: IApplicationContext,
   {
@@ -73,20 +61,13 @@ export const getCaseDeadlinesInteractor = async (
         'docketNumber',
         'docketNumberSuffix',
         'docketNumberWithSuffix',
+        'leadDocketNumber',
       ]),
     }));
 
   return { deadlines: afterCaseMapping, totalCount };
 };
 
-/**
- * Helper function to grab all of the cases from persistence; only return the valid cases
- *
- * @param {object} providers The providers
- * @param {object} providers.applicationContext the application context
- * @param {array}  providers.docketNumbers an array of docket numbers to retrieve from persistence
- * @returns {array} a validated array of cases
- */
 const getCasesByDocketNumbers = async ({
   applicationContext,
   docketNumbers,

--- a/shared/src/persistence/dynamo/caseDeadlines/createCaseDeadline.ts
+++ b/shared/src/persistence/dynamo/caseDeadlines/createCaseDeadline.ts
@@ -1,13 +1,5 @@
 import { put } from '../../dynamodbClientService';
 
-/**
- * createCaseDeadline
- *
- * @param {object} providers the providers object
- * @param {object} providers.applicationContext the application context
- * @param {object} providers.caseDeadline the case deadline data
- * @returns {Promise} resolves upon creation of case deadline
- */
 export const createCaseDeadline = ({
   applicationContext,
   caseDeadline,

--- a/web-api/workflow-terraform/migration/main/lambdas/migrations/0010-add-lead-docket-number-to-case-deadline.test.ts
+++ b/web-api/workflow-terraform/migration/main/lambdas/migrations/0010-add-lead-docket-number-to-case-deadline.test.ts
@@ -1,0 +1,101 @@
+import { CASE_STATUS_TYPES } from '../../../../../../shared/src/business/entities/EntityConstants';
+import { aggregateCaseItems } from '../../../../../../shared/src/persistence/dynamo/helpers/aggregateCaseItems';
+import { migrateItems } from './0010-add-lead-docket-number-to-case-deadline';
+jest.mock(
+  '../../../../../../shared/src/persistence/dynamo/helpers/aggregateCaseItems',
+);
+import { queryFullCase } from '../utilities/queryFullCase';
+jest.mock('../utilities/queryFullCase');
+
+let documentClientMock;
+const MOCK_CONSOLIDATED_CASE_RECORD = {
+  associatedJudge: 'Colvin',
+  docketNumber: '101-18',
+  docketNumberWithSuffix: '101-18',
+  entityName: 'Case',
+  leadDocketNumber: '101-18',
+  pk: 'case|101-18',
+  sk: 'case|101-18',
+  status: CASE_STATUS_TYPES.calendared,
+  trialDate: '2020-03-01T00:00:00.000Z',
+  trialLocation: 'Washington, District of Columbia',
+  trialSessionId: '7805d1ab-18d0-43ec-bafb-654e83405410',
+};
+
+const MOCK_CASE_RECORD = {
+  associatedJudge: 'Colvin',
+  docketNumber: '101-18',
+  docketNumberWithSuffix: '101-18',
+  entityName: 'Case',
+  pk: 'case|101-18',
+  sk: 'case|101-18',
+  status: CASE_STATUS_TYPES.calendared,
+  trialDate: '2020-03-01T00:00:00.000Z',
+  trialLocation: 'Washington, District of Columbia',
+  trialSessionId: '7805d1ab-18d0-43ec-bafb-654e83405410',
+};
+
+describe('migrateItems', () => {
+  it('should return and not modify records that do not have a leadDocketNUmber', async () => {
+    (queryFullCase as jest.Mock).mockResolvedValue({
+      pk: `case|${MOCK_CASE_RECORD.docketNumber}`,
+      sk: `case|${MOCK_CASE_RECORD.docketNumber}`,
+    });
+    (aggregateCaseItems as jest.Mock).mockReturnValue(MOCK_CASE_RECORD);
+
+    const mockNonConsolidatedCaseDeadlineItem = [
+      {
+        associatedJudge: MOCK_CASE_RECORD.associatedJudge,
+        caseDeadLineId: '97a214a0-437d-461b-80a9-1cfd3d669690',
+        createdAt: '2023-06-06T18:55:57.361Z',
+        deadlineDate: '2023-06-10T04:00:00.000Z',
+        description: 'test',
+        docketNumber: MOCK_CASE_RECORD.docketNumber,
+        entityName: 'CaseDeadline',
+        pk: 'case-deadline|97a214a0-437d-461b-80a9-1cfd3d669690',
+        sk: 'case-deadline|97a214a0-437d-461b-80a9-1cfd3d669690',
+        sortableDocketNumber: 2018000101,
+      },
+    ];
+
+    const results = await migrateItems(
+      mockNonConsolidatedCaseDeadlineItem,
+      documentClientMock,
+    );
+
+    expect(results).toEqual(mockNonConsolidatedCaseDeadlineItem);
+  });
+
+  it('should modify CaseDeadline when the case has a leadDocketNumber, adding the case\'s property "leadDocketNUmber" to the CaseDeadline', async () => {
+    (queryFullCase as jest.Mock).mockResolvedValue({
+      pk: `case|${MOCK_CONSOLIDATED_CASE_RECORD.docketNumber}`,
+      sk: `case|${MOCK_CONSOLIDATED_CASE_RECORD.docketNumber}`,
+    });
+    (aggregateCaseItems as jest.Mock).mockReturnValue(
+      MOCK_CONSOLIDATED_CASE_RECORD,
+    );
+
+    const mockConsolidatedCaseDeadlineItem = [
+      {
+        associatedJudge: MOCK_CONSOLIDATED_CASE_RECORD.associatedJudge,
+        caseDeadLineId: '97a214a0-437d-461b-80a9-1cfd3d669690',
+        createdAt: '2023-06-06T18:55:57.361Z',
+        deadlineDate: '2023-06-10T04:00:00.000Z',
+        description: 'test',
+        docketNumber: MOCK_CONSOLIDATED_CASE_RECORD.docketNumber,
+        entityName: 'CaseDeadline',
+        leadDocketNumber: MOCK_CONSOLIDATED_CASE_RECORD.leadDocketNumber,
+        pk: 'case-deadline|97a214a0-437d-461b-80a9-1cfd3d669690',
+        sk: 'case-deadline|97a214a0-437d-461b-80a9-1cfd3d669690',
+        sortableDocketNumber: 2018000101,
+      },
+    ];
+
+    const results = await migrateItems(
+      mockConsolidatedCaseDeadlineItem,
+      documentClientMock,
+    );
+
+    expect(results).toEqual(mockConsolidatedCaseDeadlineItem);
+  });
+});

--- a/web-api/workflow-terraform/migration/main/lambdas/migrations/0010-add-lead-docket-number-to-case-deadline.ts
+++ b/web-api/workflow-terraform/migration/main/lambdas/migrations/0010-add-lead-docket-number-to-case-deadline.ts
@@ -1,0 +1,39 @@
+import { CaseDeadline } from '../../../../../../shared/src/business/entities/CaseDeadline';
+import { aggregateCaseItems } from '../../../../../../shared/src/persistence/dynamo/helpers/aggregateCaseItems';
+import { createApplicationContext } from '../../../../../src/applicationContext';
+import { queryFullCase } from '../utilities/queryFullCase';
+
+const applicationContext = createApplicationContext({});
+
+const isCaseDeadlineItem = item => {
+  return (
+    item.pk.startsWith('case-deadline|') && item.sk.startsWith('case-deadline|')
+  );
+};
+
+export const migrateItems = async (items, documentClient) => {
+  const itemsAfter = [];
+
+  for (const item of items) {
+    if (isCaseDeadlineItem(item)) {
+      const fullCase = await queryFullCase(documentClient, item.docketNumber);
+      const caseRecord = aggregateCaseItems(fullCase);
+
+      const theCaseDeadline = new CaseDeadline(
+        {
+          ...item,
+          leadDocketNumber: caseRecord.leadDocketNumber,
+        },
+        {
+          applicationContext,
+        },
+      ).validateWithLogging(applicationContext);
+
+      item.leadDocketNumber = theCaseDeadline.leadDocketNumber;
+    }
+
+    itemsAfter.push(item);
+  }
+
+  return itemsAfter;
+};

--- a/web-api/workflow-terraform/migration/main/lambdas/migrationsToRun.ts
+++ b/web-api/workflow-terraform/migration/main/lambdas/migrationsToRun.ts
@@ -1,6 +1,7 @@
 import { migrateItems as migration0007 } from './migrations/0007-update-corporate-disclosure-document';
 import { migrateItems as migration0008 } from './migrations/0008-add-assignee-id-gsi2pk-to-work-item';
 import { migrateItems as migration0009 } from './migrations/0009-add-trial-location-field-to-work-item';
+import { migrateItems as migration0010 } from './migrations/0010-add-lead-docket-number-to-case-deadline';
 
 export const migrationsToRun = [
   {
@@ -14,5 +15,9 @@ export const migrationsToRun = [
   {
     key: '0009-add-trial-location-field-to-work-item.ts',
     script: migration0009,
+  },
+  {
+    key: '0010-add-lead-docket-number-to-case-deadline.ts',
+    script: migration0010,
   },
 ];

--- a/web-client/src/presenter/actions/CaseDeadline/getCaseDeadlineFromFormAction.test.ts
+++ b/web-client/src/presenter/actions/CaseDeadline/getCaseDeadlineFromFormAction.test.ts
@@ -47,6 +47,38 @@ describe('getCaseDeadlineFromFormAction', () => {
         caseDetail: {
           associatedJudge: mockJudge,
           docketNumber: mockDocketNumber,
+          leadDocketNumber: mockDocketNumber,
+        },
+        form: {
+          day: 5,
+          month: 2,
+          searchError: {},
+          year: 1993,
+        },
+      },
+    });
+
+    expect(result.output).toEqual({
+      associatedJudge: mockJudge,
+      deadlineDate: computedDateFromProps,
+      docketNumber: mockDocketNumber,
+      leadDocketNumber: mockDocketNumber,
+    });
+  });
+
+  it('returns a caseDeadline with props.computedDate and form values when props.computedDeadline is defined when case does not have a leadDocketNumber', async () => {
+    const result = await runAction(getCaseDeadlineFromFormAction, {
+      modules: {
+        presenter,
+      },
+      props: {
+        computedDate: computedDateFromProps,
+      },
+      state: {
+        caseDetail: {
+          associatedJudge: mockJudge,
+          docketNumber: mockDocketNumber,
+          leadDocketNumber: undefined,
         },
         form: {
           day: 5,

--- a/web-client/src/presenter/actions/CaseDeadline/getCaseDeadlineFromFormAction.ts
+++ b/web-client/src/presenter/actions/CaseDeadline/getCaseDeadlineFromFormAction.ts
@@ -22,7 +22,9 @@ export const getCaseDeadlineFromFormAction = ({
       .createISODateString(props.computedDate);
   }
 
-  const { associatedJudge, docketNumber } = get(state.caseDetail);
+  const { associatedJudge, docketNumber, leadDocketNumber } = get(
+    state.caseDetail,
+  );
 
   const caseDeadline = omit(
     {
@@ -30,6 +32,7 @@ export const getCaseDeadlineFromFormAction = ({
       associatedJudge,
       deadlineDate,
       docketNumber,
+      leadDocketNumber,
     },
     ['day', 'month', 'year', 'searchError'],
   );

--- a/web-client/src/presenter/actions/CaseDeadline/getCaseDeadlinesAction.ts
+++ b/web-client/src/presenter/actions/CaseDeadline/getCaseDeadlinesAction.ts
@@ -1,12 +1,5 @@
 import { state } from 'cerebral';
 
-/**
- * get case deadlines between start and end date
- * @param {object} providers the providers object
- * @param {object} providers.applicationContext the application context
- * @param {function} providers.get the get function
- * @returns {object} the case deadlines
- */
 export const getCaseDeadlinesAction = async ({
   applicationContext,
   get,

--- a/web-client/src/presenter/computeds/caseDeadlineReportHelper.test.ts
+++ b/web-client/src/presenter/computeds/caseDeadlineReportHelper.test.ts
@@ -94,6 +94,52 @@ describe('caseDeadlineReportHelper', () => {
     expect(result.caseDeadlines[3].associatedJudgeFormatted).toEqual('Barney');
   });
 
+  it('should format the caseDeadline with consolidated cases with correct icons and tool tips', () => {
+    const consolidatedCaseDeadlines = [
+      {
+        associatedJudge: 'Judge of Madea Rummy',
+        deadlineDate: '2019-08-21T04:00:00.000Z',
+        docketNumber: '101-19',
+        leadDocketNumber: '101-19',
+      },
+      {
+        associatedJudge: 'Not A Judge Barney',
+        deadlineDate: '2019-08-21T04:00:00.000Z',
+        docketNumber: '102-19',
+        leadDocketNumber: '101-19',
+      },
+      {
+        associatedJudge: 'In Training Judge Brandeis',
+        deadlineDate: '2019-08-24T04:00:00.000Z',
+        docketNumber: '103-19',
+      },
+    ];
+    const result = runCompute(caseDeadlineReportHelper, {
+      state: {
+        caseDeadlineReport: { caseDeadlines: consolidatedCaseDeadlines },
+        judges: [{ name: 'Carluzzo' }, { name: 'Buch' }],
+        screenMetadata: {
+          filterEndDate: '2019-08-21T12:59:59.000Z',
+          filterStartDate: '2019-08-21T04:00:00.000Z',
+        },
+      },
+    });
+
+    expect(result.caseDeadlines[0].inConsolidatedGroup).toEqual(true);
+    expect(result.caseDeadlines[0].inLeadCase).toEqual(true);
+    expect(result.caseDeadlines[0].consolidatedIconTooltipText).toEqual(
+      'Lead case',
+    );
+    expect(result.caseDeadlines[1].inConsolidatedGroup).toEqual(true);
+    expect(result.caseDeadlines[1].inLeadCase).toEqual(false);
+    expect(result.caseDeadlines[1].consolidatedIconTooltipText).toEqual(
+      'Consolidated case',
+    );
+    expect(result.caseDeadlines[2].inConsolidatedGroup).toEqual(false);
+    expect(result.caseDeadlines[2].inLeadCase).toEqual(false);
+    expect(result.caseDeadlines[2].consolidatedIconTooltipText).toBeUndefined();
+  });
+
   describe('showLoadMoreButton', () => {
     it('should return showLoadMoreButton true when caseDeadlines length is less than totalCount', () => {
       const result = runCompute(caseDeadlineReportHelper, {

--- a/web-client/src/presenter/computeds/caseDeadlineReportHelper.ts
+++ b/web-client/src/presenter/computeds/caseDeadlineReportHelper.ts
@@ -41,16 +41,26 @@ export const caseDeadlineReportHelper = (get, applicationContext) => {
         .formatDateString(filterEndDate, DATE_FORMATS.MONTH_DAY_YEAR);
   }
 
-  caseDeadlines = caseDeadlines.map(d => ({
-    ...d,
-    associatedJudgeFormatted: applicationContext
-      .getUtilities()
-      .getJudgeLastName(d.associatedJudge),
-    caseTitle: applicationContext.getCaseTitle(d.caseCaption || ''),
-    formattedDeadline: applicationContext
-      .getUtilities()
-      .formatDateString(d.deadlineDate, 'MMDDYY'),
-  }));
+  caseDeadlines = caseDeadlines.map(d => {
+    const inConsolidatedGroup = !!d.leadDocketNumber;
+    const inLeadCase = d.leadDocketNumber === d.docketNumber;
+    const consolidatedIconTooltipText =
+      inConsolidatedGroup && inLeadCase ? 'Lead case' : 'Consolidated case';
+
+    return {
+      ...d,
+      associatedJudgeFormatted: applicationContext
+        .getUtilities()
+        .getJudgeLastName(d.associatedJudge),
+      caseTitle: applicationContext.getCaseTitle(d.caseCaption || ''),
+      consolidatedIconTooltipText,
+      formattedDeadline: applicationContext
+        .getUtilities()
+        .formatDateString(d.deadlineDate, 'MMDDYY'),
+      inConsolidatedGroup,
+      inLeadCase,
+    };
+  });
 
   return {
     caseDeadlines,

--- a/web-client/src/presenter/computeds/caseDeadlineReportHelper.ts
+++ b/web-client/src/presenter/computeds/caseDeadlineReportHelper.ts
@@ -44,8 +44,15 @@ export const caseDeadlineReportHelper = (get, applicationContext) => {
   caseDeadlines = caseDeadlines.map(d => {
     const inConsolidatedGroup = !!d.leadDocketNumber;
     const inLeadCase = d.leadDocketNumber === d.docketNumber;
-    const consolidatedIconTooltipText =
-      inConsolidatedGroup && inLeadCase ? 'Lead case' : 'Consolidated case';
+    let consolidatedIconTooltipText;
+
+    if (inConsolidatedGroup) {
+      if (inLeadCase) {
+        consolidatedIconTooltipText = 'Lead case';
+      } else {
+        consolidatedIconTooltipText = 'Consolidated case';
+      }
+    }
 
     return {
       ...d,

--- a/web-client/src/views/CaseDeadlines/CaseDeadlines.tsx
+++ b/web-client/src/views/CaseDeadlines/CaseDeadlines.tsx
@@ -2,6 +2,7 @@ import { BigHeader } from '../BigHeader';
 import { BindedSelect } from '../../ustc-ui/BindedSelect/BindedSelect';
 import { Button } from '../../ustc-ui/Button/Button';
 import { CaseLink } from '../../ustc-ui/CaseLink/CaseLink';
+import { ConsolidatedCaseIcon } from '../../ustc-ui/Icon/ConsolidatedCaseIcon';
 import { DateRangePickerComponent } from '../../ustc-ui/DateInput/DateRangePickerComponent';
 import { ErrorNotification } from '../ErrorNotification';
 import { SuccessNotification } from '../SuccessNotification';
@@ -124,6 +125,10 @@ export const CaseDeadlines = connect(
                   <thead>
                     <tr>
                       <th>Due Date</th>
+                      <th
+                        aria-hidden="true"
+                        className="consolidated-case-column"
+                      ></th>
                       <th aria-label="docket number">Docket No.</th>
                       <th>Case Title</th>
                       <th>Description</th>
@@ -135,6 +140,15 @@ export const CaseDeadlines = connect(
                       <tr key={item.caseDeadlineId}>
                         <td className="smaller-column semi-bold">
                           {item.formattedDeadline}
+                        </td>
+                        <td className="consolidated-case-column">
+                          <ConsolidatedCaseIcon
+                            consolidatedIconTooltipText={
+                              item.consolidatedIconTooltipText
+                            }
+                            inConsolidatedGroup={item.inConsolidatedGroup}
+                            showLeadCaseIcon={item.inLeadCase}
+                          />
                         </td>
                         <td className="smaller-column semi-bold">
                           <CaseLink formattedCase={item} />


### PR DESCRIPTION
This PR adds consolidated case icons and associated tool tips to docket entries on the Deadlines report.

**NOTE**: Will need to run a migration.
------

![Screenshot 2023-06-05 at 14 23 14](https://github.com/ustaxcourt/ef-cms/assets/53133657/59cf04b6-2aa2-4be2-a407-22548342ec39)
