### PR TITLE
10366 Bug: hide "Load More" button if no judge is selected

### DIFF
--- a/web-client/src/presenter/computeds/pendingReportListHelper.test.ts
+++ b/web-client/src/presenter/computeds/pendingReportListHelper.test.ts
@@ -9,7 +9,7 @@ describe('pendingReportListHelper', () => {
     applicationContext,
   );
 
-  it('should display load more button if more results are to be loaded', () => {
+  it('should set showLoadMore to true when there are additional results to load', () => {
     const mockState = {
       pendingReports: {
         hasPendingItemsResults: true,
@@ -26,7 +26,7 @@ describe('pendingReportListHelper', () => {
     expect(showLoadMore).toBe(true);
   });
 
-  it('should hide the load more button if more results are to be loaded', () => {
+  it('should set showLoadMore to false when there are no additional results to load', () => {
     const mockState = {
       pendingReports: {
         hasPendingItemsResults: true,

--- a/web-client/src/presenter/sequences/Pending/setPendingReportSelectedJudgeSequence.ts
+++ b/web-client/src/presenter/sequences/Pending/setPendingReportSelectedJudgeSequence.ts
@@ -1,3 +1,4 @@
+import { clearPendingReportsAction } from '@web-client/presenter/actions/PendingItems/clearPendingReportsAction';
 import { fetchPendingItemsAction } from '../../actions/PendingItems/fetchPendingItemsAction';
 import { isJudgeSelectedAction } from '../../actions/PendingItems/isJudgeSelectedAction';
 import { setPendingItemsAction } from '../../actions/PendingItems/setPendingItemsAction';
@@ -8,7 +9,7 @@ export const setPendingReportSelectedJudgeSequence = [
   setPendingReportSelectedJudgeAction,
   isJudgeSelectedAction,
   {
-    no: [],
+    no: [clearPendingReportsAction],
     yes: [
       showProgressSequenceDecorator([
         fetchPendingItemsAction,


### PR DESCRIPTION
See [10366](https://app.zenhub.com/workspaces/flexionef-cms-5bbe4bed4b5806bc2bec65d3/issues/gh/flexion/ef-cms/10366)

This PR resets `pendingReports` state to its initial value when the default placeholder is selected in the judge's dropdown on the "Pending Reports" page.

As a result, the "Load More" button will no longer appear when switching back to the placeholder after selecting a judge with enough items to show the button.