### PR TITLE
opex: unset AWS_PROFILE when using env switcher

### DIFF
--- a/scripts/env/assume-role.zsh
+++ b/scripts/env/assume-role.zsh
@@ -18,6 +18,8 @@ if [ "${EXIT_CODE}" != "0" ]; then
   return 1
 fi
 
+unset AWS_PROFILE
+
 export AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' <<< $AWS_SESSION_INFO)
 export AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' <<< $AWS_SESSION_INFO)
 export AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' <<< $AWS_SESSION_INFO)


### PR DESCRIPTION
we observed vendor aws-sdk calls firing from the vendor's account rather than the assumed role's account information