### PR TITLE
10270 zip bug

### DIFF
--- a/cypress/cypress-readonly/integration/public/public-docket-record.cy.ts
+++ b/cypress/cypress-readonly/integration/public/public-docket-record.cy.ts
@@ -1,0 +1,12 @@
+describe('Public Docket Record', () => {
+  it('should allow the user to generate and download a PDF of the docket record', () => {
+    cy.visit('/');
+    cy.get('input#docket-number').type('104-20');
+    cy.get('button#docket-search-button').click();
+    cy.get('[data-testid="header-public-case-detail"]').contains(
+      'Docket Number: 104-20',
+    );
+    cy.get('[data-testid="print-public-docket-record-button"]').click();
+    cy.get('[data-testid="modal-header"]');
+  });
+});

--- a/iam/terraform/account-specific/main/lambda-logs-to-elasticsearch.tf
+++ b/iam/terraform/account-specific/main/lambda-logs-to-elasticsearch.tf
@@ -1,7 +1,7 @@
 data "archive_file" "zip_logs_to_es_lambda" {
   type        = "zip"
   output_path = "${path.cwd}/../../../../aws/lambdas/LogsToElasticSearch_info.zip"
-  source_file = "${path.cwd}/../../../../aws/lambdas/LogsToElasticSearch_info/index.js"
+  source_dir = "${path.cwd}/../../../../aws/lambdas/LogsToElasticSearch_info/"
 }
 
 resource "aws_lambda_function" "logs_to_es" {

--- a/iam/terraform/account-specific/main/lambda-rotate-info-indices.tf
+++ b/iam/terraform/account-specific/main/lambda-rotate-info-indices.tf
@@ -1,7 +1,7 @@
 data "archive_file" "zip_rotate_info_indices_lambda" {
   type        = "zip"
   output_path = "${path.cwd}/../../../../aws/lambdas/RotateInfoIndices.zip"
-  source_file = "${path.cwd}/../../../../aws/lambdas/RotateInfoIndices/dist/index.js"
+  source_dir = "${path.cwd}/../../../../aws/lambdas/RotateInfoIndices/dist/"
 }
 
 resource "aws_lambda_function" "rotate_info_indices" {

--- a/web-api/terraform/template/cognito-authorizer.tf
+++ b/web-api/terraform/template/cognito-authorizer.tf
@@ -2,7 +2,7 @@ data "archive_file" "zip_authorizer" {
   type        = "zip"
   output_path = "${path.module}/lambdas/cognito-authorizer.js.zip"
   source_dir = "${path.module}/lambdas/dist/"
-  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["cognito-authorizer.js"])
+  excludes = setsubtract(var.template_lambdas, ["cognito-authorizer.js"])
 }
 
 resource "aws_lambda_function" "cognito_authorizer_lambda" {

--- a/web-api/terraform/template/cognito-authorizer.tf
+++ b/web-api/terraform/template/cognito-authorizer.tf
@@ -1,7 +1,8 @@
 data "archive_file" "zip_authorizer" {
   type        = "zip"
   output_path = "${path.module}/lambdas/cognito-authorizer.js.zip"
-  source_file = "${path.module}/lambdas/dist/cognito-authorizer.js"
+  source_dir = "${path.module}/lambdas/dist/"
+  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["cognito-authorizer.js"])
 }
 
 resource "aws_lambda_function" "cognito_authorizer_lambda" {

--- a/web-api/terraform/template/locals.tf
+++ b/web-api/terraform/template/locals.tf
@@ -30,5 +30,28 @@ data "null_data_source" "locals" {
     TEMP_DOCUMENTS_BUCKET_NAME         = "${var.dns_domain}-temp-documents-${var.environment}-us-east-1"
     USER_POOL_ID                       = aws_cognito_user_pool.pool.id
     USER_POOL_IRS_ID                   = aws_cognito_user_pool.irs_pool.id
+    
   }
 }
+
+data "null_data_source" "template_lambdas" {
+  inputs = [
+      "api-public.js",
+      "api.js",
+      "cognito-authorizer.js",
+      "cognito-triggers.js",
+      "cron.js",
+      "handle-bounced-service-email.js",
+      "maintenance-notify.js",
+      "pdf-generation.js",
+      "public-api-authorizer.js",
+      "report.html",
+      "seal-in-lower-environment.js",
+      "send-emails.js",
+      "streams.js",
+      "trial-session.js",
+      "websocket-authorizer.js",
+      "websockets.js",
+  ]
+}
+

--- a/web-api/terraform/template/locals.tf
+++ b/web-api/terraform/template/locals.tf
@@ -30,28 +30,5 @@ data "null_data_source" "locals" {
     TEMP_DOCUMENTS_BUCKET_NAME         = "${var.dns_domain}-temp-documents-${var.environment}-us-east-1"
     USER_POOL_ID                       = aws_cognito_user_pool.pool.id
     USER_POOL_IRS_ID                   = aws_cognito_user_pool.irs_pool.id
-    
   }
 }
