### PR TITLE
10399 Bug: direct users editing a PDF upload to the correct form

### DIFF
--- a/cypress/local-only/tests/integration/caseDetail/docketRecord/courtIssuedFiling/docket-clerk-uploads-and-edits-court-issued-docket-entry.cy.ts
+++ b/cypress/local-only/tests/integration/caseDetail/docketRecord/courtIssuedFiling/docket-clerk-uploads-and-edits-court-issued-docket-entry.cy.ts
@@ -1,0 +1,60 @@
+import { faker } from '@faker-js/faker';
+import { goToCase } from '../../../../../../helpers/caseDetail/go-to-case';
+import { loginAsDocketClerk1 } from '../../../../../../helpers/authentication/login-as-helpers';
+
+describe('Docket clerk uploads and edits court-issued docket entries', () => {
+  it('should let a docket clerk upload a court-issued docket entry and the edit it while it is unsigned', () => {
+    const leadCase = '111-19';
+
+    loginAsDocketClerk1();
+    goToCase(leadCase);
+
+    // Arrange: create the docket entry
+    cy.get('[data-testid="case-detail-menu-button"]').click();
+    cy.get('[data-testid="menu-button-upload-pdf"]').click();
+    const title = `${faker.word.adjective()} ${faker.word.noun()}`;
+    cy.get('[data-testid="upload-description"]').type(title);
+    cy.readFile('cypress/helpers/file/sample.pdf', null).then(fileContent => {
+      cy.get('[data-testid="primary-document-file"]').attachFile({
+        fileContent,
+        fileName: 'sample.pdf',
+        mimeType: 'application/pdf',
+      });
+      cy.get('[data-testid="save-uploaded-pdf-button"]').click();
+    });
+
+    // Act: edit the docket entry
+    cy.get('[data-testid="tab-drafts"').click();
+    cy.get('[data-testid="draft-edit-button-not-signed"]').click();
+    const newTitle = `${faker.word.adjective()} ${faker.word.noun()}`;
+    cy.get('[data-testid="upload-description"]').clear();
+    cy.get('[data-testid="upload-description"]').type(newTitle);
+    cy.get('[data-testid="save-edited-pdf-button"]').click();
+
+    // Assert: the new description should display for the edited docket entry
+    cy.get('[data-testid^="docket-entry-description-"]').then($els => {
+      const matchingElements = $els.filter((index, el) => {
+        return Cypress.$(el).text().includes(newTitle);
+      });
+
+      expect(
+        matchingElements.length,
+        `Expected to find "${newTitle}" in at least one element`,
+      ).to.be.greaterThan(0);
+    });
+
+    // TODO: the above assertion fails because the updated document title does not display in the draft menu
+  });
+
+  it('should let a docket clerk upload a court-issued docket entry and the edit it after it is signed', () => {
+    const leadCase = '111-19';
+
+    loginAsDocketClerk1();
+    goToCase(leadCase);
+
+    cy.get('data-testid=[docket-entry-description-0').click();
+    cy.get('data-testid="edit-order-button"').click();
+    cy.get('data-testid="modal-button-confirm"').click();
+    // TODO: the call to `/remove-signature` on the backend throws a 400 error
+  });
+});

