### PR TITLE
Devex 10337: use the region that is contextual to the running lambda when instantiating the SES and SQS clients (to `test`)

### DIFF
--- a/web-api/src/applicationContext.ts
+++ b/web-api/src/applicationContext.ts
@@ -217,6 +217,7 @@ export const createApplicationContext = (
       if (!sqsCache) {
         sqsCache = new SQSClient({
           maxAttempts: 3,
+          region: environment.region,
           requestHandler: new NodeHttpHandler({
             connectionTimeout: 3_000,
             requestTimeout: 5_000,

--- a/web-api/src/persistence/messages/getEmailClient.ts
+++ b/web-api/src/persistence/messages/getEmailClient.ts
@@ -1,8 +1,10 @@
 import { EmailResponse } from './sendEmailToUser';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
 import { SESClient } from '@aws-sdk/client-ses';
+import { environment } from '@web-api/environment';
 
 let sesCache: SESClient;
+const { region } = environment;
 
 export function getEmailClient() {
   if (process.env.CI || process.env.DISABLE_EMAILS === 'true') {
@@ -17,6 +19,7 @@ export function getEmailClient() {
     if (!sesCache) {
       sesCache = new SESClient({
         maxAttempts: 3,
+        region,
         requestHandler: new NodeHttpHandler({
           connectionTimeout: 3_000,
           requestTimeout: 5_000,


### PR DESCRIPTION
In case not specifying a region doesn't work, we'll try specifying the region in which the lambda is running.

Note: the `migration_segments` lambda does not use the SQS client from `applicationContext`; we did not need to modify it because it was already configured to always use `us-east-1`.