### PR TITLE
10249-fix-pre-epoch-cases

### DIFF
--- a/shared/src/business/entities/customCaseReportSearch/CustomCaseReportSearch.ts
+++ b/shared/src/business/entities/customCaseReportSearch/CustomCaseReportSearch.ts
@@ -99,7 +99,7 @@ export class CustomCaseReportSearch extends JoiValidationEntity {
           pk: joi.string().allow('').required(),
           receivedAt: joi.number().required(),
         })
-        .required(),
+        .optional(),
       startDate: JoiValidationConstants.ISO_DATE.max('now')
         .description(
           'The start date to search by, which cannot be greater than the current date, and is required when there is an end date provided',

--- a/shared/src/business/entities/customCaseReportSearch/CustomCaseReportSearch.ts
+++ b/shared/src/business/entities/customCaseReportSearch/CustomCaseReportSearch.ts
@@ -96,10 +96,10 @@ export class CustomCaseReportSearch extends JoiValidationEntity {
       searchAfter: joi
         .object()
         .keys({
-          pk: joi.string().allow('').required(),
-          receivedAt: joi.number().required(),
+          pk: joi.string().allow(null).required(),
+          receivedAt: joi.number().allow(null).required(),
         })
-        .optional(),
+        .required(),
       startDate: JoiValidationConstants.ISO_DATE.max('now')
         .description(
           'The start date to search by, which cannot be greater than the current date, and is required when there is an end date provided',

--- a/web-api/src/business/useCases/caseInventoryReport/getCustomCaseReportInteractor.ts
+++ b/web-api/src/business/useCases/caseInventoryReport/getCustomCaseReportInteractor.ts
@@ -12,7 +12,6 @@ import {
   isAuthorized,
 } from '@shared/authorization/authorizationClientService';
 import { UnauthorizedError } from '@web-api/errors/errors';
-import { isEmpty } from 'lodash';
 
 export type CustomCaseReportFilters = {
   caseStatuses: CaseStatus[];
@@ -28,10 +27,7 @@ export type CustomCaseReportFilters = {
 
 export type GetCustomCaseReportRequest = CustomCaseReportFilters & {
   pageSize: number;
-  searchAfter?: {
-    receivedAt: number;
-    pk: string;
-  };
+  searchAfter: CustomCaseReportSearchAfter;
 };
 
 export type GetCustomCaseReportResponse = {
@@ -55,6 +51,11 @@ export type CaseInventory = Pick<
   | 'highPriority'
 >;
 
+export type CustomCaseReportSearchAfter = {
+  pk: string | null;
+  receivedAt: number | null;
+};
+
 export const getCustomCaseReportInteractor = async (
   applicationContext: IApplicationContext,
   params: GetCustomCaseReportRequest,
@@ -68,10 +69,6 @@ export const getCustomCaseReportInteractor = async (
   params.caseTypes = params.caseTypes || [];
   params.judges = params.judges || [];
   params.preferredTrialCities = params.preferredTrialCities || [];
-  params.searchAfter =
-    isEmpty(params.searchAfter?.pk) || isEmpty(params.searchAfter?.receivedAt)
-      ? undefined
-      : params.searchAfter;
 
   new CustomCaseReportSearch(params).validate();
 

--- a/web-api/src/business/useCases/caseInventoryReport/getCustomCaseReportInteractor.ts
+++ b/web-api/src/business/useCases/caseInventoryReport/getCustomCaseReportInteractor.ts
@@ -12,6 +12,7 @@ import {
   isAuthorized,
 } from '@shared/authorization/authorizationClientService';
 import { UnauthorizedError } from '@web-api/errors/errors';
+import { isEmpty } from 'lodash';
 
 export type CustomCaseReportFilters = {
   caseStatuses: CaseStatus[];
@@ -27,7 +28,7 @@ export type CustomCaseReportFilters = {
 
 export type GetCustomCaseReportRequest = CustomCaseReportFilters & {
   pageSize: number;
-  searchAfter: {
+  searchAfter?: {
     receivedAt: number;
     pk: string;
   };
@@ -67,6 +68,10 @@ export const getCustomCaseReportInteractor = async (
   params.caseTypes = params.caseTypes || [];
   params.judges = params.judges || [];
   params.preferredTrialCities = params.preferredTrialCities || [];
+  params.searchAfter =
+    isEmpty(params.searchAfter?.pk) || isEmpty(params.searchAfter?.receivedAt)
+      ? undefined
+      : params.searchAfter;
 
   new CustomCaseReportSearch(params).validate();
 

--- a/web-api/src/business/useCases/caseInventoryReport/getCustomCaseReportInteractor.ts
+++ b/web-api/src/business/useCases/caseInventoryReport/getCustomCaseReportInteractor.ts
@@ -69,6 +69,10 @@ export const getCustomCaseReportInteractor = async (
   params.caseTypes = params.caseTypes || [];
   params.judges = params.judges || [];
   params.preferredTrialCities = params.preferredTrialCities || [];
+  params.searchAfter = params.searchAfter || {
+    pk: null,
+    receivedAt: null,
+  };
 
   new CustomCaseReportSearch(params).validate();
 

--- a/web-api/src/business/useCases/customCaseReport/createCsvCustomCaseReportFileInteractor.ts
+++ b/web-api/src/business/useCases/customCaseReport/createCsvCustomCaseReportFileInteractor.ts
@@ -39,7 +39,7 @@ export const createCsvCustomCaseReportFileInteractor = async (
     throw new UnauthorizedError('Unauthorized');
   }
 
-  let searchAfter = { pk: '', receivedAt: 0 };
+  let searchAfter;
   const pageSize = 9000;
 
   const loops = Math.floor(totalCount / pageSize) + 1;

--- a/web-api/src/business/useCases/customCaseReport/createCsvCustomCaseReportFileInteractor.ts
+++ b/web-api/src/business/useCases/customCaseReport/createCsvCustomCaseReportFileInteractor.ts
@@ -2,6 +2,7 @@ import { Case } from '@shared/business/entities/cases/Case';
 import {
   CaseInventory,
   CustomCaseReportFilters,
+  CustomCaseReportSearchAfter,
   GetCustomCaseReportResponse,
 } from '@web-api/business/useCases/caseInventoryReport/getCustomCaseReportInteractor';
 import { FORMATS } from '@shared/business/utilities/DateHandler';
@@ -39,7 +40,10 @@ export const createCsvCustomCaseReportFileInteractor = async (
     throw new UnauthorizedError('Unauthorized');
   }
 
-  let searchAfter;
+  let searchAfter: CustomCaseReportSearchAfter = {
+    pk: null,
+    receivedAt: null,
+  };
   const pageSize = 9000;
 
   const loops = Math.floor(totalCount / pageSize) + 1;

--- a/web-api/src/persistence/elasticsearch/getCasesByFilters.ts
+++ b/web-api/src/persistence/elasticsearch/getCasesByFilters.ts
@@ -137,7 +137,9 @@ export const getCasesByFilters = async ({
           must: mustClause,
         },
       },
-      search_after: [params.searchAfter.receivedAt, params.searchAfter.pk],
+      search_after: params.searchAfter
+        ? [params.searchAfter.receivedAt, params.searchAfter.pk]
+        : undefined,
       sort: [{ 'receivedAt.S': 'asc' }, { 'pk.S': 'asc' }],
     },
     index: 'efcms-case',

--- a/web-api/src/persistence/elasticsearch/getCasesByFilters.ts
+++ b/web-api/src/persistence/elasticsearch/getCasesByFilters.ts
@@ -137,9 +137,10 @@ export const getCasesByFilters = async ({
           must: mustClause,
         },
       },
-      search_after: params.searchAfter
-        ? [params.searchAfter.receivedAt, params.searchAfter.pk]
-        : undefined,
+      search_after:
+        params.searchAfter.receivedAt && params.searchAfter.pk
+          ? params.searchAfter
+          : undefined,
       sort: [{ 'receivedAt.S': 'asc' }, { 'pk.S': 'asc' }],
     },
     index: 'efcms-case',

--- a/web-client/src/presenter/actions/CaseInventoryReport/getCustomCaseReportAction.test.ts
+++ b/web-client/src/presenter/actions/CaseInventoryReport/getCustomCaseReportAction.test.ts
@@ -49,7 +49,7 @@ describe('getCustomCaseReportAction', () => {
       ...filterValues,
       endDate: '2022-05-15T03:59:59.999Z',
       pageSize: CUSTOM_CASE_REPORT_PAGE_SIZE,
-      searchAfter: { pk: '', receivedAt: 0 },
+      searchAfter: { pk: null, receivedAt: null },
       startDate: '2022-05-10T04:00:00.000Z',
     };
   });
@@ -65,7 +65,7 @@ describe('getCustomCaseReportAction', () => {
       state: {
         customCaseReport: {
           filters: filterValues,
-          lastIdsOfPages: [{ pk: '', receivedAt: 0 }],
+          lastIdsOfPages: [{ pk: null, receivedAt: null }],
         },
       },
     });
@@ -80,7 +80,7 @@ describe('getCustomCaseReportAction', () => {
       mockCustomCaseReportResponse.totalCount,
     );
     expect(result.state.customCaseReport.lastIdsOfPages).toMatchObject([
-      { pk: '', receivedAt: 0 },
+      { pk: null, receivedAt: null },
       lastCaseId,
     ]);
   });
@@ -113,7 +113,7 @@ describe('getCustomCaseReportAction', () => {
       state: {
         customCaseReport: {
           filters: filterValues,
-          lastIdsOfPages: [{ pk: '', receivedAt: 0 }, page1SearchId],
+          lastIdsOfPages: [{ pk: null, receivedAt: null }, page1SearchId],
         },
       },
     });
@@ -128,7 +128,7 @@ describe('getCustomCaseReportAction', () => {
       mockCustomCaseReportResponse.totalCount,
     );
     expect(result.state.customCaseReport.lastIdsOfPages).toMatchObject([
-      { pk: '', receivedAt: 0 },
+      { pk: null, receivedAt: null },
       page1SearchId,
       page2SearchId,
     ]);
@@ -145,7 +145,7 @@ describe('getCustomCaseReportAction', () => {
       state: {
         customCaseReport: {
           filters: { ...filterValues, highPriority: false },
-          lastIdsOfPages: [{ pk: '', receivedAt: 0 }],
+          lastIdsOfPages: [{ pk: null, receivedAt: null }],
         },
       },
     });
@@ -174,7 +174,7 @@ describe('getCustomCaseReportAction', () => {
       state: {
         customCaseReport: {
           filters: filterValues,
-          lastIdsOfPages: [{ pk: '', receivedAt: 0 }],
+          lastIdsOfPages: [{ pk: null, receivedAt: null }],
         },
       },
     });
@@ -209,7 +209,7 @@ describe('getCustomCaseReportAction', () => {
       state: {
         customCaseReport: {
           filters: filterValues,
-          lastIdsOfPages: [{ pk: '', receivedAt: 0 }],
+          lastIdsOfPages: [{ pk: null, receivedAt: null }],
         },
         judges: [judgeSotomayor, judgeColvin],
       },

--- a/web-client/src/presenter/actions/CaseInventoryReport/getCustomCaseReportAction.ts
+++ b/web-client/src/presenter/actions/CaseInventoryReport/getCustomCaseReportAction.ts
@@ -53,7 +53,7 @@ export const getCustomCaseReportAction = async ({
     .getCustomCaseReportInteractor(applicationContext, {
       ...filterValues,
       endDate: formattedEndDate,
-      judges: judgesIds,
+      judges: judgesIds!,
       pageSize: CUSTOM_CASE_REPORT_PAGE_SIZE,
       searchAfter,
       startDate: formattedStartDate,

--- a/web-client/src/presenter/customCaseReportState.ts
+++ b/web-client/src/presenter/customCaseReportState.ts
@@ -1,13 +1,14 @@
 import {
   CaseInventory,
   CustomCaseReportFilters,
-} from '../../../web-api/src/business/useCases/caseInventoryReport/getCustomCaseReportInteractor';
+  CustomCaseReportSearchAfter,
+} from '@web-api/business/useCases/caseInventoryReport/getCustomCaseReportInteractor';
 
 export type CustomCaseReportState = {
   totalCases: number;
   cases: CaseInventory[];
   filters: CustomCaseReportFilters;
-  lastIdsOfPages: { receivedAt: number; pk: string }[];
+  lastIdsOfPages: CustomCaseReportSearchAfter[];
 };
 
 export const initialCustomCaseReportState: CustomCaseReportState = {
@@ -23,6 +24,6 @@ export const initialCustomCaseReportState: CustomCaseReportState = {
     procedureType: 'All',
     startDate: '',
   },
-  lastIdsOfPages: [{ pk: '', receivedAt: 0 }],
+  lastIdsOfPages: [{ pk: null, receivedAt: null }],
   totalCases: 0,
 };


### PR DESCRIPTION
This PR allows cases with a `receivedAt` of before the UNIX date time epoch to show up in the Custom Case Report as well as the downloadable custom case report. For the first page of the Custom Case Report, we will simply not include a `searchAfter` parameter to the Opensearch query instead of the default `receivedAt` of `0`. This way `receivedAt` with negative values will be included.

<img width="1501" alt="Screenshot 2024-03-20 at 4 41 49 PM" src="https://github.com/ustaxcourt/ef-cms/assets/5023502/1ee4e350-a48e-417d-a3d0-8a8c5598c685">
