### PR TITLE
10011 disable cognito UI signup

### DIFF
--- a/web-api/terraform/template/cognito.tf
+++ b/web-api/terraform/template/cognito.tf
@@ -48,7 +48,7 @@ resource "aws_cognito_user_pool" "pool" {
   sms_authentication_message = "{####}"
 
   admin_create_user_config {
-    allow_admin_create_user_only = false
+    allow_admin_create_user_only = true
     invite_message_template {
       sms_message   = "Your username is {username} and temporary password is {####}."
       email_subject = "An account has been set up for you with the U.S. Tax Court"

--- a/web-api/terraform/template/cognito.tf
+++ b/web-api/terraform/template/cognito.tf
@@ -45,8 +45,6 @@ resource "aws_cognito_user_pool" "pool" {
     }
   }
 
-  sms_authentication_message = "{####}"
-
   admin_create_user_config {
     allow_admin_create_user_only = true
     invite_message_template {
@@ -201,8 +199,6 @@ resource "aws_cognito_user_pool" "irs_pool" {
     email_message_by_link = "Please click the link below to verify your email address. {##Verify Email##} "
     email_subject_by_link = "U.S. Tax Court account verification"
   }
-
-  sms_authentication_message = "{####}"
 
   admin_create_user_config {
     allow_admin_create_user_only = true


### PR DESCRIPTION
- this disables the sign up link in the Cognito UI ensuring users can only create accounts with our UI

<img width="478" alt="Screenshot 2023-12-06 at 2 49 07 PM" src="https://github.com/ustaxcourt/ef-cms/assets/5023502/036dee31-5074-4c0a-b110-f28e75f40c3b">

- also a little refactor to remove cognito config var that wasn't being used because we don't use sms verification at the moment. it was causing terraform to update our cognito user pool even when we weren't making any changes.

<img width="648" alt="Screenshot 2023-12-06 at 2 53 21 PM" src="https://github.com/ustaxcourt/ef-cms/assets/5023502/00fc13c7-d37d-4af1-8a81-bc5200ac8c23">

[successful deployment to dev environment](https://app.circleci.com/pipelines/github/ustaxcourt/ef-cms/6690/workflows/019310a5-90e1-47aa-a533-70534aa7efe4)