### PR TITLE
Downgrade USWDS to 3.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@joi/date": "2.1.0",
         "@opensearch-project/opensearch": "2.6.0",
         "@sparticuz/chromium": "112.0.2",
-        "@uswds/uswds": "3.8.0",
+        "@uswds/uswds": "3.7.1",
         "archiver": "7.0.1",
         "aws-lambda": "1.0.7",
         "aws-sdk": "2.1577.0",
@@ -12869,9 +12869,9 @@
       "dev": true
     },
     "node_modules/@uswds/uswds": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.8.0.tgz",
-      "integrity": "sha512-rMwCXe/u4HGkfskvS1Iuabapi/EXku3ChaIFW7y/dUhc7R1TXQhbbfp8YXEjmXPF0yqJnv9T08WPgS0fQqWZ8w==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.7.1.tgz",
+      "integrity": "sha512-32u2S50bf5dwIujebqL+f1Jgx2rmRrpxcaccSZzdo3Qv9HaDUdcmeavlrxHqN30edHc7p8kRPjvjevOmOJKB7w==",
       "dependencies": {
         "classlist-polyfill": "1.2.0",
         "object-assign": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@joi/date": "2.1.0",
     "@opensearch-project/opensearch": "2.6.0",
     "@sparticuz/chromium": "112.0.2",
-    "@uswds/uswds": "3.8.0",
+    "@uswds/uswds": "3.7.1",
     "archiver": "7.0.1",
     "aws-lambda": "1.0.7",
     "aws-sdk": "2.1577.0",


### PR DESCRIPTION
USWDS version 3.8.0 causes Cypress to lose styles when inspecting snapshots, and causes several other minor visual changes. This will revert to a functioning version until we can resolve the new issues