### PR TITLE
dependencies: increment docker container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   git-shallow-clone: guitarrapc/git-shallow-clone@2.6.0
-define: &efcms-docker-image $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:3.0.10
+define: &efcms-docker-image $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:3.0.11
 
 commands:
   npm-and-cypress-install:


### PR DESCRIPTION
It appears that we incremented requirement for Terraform to `v1.5.5`, but we failed to push a docker image with that had `v1.5.5` installed. 

Changes were made to the Docker image that installs `v1.5.5`, but it simply wasn't pushed referenced in the Circle Config. 

An image for `3.0.11` has been pushed, and is now referenced here.