### PR TITLE
10069: Caching SES health

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "logform": "^2.5.1",
         "luxon": "^3.3.0",
         "moize": "^6.1.6",
+        "node-cache": "^5.1.2",
         "parse-full-name": "^1.2.6",
         "pdf-lib": "^1.17.1",
         "pdfjs-dist": "^2.16.105",
@@ -95,7 +96,7 @@
         "@babel/register": "^7.22.5",
         "@faker-js/faker": "^8.0.2",
         "@miovision/eslint-plugin-disallow-date": "^2.0.0",
-        "@sparticuz/chromium": "^112.0.2",
+        "@sparticuz/chromium": "112.0.2",
         "@types/aws-lambda": "^8.10.115",
         "@types/jest": "^29.5.2",
         "@types/lodash": "^4.14.195",
@@ -24567,6 +24568,17 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
       "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
       "dev": true
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.6.11",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "logform": "^2.5.1",
     "luxon": "^3.3.0",
     "moize": "^6.1.6",
+    "node-cache": "^5.1.2",
     "parse-full-name": "^1.2.6",
     "pdf-lib": "^1.17.1",
     "pdfjs-dist": "^2.16.105",

--- a/shared/src/persistence/ses/getSesStatus.test.ts
+++ b/shared/src/persistence/ses/getSesStatus.test.ts
@@ -15,6 +15,7 @@ describe('getSesStatus', () => {
             }),
         }),
       }),
+      logger: { error: () => true, info: () => true },
     };
 
     const status = await getSesStatus({
@@ -38,6 +39,7 @@ describe('getSesStatus', () => {
             }),
         }),
       }),