--- a/shared/src/business/entities/DocketEntry.ts
+++ b/shared/src/business/entities/DocketEntry.ts
@@ -94,7 +94,7 @@ export class DocketEntry extends JoiValidationEntity {
   public documentContentsId?: string;
   public documentIdBeforeSignature?: string;
   public documentTitle: string;
-  public documentType: string;
+  public documentType?: string;
   public eventCode: string;
   public filedBy?: string;
   public filedByRole?: string;
@@ -143,7 +143,25 @@ export class DocketEntry extends JoiValidationEntity {
   public privatePractitioners?: any[];
   public servedParties?: any[];
   public signedAt?: string;
-  public draftOrderState?: object;
+  public draftOrderState?: {
+    additionalOrderText?: string;
+    docketNumber?: string;
+    documentTitle?: string;
+    documentType?: string;
+    dueDate?: string;
+    eventCode?: string;
+    freeText?: string;
+    generatedDocumentTitle?: string;
+    issueOrder?: string;
+    jurisdiction?: string;
+    orderType?: string;
+    primaryDocumentFileSize?: number;
+    richText?: string;
+    scenario?: string;
+    statusReportFilingDate?: string;
+    statusReportIndex?: string;
+    strickenFromTrialSessions?: boolean;
+  };
   public stampData!: object;
   public isDraft?: boolean;
   public redactionAcknowledgement?: boolean;

--- a/shared/src/business/entities/DocketEntry.ts
+++ b/shared/src/business/entities/DocketEntry.ts
@@ -513,15 +513,16 @@ export class DocketEntry extends JoiValidationEntity {
    *  otherwise false
    */
   isAutoServed() {
-    const isExternalDocumentType = EXTERNAL_DOCUMENT_TYPES.includes(
-      this.documentType,
-    );
+    const documentType = this.documentType as string;
+
+    const isExternalDocumentType =
+      EXTERNAL_DOCUMENT_TYPES.includes(documentType);
 
     const isPractitionerAssociationDocumentType =
-      PRACTITIONER_ASSOCIATION_DOCUMENT_TYPES.includes(this.documentType);
+      PRACTITIONER_ASSOCIATION_DOCUMENT_TYPES.includes(documentType);
 
     // if fully concatenated document title includes the word Simultaneous, do not auto-serve
-    const isSimultaneous = (this.documentTitle || this.documentType).includes(
+    const isSimultaneous = (this.documentTitle || documentType).includes(
       'Simultaneous',
     );
 

--- a/shared/src/business/entities/DocketEntry.ts
+++ b/shared/src/business/entities/DocketEntry.ts
@@ -621,7 +621,10 @@ export class DocketEntry extends JoiValidationEntity {
       return true;
     }
 
-    if (!rootDocument || !DocketEntry.isBriefType(rootDocument.documentType)) {
+    if (
+      !rootDocument ||
+      !DocketEntry.isBriefType(rootDocument.documentType || '')
+    ) {
       return false;
     }
 

--- a/shared/src/business/utilities/formatPendingItem.ts
+++ b/shared/src/business/utilities/formatPendingItem.ts
@@ -33,7 +33,7 @@ export const formatPendingItem = (
     .getUtilities()
     .formatJudgeName(item.associatedJudge);
 
-  const formattedName = item.documentTitle || item.documentType;
+  const formattedName = item.documentTitle || item.documentType || '';
 
   const formattedStatus: string = applicationContext
     .getUtilities()

--- a/shared/src/business/utilities/getFormattedCaseDetail.test.ts
+++ b/shared/src/business/utilities/getFormattedCaseDetail.test.ts
@@ -528,33 +528,63 @@ describe('getFormattedCaseDetail', () => {
     });
 
     it('should format draft documents', () => {
+      const orderDocketEntry = {
+        archived: false,
+        createdAt: getDateISO(),
+        docketEntryId: 'd-1-2-3',
+        docketNumber: '101-18',
+        documentType: 'Order',
+        isDraft: true,
+      };
+
+      const stipulatedDecisionDocketEntry = {
+        archived: false,
+        createdAt: getDateISO(),
+        docketEntryId: 'd-2-3-4',
+        docketNumber: '101-18',
+        documentType: 'Stipulated Decision',
+        isDraft: true,
+      };
+
+      const miscellaneousDocketEntry = {
+        archived: false,
+        createdAt: getDateISO(),
+        docketEntryId: 'd-3-4-5',
+        docketNumber: '101-18',
+        documentType: 'Miscellaneous',
+        isDraft: true,
+      };
+
+      const miscellaneousDocketEntryWithUndefinedDocumentType = {
+        archived: false,
+        createdAt: getDateISO(),
+        docketEntryId: 'd-3-4-5',
+        docketNumber: '101-18',
+        isDraft: true,
+      };
+
+      const statusReportOrderDocketEntry = {
+        archived: false,
+        createdAt: getDateISO(),
+        docketEntryId: 'd-3-4-5',
+        docketNumber: '101-18',
+        draftOrderState: {
+          orderType: 'statusReport',
+        },
+        isDraft: true,
+      };
+
       const result = getFormattedCaseDetail({
         applicationContext,
         authorizedUser: undefined,
         caseDetail: {
           ...MOCK_CASE,
           docketEntries: [
-            {
-              archived: false,
-              createdAt: getDateISO(),
-              docketEntryId: 'd-1-2-3',
-              documentType: 'Order',
-              isDraft: true,
-            },
-            {
-              archived: false,
-              createdAt: getDateISO(),
-              docketEntryId: 'd-2-3-4',
-              documentType: 'Stipulated Decision',
-              isDraft: true,
-            },
-            {
-              archived: false,
-              createdAt: getDateISO(),
-              docketEntryId: 'd-3-4-5',
-              documentType: 'Miscellaneous',
-              isDraft: true,
-            },
+            orderDocketEntry,
+            stipulatedDecisionDocketEntry,
+            miscellaneousDocketEntry,
+            miscellaneousDocketEntryWithUndefinedDocumentType,
+            statusReportOrderDocketEntry,
           ],
         },
         docketRecordSort: 'byDate',
@@ -573,6 +603,16 @@ describe('getFormattedCaseDetail', () => {
         },
         {
           editUrl: `/case-detail/${MOCK_CASE.docketNumber}/edit-upload-court-issued/d-3-4-5`,
+          signUrl: `/case-detail/${MOCK_CASE.docketNumber}/edit-order/d-3-4-5/sign`,
+          signedAtFormatted: '',
+        },
+        {
+          editUrl: `/case-detail/${MOCK_CASE.docketNumber}/edit-upload-court-issued/d-3-4-5`,
+          signUrl: `/case-detail/${MOCK_CASE.docketNumber}/edit-order/d-3-4-5/sign`,
+          signedAtFormatted: '',
+        },
+        {
+          editUrl: `/case-detail/${MOCK_CASE.docketNumber}/edit-order/d-3-4-5`,
           signUrl: `/case-detail/${MOCK_CASE.docketNumber}/edit-order/d-3-4-5/sign`,
           signedAtFormatted: '',
         },

--- a/shared/src/business/utilities/getFormattedCaseDetail.ts
+++ b/shared/src/business/utilities/getFormattedCaseDetail.ts
@@ -16,6 +16,7 @@ import {
 } from './DateHandler';
 import { UnknownAuthUser } from '@shared/business/entities/authUser/AuthUser';
 import { cloneDeep, isEmpty, sortBy } from 'lodash';
+import { isMiscellaneousDocketEntry } from '@shared/business/utilities/isMiscellaneousDocketEntry';
 
 const computeIsInProgress = ({ formattedEntry }) => {
   return (
@@ -248,18 +249,12 @@ const formatTrialSessionScheduling = ({
   }
 };
 
-const getEditUrl = ({
-  docketEntryId,
-  docketNumber,
-  documentType,
-}: {
-  docketNumber: string;
-  documentType: string;
-  docketEntryId: string;
-}) => {
-  return documentType === 'Miscellaneous'
-    ? `/case-detail/${docketNumber}/edit-upload-court-issued/${docketEntryId}`
-    : `/case-detail/${docketNumber}/edit-order/${docketEntryId}`;
+const getEditUrl = (docketEntry: RawDocketEntry): string => {
+  const routeToEditUploadCourtIssued = isMiscellaneousDocketEntry(docketEntry);
+
+  return routeToEditUploadCourtIssued
+    ? `/case-detail/${docketEntry.docketNumber}/edit-upload-court-issued/${docketEntry.docketEntryId}`
+    : `/case-detail/${docketEntry.docketNumber}/edit-order/${docketEntry.docketEntryId}`;
 };
 
 export const formatCase = (
@@ -277,11 +272,7 @@ export const formatCase = (
       .filter(docketEntry => docketEntry.isDraft && !docketEntry.archived)
       .map(docketEntry => ({
         ...formatDocketEntry(applicationContext, docketEntry),
-        editUrl: getEditUrl({
-          docketEntryId: docketEntry.docketEntryId,
-          docketNumber: caseDetail.docketNumber,
-          documentType: docketEntry.documentType,
-        }),
+        editUrl: getEditUrl(docketEntry),
         signUrl: `/case-detail/${caseDetail.docketNumber}/edit-order/${docketEntry.docketEntryId}/sign`,
         signedAtFormatted: applicationContext
           .getUtilities()

--- a/shared/src/business/utilities/isMiscellaneousDocketEntry.test.ts
+++ b/shared/src/business/utilities/isMiscellaneousDocketEntry.test.ts
@@ -1,0 +1,84 @@
+import { isMiscellaneousDocketEntry } from './isMiscellaneousDocketEntry';
+
+describe('isMiscellaneousDocument', () => {
+  it("should return true when passed a docket entry that has a document type of 'Miscellaneous'", () => {
+    const result = isMiscellaneousDocketEntry({
+      createdAt: '2019-11-21T21:49:28.192Z',
+      docketEntryId: '062c9a5d-1a65-4273-965e-25d41607bc98',
+      docketNumber: '101-18',
+      documentTitle: 'Attachment to Petition',
+      documentType: 'Miscellaneous',
+      entityName: 'DocketEntry',
+      eventCode: 'ATP',
+      filers: [],
+      filingDate: '2017-03-01T09:00:00.000Z',
+      isOnDocketRecord: true,
+      processingStatus: 'pending',
+      receivedAt: '2018-03-01T05:00:00.000Z',
+      stampData: {},
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('should return true when passed a docket entry that has an undefined document type and that is not a draft status report order', () => {
+    const result = isMiscellaneousDocketEntry({
+      createdAt: '2019-11-21T21:49:28.192Z',
+      docketEntryId: '062c9a5d-1a65-4273-965e-25d41607bc98',
+      docketNumber: '101-18',
+      documentTitle: 'Attachment to Petition',
+      entityName: 'DocketEntry',
+      eventCode: 'ATP',
+      filers: [],
+      filingDate: '2017-03-01T09:00:00.000Z',
+      isOnDocketRecord: true,
+      processingStatus: 'pending',
+      receivedAt: '2018-03-01T05:00:00.000Z',
+      stampData: {},
+    });
+
+    expect(result).toEqual(true);
+  });
+
+  it('should return false when passed a docket entry is a draft status report order', () => {
+    const result = isMiscellaneousDocketEntry({
+      createdAt: '2019-11-21T21:49:28.192Z',
+      docketEntryId: '062c9a5d-1a65-4273-965e-25d41607bc98',
+      docketNumber: '101-18',
+      documentTitle: 'Attachment to Petition',
+      draftOrderState: {
+        orderType: 'statusReport',
+      },
+      entityName: 'DocketEntry',
+      eventCode: 'ATP',
+      filers: [],
+      filingDate: '2017-03-01T09:00:00.000Z',
+      isOnDocketRecord: true,
+      processingStatus: 'pending',
+      receivedAt: '2018-03-01T05:00:00.000Z',
+      stampData: {},
+    });
+
+    expect(result).toEqual(false);
+  });
+
+  it('should return false when passed a docket entry is not a draft status report order', () => {
+    const result = isMiscellaneousDocketEntry({
+      createdAt: '2019-11-21T21:49:28.192Z',
+      docketEntryId: '062c9a5d-1a65-4273-965e-25d41607bc98',
+      docketNumber: '101-18',
+      documentTitle: 'Attachment to Petition',
+      documentType: 'Order',
+      entityName: 'DocketEntry',
+      eventCode: 'ATP',
+      filers: [],
+      filingDate: '2017-03-01T09:00:00.000Z',
+      isOnDocketRecord: true,
+      processingStatus: 'pending',
+      receivedAt: '2018-03-01T05:00:00.000Z',
+      stampData: {},
+    });
+
+    expect(result).toEqual(false);
+  });
+});

--- a/shared/src/business/utilities/isMiscellaneousDocketEntry.ts
+++ b/shared/src/business/utilities/isMiscellaneousDocketEntry.ts
@@ -1,0 +1,22 @@
+import {
+  PRACTITIONER_DOCUMENT_TYPES_MAP,
+  STATUS_REPORT_ORDER_OPTIONS,
+} from '../entities/EntityConstants';
+
+export const isMiscellaneousDocketEntry = (
+  docketEntry: RawDocketEntry,
+): boolean => {
+  const draftStatusReportOrderTypes = Object.values(
+    STATUS_REPORT_ORDER_OPTIONS.orderTypeOptions,
+  );
+
+  const isDraftStatusReportOrder = draftStatusReportOrderTypes.includes(
+    docketEntry?.draftOrderState?.orderType || '',
+  );
+
+  return (
+    docketEntry.documentType ===
+      PRACTITIONER_DOCUMENT_TYPES_MAP.MISCELLANEOUS ||
+    (!isDraftStatusReportOrder && !docketEntry.documentType)
+  );
+};

--- a/web-api/src/business/useCases/docketEntry/completeDocketEntryQCInteractor.ts
+++ b/web-api/src/business/useCases/docketEntry/completeDocketEntryQCInteractor.ts
@@ -216,7 +216,9 @@ const completeDocketEntryQC = async (
 
   if (
     overridePaperServiceAddress ||
-    CONTACT_CHANGE_DOCUMENT_TYPES.includes(updatedDocketEntry.documentType)
+    CONTACT_CHANGE_DOCUMENT_TYPES.includes(
+      updatedDocketEntry.documentType || '',
+    )
   ) {
     if (servedParties.paper.length > 0) {
       const pdfData = await applicationContext

--- a/web-client/src/presenter/actions/checkDocumentTypeAction.test.ts
+++ b/web-client/src/presenter/actions/checkDocumentTypeAction.test.ts
@@ -9,7 +9,6 @@ describe('checkDocumentTypeAction', () => {
   const mockDocketEntryId = '67890';
   const mockParentMessageId = 'abcdef';
   const propsBase = {
-    caseDetail: { docketNumber: mockDocketNumber },
     docketEntryIdToEdit: mockDocketEntryId,
   };
 
@@ -29,7 +28,15 @@ describe('checkDocumentTypeAction', () => {
   it('should return the correct path for Miscellaneous document type without parentMessageId', async () => {
     const props = {
       ...propsBase,
-      documentType: 'Miscellaneous',
+      caseDetail: {
+        docketEntries: [
+          {
+            docketEntryId: mockDocketEntryId,
+            documentType: 'Miscellaneous',
+          },
+        ],
+        docketNumber: mockDocketNumber,
+      },
     };
 
     await runAction(checkDocumentTypeAction, {
@@ -45,6 +52,16 @@ describe('checkDocumentTypeAction', () => {
   it('should return the correct path for Miscellaneous document type with parentMessageId', async () => {
     const props = {
       ...propsBase,
+      caseDetail: {
+        docketEntries: [
+          {
+            docketEntryId: mockDocketEntryId,
+            documentType: 'Miscellaneous',
+          },
+        ],
+        docketNumber: mockDocketNumber,
+      },
+
       documentType: 'Miscellaneous',
       parentMessageId: mockParentMessageId,
     };
@@ -62,7 +79,15 @@ describe('checkDocumentTypeAction', () => {
   it('should return the correct path for Order document type without parentMessageId', async () => {
     const props = {
       ...propsBase,
-      documentType: 'Order',
+      caseDetail: {
+        docketEntries: [
+          {
+            docketEntryId: mockDocketEntryId,
+            documentType: 'Order',
+          },
+        ],
+        docketNumber: mockDocketNumber,
+      },
     };
 
     await runAction(checkDocumentTypeAction, {
@@ -78,7 +103,15 @@ describe('checkDocumentTypeAction', () => {
   it('should return the correct path for Order document type with parentMessageId', async () => {
     const props = {
       ...propsBase,
-      documentType: 'Order',
+      caseDetail: {
+        docketEntries: [
+          {
+            docketEntryId: mockDocketEntryId,
+            documentType: 'Order',
+          },
+        ],
+        docketNumber: mockDocketNumber,
+      },
       parentMessageId: mockParentMessageId,
     };
 
@@ -95,6 +128,14 @@ describe('checkDocumentTypeAction', () => {
   it('should return the correct path for a document that is not a status report order with an undefined document type without parentMessageId', async () => {
     const props = {
       ...propsBase,
+      caseDetail: {
+        docketEntries: [
+          {
+            docketEntryId: mockDocketEntryId,
+          },
+        ],
+        docketNumber: mockDocketNumber,
+      },
     };
 
     await runAction(checkDocumentTypeAction, {
@@ -110,6 +151,14 @@ describe('checkDocumentTypeAction', () => {
   it('should return the correct path for a document that is not a status report order with an undefined document type with parentMessageId', async () => {
     const props = {
       ...propsBase,
+      caseDetail: {
+        docketEntries: [
+          {
+            docketEntryId: mockDocketEntryId,
+          },
+        ],
+        docketNumber: mockDocketNumber,
+      },
       parentMessageId: mockParentMessageId,
     };
 
@@ -125,14 +174,15 @@ describe('checkDocumentTypeAction', () => {
 
   it('should return the correct path for a document that is a status report order with an undefined document type without parentMessageId', async () => {
     const props = {
+      ...propsBase,
       caseDetail: {
-        ...propsBase.caseDetail,
         docketEntries: [
           {
             docketEntryId: mockDocketEntryId,
             draftOrderState: { orderType: 'statusReport' },
           },
         ],
+        docketNumber: mockDocketNumber,
       },
       docketEntryIdToEdit: propsBase.docketEntryIdToEdit,
     };
@@ -149,14 +199,15 @@ describe('checkDocumentTypeAction', () => {
 
   it('should return the correct path for a document that is a status report order with an undefined document type with parentMessageId', async () => {
     const props = {
+      ...propsBase,
       caseDetail: {
-        ...propsBase.caseDetail,
         docketEntries: [
           {
             docketEntryId: mockDocketEntryId,
             draftOrderState: { orderType: 'statusReport' },
           },
         ],
+        docketNumber: mockDocketNumber,
       },
       docketEntryIdToEdit: propsBase.docketEntryIdToEdit,
       parentMessageId: mockParentMessageId,

--- a/web-client/src/presenter/actions/checkDocumentTypeAction.test.ts
+++ b/web-client/src/presenter/actions/checkDocumentTypeAction.test.ts
@@ -91,4 +91,35 @@ describe('checkDocumentTypeAction', () => {
       path: `/case-detail/${mockDocketNumber}/edit-order/${mockDocketEntryId}/${mockParentMessageId}`,
     });
   });
+
+  it('should return the correct path for a document with an undefined document type without parentMessageId', async () => {
+    const props = {
+      ...propsBase,
+    };
+
+    await runAction(checkDocumentTypeAction, {
+      modules: { presenter },
+      props,
+    });
+
+    expect(pathDocumentTypeMiscellaneousStub).toHaveBeenCalledWith({
+      path: `/case-detail/${mockDocketNumber}/edit-upload-court-issued/${mockDocketEntryId}`,
+    });
+  });
+
+  it('should return the correct path for a document with an undefined document type with parentMessageId', async () => {
+    const props = {
+      ...propsBase,
+      parentMessageId: mockParentMessageId,
+    };
+
+    await runAction(checkDocumentTypeAction, {
+      modules: { presenter },
+      props,
+    });
+
+    expect(pathDocumentTypeMiscellaneousStub).toHaveBeenCalledWith({
+      path: `/case-detail/${mockDocketNumber}/edit-upload-court-issued/${mockDocketEntryId}/${mockParentMessageId}`,
+    });
+  });
 });

--- a/web-client/src/presenter/actions/checkDocumentTypeAction.test.ts
+++ b/web-client/src/presenter/actions/checkDocumentTypeAction.test.ts
@@ -92,7 +92,7 @@ describe('checkDocumentTypeAction', () => {
     });
   });
 
-  it('should return the correct path for a document with an undefined document type without parentMessageId', async () => {
+  it('should return the correct path for a document that is not a status report order with an undefined document type without parentMessageId', async () => {
     const props = {
       ...propsBase,
     };
@@ -107,7 +107,7 @@ describe('checkDocumentTypeAction', () => {
     });
   });
 
-  it('should return the correct path for a document with an undefined document type with parentMessageId', async () => {
+  it('should return the correct path for a document that is not a status report order with an undefined document type with parentMessageId', async () => {
     const props = {
       ...propsBase,
       parentMessageId: mockParentMessageId,
@@ -120,6 +120,55 @@ describe('checkDocumentTypeAction', () => {
 
     expect(pathDocumentTypeMiscellaneousStub).toHaveBeenCalledWith({
       path: `/case-detail/${mockDocketNumber}/edit-upload-court-issued/${mockDocketEntryId}/${mockParentMessageId}`,
+    });
+  });
+
+  it('should return the correct path for a document that is a status report order with an undefined document type without parentMessageId', async () => {
+    const props = {
+      caseDetail: {
+        ...propsBase.caseDetail,
+        docketEntries: [
+          {
+            docketEntryId: mockDocketEntryId,
+            draftOrderState: { orderType: 'statusReport' },
+          },
+        ],
+      },
+      docketEntryIdToEdit: propsBase.docketEntryIdToEdit,
+    };
+
+    await runAction(checkDocumentTypeAction, {
+      modules: { presenter },
+      props,
+    });
+
+    expect(pathDocumentTypeOrderStub).toHaveBeenCalledWith({
+      path: `/case-detail/${mockDocketNumber}/edit-order/${mockDocketEntryId}`,
+    });
+  });
+
+  it('should return the correct path for a document that is a status report order with an undefined document type with parentMessageId', async () => {
+    const props = {
+      caseDetail: {
+        ...propsBase.caseDetail,
+        docketEntries: [
+          {
+            docketEntryId: mockDocketEntryId,
+            draftOrderState: { orderType: 'statusReport' },
+          },
+        ],
+      },
+      docketEntryIdToEdit: propsBase.docketEntryIdToEdit,
+      parentMessageId: mockParentMessageId,
+    };
+
+    await runAction(checkDocumentTypeAction, {
+      modules: { presenter },
+      props,
+    });
+
+    expect(pathDocumentTypeOrderStub).toHaveBeenCalledWith({
+      path: `/case-detail/${mockDocketNumber}/edit-order/${mockDocketEntryId}/${mockParentMessageId}`,
     });
   });
 });

--- a/web-client/src/presenter/actions/checkDocumentTypeAction.ts
+++ b/web-client/src/presenter/actions/checkDocumentTypeAction.ts
@@ -1,15 +1,22 @@
+import { PRACTITIONER_DOCUMENT_TYPES_MAP } from '../../../../shared/src/business/entities/EntityConstants';
+
 export const checkDocumentTypeAction = ({ path, props }: ActionProps) => {
-  const parentMessageId = props.parentMessageId
-    ? `/${props.parentMessageId}`
-    : '';
+  const { caseDetail, docketEntryIdToEdit, documentType, parentMessageId } =
+    props;
 
-  if (props.documentType === 'Miscellaneous') {
-    return path.documentTypeMiscellaneous({
-      path: `/case-detail/${props.caseDetail.docketNumber}/edit-upload-court-issued/${props.docketEntryIdToEdit}${parentMessageId}`,
-    });
-  }
+  const parentMessagePath = parentMessageId ? `/${parentMessageId}` : '';
 
-  return path.documentTypeOrder({
-    path: `/case-detail/${props.caseDetail.docketNumber}/edit-order/${props.docketEntryIdToEdit}${parentMessageId}`,
-  });
+  const basePath = `/case-detail/${caseDetail.docketNumber}`;
+
+  const isMiscellaneousDocument =
+    documentType === PRACTITIONER_DOCUMENT_TYPES_MAP.MISCELLANEOUS ||
+    !documentType;
+
+  const documentPath = isMiscellaneousDocument
+    ? `/edit-upload-court-issued/${docketEntryIdToEdit}${parentMessagePath}`
+    : `/edit-order/${docketEntryIdToEdit}${parentMessagePath}`;
+
+  return isMiscellaneousDocument
+    ? path.documentTypeMiscellaneous({ path: `${basePath}${documentPath}` })
+    : path.documentTypeOrder({ path: `${basePath}${documentPath}` });
 };

--- a/web-client/src/presenter/actions/checkDocumentTypeAction.ts
+++ b/web-client/src/presenter/actions/checkDocumentTypeAction.ts
@@ -1,37 +1,21 @@
-import {
-  PRACTITIONER_DOCUMENT_TYPES_MAP,
-  STATUS_REPORT_ORDER_OPTIONS,
-} from '../../../../shared/src/business/entities/EntityConstants';
+import { isMiscellaneousDocketEntry } from '@shared/business/utilities/isMiscellaneousDocketEntry';
 
 export const checkDocumentTypeAction = ({ path, props }: ActionProps) => {
-  const { caseDetail, docketEntryIdToEdit, documentType, parentMessageId } =
-    props;
-
-  const parentMessagePath = parentMessageId ? `/${parentMessageId}` : '';
-
-  const basePath = `/case-detail/${caseDetail.docketNumber}`;
+  const { caseDetail, docketEntryIdToEdit, parentMessageId } = props;
 
   const [docketEntry] = (props.caseDetail.docketEntries || []).filter(
     de => de.docketEntryId === docketEntryIdToEdit,
   );
 
-  const draftStatusReportOrderTypes = Object.values(
-    STATUS_REPORT_ORDER_OPTIONS.orderTypeOptions,
-  );
+  const routeToEditUploadCourtIssued = isMiscellaneousDocketEntry(docketEntry);
 
-  const isDraftStatusReportOrder = draftStatusReportOrderTypes.includes(
-    docketEntry?.draftOrderState.orderType || '',
-  );
+  const parentMessagePath = parentMessageId ? `/${parentMessageId}` : '';
 
-  const isMiscellaneousDocument =
-    documentType === PRACTITIONER_DOCUMENT_TYPES_MAP.MISCELLANEOUS ||
-    (!isDraftStatusReportOrder && !documentType);
-
-  const documentPath = isMiscellaneousDocument
-    ? `/edit-upload-court-issued/${docketEntryIdToEdit}${parentMessagePath}`
-    : `/edit-order/${docketEntryIdToEdit}${parentMessagePath}`;
-
-  return isMiscellaneousDocument
-    ? path.documentTypeMiscellaneous({ path: `${basePath}${documentPath}` })
-    : path.documentTypeOrder({ path: `${basePath}${documentPath}` });
+  return routeToEditUploadCourtIssued
+    ? path.documentTypeMiscellaneous({
+        path: `/case-detail/${caseDetail.docketNumber}/edit-upload-court-issued/${docketEntryIdToEdit}${parentMessagePath}`,
+      })
+    : path.documentTypeOrder({
+        path: `/case-detail/${caseDetail.docketNumber}/edit-order/${docketEntryIdToEdit}${parentMessagePath}`,
+      });
 };

--- a/web-client/src/presenter/actions/checkDocumentTypeAction.ts
+++ b/web-client/src/presenter/actions/checkDocumentTypeAction.ts
@@ -1,4 +1,7 @@
-import { PRACTITIONER_DOCUMENT_TYPES_MAP } from '../../../../shared/src/business/entities/EntityConstants';
+import {
+  PRACTITIONER_DOCUMENT_TYPES_MAP,
+  STATUS_REPORT_ORDER_OPTIONS,
+} from '../../../../shared/src/business/entities/EntityConstants';
 
 export const checkDocumentTypeAction = ({ path, props }: ActionProps) => {
   const { caseDetail, docketEntryIdToEdit, documentType, parentMessageId } =
@@ -8,9 +11,21 @@ export const checkDocumentTypeAction = ({ path, props }: ActionProps) => {
 
   const basePath = `/case-detail/${caseDetail.docketNumber}`;
 
+  const [docketEntry] = (props.caseDetail.docketEntries || []).filter(
+    de => de.docketEntryId === docketEntryIdToEdit,
+  );
+
+  const draftStatusReportOrderTypes = Object.values(
+    STATUS_REPORT_ORDER_OPTIONS.orderTypeOptions,
+  );
+
+  const isDraftStatusReportOrder = draftStatusReportOrderTypes.includes(
+    docketEntry?.draftOrderState.orderType || '',
+  );
+
   const isMiscellaneousDocument =
     documentType === PRACTITIONER_DOCUMENT_TYPES_MAP.MISCELLANEOUS ||
-    !documentType;
+    (!isDraftStatusReportOrder && !documentType);
 
   const documentPath = isMiscellaneousDocument
     ? `/edit-upload-court-issued/${docketEntryIdToEdit}${parentMessagePath}`

--- a/web-client/src/views/EditUploadCourtIssuedDocument/EditUploadCourtIssuedDocument.tsx
+++ b/web-client/src/views/EditUploadCourtIssuedDocument/EditUploadCourtIssuedDocument.tsx
@@ -78,6 +78,7 @@ export const EditUploadCourtIssuedDocument = connect(
                       aria-labelledby="upload-description-label"
                       autoCapitalize="none"
                       className="usa-input"
+                      data-testid="upload-description"
                       id="upload-description"
                       name="freeText"
                       type="text"
@@ -175,6 +176,8 @@ export const EditUploadCourtIssuedDocument = connect(
             <div className="grid-row grid-gap margin-top-4">
               <div className="grid-col-8">
                 <Button
+                  data-testid="save-edited-pdf-button"
+                  id="save-edited-pdf-button"
                   onClick={() => {
                     editUploadCourtIssuedDocumentSequence({
                       tab: 'drafts',


### PR DESCRIPTION
PR [2795](https://github.com/ustaxcourt/ef-cms/pull/2795/) let users create a draft document using the "Upload  PDF" form (*/upload-court-issued/*) without a default `documentType`, instead leaving that property undefined. When the document finalized in the "Add Docket Entry" form, a document type is then assigned.

Changes in PR [5108](https://github.com/ustaxcourt/ef-cms/pull/5108) introduced a [bug](https://github.com/ustaxcourt/ef-cms/pull/5108/files#r1681766044) wherein users who tried to edit a document that they uploaded using the "Upload PDF" form were directed to the wrong form.

This PR ensures that any document in draft state with an undefined `documentType` property redirects to the edit uploaded court issued pdf (_/edit-upload-court-issued/_) form, not the edit order (_/edit-order/_) form as before. 