### PR TITLE
Devex: Update Type Generation for objects

### DIFF
--- a/shared/src/business/entities/EntityConstants.ts
+++ b/shared/src/business/entities/EntityConstants.ts
@@ -48,15 +48,15 @@ export const TRIAL_SESSION_PROCEEDING_TYPES = {
   inPerson: 'In Person',
   remote: 'Remote',
 } as const;
-const TRIAL_PROCEEDINGS = Object.values(TRIAL_SESSION_PROCEEDING_TYPES);
-export type TrialSessionProceedingType = (typeof TRIAL_PROCEEDINGS)[number];
+export type TrialSessionProceedingType =
+  (typeof TRIAL_SESSION_PROCEEDING_TYPES)[keyof typeof TRIAL_SESSION_PROCEEDING_TYPES];
 
 export const TRIAL_SESSION_SCOPE_TYPES = {
   locationBased: 'Location-based',
   standaloneRemote: 'Standalone Remote',
 } as const;
-const TRIAL_SESSION_SCOPES = Object.values(TRIAL_SESSION_SCOPE_TYPES);
-export type TrialSessionScope = (typeof TRIAL_SESSION_SCOPES)[number];
+export type TrialSessionScope =
+  (typeof TRIAL_SESSION_SCOPE_TYPES)[keyof typeof TRIAL_SESSION_SCOPE_TYPES];
 
 export const JURISDICTIONAL_OPTIONS = {
   restoredToDocket: 'The case is restored to the general docket',
@@ -168,8 +168,8 @@ export const CASE_STATUS_TYPES = {
   submitted: 'Submitted', // Submitted to the judge for decision
   submittedRule122: 'Submitted - Rule 122', // Case submitted for decision without requiring a trial
 } as const;
-export const CASE_STATUSES = Object.values(CASE_STATUS_TYPES);
-export type CaseStatus = (typeof CASE_STATUSES)[number];
+export type CaseStatus =
+  (typeof CASE_STATUS_TYPES)[keyof typeof CASE_STATUS_TYPES];
 
 export const CAV_AND_SUBMITTED_CASE_STATUS = [
   CASE_STATUS_TYPES.cav,
@@ -610,16 +610,15 @@ export const DOCKET_RECORD_FILTER_OPTIONS = {
   exhibits: 'Exhibits',
   motions: 'Motions',
   orders: 'Orders',
-};
+} as const;
 
 export const PUBLIC_DOCKET_RECORD_FILTER_OPTIONS = omit(
   DOCKET_RECORD_FILTER_OPTIONS,
   ['exhibits'],
 );
-export const FILTER_OPTIONS = Object.values(
-  PUBLIC_DOCKET_RECORD_FILTER_OPTIONS,
-);
-export type PUBLIC_DOCKET_RECORD_FILTER = (typeof FILTER_OPTIONS)[number];
+
+export type PUBLIC_DOCKET_RECORD_FILTER =
+  (typeof PUBLIC_DOCKET_RECORD_FILTER_OPTIONS)[keyof typeof PUBLIC_DOCKET_RECORD_FILTER_OPTIONS];
 
 export const INITIAL_DOCUMENT_TYPES = {
   applicationForWaiverOfFilingFee: {
@@ -892,8 +891,8 @@ export const PAYMENT_STATUS = {
   UNPAID: 'Not paid',
   WAIVED: 'Waived',
 };
-const PAYMENT_TYPES = Object.values(PAYMENT_STATUS);
-export type PaymentStatusTypes = (typeof PAYMENT_TYPES)[number];
+export type PaymentStatusTypes =
+  (typeof PAYMENT_STATUS)[keyof typeof PAYMENT_STATUS];
 
 export const PROCEDURE_TYPES_MAP = {
   regular: 'Regular',
@@ -973,7 +972,7 @@ export const CASE_TYPES_MAP = {
 } as const;
 
 export const CASE_TYPES = Object.values(CASE_TYPES_MAP);
-export type CaseType = (typeof CASE_TYPES)[number];
+export type CaseType = (typeof CASE_TYPES_MAP)[keyof typeof CASE_TYPES_MAP];
 
 export const CASE_TYPE_DESCRIPTIONS_WITH_IRS_NOTICE = {
   [CASE_TYPES_MAP.deficiency]: 'Notice of Deficiency',
@@ -1034,8 +1033,7 @@ export const ROLES = {
   reportersOffice: 'reportersOffice',
   trialClerk: 'trialclerk',
 } as const;
-const ROLES_TYPES = Object.values(ROLES);
-export type Role = (typeof ROLES_TYPES)[number];
+export type Role = (typeof ROLES)[keyof typeof ROLES];
 
 // this isn't a real role someone can login with, which is why
 // it's a separate constant.
@@ -1129,12 +1127,6 @@ export const US_STATES_OTHER = {
   VI: 'Virgin Islands',
 } as const;
 
-const statesArray = [
-  ...Object.values(US_STATES),
-  ...Object.values(US_STATES_OTHER),
-];
-export type States = (typeof statesArray)[number];
-
 export type AbbrevatedStates =
   | keyof typeof US_STATES
   | keyof typeof US_STATES_OTHER;
@@ -1165,8 +1157,7 @@ export const PARTY_TYPES = {
   transferee: 'Transferee',
   trust: 'Trust',
 } as const;
-const partyTypeArray = Object.values(PARTY_TYPES);
-export type PartyType = (typeof partyTypeArray)[number];
+export type PartyType = (typeof PARTY_TYPES)[keyof typeof PARTY_TYPES];
 
 export const BUSINESS_TYPES = {
   corporation: PARTY_TYPES.corporation,
@@ -1332,8 +1323,8 @@ export const SESSION_TYPES = {
   special: 'Special',
   motionHearing: 'Motion/Hearing',
 } as const;
-const TRIAL_SESSION_TYPES = Object.values(SESSION_TYPES);
-export type TrialSessionTypes = (typeof TRIAL_SESSION_TYPES)[number];
+export type TrialSessionTypes =
+  (typeof SESSION_TYPES)[keyof typeof SESSION_TYPES];
 
 export const HYBRID_SESSION_TYPES = pick(SESSION_TYPES, [
   'hybrid',

--- a/shared/src/business/entities/customCaseReportSearch/CustomCaseReportSearch.ts
+++ b/shared/src/business/entities/customCaseReportSearch/CustomCaseReportSearch.ts
@@ -1,5 +1,5 @@
 import {
-  CASE_STATUSES,
+  CASE_STATUS_TYPES,
   CASE_TYPES,
   CaseStatus,
   CaseType,
@@ -58,7 +58,9 @@ export class CustomCaseReportSearch extends JoiValidationEntity {
 
   getValidationRules() {
     return {
-      caseStatuses: joi.array().items(joi.string().valid(...CASE_STATUSES)),
+      caseStatuses: joi
+        .array()
+        .items(joi.string().valid(...Object.values(CASE_STATUS_TYPES))),
       caseTypes: joi.array().items(joi.string().valid(...CASE_TYPES)),
       endDate: joi
         .alternatives()

--- a/shared/src/business/utilities/DateHandler.ts
+++ b/shared/src/business/utilities/DateHandler.ts
@@ -32,8 +32,7 @@ export const FORMATS = {
   YYYYMMDD: 'yyyy-MM-dd',
   YYYYMMDD_NUMERIC: 'yyyyMMdd',
 } as const;
-const FORMATS1 = Object.values(FORMATS);
-export type TimeFormats = (typeof FORMATS1)[number];
+export type TimeFormats = (typeof FORMATS)[keyof typeof FORMATS];
 export type TimeFormatNames = keyof typeof FORMATS;
 
 export const PATTERNS = {

--- a/web-client/src/presenter/computeds/customCaseReportHelper.ts
+++ b/web-client/src/presenter/computeds/customCaseReportHelper.ts
@@ -1,5 +1,5 @@
 import {
-  CASE_STATUSES,
+  CASE_STATUS_TYPES,
   CASE_TYPES,
   CHIEF_JUDGE,
   CUSTOM_CASE_REPORT_PAGE_SIZE,
@@ -37,7 +37,7 @@ export const customCaseReportHelper = (
   today: string;
   trialCitiesByState: InputOption[];
 } => {
-  const caseStatuses = CASE_STATUSES.map(status => ({
+  const caseStatuses = Object.values(CASE_STATUS_TYPES).map(status => ({
     label: status,
     value: status,
   }));


### PR DESCRIPTION
Do not create an intermediary Object.values() when generating a type. It is inefficient and unnecessary to create the type.