### PR TITLE
10270 Bug: Include deploying color in getPublicSiteUrl used by smoketests

### DIFF
--- a/cypress/cypress-integration/integration/petitions-clerk-views-case-detail.cy.ts
+++ b/cypress/cypress-integration/integration/petitions-clerk-views-case-detail.cy.ts
@@ -37,7 +37,7 @@ describe('Petitions clerk views case detail', function () {
       cy.get('.progress-indicator').should('not.exist');
       cy.get('button#tab-docket-sub-record');
 
-      cy.get('button#printable-docket-record-button').should('not.exist');
+      cy.get('[data-testid="print-docket-record-button"').should('not.exist');
     });
   });
 });

--- a/cypress/helpers/env/get-public-site-url.ts
+++ b/cypress/helpers/env/get-public-site-url.ts
@@ -1,5 +1,7 @@
 export function getPublicSiteUrl(): string {
-  const publicUrl = Cypress.env('EFCMS_DOMAIN') || 'localhost:5678';
-
-  return `http://${publicUrl}`;
+  if (Cypress.env('ENV') === 'local') {
+    return 'http://localhost:5678';
+  } else {
+    return `https://${Cypress.env('DEPLOYING_COLOR')}.${Cypress.env('EFCMS_DOMAIN')}`;
+  }
 }

--- a/scripts/run-cypress.sh
+++ b/scripts/run-cypress.sh
@@ -100,6 +100,7 @@ if [ -n "${INTEGRATION}" ]; then
   export CYPRESS_CHECK_DEPLOY_DATE_INTERVAL=5000
 elif [ -n "${CYPRESS_SMOKETESTS_LOCAL}" ]; then
   export CYPRESS_BASE_URL="http://localhost:${PORT}"
+  export ENV='local'
 else
   if [ -z "${ENV}" ]; then
     echo "Please export the environment name as a variable named ENV."

--- a/web-client/src/views/DocketRecord/DocketRecordHeader.tsx
+++ b/web-client/src/views/DocketRecord/DocketRecordHeader.tsx
@@ -185,8 +185,8 @@ export const DocketRecordHeader = connect(
                     <Button
                       link
                       aria-label="printable docket record"
+                      data-testid="print-docket-record-button"
                       icon="print"
-                      id="printable-docket-record-button"
                       onClick={() => {
                         gotoPrintableDocketRecordSequence({
                           docketNumber: formattedCaseDetail.docketNumber,

--- a/web-client/src/views/Public/PublicDocketRecordHeader.tsx
+++ b/web-client/src/views/Public/PublicDocketRecordHeader.tsx
@@ -45,7 +45,6 @@ export const PublicDocketRecordHeader = connect(
               className="hide-on-mobile float-right margin-right-0 margin-top-1"
               data-testid="print-public-docket-record-button"
               icon="print"
-              id="printable-docket-record-button"
               onClick={() => {
                 gotoPublicPrintableDocketRecordSequence({ docketNumber });
               }}


### PR DESCRIPTION
To prove this will now work on deploying environments, I ran a full build on exp5:
https://app.circleci.com/pipelines/github/flexion/ef-cms/51161/workflows/5fba4f81-4e19-4b2b-bc12-6545b8585e25