### PR TITLE
10075: do not auto-serve modified simultaneous briefs

### DIFF
--- a/shared/src/business/entities/DocketEntry.isAutoServed.test.ts
+++ b/shared/src/business/entities/DocketEntry.isAutoServed.test.ts
@@ -49,12 +49,26 @@ describe('isAutoServed', () => {
     expect(docketEntry.isAutoServed()).toBeTruthy();
   });
 
-  it('should return false if the documentType is an external document and the document is a Simultaneous Document', () => {
+  it('should return false if the documentType is an external document and the document title includes "Simultaneous" as these could be modified simultaneous briefs, not directly simultaneous', () => {
     const docketEntry = new DocketEntry(
       {
         ...A_VALID_DOCKET_ENTRY,
+        documentTitle: 'Second Amended Simultaneous Reply Brief',
         documentType: EXTERNAL_DOCUMENT_TYPES[0],
-        eventCode: SIMULTANEOUS_DOCUMENT_EVENT_CODES[0],
+        eventCode: 'AMAT',
+      },
+      { applicationContext, petitioners: MOCK_PETITIONERS },
+    );
+
+    expect(docketEntry.isAutoServed()).toBeFalsy();
+  });
+
+  it('should return false if the document type includes "Simultaneous"', () => {
+    const docketEntry = new DocketEntry(
+      {
+        ...A_VALID_DOCKET_ENTRY,
+        documentType: SIMULTANEOUS_DOCUMENT_EVENT_CODES[0],
+        eventCode: 'SIAB',
       },
       { applicationContext, petitioners: MOCK_PETITIONERS },
     );

--- a/shared/src/business/entities/DocketEntry.ts
+++ b/shared/src/business/entities/DocketEntry.ts
@@ -8,7 +8,6 @@ import {
   PARTIES_CODES,
   PRACTITIONER_ASSOCIATION_DOCUMENT_TYPES,
   ROLES,
-  SIMULTANEOUS_DOCUMENT_EVENT_CODES,
   TRACKED_DOCUMENT_TYPES_EVENT_CODES,
   UNSERVABLE_EVENT_CODES,
 } from './EntityConstants';
@@ -429,8 +428,9 @@ export class DocketEntry extends JoiValidationEntity {
     const isPractitionerAssociationDocumentType =
       PRACTITIONER_ASSOCIATION_DOCUMENT_TYPES.includes(this.documentType);
 
-    const isSimultaneous = SIMULTANEOUS_DOCUMENT_EVENT_CODES.includes(
-      this.eventCode,
+    // if fully concatenated document title includes the word Simultaneous, do not auto-serve
+    const isSimultaneous = (this.documentTitle || this.documentType).includes(
+      'Simultaneous',
     );
 
     return (


### PR DESCRIPTION
Addresses PO feedback. 

This undoes a refactoring I did. This code was originally checking the `documentTitle` which covers a situation where a brief is not specifically a simultaneous doc type, but is amending, redacting, or modifying an existing simultaneous brief, therefore you need to check the full docTitle to determine if the docket entry should be auto-served.

flexion#10075