### PR TITLE
DevEx: remove applicationContext from setup-glued-judges script

### DIFF
--- a/iam/terraform/account-specific/main/circle-ci.tf
+++ b/iam/terraform/account-specific/main/circle-ci.tf
@@ -56,6 +56,7 @@ resource "aws_iam_policy" "circle_ci_policy" {
         "cognito-idp:AdminInitiateAuth",
         "cognito-idp:AdminRespondToAuthChallenge",
         "cognito-idp:AdminSetUserPassword",
+        "cognito-idp:AdminUpdateUserAttributes",
         "cognito-idp:CreateUserPool",
         "cognito-idp:CreateUserPoolClient",
         "cognito-idp:CreateUserPoolDomain",

--- a/shared/admin-tools/user/setup-glued-judges.ts
+++ b/shared/admin-tools/user/setup-glued-judges.ts
@@ -184,7 +184,7 @@ const getJudgeUsersByName = async (): Promise<{
 
   let judgeUsers = {};
   for (const judge of results) {
-    const emailDomain = (judge as any).email.split('@')[1];
+    const emailDomain = judge.email.split('@')[1];
     if (!(judge.name in judgeUsers)) {
       judgeUsers[judge.name] = {
         email: `${

--- a/shared/admin-tools/util.ts
+++ b/shared/admin-tools/util.ts
@@ -44,7 +44,7 @@ export const requireEnvVars = (requiredEnvVars: Array<string>): void => {
   }
   if (missing) {
     console.error(`Missing environment variable(s): ${missing}`);
-    process.exit();
+    process.exit(1);
   }
 };
 


### PR DESCRIPTION
Scripts that run in circleci should not use `applicationContext`, so the `setup-glued-judges` script has been refactored to  not use it.

Additionally, we discovered that the `setup-glued-judges` script had not actually been running in `test` until #4179 was implemented.

Now that it does run, we also discovered the circleci user did not have the `AdminUpdateUserAttributes` permissions.

This PR addresses these issues. 🤞 