### PR TITLE
10459 Bug: Fix cognito users missing attributes

### DIFF
--- a/scripts/run-once-scripts/fix-cognito-users-without-ids-constants.ts
+++ b/scripts/run-once-scripts/fix-cognito-users-without-ids-constants.ts
@@ -1,0 +1,33 @@
+/* eslint-disable max-lines */
+// import { DateTime } from 'luxon';
+import { UserType } from '@aws-sdk/client-cognito-identity-provider';
+
+export const usersWithoutUserIds: UserType[] = [
+  // {
+  //   Attributes: [
+  //     {
+  //       Name: 'sub',
+  //       Value: '2e135421-9953-409b-9c69-be05670f4257',
+  //     },
+  //     {
+  //       Name: 'email_verified',
+  //       Value: 'false',
+  //     },
+  //     {
+  //       Name: 'name',
+  //       Value: 'John Doe',
+  //     },
+  //     {
+  //       Name: 'email',
+  //       Value: 'jdoe@example.com',
+  //     },
+  //   ],
+  //   Enabled: true,
+  //   UserCreateDate: DateTime.fromISO('2024-06-09T02:00:16.418Z').toJSDate(),
+  //   UserLastModifiedDate: DateTime.fromISO(
+  //     '2024-06-09T02:00:16.418Z',
+  //   ).toJSDate(),
+  //   UserStatus: 'UNCONFIRMED',
+  //   Username: '2e135421-9953-409b-9c69-be05670f4257',
+  // },
+];

