### PR TITLE
10463 Bug: update telephone input elements

### DIFF
--- a/web-client/src/styles/forms.scss
+++ b/web-client/src/styles/forms.scss
@@ -126,7 +126,6 @@ legend {
 
 input[type='email'],
 input[type='number'],
-input[type='tel'],
 input[type='text'],
 textarea,
 select {

--- a/web-client/src/views/AddPetitionerToCase/AddPetitionerToCase.tsx
+++ b/web-client/src/views/AddPetitionerToCase/AddPetitionerToCase.tsx
@@ -224,7 +224,7 @@ export const AddPetitionerToCase = connect(
                 data-testid="add-petitioner-phone"
                 id="phone"
                 name="contact.phone"
-                type="tel"
+                type="text"
                 value={form.contact.phone || ''}
                 onChange={e => {
                   updateFormValueSequence({

--- a/web-client/src/views/ContactEdit.tsx
+++ b/web-client/src/views/ContactEdit.tsx
@@ -104,7 +104,7 @@ export const ContactEdit = connect(
                 data-testid="phone-number-input"
                 id="phone"
                 name="contact.phone"
-                type="tel"
+                type="text"
                 value={form.contact.phone || ''}
                 onBlur={() => {
                   validatePetitionerSequence();

--- a/web-client/src/views/EditPetitionerInformationInternal.tsx
+++ b/web-client/src/views/EditPetitionerInformationInternal.tsx
@@ -181,7 +181,7 @@ export const EditPetitionerInformationInternal = connect(
                 className="usa-input max-width-200"
                 id="phone"
                 name="contact.phone"
-                type="tel"
+                type="text"
                 value={form.contact.phone || ''}
                 onBlur={() => {
                   validatePetitionerSequence();

--- a/web-client/src/views/Practitioners/PractitionerContactForm.tsx
+++ b/web-client/src/views/Practitioners/PractitionerContactForm.tsx
@@ -68,7 +68,7 @@ export const PractitionerContactForm = connect(
                 data-testid="practitioner-phone-input"
                 id="phone"
                 name="contact.phone"
-                type="tel"
+                type="text"
                 value={form.contact.phone || ''}
                 onBlur={() => {
                   onBlurValidationSequence();
@@ -94,7 +94,7 @@ export const PractitionerContactForm = connect(
                 className="usa-input"
                 id="additional-phone"
                 name="additionalPhone"
-                type="tel"
+                type="text"
                 value={form.additionalPhone || ''}
                 onChange={e => {
                   onChangeUpdateSequence({

--- a/web-client/src/views/StartCase/ContactPrimary.tsx
+++ b/web-client/src/views/StartCase/ContactPrimary.tsx
@@ -251,7 +251,7 @@ export const ContactPrimary = connect(
               data-testid="phone"
               id="phone"
               name="contactPrimary.phone"
-              type="tel"
+              type="text"
               value={data.contactPrimary.phone || ''}
               onBlur={() => {
                 onBlurSequence();

--- a/web-client/src/views/StartCase/ContactPrimaryUpdated.tsx
+++ b/web-client/src/views/StartCase/ContactPrimaryUpdated.tsx
@@ -249,7 +249,7 @@ export const ContactPrimaryUpdated = connect<
               id="primary-phone"
               name="contactPrimary.phone"
               ref={registerRef && registerRef('contactPrimary.phone')}
-              type="tel"
+              type="text"
               value={addressInfo.phone || ''}
               onBlur={() => {
                 handleBlur({

--- a/web-client/src/views/StartCase/ContactSecondary.tsx
+++ b/web-client/src/views/StartCase/ContactSecondary.tsx
@@ -201,7 +201,7 @@ export const ContactSecondary = connect(
                 data-testid="contact-secondary-phone-input"
                 id="secondaryPhone"
                 name="contactSecondary.phone"
-                type="tel"
+                type="text"
                 value={data.contactSecondary.phone || ''}
                 onBlur={() => {
                   onBlurSequence();

--- a/web-client/src/views/StartCase/ContactSecondaryUpdated.tsx
+++ b/web-client/src/views/StartCase/ContactSecondaryUpdated.tsx
@@ -169,7 +169,7 @@ export const ContactSecondaryUpdated = connect<
               id="secondary-phone"
               name="contactSecondary.phone"
               ref={registerRef && registerRef('contactSecondary.phone')}
-              type="tel"
+              type="text"
               value={addressInfo.phone || ''}
               onBlur={() => {
                 handleBlur({

--- a/web-client/src/views/StyleGuide/Forms.tsx
+++ b/web-client/src/views/StyleGuide/Forms.tsx
@@ -85,7 +85,7 @@ export const Forms = () => (
           <input
             className="usa-input max-width-200"
             id="input-tel"
-            type="tel"
+            type="text"
           />
         </div>
 
@@ -96,7 +96,7 @@ export const Forms = () => (
           <input
             className="usa-input max-width-200 usa-input--error"
             id="input-tel-error"
-            type="tel"
+            type="text"
           />
           <span className="usa-error-message">Error message</span>
         </div>

--- a/web-client/src/views/UserContactEditForm.tsx
+++ b/web-client/src/views/UserContactEditForm.tsx
@@ -62,7 +62,7 @@ export const UserContactEditForm = connect(
             data-testid="phone-number-input"
             id="phone"
             name="contact.phone"
-            type="tel"
+            type="text"
             value={form.contact.phone || ''}
             onBlur={() => {
               validateUserContactSequence();


### PR DESCRIPTION
Change type attribute from `tel` to `text` for phone number input elements so that users can write "N/A" as instructed on mobile, if necessary.

Using `type="tel"` [does not introduce validation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/tel) as with `email` or `url`. As far as I can tell, the key difference between a `tel` input element and a `text` one is that mobile users are directed to a numbers-only keyboard in the case of the former. Since this is the behavior we want to change, `type="text"` should work.