### PR TITLE
10144 - addressing es lint issues

### DIFF
--- a/cypress/cypress-integration/integration/docket-clerk-edits-court-issued-document.cy.ts
+++ b/cypress/cypress-integration/integration/docket-clerk-edits-court-issued-document.cy.ts
@@ -4,8 +4,6 @@ import { uploadCourtIssuedDocumentAndEditViaDocumentQC } from '../support/pages/
 describe('Docket clerk edits a court issued document', function () {
   it('upload a court issued document, click on the in progress link, and navigate to the correct page', () => {
     navigateToDashboard('docketclerk');
-
-    const attempt = cy.state('runnable')._currentRetry;
-    uploadCourtIssuedDocumentAndEditViaDocumentQC(attempt);
+    uploadCourtIssuedDocumentAndEditViaDocumentQC();
   });
 });

--- a/cypress/cypress-integration/support/pages/document-qc.ts
+++ b/cypress/cypress-integration/support/pages/document-qc.ts
@@ -43,22 +43,18 @@ export const progressIndicatorDoesNotExist = () => {
   cy.get('.progress-indicator').should('not.exist');
 };
 
-export const uploadCourtIssuedDocumentAndEditViaDocumentQC = attempt => {
+export const uploadCourtIssuedDocumentAndEditViaDocumentQC = () => {
   cy.visit('case-detail/104-20/upload-court-issued');
-  const freeText = `court document ${attempt}`;
-  cy.get('#upload-description').clear().type(freeText);
+  const freeText = `court document ${Math.random()}`;
+  cy.get('#upload-description').clear();
+  cy.get('#upload-description').type(freeText);
   cy.get('input#primary-document-file').attachFile('../fixtures/w3-dummy.pdf');
-
-  // Fix flaky test
-  // https://github.com/flexion/ef-cms/issues/10144
-  // eslint-disable-next-line cypress/no-unnecessary-waiting
-  cy.wait(0);
-
   cy.get('#save-uploaded-pdf-button').click();
   cy.get('#add-court-issued-docket-entry-button').click();
-  cy.get('#document-type .select-react-element__input-container input')
-    .clear()
-    .type('Miscellaneous');
+  cy.get('#document-type .select-react-element__input-container input').clear();
+  cy.get('#document-type .select-react-element__input-container input').type(
+    'Miscellaneous',
+  );
   cy.get('#react-select-2-option-0').click({ force: true });
   cy.get('#save-entry-button').click();
   cy.url().should('not.contain', '/add-court-issued-docket-entry');


### PR DESCRIPTION
I've re-run this test 6 times, and it passes every time:

https://github.com/ustaxcourt/ef-cms/actions/runs/6536721248

I don't know if this was the fix for the flaky test, but we had some eslint warnings saying that chaining multiple cy commands together could be "dangerous"