### PR TITLE
10464 Bug: Invalid documents in scenario dropdowns

### DIFF
--- a/web-client/src/presenter/computeds/selectDocumentTypeHelper.test.ts
+++ b/web-client/src/presenter/computeds/selectDocumentTypeHelper.test.ts
@@ -3,9 +3,10 @@ import {
   MAX_TITLE_LENGTH,
   getOptionsForCategory,
   getOrdinalValuesForUploadIteration,
-  getPreviouslyFiledDocuments,
+  getValidPreviouslyFiledDocuments,
 } from './selectDocumentTypeHelper';
 import { MOCK_CASE } from '../../../../shared/src/test/mockCase';
+import { MOCK_DOCUMENTS } from '@shared/test/mockDocketEntry';
 import { applicationContextForClient as applicationContext } from '@web-client/test/createClientTestApplicationContext';
 
 describe('selectDocumentTypeHelper', () => {
@@ -48,16 +49,28 @@ describe('selectDocumentTypeHelper', () => {
         scenario: 'Nonstandard A',
       };
 
+      const mockDocuments = MOCK_DOCUMENTS.map(d => {
+        return {
+          ...d,
+          isOnDocketRecord: true,
+          isStricken: false,
+          servedAt: '2019-08-25T05:00:00.000Z',
+        };
+      });
+
       const result = getOptionsForCategory({
         applicationContext,
-        caseDetail: MOCK_CASE,
+        caseDetail: {
+          ...MOCK_CASE,
+          docketEntries: mockDocuments,
+        },
         categoryInformation: mockCategoryInformation,
         selectedDocketEntryId: mockSelectedDocketEntryId,
       });
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         previousDocumentSelectLabel: 'Which document are you objecting to?',
-        previouslyFiledDocuments: MOCK_CASE.docketEntries.filter(
+        previouslyFiledDocuments: mockDocuments.filter(
           d => d.eventCode !== INITIAL_DOCUMENT_TYPES.stin.eventCode,
         ),
         showNonstandardForm: true,
@@ -92,17 +105,29 @@ describe('selectDocumentTypeHelper', () => {
         scenario: 'Nonstandard C',
       };
 
+      const mockDocuments = MOCK_DOCUMENTS.map(d => {
+        return {
+          ...d,
+          isOnDocketRecord: true,
+          isStricken: false,
+          servedAt: '2019-08-25T05:00:00.000Z',
+        };
+      });
+
       const result = getOptionsForCategory({
         applicationContext,
-        caseDetail: MOCK_CASE,
+        caseDetail: {
+          ...MOCK_CASE,
+          docketEntries: mockDocuments,
+        },
         categoryInformation: mockCategoryInformation,
         selectedDocketEntryId: mockSelectedDocketEntryId,
       });
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         previousDocumentSelectLabel:
           'Which document is this affidavit in support of?',
-        previouslyFiledDocuments: MOCK_CASE.docketEntries.filter(
+        previouslyFiledDocuments: mockDocuments.filter(
           d => d.eventCode !== INITIAL_DOCUMENT_TYPES.stin.eventCode,
         ),
         showNonstandardForm: true,
@@ -119,17 +144,29 @@ describe('selectDocumentTypeHelper', () => {
         scenario: 'Nonstandard D',
       };
 
+      const mockDocuments = MOCK_DOCUMENTS.map(d => {
+        return {
+          ...d,
+          isOnDocketRecord: true,
+          isStricken: false,
+          servedAt: '2019-08-25T05:00:00.000Z',
+        };
+      });
+
       const result = getOptionsForCategory({
         applicationContext,
-        caseDetail: MOCK_CASE,
+        caseDetail: {
+          ...MOCK_CASE,
+          docketEntries: mockDocuments,
+        },
         categoryInformation: mockCategoryInformation,
         selectedDocketEntryId: mockSelectedDocketEntryId,
       });
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         previousDocumentSelectLabel:
           'Which document is this Certificate of Service for?',
-        previouslyFiledDocuments: MOCK_CASE.docketEntries.filter(
+        previouslyFiledDocuments: mockDocuments.filter(
           d => d.eventCode !== INITIAL_DOCUMENT_TYPES.stin.eventCode,
         ),
         showDateFields: true,
@@ -165,17 +202,29 @@ describe('selectDocumentTypeHelper', () => {
         scenario: 'Nonstandard F',
       };
 
+      const mockDocuments = MOCK_DOCUMENTS.map(d => {
+        return {
+          ...d,
+          isOnDocketRecord: true,
+          isStricken: false,
+          servedAt: '2019-08-25T05:00:00.000Z',
+        };
+      });
+
       const result = getOptionsForCategory({
         applicationContext,
-        caseDetail: MOCK_CASE,
+        caseDetail: {
+          ...MOCK_CASE,
+          docketEntries: mockDocuments,
+        },
         categoryInformation: mockCategoryInformation,
         selectedDocketEntryId: mockSelectedDocketEntryId,
       });
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         ordinalField: 'What iteration is this filing?',
         previousDocumentSelectLabel: 'Which document is this a supplement to?',
-        previouslyFiledDocuments: MOCK_CASE.docketEntries.filter(
+        previouslyFiledDocuments: mockDocuments.filter(
           d => d.eventCode !== INITIAL_DOCUMENT_TYPES.stin.eventCode,
         ),
         showNonstandardForm: true,
@@ -292,22 +341,28 @@ describe('selectDocumentTypeHelper', () => {
     });
   });
 
-  describe('getPreviouslyFiledDocuments', () => {
+  describe('getValidPreviouslyFiledDocuments', () => {
     it('should return a list of docketEntries with STIN filtered out', () => {
       const mockCaseDetail = {
         docketEntries: [
           {
             docketEntryId: '',
             documentType: INITIAL_DOCUMENT_TYPES.stin.documentType,
+            isOnDocketRecord: true,
+            isStricken: false,
+            servedAt: '2019-08-25T05:00:00.000Z',
           },
           {
             docketEntryId: '',
             documentType: INITIAL_DOCUMENT_TYPES.petition.documentType,
+            isOnDocketRecord: true,
+            isStricken: false,
+            servedAt: '2019-08-25T05:00:00.000Z',
           },
         ],
       };
 
-      const result = getPreviouslyFiledDocuments(
+      const result = getValidPreviouslyFiledDocuments(
         applicationContext,
         mockCaseDetail,
         undefined,
@@ -328,15 +383,21 @@ describe('selectDocumentTypeHelper', () => {
             documentType:
               INITIAL_DOCUMENT_TYPES.applicationForWaiverOfFilingFee
                 .documentType,
+            isOnDocketRecord: true,
+            isStricken: false,
+            servedAt: '2019-08-25T05:00:00.000Z',
           },
           {
             docketEntryId: mockSelectedDocketEntryId,
             documentType: INITIAL_DOCUMENT_TYPES.petition.documentType,
+            isOnDocketRecord: true,
+            isStricken: false,
+            servedAt: '2019-08-25T05:00:00.000Z',
           },
         ],
       };
 
-      const result = getPreviouslyFiledDocuments(
+      const result = getValidPreviouslyFiledDocuments(
         applicationContext,
         mockCaseDetail,
         mockSelectedDocketEntryId,
@@ -354,6 +415,9 @@ describe('selectDocumentTypeHelper', () => {
         docketEntryId: '3913f8a9-891a-4c9c-827e-1a02b403fa63',
         documentTitle: 'Exhibit(s)',
         documentType: 'Exhibit(s)',
+        isOnDocketRecord: true,
+        isStricken: false,
+        servedAt: '2019-08-25T05:00:00.000Z',
       };
 
       const mockCaseDetail = {
@@ -361,11 +425,14 @@ describe('selectDocumentTypeHelper', () => {
           mockExhibit,
           {
             docketEntryId: mockSelectedDocketEntryId,
+            isOnDocketRecord: true,
+            isStricken: false,
+            servedAt: '2019-08-25T05:00:00.000Z',
           },
         ],
       };
 
-      const result = getPreviouslyFiledDocuments(
+      const result = getValidPreviouslyFiledDocuments(
         applicationContext,
         mockCaseDetail,
         mockSelectedDocketEntryId,
@@ -377,7 +444,7 @@ describe('selectDocumentTypeHelper', () => {
       expect(
         applicationContext.getUtilities().getDocumentTitleWithAdditionalInfo
           .mock.calls[0][0],
-      ).toEqual({ docketEntry: mockExhibit });
+      ).toMatchObject({ docketEntry: mockExhibit });
       expect(result[0].documentTitle).toEqual('Exhibit(s) First');
     });
 
@@ -394,6 +461,9 @@ describe('selectDocumentTypeHelper', () => {
         docketEntryId: '3913f8a9-891a-4c9c-827e-1a02b403fa63',
         documentTitle: 'Exhibit(s)',
         documentType: 'Exhibit(s)',
+        isOnDocketRecord: true,
+        isStricken: false,
+        servedAt: '2019-08-25T05:00:00.000Z',
       };
 
       const mockCaseDetail = {
@@ -401,11 +471,14 @@ describe('selectDocumentTypeHelper', () => {
           mockExhibit,
           {
             docketEntryId: mockSelectedDocketEntryId,
+            isOnDocketRecord: true,
+            isStricken: false,
+            servedAt: '2019-08-25T05:00:00.000Z',
           },
         ],
       };
 
-      const result = getPreviouslyFiledDocuments(
+      const result = getValidPreviouslyFiledDocuments(
         applicationContext,
         mockCaseDetail,
         mockSelectedDocketEntryId,
@@ -417,7 +490,7 @@ describe('selectDocumentTypeHelper', () => {
       expect(
         applicationContext.getUtilities().getDocumentTitleWithAdditionalInfo
           .mock.calls[0][0],
-      ).toEqual({ docketEntry: mockExhibit });
+      ).toMatchObject({ docketEntry: mockExhibit });
       expect(result[0].documentTitle.length).toBe(MAX_TITLE_LENGTH);
       expect(result[0].documentTitle).toEqual(
         "MOTION FOR PROTECTIVE ORDER PURSUANT TO RULE 103 REGARDING RESPONDING TO RESP'S INTERROGATORIES & R…",
@@ -435,6 +508,9 @@ describe('selectDocumentTypeHelper', () => {
         docketEntryId: '3913f8a9-891a-4c9c-827e-1a02b403fa63',
         documentTitle: 'Exhibit(s)',
         documentType: 'Exhibit(s)',
+        isOnDocketRecord: true,
+        isStricken: false,
+        servedAt: '2019-08-25T05:00:00.000Z',
       };
 
       const mockCaseDetail = {
@@ -442,11 +518,14 @@ describe('selectDocumentTypeHelper', () => {
           mockExhibit,
           {
             docketEntryId: mockSelectedDocketEntryId,
+            isOnDocketRecord: true,
+            isStricken: false,
+            servedAt: '2019-08-25T05:00:00.000Z',
           },
         ],
       };
 
-      const result = getPreviouslyFiledDocuments(
+      const result = getValidPreviouslyFiledDocuments(
         applicationContext,
         mockCaseDetail,
         mockSelectedDocketEntryId,
@@ -458,8 +537,74 @@ describe('selectDocumentTypeHelper', () => {
       expect(
         applicationContext.getUtilities().getDocumentTitleWithAdditionalInfo
           .mock.calls[0][0],
-      ).toEqual({ docketEntry: mockExhibit });
+      ).toMatchObject({ docketEntry: mockExhibit });
       expect(result[0].documentTitle).toBeUndefined();
+    });
+
+    it('should not return unserved documents', () => {
+      const mockCaseDetail = {
+        docketEntries: [
+          {
+            docketEntryId: '',
+            documentType: INITIAL_DOCUMENT_TYPES.petition.documentType,
+            isOnDocketRecord: true,
+            isStricken: false,
+            servedAt: '',
+          },
+        ],
+      };
+
+      const result = getValidPreviouslyFiledDocuments(
+        applicationContext,
+        mockCaseDetail,
+        undefined,
+      );
+
+      expect(result.length).toEqual(0);
+    });
+
+    it('should not return stricken documents', () => {
+      const mockCaseDetail = {
+        docketEntries: [
+          {
+            docketEntryId: '',
+            documentType: INITIAL_DOCUMENT_TYPES.petition.documentType,
+            isOnDocketRecord: true,
+            isStricken: true,
+            servedAt: '2019-08-25T05:00:00.000Z',
+          },
+        ],
+      };
+
+      const result = getValidPreviouslyFiledDocuments(
+        applicationContext,
+        mockCaseDetail,
+        undefined,
+      );
+
+      expect(result.length).toEqual(0);
+    });
+
+    it('should not return documents that are not on the docket record', () => {
+      const mockCaseDetail = {
+        docketEntries: [
+          {
+            docketEntryId: '',
+            documentType: INITIAL_DOCUMENT_TYPES.petition.documentType,
+            isOnDocketRecord: false,
+            isStricken: false,
+            servedAt: '2019-08-25T05:00:00.000Z',
+          },
+        ],
+      };
+
+      const result = getValidPreviouslyFiledDocuments(
+        applicationContext,
+        mockCaseDetail,
+        undefined,
+      );
+
+      expect(result.length).toEqual(0);
     });
   });
 });

--- a/web-client/src/presenter/computeds/selectDocumentTypeHelper.ts
+++ b/web-client/src/presenter/computeds/selectDocumentTypeHelper.ts
@@ -19,7 +19,7 @@ export const getOptionsForCategory = ({
     case 'Nonstandard A': {
       options = {
         previousDocumentSelectLabel: categoryInformation.labelPreviousDocument,
-        previouslyFiledDocuments: getPreviouslyFiledDocuments(
+        previouslyFiledDocuments: getValidPreviouslyFiledDocuments(
           applicationContext,
           caseDetail,
           selectedDocketEntryId,
@@ -39,7 +39,7 @@ export const getOptionsForCategory = ({
     case 'Nonstandard C': {
       options = {
         previousDocumentSelectLabel: categoryInformation.labelPreviousDocument,
-        previouslyFiledDocuments: getPreviouslyFiledDocuments(
+        previouslyFiledDocuments: getValidPreviouslyFiledDocuments(
           applicationContext,
           caseDetail,
           selectedDocketEntryId,
@@ -53,7 +53,7 @@ export const getOptionsForCategory = ({
     case 'Nonstandard D': {
       options = {
         previousDocumentSelectLabel: categoryInformation.labelPreviousDocument,
-        previouslyFiledDocuments: getPreviouslyFiledDocuments(
+        previouslyFiledDocuments: getValidPreviouslyFiledDocuments(
           applicationContext,
           caseDetail,
           selectedDocketEntryId,
@@ -76,7 +76,7 @@ export const getOptionsForCategory = ({
       options = {
         ordinalField: categoryInformation.ordinalField,
         previousDocumentSelectLabel: categoryInformation.labelPreviousDocument,
-        previouslyFiledDocuments: getPreviouslyFiledDocuments(
+        previouslyFiledDocuments: getValidPreviouslyFiledDocuments(
           applicationContext,
           caseDetail,
           selectedDocketEntryId,
@@ -133,7 +133,7 @@ export const getOrdinalValuesForUploadIteration = (): string[] => {
 };
 
 export const MAX_TITLE_LENGTH = 100;
-export const getPreviouslyFiledDocuments = (
+export const getValidPreviouslyFiledDocuments = (
   applicationContext,
   caseDetail,
   selectedDocketEntryId,
@@ -149,11 +149,23 @@ export const getPreviouslyFiledDocuments = (
     return { ...doc, documentTitle };
   };
 
-  return caseDetail.docketEntries
+  const formattedCaseDetail = applicationContext
+    .getUtilities()
+    .getFormattedCaseDetail({
+      applicationContext,
+      caseDetail,
+    });
+
+  return formattedCaseDetail.formattedDocketEntries
     .filter(
       doc =>
         doc.documentType !== INITIAL_DOCUMENT_TYPES.stin.documentType &&
-        doc.docketEntryId !== selectedDocketEntryId,
+        doc.docketEntryId !== selectedDocketEntryId &&
+        !doc.isStricken &&
+        !doc.isNotServedDocument &&
+        // Although this should never happen in practice, it is theoretically
+        // possible for a served document to not be on the docket record
+        doc.isOnDocketRecord,
     )
     .map(withDocumentTitle);
 };

--- a/web-client/src/presenter/sequences/StatusReportOrder/updateStatusReportOrderFormValueSequence.ts
+++ b/web-client/src/presenter/sequences/StatusReportOrder/updateStatusReportOrderFormValueSequence.ts
@@ -3,4 +3,4 @@ import { setFormValueAction } from '../../actions/setFormValueAction';
 export const updateStatusReportOrderFormValueSequence = [
   setFormValueAction,
   clearJurisdictionRadioAction,
-] as unknown as (props: { key: string; value: any }) => void;
+] as unknown as (props: { key: string; value: string | boolean }) => void;

--- a/web-client/src/presenter/sequences/editUnsignedDraftDocumentSequence.ts
+++ b/web-client/src/presenter/sequences/editUnsignedDraftDocumentSequence.ts
@@ -3,7 +3,6 @@ import { isStatusReportOrderAction } from '@web-client/presenter/actions/StatusR
 import { navigateToPathAction } from '../actions/navigateToPathAction';
 import { setDocumentToEditAction } from '../actions/setDocumentToEditAction';
 import { setEditStatusReportOrderFormAction } from '@web-client/presenter/actions/StatusReportOrder/setEditStatusReportOrderFormAction';
-import { statusReportOrderPdfPreviewSequence } from '@web-client/presenter/sequences/StatusReportOrder/statusReportOrderPdfPreviewSequence';
 
 export const editUnsignedDraftDocumentSequence = [
   checkDocumentTypeAction,
@@ -17,7 +16,6 @@ export const editUnsignedDraftDocumentSequence = [
         isStatusReportOrder: [
           setEditStatusReportOrderFormAction,
           navigateToPathAction,
-          statusReportOrderPdfPreviewSequence,
         ],
       },
     ],

--- a/web-client/src/presenter/state.ts
+++ b/web-client/src/presenter/state.ts
@@ -733,6 +733,7 @@ export const baseState = {
     pdfsAppended: 0,
     totalPdfs: 0,
   },
+  parentMessageId: undefined,
   pdfForSigning: {
     docketEntryId: null,
     nameForSigning: '',
@@ -843,7 +844,7 @@ export const baseState = {
   userContactEditProgress: {} as { inProgress?: boolean },
   users: [] as RawUser[],
   validationErrors: {} as Record<string, string>,
-  viewerDocumentToDisplay: undefined,
+  viewerDocumentToDisplay: undefined as unknown as ViewerDocument,
   workItem: {},
   workItemActions: {},
   workItemMetadata: {},
@@ -869,4 +870,11 @@ export type CreateCaseIrsForm = {
   taxYear?: number;
   irsNoticeFileUrl?: string;
   cityAndStateIssuingOffice?: string;
+};
+
+export type ViewerDocument = {
+  docketEntryId: string;
+  documentTitle?: string; // Should this be required?
+  filingDate?: Date;
+  index?: number;
 };

--- a/web-client/src/presenter/state.ts
+++ b/web-client/src/presenter/state.ts
@@ -875,6 +875,6 @@ export type CreateCaseIrsForm = {
 export type ViewerDocument = {
   docketEntryId: string;
   documentTitle?: string; // Should this be required?
-  filingDate?: Date;
+  filingDate?: string;
   index?: number;
 };


### PR DESCRIPTION
We do not want to show unserved, undocketed, or stricken documents from "What Document are You Filing?" dropdowns. This PR enforces these checks and updates tests accordingly.