### PR TITLE
Expand untouched file check to check ALL files for increased type error count

### DIFF
--- a/.github/workflows/typescript-all-files-check.yml
+++ b/.github/workflows/typescript-all-files-check.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  CheckUntouchedFiles:
+  CheckAllFilesForTypeErrorCount:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/typescript-all-files-check.yml
+++ b/.github/workflows/typescript-all-files-check.yml
@@ -1,4 +1,4 @@
-name: Typescript Untouched File Check
+name: Typescript File Check
 
 on:
   pull_request:
@@ -40,4 +40,4 @@ jobs:
         run: npm ci
 
       - name: Check untouched files
-        run: npx ts-node scripts/checkUntouchedFiles.ts
+        run: npx ts-node scripts/checkAllFilesForTypeErrorCount.ts

--- a/scripts/jest-scripts.config.ts
+++ b/scripts/jest-scripts.config.ts
@@ -7,7 +7,7 @@ const config: Config = {
   collectCoverage: true,
   collectCoverageFrom: [
     '**/*.{js,ts}',
-    '!checkUntouchedFiles.ts',
+    '!checkAllFilesForTypeErrorCount.ts',
     '!circleci/*.ts',
     '!circleci/judge/bulkImportJudgeUsers.ts',
     '!circleci/judge/bulkImportJudgeUsers.helpers.ts',


### PR DESCRIPTION
Expanding the TS untouched file check script to report on ALL files that increased in type error count in a PR relative to staging, instead of only untouched files.