### PR TITLE
devex: add template for flaky test

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaky-test.md
+++ b/.github/ISSUE_TEMPLATE/flaky-test.md
@@ -1,0 +1,32 @@
+---
+name: Flaky Test Report
+about: 'Template for documenting tests that have shown thesmelves to be flaky. These tests fail inconsistently and are often unrelated to the work you are doing. Often times a simple retry (or two) does the trick.'
+title: 'FLAKY TEST: '
+labels: 'flaky-test'
+assignees: ''
+
+---
+
+## Path to Test File
+
+```
+./relative/path/to/testfile.test.ts
+```
+
+## Workflows of Failrure(s)
+
+Paste any CircleCI or Github Actions runs where this test failed
+
+## What were you working on?
+
+What were you working on when this test failed?
+
+## Notes
+
+## Definition of Done (Updated 4-14-21)
+
+**Engineering**
+
+- [ ] Documentation has been added to this card with any helpful information relating to the test failures.
+- [ ] Test has been fixed or removed.
+- [ ] Test has been reattempted 5 times without fail.

--- a/.github/ISSUE_TEMPLATE/flaky-test.md
+++ b/.github/ISSUE_TEMPLATE/flaky-test.md
@@ -13,6 +13,10 @@ assignees: ''
 ./relative/path/to/testfile.test.ts
 ```
 
+## Readout of the failure
+
+Include any helpful output from the failure(s) here.
+
 ## Workflows of Failrure(s)
 
 Paste any CircleCI or Github Actions runs where this test failed


### PR DESCRIPTION
To aid in the fight against flaky tests plaguing our project, this issue is to help us track, document, and tackle tests that have shown themselves to be flaky. 

Developers will log an issue, assign it to themselves, and commit to figuring out what's going on after encountering one of these while doing normal story or devex work.