### PR TITLE
devex: enable admin user before logging in as them

### DIFF
--- a/web-api/setup-irs-user.sh
+++ b/web-api/setup-irs-user.sh
@@ -43,6 +43,8 @@ generate_post_data() {
 EOF
 }
 
+aws cognito-idp admin-enable-user --user-pool-id "${USER_POOL_ID}" --username "${USTC_ADMIN_USER}"
+
 response=$(aws cognito-idp admin-initiate-auth \
   --user-pool-id "${USER_POOL_ID}" \
   --client-id "${CLIENT_ID}" \
@@ -50,8 +52,6 @@ response=$(aws cognito-idp admin-initiate-auth \
   --auth-flow ADMIN_NO_SRP_AUTH \
   --auth-parameters USERNAME="${USTC_ADMIN_USER}"',PASSWORD'="${USTC_ADMIN_PASS}")
 adminToken=$(echo "${response}" | jq -r ".AuthenticationResult.IdToken")
-
-aws cognito-idp admin-enable-user --user-pool-id "${USER_POOL_ID}" --username "${USTC_ADMIN_USER}"
 
 curl --header "Content-Type: application/json" \
   --header "Authorization: Bearer ${adminToken}" \


### PR DESCRIPTION
this script wasn't working because we were attempting to authenticate before the user was enabled. 