### PR TITLE
PDFParseError alarm

### DIFF
--- a/web-api/src/business/useCaseHelper/pdf/parseAndScrapePdfContents.ts
+++ b/web-api/src/business/useCaseHelper/pdf/parseAndScrapePdfContents.ts
@@ -21,7 +21,6 @@ export const parseAndScrapePdfContents = async ({
     view[i] = pdfBuffer[i];
   }
 
-  // TODO: Wait to hear from Jessica on what should happen for PDF scraping failures
   try {
     return await applicationContext
       .getUtilities()

--- a/web-api/terraform/modules/api/alarms.tf
+++ b/web-api/terraform/modules/api/alarms.tf
@@ -5,7 +5,7 @@ resource "aws_cloudwatch_log_metric_filter" "pdf_parse_error_filter" {
   pattern        = "\"Failed to parse PDF\""
 
   metric_transformation {
-    name      = "PDFParseErrors"
+    name      = "PDFParseErrors_${var.environment}_${var.current_color}"
     namespace = "EFCMS"
     value     = "1"
   }


### PR DESCRIPTION
Makes alarm color and env specific, so that alarms don't all go off at once when someone uploads an bad/non-pdf