-
-data "null_data_source" "template_lambdas" {
-  inputs = [
-      "api-public.js",
-      "api.js",
-      "cognito-authorizer.js",
-      "cognito-triggers.js",
-      "cron.js",
-      "handle-bounced-service-email.js",
-      "maintenance-notify.js",
-      "pdf-generation.js",
-      "public-api-authorizer.js",
-      "report.html",
-      "seal-in-lower-environment.js",
-      "send-emails.js",
-      "streams.js",
-      "trial-session.js",
-      "websocket-authorizer.js",
-      "websockets.js",
-  ]
-}
-

--- a/web-api/terraform/template/main-east.tf
+++ b/web-api/terraform/template/main-east.tf
@@ -226,7 +226,7 @@ resource "null_resource" "maintenance_notify_east_object" {
 data "archive_file" "zip_api_public" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/api-public.js.zip"
-  source_dir = "${path.module}/../template/lambdas/dist/"
+  source_dir  = "${path.module}/../template/lambdas/dist/"
   excludes = [
     "api.js",
     "trial-session.js",

--- a/web-api/terraform/template/main-east.tf
+++ b/web-api/terraform/template/main-east.tf
@@ -1,24 +1,3 @@
-  
-  locals {
-    excludedList =  [
-      "api-public.js",
-      "api.js",
-      "cognito-authorizer.js",
-      "cognito-triggers.js",
-      "cron.js",
-      "handle-bounced-service-email.js",
-      "maintenance-notify.js",
-      "pdf-generation.js",
-      "public-api-authorizer.js",
-      "report.html",
-      "seal-in-lower-environment.js",
-      "send-emails.js",
-      "streams.js",
-      "trial-session.js",
-      "websockets.js",
-  ]
-  }
-
 resource "aws_s3_bucket" "api_lambdas_bucket_east" {
   bucket = "${var.dns_domain}.efcms.${var.environment}.us-east-1.lambdas"
   acl    = "private"
@@ -47,28 +26,28 @@ data "archive_file" "zip_api" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/api.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(local.excludedList, ["api.js"])
+  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["api.js"])
 }
 
 data "archive_file" "zip_send_emails" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/send_emails.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(local.excludedList, ["send_emails.js"])
+  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["send_emails.js"])
 }
 
 data "archive_file" "zip_trial_session" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/trial_session.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(local.excludedList, ["trial_session.js"])
+  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["trial_session.js"])
 }
 
 data "archive_file" "zip_triggers" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/cognito-triggers.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(local.excludedList, ["cognito-triggers.js"])
+  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["cognito-triggers.js"])
 }
 
 
