### PR TITLE
10068 story

### DIFF
--- a/shared/src/business/entities/cases/Case.ts
+++ b/shared/src/business/entities/cases/Case.ts
@@ -137,7 +137,7 @@ export class Case extends JoiValidationEntity {
   public initialCaption?: string;
   public irsPractitioners?: any[];
   public statistics?: any[];
-  public correspondence?: any[];
+  public correspondence: any[];
   public archivedCorrespondences?: any[];
   public hasPendingItems?: boolean;
   public consolidatedCases: RawConsolidatedCaseSummary[] = [];
@@ -161,6 +161,7 @@ export class Case extends JoiValidationEntity {
     }
 
     this.petitioners = [];
+    this.correspondence = [];
     const currentUser = applicationContext.getCurrentUser();
 
     if (!filtered || User.isInternalUser(currentUser.role)) {
@@ -1916,8 +1917,7 @@ export class Case extends JoiValidationEntity {
    * @returns {Case} this case entity
    */
   fileCorrespondence(correspondenceEntity) {
-    const correspondence = this.correspondence ? this.correspondence : [];
-    this.correspondence = [...correspondence, correspondenceEntity];
+    this.correspondence = [...this.correspondence, correspondenceEntity];
 
     return this;
   }

--- a/shared/src/business/useCases/document/batchDownloadDocketEntriesInteractor.test.ts
+++ b/shared/src/business/useCases/document/batchDownloadDocketEntriesInteractor.test.ts
@@ -85,6 +85,7 @@ describe('batchDownloadDocketEntriesInteractor', () => {
       applicationContext.getNotificationGateway().sendNotificationToUser,
     ).toHaveBeenCalledWith({
       applicationContext: expect.anything(),
+      clientConnectionId: mockClientConnectionId,
       message: {
         action: 'batch_download_error',
         error: expect.anything(),
@@ -112,6 +113,7 @@ describe('batchDownloadDocketEntriesInteractor', () => {
       applicationContext.getNotificationGateway().sendNotificationToUser,
     ).toHaveBeenCalledWith({
       applicationContext: expect.anything(),
+      clientConnectionId: mockClientConnectionId,
       message: {
         action: 'batch_download_error',
         error: expect.anything(),
@@ -138,6 +140,7 @@ describe('batchDownloadDocketEntriesInteractor', () => {
       applicationContext.getNotificationGateway().sendNotificationToUser,
     ).toHaveBeenCalledWith({
       applicationContext: expect.anything(),
+      clientConnectionId: mockClientConnectionId,
       message: {
         action: 'batch_download_error',
         error: expect.anything(),
@@ -210,6 +213,7 @@ describe('batchDownloadDocketEntriesInteractor', () => {
       applicationContext.getNotificationGateway().sendNotificationToUser,
     ).toHaveBeenCalledWith({
       applicationContext: expect.anything(),
+      clientConnectionId: mockClientConnectionId,
       message: {
         action: 'batch_download_ready',
         url: MOCK_URL,

--- a/shared/src/business/useCases/document/batchDownloadDocketEntriesInteractor.ts
+++ b/shared/src/business/useCases/document/batchDownloadDocketEntriesInteractor.ts
@@ -166,6 +166,7 @@ const batchDownloadDocketEntriesHelper = async (
 
   await applicationContext.getNotificationGateway().sendNotificationToUser({
     applicationContext,
+    clientConnectionId,
     message: {
       action: 'batch_download_ready',
       url,
@@ -185,7 +186,7 @@ export const batchDownloadDocketEntriesInteractor = async (
     );
   } catch (error) {
     const { userId } = applicationContext.getCurrentUser();
-    const { docketNumber } = downloadDocketEntryRequestInfo;
+    const { clientConnectionId, docketNumber } = downloadDocketEntryRequestInfo;
 
     const erMsg = error.message || 'unknown error';
     applicationContext.logger.error(
@@ -194,6 +195,7 @@ export const batchDownloadDocketEntriesInteractor = async (
     );
     await applicationContext.getNotificationGateway().sendNotificationToUser({
       applicationContext,
+      clientConnectionId,
       message: {
         action: 'batch_download_error',
         error,

--- a/web-client/integration-tests/permissions.test.ts
+++ b/web-client/integration-tests/permissions.test.ts
@@ -81,7 +81,6 @@ const internalFieldsBlocked = () => {
   expect(cerebralTest.getState('caseDetail.blockedDate')).toBeUndefined();
   expect(cerebralTest.getState('caseDetail.blockedReason')).toBeUndefined();
   expect(cerebralTest.getState('caseDetail.caseNote')).toBeUndefined();
-  expect(cerebralTest.getState('caseDetail.correspondence')).toBeUndefined();
   expect(cerebralTest.getState('caseDetail.damages')).toBeUndefined();
   expect(cerebralTest.getState('caseDetail.highPriority')).toBeUndefined();
   expect(


### PR DESCRIPTION
Fixes a bug where a user who tries to download docket entries with multiple tabs open will get the same number of downloads as tabs open.

Also includes a type error change.