### PR TITLE
10177: BUG: If a practitioner previews their uploaded EA doc, the Redaction acknowledgement checkbox disappears

### DIFF
--- a/web-client/integration-tests/journey/respondentRequestsAccessToCase.ts
+++ b/web-client/integration-tests/journey/respondentRequestsAccessToCase.ts
@@ -125,11 +125,18 @@ export const respondentRequestsAccessToCase = (cerebralTest, fakeFile) => {
     );
     expect(cerebralTest.getState('validationErrors')).toEqual({});
 
+    await cerebralTest.runSequence('openPdfPreviewModalSequence', {
+      file: fakeFile,
+      modalId: 'PDFPreviewModal-Entry of Appearance for Respondent',
+    });
+
     await cerebralTest.runSequence('updateFormValueSequence', {
       key: 'redactionAcknowledgement',
       value: true,
     });
 
     await cerebralTest.runSequence('submitCaseAssociationRequestSequence');
+
+    expect(cerebralTest.getState('validationErrors')).toEqual({});
   });
 };

--- a/web-client/src/presenter/computeds/fileDocumentHelper.test.ts
+++ b/web-client/src/presenter/computeds/fileDocumentHelper.test.ts
@@ -3,6 +3,7 @@ import {
   CONTACT_TYPES,
   PARTY_TYPES,
 } from '../../../../shared/src/business/entities/EntityConstants';
+import { GENERATION_TYPES } from '@web-client/getConstants';
 import { MOCK_CASE } from '../../../../shared/src/test/mockCase';
 import { MOCK_USERS } from '../../../../shared/src/test/mockUsers';
 import { applicationContext } from '../../applicationContext';
@@ -495,14 +496,15 @@ describe('fileDocumentHelper', () => {
   });
 
   describe('EARedactionAcknowledgement', () => {
-    it('should set redactionAcknowledgementEnabled to true when document type is EA and no preview url is set and the feature flag is enabled', () => {
+    it('should set EARedactionAcknowledgement to true when document type is EA, generation type is manual, and the feature flag is enabled', () => {
       state.featureFlags = {
         [ALLOWLIST_FEATURE_FLAGS.REDACTION_ACKNOWLEDGEMENT_ENABLED.key]: true,
       };
       state.form = {
         eventCode: 'EA',
+        generationType: GENERATION_TYPES.MANUAL,
       };
-      state.pdfPreviewUrl = false;
+
       const { EARedactionAcknowledgement } = runCompute(fileDocumentHelper, {
         state,
       });
@@ -510,14 +512,15 @@ describe('fileDocumentHelper', () => {
       expect(EARedactionAcknowledgement).toEqual(true);
     });
 
-    it('should set redactionAcknowledgementEnabled to false when document type is EA and a preview url is set and the feature flag is enabled', () => {
+    it('should set EARedactionAcknowledgement to false when document type is EA, generation type is auto, and the feature flag is enabled', () => {
       state.featureFlags = {
         [ALLOWLIST_FEATURE_FLAGS.REDACTION_ACKNOWLEDGEMENT_ENABLED.key]: true,
       };
       state.form = {
         eventCode: 'EA',
+        generationType: GENERATION_TYPES.AUTO,
       };
-      state.pdfPreviewUrl = true;
+
       const { EARedactionAcknowledgement } = runCompute(fileDocumentHelper, {
         state,
       });
@@ -525,14 +528,15 @@ describe('fileDocumentHelper', () => {
       expect(EARedactionAcknowledgement).toEqual(false);
     });
 
-    it('should set redactionAcknowledgementEnabled to false when document type is EA and a preview url is set and the feature flag is enabled', () => {
+    it('should set EARedactionAcknowledgement to false when document type is not EA, generation type is manual, and the feature flag is enabled', () => {
       state.featureFlags = {
         [ALLOWLIST_FEATURE_FLAGS.REDACTION_ACKNOWLEDGEMENT_ENABLED.key]: true,
       };
       state.form = {
         eventCode: 'A',
+        generationType: GENERATION_TYPES.MANUAL,
       };
-      state.pdfPreviewUrl = false;
+
       const { EARedactionAcknowledgement } = runCompute(fileDocumentHelper, {
         state,
       });
@@ -540,14 +544,15 @@ describe('fileDocumentHelper', () => {
       expect(EARedactionAcknowledgement).toEqual(false);
     });
 
-    it('should set redactionAcknowledgementEnabled to false when document type is EA and a preview url is set and the feature flag is enabled', () => {
+    it('should set EARedactionAcknowledgement to false when document type is EA, generation type is auto, but the feature flag is disabled', () => {
       state.featureFlags = {
         [ALLOWLIST_FEATURE_FLAGS.REDACTION_ACKNOWLEDGEMENT_ENABLED.key]: false,
       };
       state.form = {
         eventCode: 'EA',
+        generationType: GENERATION_TYPES.AUTO,
       };
-      state.pdfPreviewUrl = true;
+
       const { EARedactionAcknowledgement } = runCompute(fileDocumentHelper, {
         state,
       });

--- a/web-client/src/presenter/computeds/fileDocumentHelper.ts
+++ b/web-client/src/presenter/computeds/fileDocumentHelper.ts
@@ -1,3 +1,6 @@
+import { ClientApplicationContext } from '@web-client/applicationContext';
+import { GENERATION_TYPES } from '@web-client/getConstants';
+import { Get } from 'cerebral';
 import { getFilerParties } from './getFilerParties';
 import { getSupportingDocumentTypeList } from './addDocketEntryHelper';
 import { state } from '@web-client/presenter/app.cerebral';
@@ -7,11 +10,8 @@ export const supportingDocumentFreeTextTypes = [
   'Declaration in Support',
   'Unsworn Declaration under Penalty of Perjury in Support',
 ];
-
 export const SUPPORTING_DOCUMENTS_MAX_COUNT = 5;
 
-import { ClientApplicationContext } from '@web-client/applicationContext';
-import { Get } from 'cerebral';
 export const fileDocumentHelper = (
   get: Get,
   applicationContext: ClientApplicationContext,
@@ -26,8 +26,6 @@ export const fileDocumentHelper = (
 
   const form = get(state.form);
   const validationErrors = get(state.validationErrors);
-
-  const pdfPreviewUrl = get(state.pdfPreviewUrl);
 
   const supportingDocumentTypeList =
     getSupportingDocumentTypeList(CATEGORY_MAP);
@@ -83,7 +81,7 @@ export const fileDocumentHelper = (
 
   const EARedactionAcknowledgement =
     redactionAcknowledgementEnabled &&
-    !pdfPreviewUrl &&
+    form.generationType === GENERATION_TYPES.MANUAL &&
     form.eventCode === 'EA';
 
   const exported = {


### PR DESCRIPTION
- Replaces code that checks state for a pdfPreviewUrl with code that checks the generation type set on the form