### PR TITLE
10356 Bug: Navigating to Message Detail triggers 403

### DIFF
--- a/web-client/src/presenter/sequences/gotoMessageDetailSequence.ts
+++ b/web-client/src/presenter/sequences/gotoMessageDetailSequence.ts
@@ -2,14 +2,13 @@ import { clearErrorAlertsAction } from '../actions/clearErrorAlertsAction';
 import { closeMobileMenuAction } from '../actions/closeMobileMenuAction';
 import { getCaseAction } from '../actions/getCaseAction';
 import { getDefaultAttachmentViewerDocumentToDisplayAction } from '../actions/getDefaultAttachmentViewerDocumentToDisplayAction';
-import { getJudgesCaseNoteForCaseAction } from '@web-client/presenter/actions/TrialSession/getJudgesCaseNoteForCaseAction';
 import { getMessageThreadAction } from '../actions/getMessageThreadAction';
 import { getMostRecentMessageInThreadAction } from '../actions/getMostRecentMessageInThreadAction';
 import { getShouldMarkMessageAsReadAction } from '../actions/getShouldMarkMessageAsReadAction';
+import { parallel } from 'cerebral';
 import { setCaseAction } from '../actions/setCaseAction';
 import { setCaseDetailPageTabActionGenerator } from '../actions/setCaseDetailPageTabActionGenerator';
 import { setDefaultIsExpandedAction } from '../actions/setDefaultIsExpandedAction';
-import { setJudgesCaseNoteOnCaseDetailAction } from '@web-client/presenter/actions/TrialSession/setJudgesCaseNoteOnCaseDetailAction';
 import { setMessageAction } from '../actions/setMessageAction';
 import { setMessageAsReadAction } from '../actions/setMessageAsReadAction';
 import { setMessageDetailViewerDocumentToDisplayAction } from '../actions/setMessageDetailViewerDocumentToDisplayAction';
@@ -25,13 +24,11 @@ export const gotoMessageDetailSequence =
       setupCurrentPageAction('Interstitial'),
       closeMobileMenuAction,
       clearErrorAlertsAction,
-      getCaseAction,
-      setCaseAction,
-      getJudgesCaseNoteForCaseAction,
-      setJudgesCaseNoteOnCaseDetailAction,
       setParentMessageIdAction,
-      getMessageThreadAction,
-      setMessageAction,
+      parallel([
+        [getCaseAction, setCaseAction],
+        [getMessageThreadAction, setMessageAction],
+      ]),
       getMostRecentMessageInThreadAction,
       getDefaultAttachmentViewerDocumentToDisplayAction,
       setMessageDetailViewerDocumentToDisplayAction,


### PR DESCRIPTION
Do not need to get judges notes when routing to message detail. If you click a sub-nav case detail item it will trigger a reload of case detail that will fetch judges notes for users who have permission to view them