### PR TITLE
Opex: Fix cleanup step for unaliased indices getting deleted

### DIFF
--- a/web-api/elasticsearch/elasticsearch-index-settings.helpers.test.ts
+++ b/web-api/elasticsearch/elasticsearch-index-settings.helpers.test.ts
@@ -110,4 +110,18 @@ describe('deleteUnaliasedIndices', () => {
       index: mockUnaliasedIndices,
     });
   });
+
+  it('does not throw an error if the attempt to delete fails for whatever reason', async () => {
+    (mockedClient.indices.delete as jest.Mock).mockRejectedValue(
+      new Error('Cannot delete indices that are being snapshotted'),
+    );
+
+    await expect(
+      deleteUnaliasedIndices({ client: mockedClient }),
+    ).resolves.not.toThrow();
+
+    expect(mockedClient.indices.delete).toHaveBeenCalledWith({
+      index: mockUnaliasedIndices,
+    });
+  });
 });

--- a/web-api/elasticsearch/elasticsearch-index-settings.helpers.ts
+++ b/web-api/elasticsearch/elasticsearch-index-settings.helpers.ts
@@ -28,7 +28,7 @@ export const setupIndexes = async ({
         });
 
         if (!indexExists) {
-          await client.indices.create({
+          return client.indices.create({
             body: {
               mappings: {
                 dynamic: false,
@@ -39,7 +39,7 @@ export const setupIndexes = async ({
             index,
           });
         } else {
-          await client.indices.putSettings({
+          return client.indices.putSettings({
             body: {
               index: {
                 max_result_window: esSettings.index.max_result_window,

--- a/web-api/elasticsearch/elasticsearch-index-settings.helpers.ts
+++ b/web-api/elasticsearch/elasticsearch-index-settings.helpers.ts
@@ -39,7 +39,7 @@ export const setupIndexes = async ({
             index,
           });
         } else {
-          client.indices.putSettings({
+          await client.indices.putSettings({
             body: {
               index: {
                 max_result_window: esSettings.index.max_result_window,
@@ -81,9 +81,14 @@ export const deleteUnaliasedIndices = async ({
       return !aliasedIndices.includes(index);
     }) || [];
   if (unaliasedIndices.length) {
-    client.indices.delete({
-      index:
-        unaliasedIndices.length === 1 ? unaliasedIndices[0] : unaliasedIndices,
-    });
+    try {
+      await client.indices.delete({
+        index: unaliasedIndices,
+      });
+    } catch (err) {
+      console.log(
+        'We were unable to delete the unaliased indices; the next deployment should get this done',
+      );
+    }
   }
 };


### PR DESCRIPTION
We observed a CircleCI failure during the cleanup step when it was trying to delete unaliased indices. These can stick around as they are unaliased and unused. The subsequent deploy will clean these up.