### PR TITLE
Bug refactor idle timer logic to testing

### DIFF
--- a/web-client/src/views/IdleActivityMonitor.tsx
+++ b/web-client/src/views/IdleActivityMonitor.tsx
@@ -24,6 +24,20 @@ export const IdleActivityMonitor = connect(
   }) {
     useIdleTimer({
       debounce: constants.SESSION_DEBOUNCE,
+      // eslint-disable-next-line spellcheck/spell-checker
+      // we do not want 'visibilitychange', so we override the defaults
+      events: [
+        'mousemove',
+        'keydown',
+        'wheel',
+        'DOMMouseScroll',
+        'mousewheel',
+        'mousedown',
+        'touchstart',
+        'touchmove',
+        'MSPointerDown',
+        'MSPointerMove',
+      ],
       onAction: broadcastIdleStatusActiveSequence,
     });
 


### PR DESCRIPTION
When a user's computer comes out of sleep mode, if they have any dawson tab visible (even if on a second monitor), the timer will reset even though the user has not interacted with the page.  This removes the visibilitychanged event so that a user MUST use their mouse and move on the dawson window or click on something