### PR TITLE
Remove aws-v2 sdk entirely

### DIFF
--- a/scripts/user/setup-glued-judges.ts
+++ b/scripts/user/setup-glued-judges.ts
@@ -5,7 +5,7 @@ requireEnvVars([
   'ELASTICSEARCH_ENDPOINT',
   'ENV',
 ]);
-import { AwsSigv4Signer } from '@opensearch-project/opensearch/aws';
+import { AwsSigv4Signer } from '@opensearch-project/opensearch/aws-v3';
 import { Client } from '@opensearch-project/opensearch';
 import { CognitoIdentityProvider } from '@aws-sdk/client-cognito-identity-provider';
 import { DeleteItemCommand, DynamoDBClient } from '@aws-sdk/client-dynamodb';

--- a/web-api/elasticsearch/client.ts
+++ b/web-api/elasticsearch/client.ts
@@ -1,4 +1,4 @@
-import { AwsSigv4Signer } from '@opensearch-project/opensearch/aws';
+import { AwsSigv4Signer } from '@opensearch-project/opensearch/aws-v3';
 import { Client } from '@opensearch-project/opensearch';
 import {
   DescribeDomainCommand,

--- a/web-api/src/applicationContext.ts
+++ b/web-api/src/applicationContext.ts
@@ -3,7 +3,7 @@ import * as barNumberGenerator from './persistence/dynamo/users/barNumberGenerat
 import * as docketNumberGenerator from './persistence/dynamo/cases/docketNumberGenerator';
 import * as pdfLib from 'pdf-lib';
 import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf';
-import { AwsSigv4Signer } from '@opensearch-project/opensearch/aws';
+import { AwsSigv4Signer } from '@opensearch-project/opensearch/aws-v3';
 import {
   CASE_STATUS_TYPES,
   CLERK_OF_THE_COURT_CONFIGURATION,


### PR DESCRIPTION
After analyzing our bundle we were still including aws-sdk v2 even though it was not a direct dependent. It was being brought in because of the credential signer for opensearch. Updated the credential signer and POOF no more aws-sdk in our bundle

Resource: https://github.com/opensearch-project/opensearch-js/blob/HEAD/USER_GUIDE.md#using-aws-v3-sdk

With AWS-SDK V2
Bundle Size Unpacked: 30.1MB
Max mem: 286MB, 285MB
Init duration: 1929.42 ms, 2148.15ms


Without AWS-SDK V2
Bundle Size Unpacked: 20MB
Max mem: 252MB, 252MB
Init: 1812.28 ms, 1803.34 ms