@@ -76,7 +55,7 @@ data "archive_file" "pdf_generation" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/pdf-generation.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(local.excludedList, ["pdf-generation.js"])
+  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["pdf-generation.js"])
 }
 
 resource "null_resource" "pdf_generation_east_object" {
@@ -139,7 +118,7 @@ data "archive_file" "zip_websockets" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/websockets.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(local.excludedList, ["websockets.js"])
+  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["websockets.js"])
 }
 
 resource "null_resource" "websockets_east_object" {
@@ -157,7 +136,7 @@ data "archive_file" "zip_maintenance_notify" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/maintenance-notify.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(local.excludedList, ["maintenance-notify.js"])
+  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["maintenance-notify.js"])
 }
 
 resource "null_resource" "maintenance_notify_east_object" {
@@ -175,7 +154,7 @@ data "archive_file" "zip_api_public" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/api-public.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(local.excludedList, ["api-public.js"])
+  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["api-public.js"])
 }
 
 resource "null_resource" "api_public_east_object" {
@@ -205,7 +184,7 @@ data "archive_file" "zip_cron" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/cron.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(local.excludedList, ["cron.js"])
+  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["cron.js"])
 }
 
 resource "null_resource" "cron_east_object" {
@@ -223,7 +202,7 @@ data "archive_file" "zip_streams" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/streams.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(local.excludedList, ["streams.js"])
+  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["streams.js"])
 }
 
 resource "null_resource" "streams_east_object" {
@@ -241,7 +220,7 @@ data "archive_file" "zip_seal_in_lower" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/seal-in-lower-environment.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(local.excludedList, ["seal-in-lower-environment.js"])
+  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["seal-in-lower-environment.js"])
 }
 
 resource "null_resource" "seal_in_lower_east_object" {
@@ -259,7 +238,7 @@ data "archive_file" "zip_bounce_handler" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/handle-bounced-service-email.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(local.excludedList, ["handle-bounced-service-email.js"])
+  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["handle-bounced-service-email.js"])
 }
 
 resource "null_resource" "bounce_handler_east_object" {

--- a/web-api/terraform/template/main-east.tf
+++ b/web-api/terraform/template/main-east.tf
@@ -226,7 +226,23 @@ resource "null_resource" "maintenance_notify_east_object" {
 data "archive_file" "zip_api_public" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/api-public.js.zip"
-  source_file = "${path.module}/../template/lambdas/dist/api-public.js"
+  source_dir = "${path.module}/../template/lambdas/dist/"
+  excludes = [
+    "api.js",
+    "trial-session.js",
+    "send-emails.js",
+    "api.js",
+    "maintenance-notify.js",
+    "cron.js",
+    "streams.js",
+    "cognito-triggers.js",
+    "cognito-authorizer.js",
+    "public-api-authorizer.js",
+    "handle-bounced-service-email.js",
+    "seal-in-lower-environment.js",
+    "pdf-generation.js",
+    "report.html"
+  ]
 }
 
 resource "null_resource" "api_public_east_object" {
@@ -626,7 +642,7 @@ module "api-east-green" {
   region   = "us-east-1"
   validate = 1
   providers = {
-    aws = aws.us-east-1
+    aws           = aws.us-east-1
     aws.us-east-1 = aws.us-east-1
   }
   current_color                  = "green"
@@ -701,7 +717,7 @@ module "api-east-blue" {
   region   = "us-east-1"
   validate = 1
   providers = {
-    aws = aws.us-east-1
+    aws           = aws.us-east-1
     aws.us-east-1 = aws.us-east-1
   }
   current_color                  = "blue"

--- a/web-api/terraform/template/main-east.tf
+++ b/web-api/terraform/template/main-east.tf
@@ -1,3 +1,24 @@
+  
+  locals {
+    excludedList =  [
+      "api-public.js",
+      "api.js",
+      "cognito-authorizer.js",
+      "cognito-triggers.js",
+      "cron.js",
+      "handle-bounced-service-email.js",
+      "maintenance-notify.js",
+      "pdf-generation.js",
+      "public-api-authorizer.js",
+      "report.html",
+      "seal-in-lower-environment.js",
+      "send-emails.js",
+      "streams.js",
+      "trial-session.js",
+      "websockets.js",
+  ]
+  }
+
 resource "aws_s3_bucket" "api_lambdas_bucket_east" {
   bucket = "${var.dns_domain}.efcms.${var.environment}.us-east-1.lambdas"
   acl    = "private"
@@ -26,89 +47,28 @@ data "archive_file" "zip_api" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/api.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = [
-    "api-public.js",
-    "websockets.js",
-    "trial-session.js",
-    "send-emails.js",
-    "websockets.js",
-    "maintenance-notify.js",
-    "cron.js",
-    "streams.js",
-    "cognito-triggers.js",
-    "cognito-authorizer.js",
-    "public-api-authorizer.js",
-    "handle-bounced-service-email.js",
-    "seal-in-lower-environment.js",
-    "pdf-generation.js",
-    "report.html"
-  ]
+  excludes = setsubtract(local.excludedList, ["api.js"])
 }
 
 data "archive_file" "zip_send_emails" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/send_emails.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = [
-    "api-public.js",
-    "api.js",
-    "trial-session.js",
-    "websockets.js",
-    "maintenance-notify.js",
-    "cron.js",
-    "streams.js",
-    "cognito-triggers.js",
-    "cognito-authorizer.js",
-    "public-api-authorizer.js",
-    "handle-bounced-service-email.js",
-    "seal-in-lower-environment.js",
-    "pdf-generation.js",
-    "report.html"
-  ]
+  excludes = setsubtract(local.excludedList, ["send_emails.js"])
 }
 
 data "archive_file" "zip_trial_session" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/trial_session.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = [
-    "api-public.js",
-    "api.js",
-    "websockets.js",
-    "send-emails.js",
-    "maintenance-notify.js",
-    "cron.js",
-    "streams.js",
-    "cognito-triggers.js",
-    "cognito-authorizer.js",
-    "public-api-authorizer.js",
-    "handle-bounced-service-email.js",
-    "seal-in-lower-environment.js",
-    "pdf-generation.js",
-    "report.html"
-  ]
+  excludes = setsubtract(local.excludedList, ["trial_session.js"])
 }
 
 data "archive_file" "zip_triggers" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/cognito-triggers.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = [
-    "api.js",
-    "api-public.js",
-    "websockets.js",
-    "maintenance-notify.js",
-    "trial-session.js",
-    "send-emails.js",
-    "seal-in-lower-environment.js",
-    "cron.js",
-    "streams.js",
-    "cognito-authorizer.js",
-    "public-api-authorizer.js",
-    "handle-bounced-service-email.js",
-    "pdf-generation.js",
-    "report.html"
-  ]
+  excludes = setsubtract(local.excludedList, ["cognito-triggers.js"])
 }
 
 
@@ -116,21 +76,7 @@ data "archive_file" "pdf_generation" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/pdf-generation.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = [
-    "api.js",
-    "api-public.js",
-    "websockets.js",
-    "maintenance-notify.js",
-    "trial-session.js",
-    "send-emails.js",
-    "seal-in-lower-environment.js",
-    "cron.js",
-    "streams.js",
-    "cognito-authorizer.js",
-    "public-api-authorizer.js",
-    "handle-bounced-service-email.js",
-    "report.html"
-  ]
+  excludes = setsubtract(local.excludedList, ["pdf-generation.js"])
 }
 
 resource "null_resource" "pdf_generation_east_object" {
@@ -192,7 +138,8 @@ resource "null_resource" "trial_session_east_object" {
 data "archive_file" "zip_websockets" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/websockets.js.zip"
-  source_file = "${path.module}/../template/lambdas/dist/websockets.js"
+  source_dir  = "${path.module}/../template/lambdas/dist/"
+  excludes = setsubtract(local.excludedList, ["websockets.js"])
 }
 
 resource "null_resource" "websockets_east_object" {
@@ -209,7 +156,8 @@ resource "null_resource" "websockets_east_object" {
 data "archive_file" "zip_maintenance_notify" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/maintenance-notify.js.zip"
-  source_file = "${path.module}/../template/lambdas/dist/maintenance-notify.js"
+  source_dir  = "${path.module}/../template/lambdas/dist/"
+  excludes = setsubtract(local.excludedList, ["maintenance-notify.js"])
 }
 
 resource "null_resource" "maintenance_notify_east_object" {
@@ -227,22 +175,7 @@ data "archive_file" "zip_api_public" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/api-public.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = [
-    "api.js",
-    "trial-session.js",
-    "send-emails.js",
-    "api.js",
-    "maintenance-notify.js",
-    "cron.js",
-    "streams.js",
-    "cognito-triggers.js",
-    "cognito-authorizer.js",
-    "public-api-authorizer.js",
-    "handle-bounced-service-email.js",
-    "seal-in-lower-environment.js",
-    "pdf-generation.js",
-    "report.html"
-  ]
+  excludes = setsubtract(local.excludedList, ["api-public.js"])
 }
 
 resource "null_resource" "api_public_east_object" {
@@ -271,7 +204,8 @@ resource "null_resource" "puppeteer_layer_east_object" {
 data "archive_file" "zip_cron" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/cron.js.zip"
-  source_file = "${path.module}/../template/lambdas/dist/cron.js"
+  source_dir  = "${path.module}/../template/lambdas/dist/"
+  excludes = setsubtract(local.excludedList, ["cron.js"])
 }
 
 resource "null_resource" "cron_east_object" {
@@ -288,7 +222,8 @@ resource "null_resource" "cron_east_object" {
 data "archive_file" "zip_streams" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/streams.js.zip"
-  source_file = "${path.module}/../template/lambdas/dist/streams.js"
+  source_dir  = "${path.module}/../template/lambdas/dist/"
+  excludes = setsubtract(local.excludedList, ["streams.js"])
 }
 
 resource "null_resource" "streams_east_object" {
@@ -305,7 +240,8 @@ resource "null_resource" "streams_east_object" {
 data "archive_file" "zip_seal_in_lower" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/seal-in-lower-environment.js.zip"
-  source_file = "${path.module}/../template/lambdas/dist/seal-in-lower-environment.js"
+  source_dir  = "${path.module}/../template/lambdas/dist/"
+  excludes = setsubtract(local.excludedList, ["seal-in-lower-environment.js"])
 }
 
 resource "null_resource" "seal_in_lower_east_object" {
@@ -322,7 +258,8 @@ resource "null_resource" "seal_in_lower_east_object" {
 data "archive_file" "zip_bounce_handler" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/handle-bounced-service-email.js.zip"
-  source_file = "${path.module}/../template/lambdas/dist/handle-bounced-service-email.js"
+  source_dir  = "${path.module}/../template/lambdas/dist/"
+  excludes = setsubtract(local.excludedList, ["handle-bounced-service-email.js"])
 }
 
 resource "null_resource" "bounce_handler_east_object" {

--- a/web-api/terraform/template/main-east.tf
+++ b/web-api/terraform/template/main-east.tf
@@ -26,28 +26,28 @@ data "archive_file" "zip_api" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/api.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["api.js"])
+  excludes = setsubtract(var.template_lambdas, ["api.js"])
 }
 
 data "archive_file" "zip_send_emails" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/send_emails.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["send_emails.js"])
+  excludes = setsubtract(var.template_lambdas, ["send_emails.js"])
 }
 
 data "archive_file" "zip_trial_session" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/trial_session.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["trial_session.js"])
+  excludes = setsubtract(var.template_lambdas, ["trial_session.js"])
 }
 
 data "archive_file" "zip_triggers" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/cognito-triggers.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["cognito-triggers.js"])
