### PR TITLE
10403-bug: select scanner form not picking up default values

### DIFF
--- a/web-client/src/presenter/computeds/scanHelper.test.ts
+++ b/web-client/src/presenter/computeds/scanHelper.test.ts
@@ -461,4 +461,99 @@ describe('scanHelper', () => {
       expect(result.ATPFileCompleted).toEqual(false);
     });
   });
+
+  describe('disableModalSelect', () => {
+    it('should be true when scan mode and scanner are not selected', () => {
+      const result = runCompute(scanHelper, {
+        state: {
+          modal: {
+            scanMode: null,
+            scanner: null,
+          },
+          scanner: {
+            sources: ['sourceA, sourceB'],
+          },
+        },
+      });
+
+      expect(result.disableModalSelect).toEqual(true);
+    });
+
+    it('should be true when scan mode is not selected', () => {
+      const result = runCompute(scanHelper, {
+        state: {
+          modal: {
+            scanMode: null,
+            scanner: 'someScanner',
+          },
+          scanner: {
+            sources: ['sourceA, sourceB'],
+          },
+        },
+      });
+
+      expect(result.disableModalSelect).toEqual(true);
+    });
+
+    it('should be true when scanner is not selected', () => {
+      const result = runCompute(scanHelper, {
+        state: {
+          modal: {
+            scanMode: 'someScanMode',
+            scanner: null,
+          },
+          scanner: {
+            sources: ['sourceA, sourceB'],
+          },
+        },
+      });
+
+      expect(result.disableModalSelect).toEqual(true);
+    });
+
+    it('should be true when the scanner sources property in state is an empty array', () => {
+      const result = runCompute(scanHelper, {
+        state: {
+          modal: {
+            scanMode: 'someScanMode',
+            scanner: 'someScanner',
+          },
+          scanner: {
+            sources: [],
+          },
+        },
+      });
+
+      expect(result.disableModalSelect).toEqual(true);
+    });
+
+    it('should be true when there the scanner sources property in state is undefined', () => {
+      const result = runCompute(scanHelper, {
+        state: {
+          modal: {
+            scanMode: 'someScanMode',
+            scanner: 'someScanner',
+          },
+        },
+      });
+
+      expect(result.disableModalSelect).toEqual(true);
+    });
+
+    it('should be false when scan mode and scanner are selected', () => {
+      const result = runCompute(scanHelper, {
+        state: {
+          modal: {
+            scanMode: 'someScanMode',
+            scanner: 'someScanner',
+          },
+          scanner: {
+            sources: ['sourceA, sourceB'],
+          },
+        },
+      });
+
+      expect(result.disableModalSelect).toEqual(false);
+    });
+  });
 });

--- a/web-client/src/presenter/computeds/scanHelper.ts
+++ b/web-client/src/presenter/computeds/scanHelper.ts
@@ -20,6 +20,7 @@ export const scanHelper = (
   const formCaseDocuments = get(state.form.docketEntries);
   const initiateScriptLoaded = get(state.scanner.initiateScriptLoaded);
   const configScriptLoaded = get(state.scanner.configScriptLoaded);
+  const sources = get(state.scanner.sources);
 
   const APWFileCompleted =
     !!get(state.form.applicationForWaiverOfFilingFeeFile) ||
@@ -72,6 +73,14 @@ export const scanHelper = (
     };
   });
 
+  const scanModeNotSelected = !get(state.modal.scanMode);
+  const scannerNotSelected = !get(state.modal.scanner);
+  const disableModalSelect =
+    scanModeNotSelected ||
+    scannerNotSelected ||
+    !sources ||
+    sources.length === 0;
+
   return {
     APWFileCompleted,
     ATPFileCompleted,
@@ -79,6 +88,7 @@ export const scanHelper = (
     PFileCompleted,
     RQTFileCompleted,
     STINFileCompleted,
+    disableModalSelect,
     hasLoadedScanDependencies: initiateScriptLoaded && configScriptLoaded,
     hasScanFeature: !!(
       user &&
@@ -86,9 +96,11 @@ export const scanHelper = (
       applicationContext.getUtilities().isInternalUser(user.role)
     ),
     scanFeatureEnabled,
+    scanModeNotSelected,
     scanModeOptions,
+    scannerNotSelected,
     showScannerSourceModal:
       get(state.modal.showModal) === 'SelectScannerSourceModal',
-    sources: get(state.scanner.sources),
+    sources,
   };
 };

--- a/web-client/src/views/ScanBatchPreviewer/SelectScannerSourceModal.tsx
+++ b/web-client/src/views/ScanBatchPreviewer/SelectScannerSourceModal.tsx
@@ -8,24 +8,22 @@ export const SelectScannerSourceModal = connect(
   {
     clearModalSequence: sequences.clearModalSequence,
     modal: state.modal,
-    scanModeOptions: state.scanHelper.scanModeOptions,
+    scanHelper: state.scanHelper,
     selectScannerSequence: sequences.selectScannerSequence,
-    sources: state.scanHelper.sources,
     updateModalValueSequence: sequences.updateModalValueSequence,
   },
   function SelectScannerSourceModal({
     clearModalSequence,
     modal,
-    scanModeOptions,
+    scanHelper,
     selectScannerSequence,
-    sources,
     updateModalValueSequence,
   }) {
     return (
       <ConfirmModal
         cancelLabel="Cancel"
         confirmLabel="Select"
-        noConfirm={sources.length === 0}
+        noConfirm={scanHelper.disableModalSelect}
         title="Select a Scanner"
         onCancelSequence={clearModalSequence}
         onConfirmSequence={selectScannerSequence}
@@ -49,7 +47,10 @@ export const SelectScannerSourceModal = connect(
               });
             }}
           >
-            {sources.map((source, index) => {
+            {scanHelper.scannerNotSelected && (
+              <option value="">- Select -</option>
+            )}
+            {scanHelper.sources.map((source, index) => {
               return (
                 <option
                   data-index={index}
@@ -79,7 +80,10 @@ export const SelectScannerSourceModal = connect(
               });
             }}
           >
-            {scanModeOptions.map(scanMode => {
+            {scanHelper.scanModeNotSelected && (
+              <option value="">- Select -</option>
+            )}
+            {scanHelper.scanModeOptions.map(scanMode => {
               return (
                 <option key={scanMode.value} value={scanMode.value}>
                   - {scanMode.label} -
@@ -88,7 +92,7 @@ export const SelectScannerSourceModal = connect(
             })}
           </select>
         </div>
-        {sources.length === 0 && (
+        {scanHelper.sources.length === 0 && (
           <p>There are currently no scanner sources available.</p>
         )}
       </ConfirmModal>


### PR DESCRIPTION
The SelectScannerSourceModal component only sets the scanner and scan mode properties in state if the user triggers a change event on the select elements keyed to those properties.

Before the changes in this PR, for a user who does not have preferred scanner settings already in place, the modal initially displayed the first options in each dropdown menu even though scanner and scan mode were not set in state. This means that when the user then submitted the form in the modal without changing the default options, scanner and scan mode would remain unset in state even though the UI indicated otherwise.

After these changes, the modal now initializes with placeholder values, which the user is required to change before submitting the form in the modal.