### PR TITLE
fix rm in Dockerfile - to test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /home/app
 RUN mkdir -p /usr/share/man/man1
 
 # delete duplicate list if it exists
-RUN [ -f /etc/apt/sources.list.d/microsoft-edge.list ] && rm /etc/apt/sources.list.d/microsoft-edge-stable.list
+RUN [ -f /etc/apt/sources.list.d/microsoft-edge.list ] && [ -f /etc/apt/sources.list.d/microsoft-edge-stable.list ] && rm /etc/apt/sources.list.d/microsoft-edge-stable.list
 
 RUN apt-get update
 


### PR DESCRIPTION
Sometimes Cypress mistakenly publishes two lists in their package which causes us to get errors. This line removes one of them.
`rm` exits 1 if the file wasn't found, so this change accounts for that.