### PR TITLE
10321: do not preserve whitespace when copying into quill

### DIFF
--- a/web-client/src/views/CreateOrder/TextEditor.tsx
+++ b/web-client/src/views/CreateOrder/TextEditor.tsx
@@ -77,7 +77,6 @@ export const TextEditor = ({
               ],
             ],
           }}
-          preserveWhitespace={true}
           tabIndex={0}
           onChange={(content, delta, source, editor) => {
             const fullDelta = editor.getContents();


### PR DESCRIPTION
This is difficult to test without a copy of Word, but the working theory is that the desktop version is adding extra whitespace for formatting