### PR TITLE
10226 Bug: Fix Pill Button Accessibility

### DIFF
--- a/web-client/src/styles/custom.scss
+++ b/web-client/src/styles/custom.scss
@@ -2199,6 +2199,12 @@ button.change-scanner-button {
   color: $color-white;
   font-weight: $font-semibold;
   text-align: center;
+
+  button {
+    border: none;
+    background: none;
+    color: white;
+  }
 }
 
 .cursor-pointer {
@@ -2388,13 +2394,4 @@ button.change-scanner-button {
 
 .no-wrap-white-space {
   white-space: normal;
-}
-
-.align-items-center {
-  align-items: center;
-}
-
-.petitioner-welcome-name {
-  overflow-wrap: break-word;
-  word-break: break-word;
 }

--- a/web-client/src/styles/custom.scss
+++ b/web-client/src/styles/custom.scss
@@ -2395,3 +2395,12 @@ button.change-scanner-button {
 .no-wrap-white-space {
   white-space: normal;
 }
+
+.align-items-center {
+  align-items: center;
+}
+
+.petitioner-welcome-name {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}

--- a/web-client/src/ustc-ui/Button/PillButton.tsx
+++ b/web-client/src/ustc-ui/Button/PillButton.tsx
@@ -1,0 +1,22 @@
+import { Icon } from '../../ustc-ui/Icon/Icon';
+import React from 'react';
+
+interface PillButtonProps {
+  text: string;
+  onRemove: () => void;
+}
+
+export const PillButton = ({ onRemove, text }: PillButtonProps) => {
+  return (
+    <span className="blue-pill">
+      {text}
+      <button
+        aria-label={`remove ${text} selection`}
+        className="margin-left-1 cursor-pointer transparent-button"
+        onClick={onRemove}
+      >
+        <Icon className="icon-class" icon="times" size="1x" />
+      </button>
+    </span>
+  );
+};

--- a/web-client/src/views/CustomCaseReport/CustomCaseReport.tsx
+++ b/web-client/src/views/CustomCaseReport/CustomCaseReport.tsx
@@ -7,6 +7,7 @@ import { DateRangePickerComponent } from '../../ustc-ui/DateInput/DateRangePicke
 import { ErrorNotification } from '../ErrorNotification';
 import { Icon } from '../../ustc-ui/Icon/Icon';
 import { Paginator } from '../../ustc-ui/Pagination/Paginator';
+import { PillButton } from '@web-client/ustc-ui/Button/PillButton';
 import { SelectSearch } from '../../ustc-ui/Select/SelectSearch';
 import { SuccessNotification } from '../SuccessNotification';
 import { connect } from '@web-client/presenter/shared.cerebral';
@@ -359,87 +360,66 @@ export const CustomCaseReport = connect(
           <div className="grid-col-12">
             <div className="grid-row">
               {customCaseReportFilters.caseStatuses.map(status => (
-                <span className="blue-pill" key={status}>
-                  {status}
-                  <Icon
-                    aria-label={`remove ${status} selection`}
-                    className="margin-left-1 cursor-pointer"
-                    icon="times"
-                    size="1x"
-                    onClick={() => {
+                <PillButton
+                  key={status}
+                  text={status}
+                  onRemove={() => {
+                    setCustomCaseReportFiltersSequence({
+                      caseStatuses: {
+                        action: 'remove',
+                        caseStatus: status,
+                      },
+                    });
+                  }}
+                />
+              ))}
+              {customCaseReportFilters.caseTypes.map(caseType => {
+                return (
+                  <PillButton
+                    key={caseType}
+                    text={caseType}
+                    onRemove={() => {
                       setCustomCaseReportFiltersSequence({
-                        caseStatuses: {
+                        caseTypes: {
                           action: 'remove',
-                          caseStatus: status,
+                          caseType,
                         },
                       });
                     }}
                   />
-                </span>
-              ))}
-
-              {customCaseReportFilters.caseTypes.map(caseType => {
-                return (
-                  <span className="blue-pill" key={caseType}>
-                    {caseType}
-                    <Icon
-                      aria-label={`remove ${caseType} selection`}
-                      className="margin-left-1 cursor-pointer"
-                      icon="times"
-                      size="1x"
-                      onClick={() => {
-                        setCustomCaseReportFiltersSequence({
-                          caseTypes: {
-                            action: 'remove',
-                            caseType,
-                          },
-                        });
-                      }}
-                    />
-                  </span>
                 );
               })}
 
               {customCaseReportFilters.judges.map(judge => {
                 return (
-                  <span className="blue-pill" key={judge}>
-                    {judge}
-                    <Icon
-                      aria-label={`remove ${judge} selection`}
-                      className="margin-left-1 cursor-pointer"
-                      icon="times"
-                      size="1x"
-                      onClick={() => {
-                        setCustomCaseReportFiltersSequence({
-                          judges: {
-                            action: 'remove',
-                            judge,
-                          },
-                        });
-                      }}
-                    />
-                  </span>
+                  <PillButton
+                    key={judge}
+                    text={judge}
+                    onRemove={() => {
+                      setCustomCaseReportFiltersSequence({
+                        judges: {
+                          action: 'remove',
+                          judge,
+                        },
+                      });
+                    }}
+                  />
                 );
               })}
               {customCaseReportFilters.preferredTrialCities.map(city => {
                 return (
-                  <span className="blue-pill" key={city}>
-                    {city}
-                    <Icon
-                      aria-label={`remove ${city} selection`}
-                      className="margin-left-1 cursor-pointer"
-                      icon="times"
-                      size="1x"
-                      onClick={() => {
-                        setCustomCaseReportFiltersSequence({
-                          preferredTrialCities: {
-                            action: 'remove',
-                            preferredTrialCity: city,
-                          },
-                        });
-                      }}
-                    />
-                  </span>
+                  <PillButton
+                    key={city}
+                    text={city}
+                    onRemove={() => {
+                      setCustomCaseReportFiltersSequence({
+                        preferredTrialCities: {
+                          action: 'remove',
+                          preferredTrialCity: city,
+                        },
+                      });
+                    }}
+                  />
                 );
               })}
             </div>


### PR DESCRIPTION
Selected options for filters in the Custom Case Report (the blue "pill buttons" in the screen shot below) are not currently able to be removed by keyboard. This PR fixes the issue and creates a reusable PillButton component that can be used for https://app.zenhub.com/workspaces/flexionef-cms-5bbe4bed4b5806bc2bec65d3/issues/gh/flexion/ef-cms/10411.

<img width="872" alt="Screenshot 2024-08-23 at 9 38 36 AM" src="https://github.com/user-attachments/assets/1a4eabfb-c839-4ad5-a4c6-be579bb6e950">
