### PR TITLE
devex: fix smoketests if practitioner does not have any cases

### DIFF
--- a/cypress/helpers/auth/login-as-helpers.ts
+++ b/cypress/helpers/auth/login-as-helpers.ts
@@ -5,7 +5,10 @@ export function loginAsTestAdmissionsClerk() {
 
 export function loginAsPrivatePractitioner() {
   cy.login('privatePractitioner1');
-  cy.get('[data-testid="case-list-table"]').should('exist');
+  cy.get('[data-testid="file-a-petition"]').should('exist');
+  cy.get('[data-testid="search-for-a-case-card"]').should('exist');
+  cy.get('[data-testid="open-cases-count"]').contains('Open Cases');
+  cy.get('[data-testid="closed-cases-count"]').contains('Closed Cases');
 }
 
 export function loginAsPetitioner() {

--- a/web-client/src/views/CaseListTable.tsx
+++ b/web-client/src/views/CaseListTable.tsx
@@ -130,6 +130,7 @@ export const CaseListTable = connect(
                   defaultActiveTab={openTab}
                 >
                   <Tab
+                    data-testid="open-cases-count"
                     id="tab-open"
                     tabName={openTab}
                     title={`Open Cases (${externalUserCasesHelper.openCasesCount})`}
@@ -143,6 +144,7 @@ export const CaseListTable = connect(
                     })}
                   </Tab>
                   <Tab
+                    data-testid="closed-cases-count"
                     id="tab-closed"
                     tabName={closedTab}
                     title={`Closed Cases (${externalUserCasesHelper.closedCasesCount})`}

--- a/web-client/src/views/CaseSearchBox.tsx
+++ b/web-client/src/views/CaseSearchBox.tsx
@@ -27,7 +27,7 @@ export const CaseSearchBox = connect(
           }}
         >
           <div className="case-search margin-bottom-4">
-            <div className="card">
+            <div className="card" data-testid="search-for-a-case-card">
               <div className="content-wrapper gray">
                 <div className="grid-row underlined">
                   <div className="grid-col-8">


### PR DESCRIPTION
After wiping the data in `test` due to a Glue Job, we are seeing smoketests fail due to the expectation that a case list table exists. However, Private Practitioner 1 does not have any cases, and so the table is not displayed. This PR changes that expectation to other items that would show up on the page regardless of whether or not they have previously created cases.

- [CircleCI Failure](https://app.circleci.com/pipelines/github/ustaxcourt/ef-cms/6658/workflows/5b8bf886-6719-4579-93ad-7d89ee69e572)
