### PR TITLE
10431 bug: fix for bug in bug fix 10403

### DIFF
--- a/web-client/src/presenter/actions/primeScannerSourceAction.test.ts
+++ b/web-client/src/presenter/actions/primeScannerSourceAction.test.ts
@@ -69,4 +69,17 @@ describe('primeScannerSourceAction', () => {
 
     expect(result.output.scanMode).toEqual(SCAN_MODES.FEEDER);
   });
+
+  it('should convert scanner.modal.index to a number if it is a string before returning it', async () => {
+    const result = await runAction(primeScannerSourceAction, {
+      modules: {
+        presenter,
+      },
+      state: {
+        modal: { index: '0' },
+      },
+    });
+
+    expect(result.output.scannerSourceIndex).toEqual(0);
+  });
 });

--- a/web-client/src/presenter/actions/primeScannerSourceAction.ts
+++ b/web-client/src/presenter/actions/primeScannerSourceAction.ts
@@ -13,8 +13,13 @@ export const primeScannerSourceAction = ({
   const { SCAN_MODES } = applicationContext.getConstants();
 
   const scannerSourceName = get(state.modal.scanner);
-  const scannerSourceIndex = get(state.modal.index);
   const scanMode = get(state.modal.scanMode) || SCAN_MODES.FEEDER;
+
+  let scannerSourceIndex = get(state.modal.index);
+  scannerSourceIndex =
+    typeof scannerSourceIndex === 'string'
+      ? parseInt(scannerSourceIndex, 10)
+      : scannerSourceIndex;
 
   return { scanMode, scannerSourceIndex, scannerSourceName };
 };

--- a/web-client/src/views/ScanBatchPreviewer/SelectScannerSourceModal.tsx
+++ b/web-client/src/views/ScanBatchPreviewer/SelectScannerSourceModal.tsx
@@ -37,13 +37,16 @@ export const SelectScannerSourceModal = connect(
             defaultValue={modal.scanner}
             id="scanner-select"
             onChange={e => {
+              const selectedOption = e.target.options[e.target.selectedIndex];
+              const dataIndex = selectedOption.getAttribute('data-index');
+
               updateModalValueSequence({
                 key: 'scanner',
                 value: e.target.value,
               });
               updateModalValueSequence({
                 key: 'index',
-                value: e.target.selectedIndex,
+                value: dataIndex,
               });
             }}
           >


### PR DESCRIPTION
Cause of the regression issue:

The select element for setting a scanner was previously updating the scanner index based on the selected option element's [selectedIndex property](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement/selectedIndex). However, the addition of a new placeholder option element, which appears only when a scanner has not been set, caused the index values passed from the form to state to be off by one.

Instead of using the selectedIndex property, the solution involves passing the value of the preexisting "index" data attribute during the update.

Work being tracked as [10431](https://app.zenhub.com/workspaces/flexionef-cms-5bbe4bed4b5806bc2bec65d3/issues/gh/flexion/ef-cms/10431).