### PR TITLE
10231: if migrating, only create indices on destination domain

### DIFF
--- a/web-api/setup-elasticsearch-index.sh
+++ b/web-api/setup-elasticsearch-index.sh
@@ -39,10 +39,16 @@ fi
 
 popd
 
+echo "- ELASTICSEARCH_ENDPOINT_ALPHA: ${ELASTICSEARCH_ENDPOINT_ALPHA}"
+echo "- MIGRATE_FLAG: ${MIGRATE_FLAG}"
+echo "- DESTINATION_DOMAIN: ${DESTINATION_DOMAIN}"
+
 if [[ -n "${ELASTICSEARCH_ENDPOINT_ALPHA}"  && ( "${MIGRATE_FLAG}" == 'false' || "${DESTINATION_DOMAIN}" == *'alpha'* ) ]]; then
+  echo " ==> Setting up Alpha Cluster"
   npx ts-node --transpile-only ./web-api/elasticsearch/elasticsearch-index-settings.ts "${ELASTICSEARCH_ENDPOINT_ALPHA}"
 fi
 
 if [[ -n "${ELASTICSEARCH_ENDPOINT_BETA}"  && ( "${MIGRATE_FLAG}" == 'false' || "${DESTINATION_DOMAIN}" == *'beta'* ) ]]; then
+  echo " ==> Setting up Beta Cluster"
   npx ts-node --transpile-only ./web-api/elasticsearch/elasticsearch-index-settings.ts "${ELASTICSEARCH_ENDPOINT_BETA}"
 fi

--- a/web-api/setup-elasticsearch-index.sh
+++ b/web-api/setup-elasticsearch-index.sh
@@ -39,10 +39,10 @@ fi
 
 popd
 
-if [[ -n "${ELASTICSEARCH_ENDPOINT_ALPHA}" ]]; then
+if [[ -n "${ELASTICSEARCH_ENDPOINT_ALPHA}"  && ( "${MIGRATE_FLAG}" == 'false' || "${DESTINATION_DOMAIN}" == *'alpha'* ) ]]; then
   npx ts-node --transpile-only ./web-api/elasticsearch/elasticsearch-index-settings.ts "${ELASTICSEARCH_ENDPOINT_ALPHA}"
 fi
 
-if [[ -n "${ELASTICSEARCH_ENDPOINT_BETA}" ]]; then
+if [[ -n "${ELASTICSEARCH_ENDPOINT_BETA}"  && ( "${MIGRATE_FLAG}" == 'false' || "${DESTINATION_DOMAIN}" == *'beta'* ) ]]; then
   npx ts-node --transpile-only ./web-api/elasticsearch/elasticsearch-index-settings.ts "${ELASTICSEARCH_ENDPOINT_BETA}"
 fi


### PR DESCRIPTION
flexion#10231

[Successful deploy](https://app.circleci.com/pipelines/github/ustaxcourt/ef-cms/6870/workflows/f96a2b81-f062-45ed-91a6-dc9d05d24b74) over on `develop`. 