+  excludes = setsubtract(var.template_lambdas, ["cognito-triggers.js"])
 }
 
 
@@ -55,7 +55,7 @@ data "archive_file" "pdf_generation" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/pdf-generation.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["pdf-generation.js"])
+  excludes = setsubtract(var.template_lambdas, ["pdf-generation.js"])
 }
 
 resource "null_resource" "pdf_generation_east_object" {
@@ -118,7 +118,7 @@ data "archive_file" "zip_websockets" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/websockets.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["websockets.js"])
+  excludes = setsubtract(var.template_lambdas, ["websockets.js"])
 }
 
 resource "null_resource" "websockets_east_object" {
@@ -136,7 +136,7 @@ data "archive_file" "zip_maintenance_notify" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/maintenance-notify.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["maintenance-notify.js"])
+  excludes = setsubtract(var.template_lambdas, ["maintenance-notify.js"])
 }
 
 resource "null_resource" "maintenance_notify_east_object" {
@@ -154,7 +154,7 @@ data "archive_file" "zip_api_public" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/api-public.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["api-public.js"])
+  excludes = setsubtract(var.template_lambdas, ["api-public.js"])
 }
 
 resource "null_resource" "api_public_east_object" {
@@ -184,7 +184,7 @@ data "archive_file" "zip_cron" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/cron.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["cron.js"])
+  excludes = setsubtract(var.template_lambdas, ["cron.js"])
 }
 
 resource "null_resource" "cron_east_object" {
@@ -202,7 +202,7 @@ data "archive_file" "zip_streams" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/streams.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["streams.js"])
+  excludes = setsubtract(var.template_lambdas, ["streams.js"])
 }
 
 resource "null_resource" "streams_east_object" {
@@ -220,7 +220,7 @@ data "archive_file" "zip_seal_in_lower" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/seal-in-lower-environment.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["seal-in-lower-environment.js"])
+  excludes = setsubtract(var.template_lambdas, ["seal-in-lower-environment.js"])
 }
 
 resource "null_resource" "seal_in_lower_east_object" {
@@ -238,7 +238,7 @@ data "archive_file" "zip_bounce_handler" {
   type        = "zip"
   output_path = "${path.module}/../template/lambdas/handle-bounced-service-email.js.zip"
   source_dir  = "${path.module}/../template/lambdas/dist/"
-  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["handle-bounced-service-email.js"])
+  excludes = setsubtract(var.template_lambdas, ["handle-bounced-service-email.js"])
 }
 
 resource "null_resource" "bounce_handler_east_object" {

--- a/web-api/terraform/template/public-api-authorizer.tf
+++ b/web-api/terraform/template/public-api-authorizer.tf
@@ -2,7 +2,7 @@ data "archive_file" "zip_public_authorizer" {
   type        = "zip"
   output_path = "${path.module}/lambdas/public-api-authorizer.js.zip"
   source_dir = "${path.module}/lambdas/dist/"
-  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["public-api-authorizer.js"])
+  excludes = setsubtract(var.template_lambdas, ["public-api-authorizer.js"])
 }
 
 resource "aws_lambda_function" "public_api_authorizer_lambda" {

--- a/web-api/terraform/template/public-api-authorizer.tf
+++ b/web-api/terraform/template/public-api-authorizer.tf
@@ -1,7 +1,8 @@
 data "archive_file" "zip_public_authorizer" {
   type        = "zip"
   output_path = "${path.module}/lambdas/public-api-authorizer.js.zip"
-  source_file = "${path.module}/lambdas/dist/public-api-authorizer.js"
+  source_dir = "${path.module}/lambdas/dist/"
+  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["public-api-authorizer.js"])
 }
 
 resource "aws_lambda_function" "public_api_authorizer_lambda" {

--- a/web-api/terraform/template/variables.tf
+++ b/web-api/terraform/template/variables.tf
@@ -141,3 +141,25 @@ variable "enable_health_checks" {
 variable "deployment_timestamp" {
   type = number
 }
+
+variable "template_lambdas" {
+  type = list(string)
+  default = [
+      "api-public.js",
+      "api.js",
+      "cognito-authorizer.js",
+      "cognito-triggers.js",
+      "cron.js",
+      "handle-bounced-service-email.js",
+      "maintenance-notify.js",
+      "pdf-generation.js",
+      "public-api-authorizer.js",
+      "report.html",
+      "seal-in-lower-environment.js",
+      "send-emails.js",
+      "streams.js",
+      "trial-session.js",
+      "websocket-authorizer.js",
+      "websockets.js",
+  ]
+}

--- a/web-api/terraform/template/websocket-authorizer.tf
+++ b/web-api/terraform/template/websocket-authorizer.tf
@@ -2,7 +2,7 @@ data "archive_file" "websocket_authorizer" {
   type        = "zip"
   output_path = "${path.module}/lambdas/websocket-authorizer.js.zip"
   source_dir = "${path.module}/lambdas/dist/"
-  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["websocket-authorizer.js"])
+  excludes = setsubtract(var.template_lambdas, ["websocket-authorizer.js"])
 
 }
 

--- a/web-api/terraform/template/websocket-authorizer.tf
+++ b/web-api/terraform/template/websocket-authorizer.tf
@@ -1,7 +1,9 @@
 data "archive_file" "websocket_authorizer" {
   type        = "zip"
   output_path = "${path.module}/lambdas/websocket-authorizer.js.zip"
-  source_file = "${path.module}/lambdas/dist/websocket-authorizer.js"
+  source_dir = "${path.module}/lambdas/dist/"
+  excludes = setsubtract(data.null_data_source.template_lambdas.outputs, ["websocket-authorizer.js"])
+
 }
 
 resource "aws_lambda_function" "websocket_authorizer_lambda" {

--- a/web-client/src/views/ModalDialog.tsx
+++ b/web-client/src/views/ModalDialog.tsx
@@ -128,7 +128,11 @@ export const ModalDialog = ({
               <div className="grid-row">
                 <div className="mobile-lg:grid-col-9">
                   {title && (
-                    <h3 className="modal-header__title" tabIndex={-1}>
+                    <h3
+                      className="modal-header__title"
+                      data-testid="modal-header"
+                      tabIndex={-1}
+                    >
                       {title}
                     </h3>
                   )}

--- a/web-client/src/views/Public/PublicDocketRecordHeader.tsx
+++ b/web-client/src/views/Public/PublicDocketRecordHeader.tsx
@@ -43,6 +43,7 @@ export const PublicDocketRecordHeader = connect(
             <Button
               link
               className="hide-on-mobile float-right margin-right-0 margin-top-1"
+              data-testid="print-public-docket-record-button"
               icon="print"
               id="printable-docket-record-button"
               onClick={() => {

--- a/web-client/terraform/common/header-security-lambda.tf
+++ b/web-client/terraform/common/header-security-lambda.tf
@@ -2,8 +2,9 @@ data "aws_caller_identity" "current" {}
 
 data "archive_file" "zip_header_security_lambda" {
   type        = "zip"
-  source_file = "${path.module}/cloudfront-edge/header-security-lambda.js"
+  source_dir = "${path.module}/cloudfront-edge/"
   output_path = "${path.module}/cloudfront-edge/header-security-lambda.js.zip"
+  excludes = ["strip-basepath-lambda.js"]
 }
 
 resource "aws_lambda_function" "header_security_lambda" {

--- a/web-client/terraform/common/strip-basepath-lambda.tf
+++ b/web-client/terraform/common/strip-basepath-lambda.tf
@@ -1,7 +1,8 @@
 data "archive_file" "zip_strip_basepath_lambda" {
   type        = "zip"
-  source_file = "${path.module}/cloudfront-edge/strip-basepath-lambda.js"
+  source_dir = "${path.module}/cloudfront-edge/"
   output_path = "${path.module}/cloudfront-edge/strip-basepath-lambda.js.zip"
+  excludes = ["header-security-lambda.js"]
 }
 
 resource "aws_lambda_function" "strip_basepath_lambda" {


### PR DESCRIPTION
# What error is occurring?
- On the public api when downloading the printable docket record the lambda explodes with the below error:
```
Cannot find module './572.js'
Require stack:
- /var/task/api-public.js
- /var/runtime/index.mjs
```

## Why is this error ocurring?
This error is occurring because terraform is not zipping all of the build files that are generated by webpack. When webpack bundles our code it outputs multiple *.js files for the entry-points but it also outputs files that are not related to any entry points. If you run a lambda build by running `npm run build:lambda:api` and look in the output directory `web-api/terraform/template/lambdas/dist` You will see these files:
 - 10.js
 - 136.js
 - 232.js
 - 304.js
 - 360.js
 - 572.js
 - 656.js
 - 660.js
 - 776.js
 - 876.js
 - api-public.js

Looking at these files you can see 572.js file which is the file that the public-api error is mentioning. Terraform is not bundling api-public.js + 572.js into the same .zip file when it creates the zip and uploads it to AWS. The reason that Terraform is not bundling 572.js is because we are only telling terraform to create a zip of api-public.js instead of the whole directory. This is occurring on line 229 inside file `web-api/terraform/template/main-east.tf`

## Why does webpack produce multiple files for a single entry point?
Webpack produces multiple files for a single entry point when our app or our dependencies utilize dynamic imports. A dynamic import is an import that happens in-line instead of the top level of a file and is utilized to help reduce load times caused by imports, and only to import a file when it is needed. A dynamic import looks like this: `const { default: chromium } = await import('@sparticuz/chromium');`.

## Why does it only occur on public?
This occurs only on public because the public api terraform creates a zip out of a single file while the regular app makes a zip out of the whole directory

## Why did this start happening with an upgrade to @aws-sdk/client-lambda?
This likely occurred because @aws-sdk/client-lambda lambda started to utilize dynamic imports somewhere in their codebase, causing webpack to code split and make multiple output files.

Successful deploy: https://app.circleci.com/pipelines/github/flexion/ef-cms/51044/workflows/df8fe717-a363-4550-9aa8-f65a6e6c563d
