### PR TITLE
10309 Opex:  Fix MaxListenersExceededWarning

### DIFF
--- a/web-api/src/logger.ts
+++ b/web-api/src/logger.ts
@@ -12,11 +12,9 @@ const console = () =>
     handleRejections: true,
   }));
 
-export const logger =
-  (transport = console()) =>
-  (req, res, next) => {
-    const createdLogger = createLogger({ transports: [transport] });
-
+export const logger = (transport = console()) => {
+  const createdLogger = createLogger({ transports: [transport] });
+  return (req, res, next) => {
     if (process.env.NODE_ENV === 'production') {
       const requestBody = cloneDeep(req.body);
 
@@ -66,6 +64,7 @@ export const logger =
 
     return next();
   };
+};
 
 function redactPasswordFields(obj) {
   const passwordRegex = /password/i;


### PR DESCRIPTION
In `app.ts` and `app-public.ts`, we run the logging middleware via `app.use(logger())`. However, the way `logger` is set up means that we are re-creating our logger--and re-adding related event listeners--on every request. This quickly leads to a `MaxListenersExceededWarning` (for instance, just refresh the page a few times). This PR fixes the issue by using a closure to create the logger once at app initialization rather than once per request.