### PR TITLE
hotfix: fix paginator on Judge Activity Report

### DIFF
--- a/shared/src/business/useCases/judgeActivityReport/getCasesByStatusAndByJudgeInteractor.test.ts
+++ b/shared/src/business/useCases/judgeActivityReport/getCasesByStatusAndByJudgeInteractor.test.ts
@@ -147,6 +147,18 @@ describe('getCasesByStatusAndByJudgeInteractor', () => {
       MOCK_SUBMITTED_CASE_WITH_SDEC_ON_DOCKET_RECORD.docketNumber,
     ];
 
+    applicationContext
+      .getPersistenceGateway()
+      .getDocketNumbersByStatusAndByJudge.mockReturnValueOnce(
+        mockGetDocketNumbersByStatusAndByJudgeResult,
+      );
+
+    applicationContext
+      .getPersistenceGateway()
+      .getDocketNumbersWithServedEventCodes.mockReturnValueOnce(
+        mockGetDocketNumbersWithServedEventCodesResult,
+      );
+
     const result = await getCasesByStatusAndByJudgeInteractor(
       applicationContext,
       mockValidRequest,
@@ -182,6 +194,18 @@ describe('getCasesByStatusAndByJudgeInteractor', () => {
     ];
     mockGetDocketNumbersWithServedEventCodesResult = [];
 
+    applicationContext
+      .getPersistenceGateway()
+      .getDocketNumbersByStatusAndByJudge.mockReturnValueOnce(
+        mockGetDocketNumbersByStatusAndByJudgeResult,
+      );
+
+    applicationContext
+      .getPersistenceGateway()
+      .getDocketNumbersWithServedEventCodes.mockReturnValueOnce(
+        mockGetDocketNumbersWithServedEventCodesResult,
+      );
+
     const result = await getCasesByStatusAndByJudgeInteractor(
       applicationContext,
       {
@@ -192,7 +216,9 @@ describe('getCasesByStatusAndByJudgeInteractor', () => {
       },
     );
 
-    expect(result.totalCount).toBe(mockPageSize);
+    expect(result.totalCount).toBe(
+      mockGetDocketNumbersByStatusAndByJudgeResult.length,
+    );
   });
 
   it('should return all results when page number and page size are not provided', async () => {
@@ -210,6 +236,18 @@ describe('getCasesByStatusAndByJudgeInteractor', () => {
       },
     ];
     mockGetDocketNumbersWithServedEventCodesResult = [];
+
+    applicationContext
+      .getPersistenceGateway()
+      .getDocketNumbersByStatusAndByJudge.mockReturnValueOnce(
+        mockGetDocketNumbersByStatusAndByJudgeResult,
+      );
+
+    applicationContext
+      .getPersistenceGateway()
+      .getDocketNumbersWithServedEventCodes.mockReturnValueOnce(
+        mockGetDocketNumbersWithServedEventCodesResult,
+      );
 
     const result = await getCasesByStatusAndByJudgeInteractor(
       applicationContext,
@@ -239,13 +277,13 @@ describe('getCasesByStatusAndByJudgeInteractor', () => {
 
     applicationContext
       .getPersistenceGateway()
-      .getDocketNumbersByStatusAndByJudge.mockReturnValue(
+      .getDocketNumbersByStatusAndByJudge.mockReturnValueOnce(
         mockGetDocketNumbersByStatusAndByJudgeResult,
       );
 
     applicationContext
       .getPersistenceGateway()
-      .getDocketNumbersWithServedEventCodes.mockReturnValue(
+      .getDocketNumbersWithServedEventCodes.mockReturnValueOnce(
         mockGetDocketNumbersWithServedEventCodesResult,
       );
 

--- a/shared/src/business/useCases/judgeActivityReport/getCasesByStatusAndByJudgeInteractor.ts
+++ b/shared/src/business/useCases/judgeActivityReport/getCasesByStatusAndByJudgeInteractor.ts
@@ -87,7 +87,7 @@ export const getCasesByStatusAndByJudgeInteractor = async (
 
   return {
     cases: paginatedCaseResults || allCaseResults,
-    totalCount: (paginatedCaseResults || allCaseResults).length,
+    totalCount: allCaseResults.length,
   };
 };
 

--- a/web-client/integration-tests/journey/viewJudgeActivityReportResults.ts
+++ b/web-client/integration-tests/journey/viewJudgeActivityReportResults.ts
@@ -68,6 +68,9 @@ export const viewJudgeActivityReportResults = (
       }),
     );
 
+    const { totalCountForSubmittedAndCavCases: initialTotal } =
+      cerebralTest.getState('judgeActivityReport.judgeActivityReportData');
+
     await cerebralTest.runSequence('getCavAndSubmittedCasesForJudgesSequence', {
       selectedPage: 1,
     });
@@ -79,5 +82,11 @@ export const viewJudgeActivityReportResults = (
         submittedAndCavCasesByJudge: expect.anything(),
       }),
     );
+
+    expect(
+      cerebralTest.getState(
+        'judgeActivityReport.judgeActivityReportData.totalCountForSubmittedAndCavCases',
+      ),
+    ).toEqual(initialTotal);
   });
 };


### PR DESCRIPTION
- Fixes a bug seen only on staging 
- Reverts a change made to the calculation of totalCount in getCasesByStatusAndByJudgeInteractor

Bug: 
- totalCount was being calculated incorrectly in getCasesByStatusAndByJudgeInteractor which was causing the judgeActivityReportHelper to incorrectly calculate pageCount. This in turn caused the paginator to cease being shown because the incorrectly calculated pageCount for page 2 of results was < 1 : 
``` 
 const pageCount = Math.ceil(
    totalCountForSubmittedAndCavCases / CAV_AND_SUBMITTED_CASES_PAGE_SIZE,
  );
```