--- a/scripts/run-once-scripts/fix-cognito-users-without-ids.ts
+++ b/scripts/run-once-scripts/fix-cognito-users-without-ids.ts
@@ -77,13 +77,15 @@ const setUserAttributes = async ({
         continue;
       }
 
-      await createPetitionerUserRecords({
-        applicationContext,
-        user: omit(user, 'userId'),
-        userId: user.userId,
-      });
-      console.log(`Created petitioner entity in Dynamo for ${user.email}.`);
-      totals.userEntitiesCreatedInDynamo++;
+      if (cognitoUser.UserStatus === 'CONFIRMED') {
+        await createPetitionerUserRecords({
+          applicationContext,
+          user: omit(user, 'userId'),
+          userId: user.userId,
+        });
+        console.log(`Created petitioner entity in Dynamo for ${user.email}.`);
+        totals.userEntitiesCreatedInDynamo++;
+      }
 
       if (cognitoUser.UserStatus === 'UNCONFIRMED') {
         await createUserConfirmation(applicationContext, {

--- a/scripts/run-once-scripts/fix-cognito-users-without-ids.ts
+++ b/scripts/run-once-scripts/fix-cognito-users-without-ids.ts
@@ -1,20 +1,19 @@
-import { RawUser } from '../../shared/src/business/entities/User';
+import { RawUser } from '@shared/business/entities/User';
 import {
   type ServerApplicationContext,
   createApplicationContext,
-} from '../../web-api/src/applicationContext';
-import { createPetitionerUserRecords } from '../../web-api/src/persistence/dynamo/users/createPetitionerUserRecords';
-import { createUserConfirmation } from '../../web-api/src/business/useCaseHelper/auth/createUserConfirmation';
+} from '@web-api/applicationContext';
+import { createPetitionerUserRecords } from '@web-api/persistence/dynamo/users/createPetitionerUserRecords';
+import { createUserConfirmation } from '@web-api/business/useCaseHelper/auth/createUserConfirmation';
 import { omit } from 'lodash';
 import { usersWithoutUserIds } from './fix-cognito-users-without-ids-constants';
 import type { UserType } from '@aws-sdk/client-cognito-identity-provider';
 
 const getAttributeValue = (
   cognitoUser: UserType,
-  attributeName: string,
+  attr: string,
 ): string | undefined => {
-  return cognitoUser.Attributes?.find(attrib => attrib.Name === attributeName)
-    ?.Value;
+  return cognitoUser.Attributes?.find(attrib => attrib.Name === attr)?.Value;
 };
 
 const buildRawUser = (cognitoUser: UserType): RawUser | undefined => {
@@ -62,11 +61,7 @@ const setUserAttributes = async ({
 (async () => {
   const applicationContext = createApplicationContext({});
 
-  const totals: {
-    emailConfirmationsSent: number;
-    userEntitiesCreatedInDynamo: number;
-    usersUpdatedInCognito: number;
-  } = {
+  const totals = {
     emailConfirmationsSent: 0,
     userEntitiesCreatedInDynamo: 0,
     usersUpdatedInCognito: 0,

--- a/scripts/run-once-scripts/fix-cognito-users-without-ids.ts
+++ b/scripts/run-once-scripts/fix-cognito-users-without-ids.ts
@@ -88,7 +88,7 @@ const setUserAttributes = async ({
         userId: user.userId,
       });
       console.log(`Created petitioner entity in Dynamo for ${user.email}.`);
-      totals.usersUpdatedInCognito++;
+      totals.userEntitiesCreatedInDynamo++;
 
       if (cognitoUser.UserStatus === 'UNCONFIRMED') {
         await createUserConfirmation(applicationContext, {

--- a/scripts/run-once-scripts/fix-cognito-users-without-ids.ts
+++ b/scripts/run-once-scripts/fix-cognito-users-without-ids.ts
@@ -1,0 +1,104 @@
+import { RawUser } from '../../shared/src/business/entities/User';
+import {
+  type ServerApplicationContext,
+  createApplicationContext,
+} from '../../web-api/src/applicationContext';
+import { createPetitionerUserRecords } from '../../web-api/src/persistence/dynamo/users/createPetitionerUserRecords';
+import { createUserConfirmation } from '../../web-api/src/business/useCaseHelper/auth/createUserConfirmation';
+import { omit } from 'lodash';
+import { usersWithoutUserIds } from './fix-cognito-users-without-ids-constants';
+import type { UserType } from '@aws-sdk/client-cognito-identity-provider';
+
+const getAttributeValue = (
+  cognitoUser: UserType,
+  attributeName: string,
+): string | undefined => {
+  return cognitoUser.Attributes?.find(attrib => attrib.Name === attributeName)
+    ?.Value;
+};
+
+const buildRawUser = (cognitoUser: UserType): RawUser | undefined => {
+  const userId = cognitoUser.Username;
+  const email = getAttributeValue(cognitoUser, 'email');
+  const name = getAttributeValue(cognitoUser, 'name');
+  if (!!userId && !!email && !!name) {
+    return {
+      email,
+      entityName: 'User',
+      name,
+      role: 'petitioner',
+      userId,
+    } as RawUser;
+  }
+};
+
+const setUserAttributes = async ({
+  applicationContext,
+  cognitoUser,
+}: {
+  applicationContext: ServerApplicationContext;
+  cognitoUser: UserType;
+}): Promise<void> => {
+  if (cognitoUser && cognitoUser.Username) {
+    const cognito = applicationContext.getCognito();
+    await cognito.adminUpdateUserAttributes({
+      UserAttributes: [
+        {
+          Name: 'custom:userId',
+          Value: cognitoUser.Username,
+        },
+        {
+          Name: 'custom:role',
+          Value: 'petitioner',
+        },
+      ],
+      UserPoolId: applicationContext.environment.userPoolId,
+      Username: cognitoUser.Username,
+    });
+  }
+};
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+(async () => {
+  const applicationContext = createApplicationContext({});
+
+  const totals: {
+    emailConfirmationsSent: number;
+    userEntitiesCreatedInDynamo: number;
+    usersUpdatedInCognito: number;
+  } = {
+    emailConfirmationsSent: 0,
+    userEntitiesCreatedInDynamo: 0,
+    usersUpdatedInCognito: 0,
+  };
+  for (const cognitoUser of usersWithoutUserIds) {
+    const user = buildRawUser(cognitoUser);
+    if (user) {
+      await setUserAttributes({ applicationContext, cognitoUser });
+      console.log(`Updated cognito user attributes for ${user.email}.`);
+      totals.usersUpdatedInCognito++;
+
+      if (!cognitoUser.Enabled) {
+        continue;
+      }
+
+      await createPetitionerUserRecords({
+        applicationContext,
+        user: omit(user, 'userId'),
+        userId: user.userId,
+      });
+      console.log(`Created petitioner entity in Dynamo for ${user.email}.`);
+      totals.usersUpdatedInCognito++;
+
+      if (cognitoUser.UserStatus === 'UNCONFIRMED') {
+        await createUserConfirmation(applicationContext, {
+          email: user.email!,
+          userId: user.userId,
+        });
+        console.log(`Sent new email confirmation link to ${user.email}.`);
+        totals.emailConfirmationsSent++;
+      }
+    }
+  }
+  console.log('Totals', totals);
+})();


### PR DESCRIPTION
In prod, there are 37 users in cognito that don't have the `custom:userId` and `custom:role` attributes.

For all 37 users, let's:
* update their cognito records:
  * set their `custom:userId` to be the same as their `sub`
  * set their `custom:role` attribute to "petitioner"

For the users that have already confirmed their email addresses, let's add a user entity in dynamodb.

To the users that have not confirmed their email addresses, let's send another confirmation email.

To execute:
```bash
. scripts/env/set-env.zsh <ENV>
npx ts-node --transpile-only scripts/run-once-scripts/fix-cognito-users-without-ids.ts
```