### PR TITLE
10158: Flakey test: `court-issued-documents.cy.ts`

### DIFF
--- a/cypress/cypress-smoketests/support/pages/create-electronic-petition.ts
+++ b/cypress/cypress-smoketests/support/pages/create-electronic-petition.ts
@@ -42,9 +42,8 @@ export const goToWizardStep5 = () => {
 };
 
 export const submitPetition = testData => {
-  cy.get('button#submit-case').scrollIntoView().click();
-
   cy.intercept('POST', '**/cases').as('postCase');
+  cy.get('button#submit-case').scrollIntoView().click();
   cy.wait('@postCase').then(({ response }) => {
     expect(response.body).to.have.property('docketNumber');
     const { docketNumber } = response.body;


### PR DESCRIPTION
[Card](https://app.zenhub.com/workspaces/flexionef-cms-5bbe4bed4b5806bc2bec65d3/issues/gh/flexion/ef-cms/10158)
The working theory is that calling `cy.intercept()` after kicking a network request is causing a race condition between that `intercept` and the request itself.
[Docs on cypress intercept](https://learn.cypress.io/advanced-cypress-concepts/intercepting-network-requests)
[Random blog describing similar problem](https://glebbahmutov.com/blog/cypress-intercept-problems/)