### PR TITLE
9995: UX Feedback - Primary issue row should span more columns

### DIFF
--- a/web-client/integration-tests/caseWorksheetsJourney.test.ts
+++ b/web-client/integration-tests/caseWorksheetsJourney.test.ts
@@ -80,6 +80,9 @@ describe('Case Worksheets Journey', () => {
       docketNumber: cavCase!.docketNumber,
     });
 
+    const { modal } = cerebralTest.getState();
+    expect(modal.showModal).toEqual('AddEditPrimaryIssueModal');
+
     const expectedPrimaryIssue = 'I can be your hero baby';
     await cerebralTest.runSequence('cerebralBindSimpleSetStateSequence', {
       key: 'modal.primaryIssue',
@@ -87,6 +90,9 @@ describe('Case Worksheets Journey', () => {
     });
 
     await cerebralTest.runSequence('updatePrimaryIssueSequence');
+
+    const { modal: modal2 } = cerebralTest.getState();
+    expect(modal2.showModal).toBeUndefined();
 
     ({ caseWorksheetsFormatted } = runCompute(caseWorksheetsHelper, {
       state: cerebralTest.getState(),

--- a/web-client/src/views/CaseWorksheet/CaseWorksheets.tsx
+++ b/web-client/src/views/CaseWorksheet/CaseWorksheets.tsx
@@ -150,19 +150,13 @@ export const CaseWorksheets = connect(
                     </td>
                   </tr>
                   <tr>
-                    <td></td>
-                    <td></td>
-                    <td></td>
-                    <td>
+                    <td colSpan={3}></td>
+                    <td colSpan={5}>
                       <span className="text-bold margin-right-1">
                         Primary Issue:
                       </span>
                       {formattedCase.worksheet.primaryIssue}
                     </td>
-                    <td></td>
-                    <td></td>
-                    <td></td>
-                    <td></td>
                     <td>
                       {!formattedCase.worksheet.primaryIssue && (
                         <Button


### PR DESCRIPTION
Before: 
![image](https://github.com/ustaxcourt/ef-cms/assets/20249233/b7c65379-495d-4a36-8e9c-b24c4d7dcdea)

After:
![image](https://github.com/ustaxcourt/ef-cms/assets/20249233/2b0def95-5882-49d1-a3b2-9a809489e17d)

This PR also includes a small addition to the integration test which ensures the Add/Edit Primary Issue modal opens when the user clicks the button to add/edit a primary issue.