### PR TITLE
DX-1235 - Removed bold texts

### DIFF
--- a/web-client/src/views/CaseDeadlines/CaseDeadlines.tsx
+++ b/web-client/src/views/CaseDeadlines/CaseDeadlines.tsx
@@ -139,7 +139,7 @@ export const CaseDeadlines = connect(
                   <tbody>
                     {caseDeadlineReportHelper.caseDeadlines.map(item => (
                       <tr key={item.caseDeadlineId}>
-                        <td className="smaller-column semi-bold">
+                        <td className="smaller-column">
                           {item.formattedDeadline}
                         </td>
                         <td className="consolidated-case-column">

--- a/web-client/src/views/CaseDeadlines/CaseDeadlines.tsx
+++ b/web-client/src/views/CaseDeadlines/CaseDeadlines.tsx
@@ -151,7 +151,7 @@ export const CaseDeadlines = connect(
                             showLeadCaseIcon={item.inLeadCase}
                           />
                         </td>
-                        <td className="smaller-column semi-bold">
+                        <td className="smaller-column">
                           <CaseLink formattedCase={item} />
                         </td>
                         <td>{item.caseTitle}</td>

--- a/web-client/src/views/CaseDetail/CaseDeadlinesInternal.tsx
+++ b/web-client/src/views/CaseDetail/CaseDeadlinesInternal.tsx
@@ -40,7 +40,7 @@ export const CaseDeadlinesInternal = connect(
             <tbody>
               {formattedCaseDeadlines.map(item => (
                 <tr key={item.caseDeadlineId}>
-                  <td className="smaller-column semi-bold">
+                  <td className="smaller-column">
                     {item.deadlineDateFormatted}
                   </td>
                   <td className="overdue smaller-column center-column semi-bold">


### PR DESCRIPTION
[Design Debt 1235](https://trello.com/c/0YgcAc8A/1235-deadlines-report-and-in-docket-record-table-text-style-change)

<img width="576" alt="Screenshot 2024-01-08 at 2 00 05 PM" src="https://github.com/ustaxcourt/ef-cms/assets/13560702/4090294c-4849-40c5-9bcd-49f588d7b1fb">

<img width="659" alt="Screenshot 2024-01-08 at 1 58 43 PM" src="https://github.com/ustaxcourt/ef-cms/assets/13560702/c8abc22f-26e2-4e67-b35b-1c3fce5e145d">