### PR TITLE
Devex: fix for stuck migrations

### DIFF
--- a/web-api/workflow-terraform/migration/main/lambdas/migration.test.ts
+++ b/web-api/workflow-terraform/migration/main/lambdas/migration.test.ts
@@ -1,17 +1,17 @@
 import { MOCK_CASE } from '@shared/test/mockCase';
 import { applicationContext } from '@shared/business/test/createTestApplicationContext';
 import { getFilteredGlobalEvents, processItems } from './migration';
+import { marshall } from '@aws-sdk/util-dynamodb';
 
 describe('migration', () => {
   describe('processItems', () => {
     it('migrates items and generates dynamodb PutRequest objects with the resulting data', async () => {
-      const mockItems: Record<string, any>[] = [
-        {
-          ...MOCK_CASE,
-          pk: `case|${MOCK_CASE.docketNumber}`,
-          sk: `case|${MOCK_CASE.docketNumber}`,
-        },
-      ];
+      const mockCase = marshall({
+        ...MOCK_CASE,
+        pk: `case|${MOCK_CASE.docketNumber}`,
+        sk: `case|${MOCK_CASE.docketNumber}`,
+      });
+      const mockItems: Record<string, any>[] = [mockCase];
       const mockMigrateRecords = jest.fn().mockReturnValue(mockItems);
       const result = await processItems(applicationContext, {
         items: mockItems,

--- a/web-api/workflow-terraform/migration/main/lambdas/migration.ts
+++ b/web-api/workflow-terraform/migration/main/lambdas/migration.ts
@@ -8,6 +8,7 @@ import { chunk } from 'lodash';
 import { createApplicationContext } from '@web-api/applicationContext';
 import { createLogger } from '@web-api/createLogger';
 import { migrateRecords as migrations } from './migration-segments';
+import { unmarshall } from '@aws-sdk/util-dynamodb';
 import type { DynamoDBStreamEvent, Handler } from 'aws-lambda';
 
 type migrationsCallback = {
@@ -44,9 +45,9 @@ export const processItems = async (
 ): Promise<{ PutRequest: PutRequest }[]> => {
   items = await migrateRecords(applicationContext, { items });
 
-  return items.map(Item => ({
+  return items.map(item => ({
     PutRequest: {
-      Item,
+      Item: unmarshall(item),
     },
   }));
 };


### PR DESCRIPTION
We refactored individual put requests into `BatchWriteCommand`(s), and thereafter, "live" migrations stopped working, which resulted in the `completion-marker` not being written, which ultimately lead to migrations getting stuck at the "wait-for-reindex" step.

As it turns out, the `BatchWriteCommand` wants unmarshalled data, not marshalled data, so we now have to unmarshall a dynamo record before we can batch write it.