### PR TITLE
10282: design debt

### DIFF
--- a/web-client/src/styles/forms.scss
+++ b/web-client/src/styles/forms.scss
@@ -668,7 +668,7 @@ label.ustc-upload {
 }
 
 .usa-date-picker {
-  min-width: 245px;
+  min-width: 250px;
 
   * {
     animation: none;


### PR DESCRIPTION
Slightly bump up the minimum width of the `.usa-date-picker` from 245px to 250px class so that "September 2024" appears on a single line.