+      logger: { error: () => true, info: () => true },
     };
 
     const status = await getSesStatus({

--- a/shared/src/persistence/ses/getSesStatus.test.ts
+++ b/shared/src/persistence/ses/getSesStatus.test.ts
@@ -1,6 +1,14 @@
 import { getSesStatus } from './getSesStatus';
+import NodeCache from 'node-cache';
+
+// const mockNodeCache = new NodeCache();
+jest.mock('node-cache');
+// mockNodeCache.get.mockReturnValue(true);
 
 describe('getSesStatus', () => {
+  beforeEach(() => {
+    NodeCache.get = jest.fn().mockReturnValue(undefined);
+  });
   it('should pass when no rejects have occurred', async () => {
     const applicationContext: any = {
       getEmailClient: () => ({
@@ -21,7 +29,6 @@ describe('getSesStatus', () => {
     const status = await getSesStatus({
       applicationContext,
     });
-
     expect(status).toBeTruthy();
   });
 

--- a/shared/src/persistence/ses/getSesStatus.test.ts
+++ b/shared/src/persistence/ses/getSesStatus.test.ts
@@ -1,9 +1,7 @@
 import { getSesStatus } from './getSesStatus';
 import NodeCache from 'node-cache';
 
-// const mockNodeCache = new NodeCache();
 jest.mock('node-cache');
-// mockNodeCache.get.mockReturnValue(true);
 
 describe('getSesStatus', () => {
   beforeEach(() => {

--- a/shared/src/persistence/ses/getSesStatus.ts
+++ b/shared/src/persistence/ses/getSesStatus.ts
@@ -21,7 +21,6 @@ export const getSesStatus = async ({
   const sesHealth = SendDataPoints.slice(0, numberOfDataPoints).every(
     ({ Rejects }) => Rejects === 0,
   );
-
   cache.set(cacheKey, sesHealth);
 
   applicationContext.logger.info(

--- a/shared/src/persistence/ses/getSesStatus.ts
+++ b/shared/src/persistence/ses/getSesStatus.ts
@@ -5,7 +5,7 @@ export const getSesStatus = async ({
 }: {
   applicationContext: IApplicationContext;
 }) => {
-  const cache = new NodeCache({ checkperiod: 120, stdTTL: 300 });
+  const cache = new NodeCache({ checkperiod: 180, stdTTL: 300 });
   const cacheKey = 'SES_health';
 
   const cachedResponse = cache.get(cacheKey);

--- a/shared/src/persistence/ses/getSesStatus.ts
+++ b/shared/src/persistence/ses/getSesStatus.ts
@@ -1,13 +1,31 @@
+import NodeCache from 'node-cache';
+
 export const getSesStatus = async ({
   applicationContext,
 }: {
   applicationContext: IApplicationContext;
 }) => {
+  const cache = new NodeCache({ checkperiod: 120, stdTTL: 300 });
+  const cacheKey = 'SES_health';
+
+  const cachedResponse = cache.get(cacheKey);
+  if (cachedResponse) {
+    applicationContext.logger.info('Returning SES health status from cache');
+    return cachedResponse;
+  }
+
   const SES = applicationContext.getEmailClient();
   const HOURS_TO_MONITOR = 24;
   const { SendDataPoints } = await SES.getSendStatistics({}).promise();
   const numberOfDataPoints = HOURS_TO_MONITOR * 4; // each data point is a 15 minute increment
-  return SendDataPoints.slice(0, numberOfDataPoints).every(
+  const sesHealth = SendDataPoints.slice(0, numberOfDataPoints).every(
     ({ Rejects }) => Rejects === 0,
   );
+
+  cache.set(cacheKey, sesHealth);
+
+  applicationContext.logger.info(
+    'Returning SES health status from SES service',
+  );
+  return sesHealth;
 };

--- a/shared/src/persistence/ses/getSesStatus.ts
+++ b/shared/src/persistence/ses/getSesStatus.ts
@@ -1,13 +1,12 @@
 import NodeCache from 'node-cache';
+const cache = new NodeCache({ checkperiod: 180, stdTTL: 300 });
+const cacheKey = 'SES_health';
 
 export const getSesStatus = async ({
   applicationContext,
 }: {
   applicationContext: IApplicationContext;
 }) => {
-  const cache = new NodeCache({ checkperiod: 180, stdTTL: 300 });
-  const cacheKey = 'SES_health';
-
   const cachedResponse = cache.get(cacheKey);
   if (cachedResponse) {
     applicationContext.logger.info('Returning SES health status from cache');

--- a/web-client/terraform/main/main.tf
+++ b/web-client/terraform/main/main.tf
@@ -258,7 +258,7 @@ resource "aws_route53_health_check" "status_health_check_west" {
   type               = "HTTPS_STR_MATCH"
   resource_path      = "/public-api/health"
   failure_threshold  = "3"
-  request_interval   = "60"
+  request_interval   = "30"
   count              = var.enable_health_checks
   invert_healthcheck = false
   search_string      = "pass"                                       # Search for a JSON property returning "pass"; fail check if not present
@@ -271,7 +271,7 @@ resource "aws_route53_health_check" "status_health_check_east" {
   type               = "HTTPS_STR_MATCH"
   resource_path      = "/public-api/health"
   failure_threshold  = "3"
-  request_interval   = "60"
+  request_interval   = "30"
   count              = var.enable_health_checks
   invert_healthcheck = false
   search_string      = "pass"                                  # Search for a JSON property returning "pass"; fail check if not present

--- a/web-client/terraform/main/main.tf
+++ b/web-client/terraform/main/main.tf
@@ -213,7 +213,7 @@ resource "aws_route53_health_check" "ui_health_check" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "status_health_check_east" {
-  alarm_name          = "${var.dns_domain} health check endpoint"
+  alarm_name          = "${var.dns_domain} east health check endpoint"
   namespace           = "AWS/Route53"
   metric_name         = "HealthCheckStatus"
   comparison_operator = "LessThanThreshold"
@@ -233,7 +233,7 @@ resource "aws_cloudwatch_metric_alarm" "status_health_check_east" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "status_health_check_west" {
-  alarm_name          = "${var.dns_domain} health check endpoint"
+  alarm_name          = "${var.dns_domain} west health check endpoint"
   namespace           = "AWS/Route53"
   metric_name         = "HealthCheckStatus"
   comparison_operator = "LessThanThreshold"

--- a/web-client/terraform/main/main.tf
+++ b/web-client/terraform/main/main.tf
@@ -258,7 +258,7 @@ resource "aws_route53_health_check" "status_health_check_west" {
   type               = "HTTPS_STR_MATCH"
   resource_path      = "/public-api/health"
   failure_threshold  = "3"
-  request_interval   = "30"
+  request_interval   = "60"
   count              = var.enable_health_checks
   invert_healthcheck = false
   search_string      = "pass"                                       # Search for a JSON property returning "pass"; fail check if not present
@@ -271,7 +271,7 @@ resource "aws_route53_health_check" "status_health_check_east" {
   type               = "HTTPS_STR_MATCH"
   resource_path      = "/public-api/health"
   failure_threshold  = "3"
-  request_interval   = "30"
+  request_interval   = "60"
   count              = var.enable_health_checks
   invert_healthcheck = false
   search_string      = "pass"                                  # Search for a JSON property returning "pass"; fail check if not present


### PR DESCRIPTION
- Creates alarms correctly for _both_ health check endpoints
- Adds 5 minute cache to SES health checker to avoid throttling