### PR TITLE
devex: remove deprecated config

### DIFF
--- a/cypress-smoketests-readonly-public.config.ts
+++ b/cypress-smoketests-readonly-public.config.ts
@@ -17,7 +17,6 @@ export default defineConfig({
   screenshotsFolder: 'cypress/cypress-readonly/screenshots',
   video: true,
   videoCompression: 10,
-  videoUploadOnPasses: false,
   videosFolder: 'cypress/cypress-readonly/videos',
   viewportHeight: 900,
   viewportWidth: 1200,

--- a/cypress-smoketests-readonly.config.ts
+++ b/cypress-smoketests-readonly.config.ts
@@ -30,7 +30,6 @@ export default defineConfig({
   screenshotsFolder: 'cypress/cypress-readonly/screenshots',
   video: true,
   videoCompression: 10,
-  videoUploadOnPasses: false,
   videosFolder: 'cypress/cypress-readonly/videos',
   viewportHeight: 900,
   viewportWidth: 1200,

--- a/cypress-smoketests.config.ts
+++ b/cypress-smoketests.config.ts
@@ -42,7 +42,6 @@ export default defineConfig({
   screenshotsFolder: 'cypress/cypress-smoketests/screenshots',
   video: true,
   videoCompression: 10,
-  videoUploadOnPasses: false,
   videosFolder: 'cypress/cypress-smoketests/videos',
   viewportHeight: 900,
   viewportWidth: 1200,


### PR DESCRIPTION
Seeing these in our logs, and it looks like this config was deprecated, and it's safe to remove.

<img width="753" alt="Screenshot 2023-11-20 at 3 47 08 PM" src="https://github.com/ustaxcourt/ef-cms/assets/5023502/363fc5b7-d5c9-479b-a26a-51f7ea58d552">
