### PR TITLE
10396-story: Fix a11y nested-interactive issue

### DIFF
--- a/cypress/local-only/support/generalCommands/checkA11y.ts
+++ b/cypress/local-only/support/generalCommands/checkA11y.ts
@@ -9,9 +9,6 @@ export function checkA11y(): void {
     {
       includedImpacts: impactLevel,
       retries: 3,
-      rules: {
-        'nested-interactive': { enabled: false }, // https://github.com/flexion/ef-cms/issues/10396
-      },
     },
     terminalLog,
   );

--- a/cypress/local-only/support/pages/create-paper-petition.ts
+++ b/cypress/local-only/support/pages/create-paper-petition.ts
@@ -8,7 +8,7 @@ export const createPaperPetition = () => {
   navigateToDocumentQC('petitionsclerk');
 
   getCreateACaseButton().click();
-  cy.get('#tab-parties').parent().should('have.attr', 'aria-selected');
+  cy.get('#tab-parties').should('have.attr', 'aria-selected');
 
   fillInCreateCaseFromPaperForm();
   return postPaperPetition();

--- a/cypress/local-only/tests/integration/caseDetail/notes/judges-notes-icon.cy.ts
+++ b/cypress/local-only/tests/integration/caseDetail/notes/judges-notes-icon.cy.ts
@@ -20,7 +20,7 @@ describe('Notes Icon triggered by Judges Notes', () => {
     navigateToDocumentQC('petitionsclerk');
 
     getCreateACaseButton().click();
-    cy.get('#tab-parties').parent().should('have.attr', 'aria-selected');
+    cy.get('#tab-parties').should('have.attr', 'aria-selected');
 
     fillInCreateCaseFromPaperForm();
 

--- a/cypress/local-only/tests/integration/fileAPetition/petitions-clerk-creates-paper-case.cy.ts
+++ b/cypress/local-only/tests/integration/fileAPetition/petitions-clerk-creates-paper-case.cy.ts
@@ -23,7 +23,7 @@ describe('Petition clerk creates a paper filing', function () {
       navigateToDocumentQC('petitionsclerk');
 
       getCreateACaseButton().click();
-      cy.get('#tab-parties').parent().should('have.attr', 'aria-selected');
+      cy.get('#tab-parties').should('have.attr', 'aria-selected');
 
       fillInCreateCaseFromPaperForm();
     });

--- a/cypress/local-only/tests/integration/trialSession/trial-session-paper-pdf.cy.ts
+++ b/cypress/local-only/tests/integration/trialSession/trial-session-paper-pdf.cy.ts
@@ -50,7 +50,7 @@ describe('Trial Session Paper Pdf', { scrollBehavior: 'center' }, () => {
 
         cy.visit('/document-qc');
         getCreateACaseButton().click();
-        cy.get('#tab-parties').parent().should('have.attr', 'aria-selected');
+        cy.get('#tab-parties').should('have.attr', 'aria-selected');
         fillInCreateCaseFromPaperForm();
 
         cy.intercept('POST', '**/paper').as('postPaperCase');

--- a/web-client/src/styles/custom.scss
+++ b/web-client/src/styles/custom.scss
@@ -1513,12 +1513,6 @@ hr.lighter {
   }
 }
 
-.statusReportOrderResponsePdfPreview {
-  .pdf-preview-viewer {
-    height: 846px;
-  }
-}
-
 .ustc-ui-tabs.container-tabs {
   border-bottom: 0;
   background-color: white;

--- a/web-client/src/styles/custom.scss
+++ b/web-client/src/styles/custom.scss
@@ -1513,6 +1513,12 @@ hr.lighter {
   }
 }
 
+.statusReportOrderResponsePdfPreview {
+  .pdf-preview-viewer {
+    height: 846px;
+  }
+}
+
 .ustc-ui-tabs.container-tabs {
   border-bottom: 0;
   background-color: white;
@@ -2286,7 +2292,7 @@ button.change-scanner-button {
 }
 
 .before-case-button {
-	margin-top: 2.5rem;
+  margin-top: 2.5rem;
 }
 
 .before-case-follow-up-button {
@@ -2296,7 +2302,7 @@ button.change-scanner-button {
 }
 
 .create-petition-navigation-buttons {
-	margin-top: 2.5rem;
+  margin-top: 2.5rem;
 }
 
 .create-petition-navigation-follow-up-buttons {
@@ -2317,6 +2323,18 @@ button.change-scanner-button {
 .preformatted-text {
   font-family: $font-source-sans;
   text-wrap: balance;
+}
+
+// For content that should be visually hidden but present in the accessibility tree
+.sr-only {
+  position: absolute;
+  overflow: hidden;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  border: 0;
+  margin: -1px;
+  clip: rect(0, 0, 0, 0);
 }
 
 .petition-review-petitioner-section {
@@ -2343,7 +2361,6 @@ button.change-scanner-button {
   }
 }
 
-
 .petition-review-case-information-section {
   display: grid;
   column-gap: 20px;
@@ -2356,10 +2373,9 @@ button.change-scanner-button {
   }
 }
 
-
 @media only screen and (max-width: $medium-screen) {
   .petition-review-spacing {
-    margin-top: 1.5rem
+    margin-top: 1.5rem;
   }
 }
 

--- a/web-client/src/styles/tabs.scss
+++ b/web-client/src/styles/tabs.scss
@@ -45,7 +45,6 @@
         cursor: pointer;
 
         .button-text {
-          display: inline;
           font-family: $font-serif;
           font-size: 32px;
           font-weight: bold;

--- a/web-client/src/ustc-ui/Tabs/Tabs.test.tsx
+++ b/web-client/src/ustc-ui/Tabs/Tabs.test.tsx
@@ -104,7 +104,24 @@ describe('TabsComponent', () => {
     );
   });
 
-  it('should use a span tag for tab label if no headingLevel parameter is provided', () => {
+  it('should render tab heading when heading level is specified', () => {
+    let testRenderer;
+    act(() => {
+      testRenderer = TestRenderer.create(
+        <TabsComponent headingLevel="2">
+          <Tab tabName="myTabName" title="Heading Level Two">
+            Some content
+          </Tab>
+        </TabsComponent>,
+      );
+    });
+
+    const testInstance = testRenderer.root;
+
+    expect(testInstance.findByType('h2')).toBeDefined();
+  });
+
+  it('should not render tab heading when heading level is unspecified', () => {
     let testRenderer;
     act(() => {
       testRenderer = TestRenderer.create(
@@ -115,23 +132,17 @@ describe('TabsComponent', () => {
     });
 
     const testInstance = testRenderer.root;
+    let hElement = null;
+    for (const h of ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']) {
+      try {
+        hElement = testInstance.findByType(h);
+        break;
+      } catch (error) {
+        // Element not found
+      }
+    }
 
-    expect(testInstance.findByType('span')).toBeDefined();
-  });
-
-  it('should render tab label within the proper heading tag if headingLevel parameter is present', () => {
-    let testRenderer;
-    act(() => {
-      testRenderer = TestRenderer.create(
-        <TabsComponent headingLevel="2">
-          <Tab tabName="myTabName" title="Heading Level Two" />
-        </TabsComponent>,
-      );
-    });
-
-    const testInstance = testRenderer.root;
-
-    expect(testInstance.findByType('h2')).toBeDefined();
+    expect(hElement).toBeNull();
   });
 
   it('should create a default tab element id if one is not provided', () => {
@@ -170,7 +181,7 @@ describe('TabsComponent', () => {
     const testInstance = testRenderer.root;
 
     expect(
-      testInstance.findByProps({ id: 'tab-with-content' }).parent.props[
+      testInstance.findByProps({ id: 'tab-with-content' }).props[
         'aria-controls'
       ],
     ).toEqual('tabContent-withContent');

--- a/web-client/src/ustc-ui/Tabs/Tabs.tsx
+++ b/web-client/src/ustc-ui/Tabs/Tabs.tsx
@@ -11,13 +11,7 @@ import { state } from '@web-client/presenter/app.cerebral';
 import React, { ReactNode, useState } from 'react';
 import classNames from 'classnames';
 
-const renderTabFactory = ({
-  activeKey,
-  asSwitch,
-  boxed,
-  headingLevel,
-  setTab,
-}) =>
+const renderTabFactory = ({ activeKey, asSwitch, boxed, setTab }) =>
   function TabComponent(child) {
     const {
       children: tabChildren,
@@ -43,27 +37,27 @@ const renderTabFactory = ({
       return null;
     }
 
-    const HeadingElement = headingLevel ? `h${headingLevel}` : 'span';
     const tabProps = {
-      'aria-controls': tabContentId,
-      'aria-selected': isActiveTab,
       className: liClass,
-      role: 'tab',
+      role: 'presentation',
     };
 
     const buttonProps = {
+      'aria-controls': tabContentId,
+      'aria-selected': isActiveTab,
       className: childClassName,
       disabled,
       id: buttonId,
       onClick: () => setTab(tabName),
+      role: 'tab',
       type: 'button',
     };
 
     return (
       <li {...tabProps}>
+        {' '}
         <button {...buttonProps} data-testid={child.props['data-testid']}>
-          <HeadingElement className="button-text">{title}</HeadingElement>{' '}
-          {icon}
+          <span className="button-text">{title}</span> {icon}
         </button>
       </li>
     );
@@ -83,6 +77,19 @@ export function Tab(properties: {
 }) {
   return <></>;
 }
+
+// Tabs convey the document headings implicitly, but we also add an invisible header for accessibility reasons
+const HeadingElement = ({ children, level }) => {
+  return React.createElement(
+    `h${level}`,
+    { ariaHidden: 'false', className: 'sr-only' },
+    children,
+  );
+};
+
+const getTabHeadingTitle = word => {
+  return word.charAt(0).toUpperCase() + word.slice(1);
+};
 
 /**
  * TabsComponent
@@ -151,7 +158,16 @@ export function TabsComponent({
     }
 
     if (tabName && isActiveTab && tabChildren) {
-      return <div {...contentProps}>{tabChildren}</div>;
+      return (
+        <div {...contentProps}>
+          {headingLevel && (
+            <HeadingElement level={headingLevel}>
+              {getTabHeadingTitle(tabName)}
+            </HeadingElement>
+          )}
+          {tabChildren}
+        </div>
+      );
     }
 
     return null;


### PR DESCRIPTION
**The issue**

In our DOM tree, we were generating something like the following:

```
<ul role="tablist">
  <li aria-controls=... aria-selected=..., role='tab'>
    <button>Blah</button>
  </li>
  ...
</ul>
```
The issue here is that button is inherently interactive, and it was being nested within an li that was rendered interactive because of its role as a tab child element. I fixed this by moving the role, aria-control, and aria-selected properties to the button element and signaling that the li element is non-semantic (in other words, just used for display) with role='presentation'. **This is already in test.**

**Related issue**

Originally, we conditionally put h2 headings into our tabs to fix an issue in which we rendered h1 and h3 but not h2 on certain pages (see https://app.zenhub.com/workspaces/flexionef-cms-5bbe4bed4b5806bc2bec65d3/issues/gh/flexion/ef-cms/8106). However, this solution does not work: everything nested within a role="tab" element is kept out of the accessibility tree (see [here](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role#all_descendants_are_presentational)), so adding an h2 within the "tab" element was no better than not adding one at all. Unfortunately, surrounding the "tab" element in a heading (rather than nesting it within)--which was my first approach to correcting this--leads to other accessibility violations.

From what I can tell after some thinking and sleuthing, the best way to handle things is to conditionally put a non-visual heading within the tab panel _content_ (i.e., not within the "tab" at all) that is still accessible in the accessibility tree. This solution ensures the following:

1. We have no accessibility violations.
2. As before, we can programmatically tell tabs when they need to render a heading to avoid skipping heading levels.
3. The heading is actually part of the accessibility tree.
4. While separate from the tab button, the heading does not appear on screen, which would look strange (since it would just display the same name as the tab itself).