### PR TITLE
Revert 10427 changes that inadvertently had too broad of an impact

### DIFF
--- a/cypress/helpers/authentication/login-as-helpers.ts
+++ b/cypress/helpers/authentication/login-as-helpers.ts
@@ -59,11 +59,7 @@ export function loginAsIrsPractitioner1() {
 }
 
 export function loginAsPetitioner(
-  petitionerUser:
-    | 'petitioner'
-    | 'petitioner1'
-    | 'petitioner2'
-    | 'petitioner7' = 'petitioner1',
+  petitionerUser: 'petitioner' | 'petitioner1' | 'petitioner7' = 'petitioner1',
 ) {
   cy.login(petitionerUser);
   cy.get('[data-testid="file-a-petition"]').should('exist');

--- a/cypress/local-only/tests/integration/caseDetail/docketRecord/electronicFiling/logged-in-user-can-see-un-served-petition-document.cy.ts
+++ b/cypress/local-only/tests/integration/caseDetail/docketRecord/electronicFiling/logged-in-user-can-see-un-served-petition-document.cy.ts
@@ -1,6 +1,5 @@
 import { externalUserSearchesDocketNumber } from '../../../../../../helpers/advancedSearch/external-user-searches-docket-number';
 import {
-  loginAsDocketClerk1,
   loginAsPetitioner,
   loginAsPrivatePractitioner,
 } from '../../../../../../helpers/authentication/login-as-helpers';
@@ -11,7 +10,7 @@ describe('Logged In User Can See Un-Served Petition Document', () => {
     loginAsPetitioner();
     petitionerCreatesElectronicCaseForBusiness().as('DOCKET_NUMBER');
 
-    loginAsPetitioner('petitioner1');
+    cy.login('petitioner1');
     cy.get<string>('@DOCKET_NUMBER').then(docketNumber => {
       externalUserSearchesDocketNumber(docketNumber);
     });
@@ -21,7 +20,7 @@ describe('Logged In User Can See Un-Served Petition Document', () => {
     cy.get('[data-testid="document-download-link-DISC"]').should('exist');
     cy.get('[data-testid="document-download-link-ATP"]').should('exist');
 
-    loginAsPetitioner('petitioner2');
+    cy.login('petitioner2');
     cy.get<string>('@DOCKET_NUMBER').then(docketNumber => {
       externalUserSearchesDocketNumber(docketNumber);
     });
@@ -31,7 +30,7 @@ describe('Logged In User Can See Un-Served Petition Document', () => {
     cy.get('[data-testid="document-download-link-DISC"]').should('not.exist');
     cy.get('[data-testid="document-download-link-ATP"]').should('not.exist');
 
-    loginAsDocketClerk1();
+    cy.login('docketClerk1');
     cy.get<string>('@DOCKET_NUMBER').then(docketNumber => {
       cy.get('[data-testid="docket-number-search-input"]').type(docketNumber);
       cy.get('[data-testid="search-docket-number"]').click();
@@ -47,7 +46,7 @@ describe('Logged In User Can See Un-Served Petition Document', () => {
     loginAsPrivatePractitioner();
     petitionerCreatesElectronicCaseForBusiness().as('DOCKET_NUMBER');
 
-    loginAsPrivatePractitioner('privatePractitioner1');
+    cy.login('privatePractitioner1');
     cy.get<string>('@DOCKET_NUMBER').then(docketNumber => {
       externalUserSearchesDocketNumber(docketNumber);
     });
@@ -57,7 +56,7 @@ describe('Logged In User Can See Un-Served Petition Document', () => {
     cy.get('[data-testid="document-download-link-DISC"]').should('exist');
     cy.get('[data-testid="document-download-link-ATP"]').should('exist');
 
-    loginAsPrivatePractitioner('privatePractitioner2');
+    cy.login('privatePractitioner2');
     cy.get<string>('@DOCKET_NUMBER').then(docketNumber => {
       externalUserSearchesDocketNumber(docketNumber);
     });
@@ -67,7 +66,7 @@ describe('Logged In User Can See Un-Served Petition Document', () => {
     cy.get('[data-testid="document-download-link-DISC"]').should('not.exist');
     cy.get('[data-testid="document-download-link-ATP"]').should('not.exist');
 
-    loginAsDocketClerk1();
+    cy.login('docketClerk1');
     cy.get<string>('@DOCKET_NUMBER').then(docketNumber => {
       cy.get('[data-testid="docket-number-search-input"]').type(docketNumber);
       cy.get('[data-testid="search-docket-number"]').click();

--- a/web-client/src/styles/buttons.scss
+++ b/web-client/src/styles/buttons.scss
@@ -71,13 +71,12 @@ button:disabled {
   }
 
   &.ustc-button--unstyled {
-    margin-top: 0.75rem;
-    margin-bottom: 0.75rem;
+    padding: 0.75rem 0;
     line-height: normal;
     text-align: center;
 
-    &.margin-top-0 {
-      margin-top: 0;
+    &.padding-top-0 {
+      padding-top: 0;
     }
   }
 
@@ -230,9 +229,7 @@ table.ustc-table .ustc-button--unstyled {
     color: $color-white;
 
     &.usa-button--unstyled {
-      padding: 0.75rem 0 0.75rem 20px;
-      margin-top: 0;
-      margin-bottom: 0;
+      padding-left: 20px;
     }
 
     &:hover {

--- a/web-client/src/styles/custom.scss
+++ b/web-client/src/styles/custom.scss
@@ -38,13 +38,6 @@ hr {
   &.underlined {
     border-bottom: 1px solid color($theme-color-base-lighter);
   }
-
-  /* big screens */
-  @media only screen and (min-width: $medium-screen) {
-    &.flex-justify-space-between {
-      justify-content: space-between;
-    }
-  }
 }
 
 .max-width-200 {

--- a/web-client/src/styles/nav.scss
+++ b/web-client/src/styles/nav.scss
@@ -272,10 +272,10 @@
 
             /* this is for buttons in submenus that should be styled the same as links in submenus */
             .usa-nav__submenu-item button {
-              padding: 0;
+              padding-top: 0;
+              padding-bottom: 0;
               color: $color-white;
               font-weight: $font-regular;
-              line-height: 1.3;
 
               &:hover {
                 text-decoration: underline;

--- a/web-client/src/ustc-ui/Modal/ConfirmModal.tsx
+++ b/web-client/src/ustc-ui/Modal/ConfirmModal.tsx
@@ -98,7 +98,7 @@ export const ConfirmModal = connect<ConfirmModalProps, typeof confirmModalDeps>(
                 <Button
                   iconRight
                   link
-                  className="text-no-underline hide-on-mobile float-right margin-right-0 margin-top-0"
+                  className="text-no-underline hide-on-mobile float-right margin-right-0 padding-top-0"
                   icon="times-circle"
                   onClick={event => {
                     event.stopPropagation();

--- a/web-client/src/views/CreateOrder/CreateOrder.tsx
+++ b/web-client/src/views/CreateOrder/CreateOrder.tsx
@@ -86,7 +86,7 @@ export const CreateOrder = connect(
                 {createOrderHelper.showAddDocketNumbersButton && (
                   <Button
                     link
-                    className="margin-top-0"
+                    className="padding-top-0"
                     data-testid="add-docket-number-btn"
                     icon={createOrderHelper.addDocketNumbersButtonIcon}
                     id="add-docket-numbers-btn"

--- a/web-client/src/views/Header/Header.tsx
+++ b/web-client/src/views/Header/Header.tsx
@@ -305,7 +305,7 @@ export const Header = connect(
                   <Button
                     iconRight
                     link
-                    className="usa-nav__close float-right margin-right-0 margin-top-0"
+                    className="usa-nav__close float-right margin-right-0 padding-top-0"
                     icon="times-circle"
                     onClick={() => toggleMobileMenuSequence()}
                   >

--- a/web-client/src/views/Header/ReportsMenu.tsx
+++ b/web-client/src/views/Header/ReportsMenu.tsx
@@ -1,3 +1,4 @@
+import { Button } from '../../ustc-ui/Button/Button';
 import { connect } from '@web-client/presenter/shared.cerebral';
 import { sequences } from '@web-client/presenter/app.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
@@ -57,7 +58,8 @@ export const ReportsMenu = connect(
               </li>
             )}
             <li className="usa-nav__submenu-item">
-              <button
+              <Button
+                link
                 id="case-inventory-btn"
                 onClick={() => {
                   resetHeaderAccordionsSequence();
@@ -66,7 +68,7 @@ export const ReportsMenu = connect(
                 }}
               >
                 Case Inventory
-              </button>
+              </Button>
             </li>
 
             <li className="usa-nav__submenu-item">
@@ -134,7 +136,8 @@ export const ReportsMenu = connect(
               </a>
             </li>
             <li className="usa-nav__submenu-item" id="reports-nav">
-              <button
+              <Button
+                link
                 id="trial-session-planning-btn"
                 onClick={() => {
                   resetHeaderAccordionsSequence();
@@ -143,7 +146,7 @@ export const ReportsMenu = connect(
                 }}
               >
                 Trial Session Planning
-              </button>
+              </Button>
             </li>
           </ul>
         )}

--- a/web-client/src/views/Login/Login.tsx
+++ b/web-client/src/views/Login/Login.tsx
@@ -119,7 +119,7 @@ export const Login = connect(
                     <span>
                       Don&apos;t have an account?{' '}
                       <Button
-                        className="margin-top-0"
+                        className="padding-top-0"
                         link={true}
                         type="button"
                         onClick={e => {

--- a/web-client/src/views/ModalDialog.tsx
+++ b/web-client/src/views/ModalDialog.tsx
@@ -127,7 +127,7 @@ export const ModalDialog = ({
                     <Button
                       iconRight
                       link
-                      className="text-no-underline hide-on-mobile float-right margin-right-0 margin-top-0"
+                      className="text-no-underline hide-on-mobile float-right margin-right-0 padding-top-0"
                       data-testid="close-modal-button"
                       icon="times-circle"
                       id="close-modal-button"

--- a/web-client/src/views/ScanBatchPreviewer.tsx
+++ b/web-client/src/views/ScanBatchPreviewer.tsx
@@ -279,7 +279,7 @@ export const ScanBatchPreviewer = connect(
           <div className="padding-top-2">
             <Button
               link
-              className="red-warning push-right margin-bottom-1 margin-top-0"
+              className="red-warning push-right margin-bottom-1 padding-top-0"
               data-testid="remove-pdf"
               onClick={() => {
                 openConfirmDeletePDFModalSequence();

--- a/web-client/src/views/StartCaseUpdated/PetitionFactOrReason.tsx
+++ b/web-client/src/views/StartCaseUpdated/PetitionFactOrReason.tsx
@@ -75,7 +75,7 @@ export const PetitionFactOrReason = connect<
               {factOrReasonCount > 0 && (
                 <Button
                   link
-                  className="reason-button remove-fact-reason-button flex-align-self-center"
+                  className="reason-button remove-fact-reason-button"
                   icon="times"
                   onClick={() =>
                     removeFactOrReasonSequence({

--- a/web-client/src/views/StartCaseUpdated/UpdatedFilePetitionStep3.tsx
+++ b/web-client/src/views/StartCaseUpdated/UpdatedFilePetitionStep3.tsx
@@ -169,7 +169,7 @@ export const UpdatedFilePetitionStep3 = connect(
                 {irsNoticeUploadFormInfo.length < 5 && (
                   <Button
                     link
-                    className={classNames('margin-top-0', 'text-left')}
+                    className={classNames('padding-top-0', 'text-left')}
                     data-testid="add-another-irs-notice-button"
                     onClick={() => addAnotherIrsNoticeToFormSequence()}
                   >

--- a/web-client/src/views/TrialSessionDetail/ServeThirtyDayNoticeModal.tsx
+++ b/web-client/src/views/TrialSessionDetail/ServeThirtyDayNoticeModal.tsx
@@ -30,7 +30,7 @@ const component = ({
             <Button
               iconRight
               link
-              className="text-no-underline hide-on-mobile float-right margin-right-0 margin-top-0"
+              className="text-no-underline hide-on-mobile float-right margin-right-0 padding-top-0"
               icon="times-circle"
               onClick={() => closeModalSequence()}
             >

--- a/web-client/src/views/TrialSessionDetail/TrialSessionInformation.tsx
+++ b/web-client/src/views/TrialSessionDetail/TrialSessionInformation.tsx
@@ -90,7 +90,7 @@ export const TrialSessionInformation = connect(
     return (
       <>
         <div className="grid-container padding-x-0">
-          <div className="grid-row flex-justify-space-between">
+          <div className="grid-row">
             <div className="grid-col-auto">
               <h1>
                 Session Information
@@ -115,7 +115,7 @@ export const TrialSessionInformation = connect(
                 )}
               </h1>
             </div>
-            <div className="grid-col-fill tablet:grid-col-auto">
+            <div className="grid-col-fill display-flex flex-justify-end">
               {formattedTrialSessionDetails.canDelete && (
                 <Button
                   link

--- a/web-client/src/views/WorkQueue/RecentMessages.tsx
+++ b/web-client/src/views/WorkQueue/RecentMessages.tsx
@@ -5,7 +5,12 @@ import React from 'react';
 export const RecentMessages = () => {
   return (
     <div className="margin-top-4">
-      <Button link className="float-right" href="/messages/my/inbox">
+      <Button
+        link
+        className="float-right"
+        href="/messages/my/inbox"
+        overrideMargin="margin-0"
+      >
         View All Messages
       </Button>
 


### PR DESCRIPTION
This reverts commit 3b647c84c8c392d1292e3d1092544d8f234ac932.

Revert "10427: fix message-document-viewer misalignment due to button padding change"

This reverts commit 0c2cbf91d6cc02ecd09154c696e0aa98a1c028ac.

Revert "10427: fix nav item button spacing introduced by previous padding change"

This reverts commit 483ab8c160bbbe7485feb13033c50a9ad25a9cbf.

Revert "10427: change classname from paddin-top to margin-top"

This reverts commit 1f973546497149475d2ae0be77d9703de8e56bd8.

Revert "10427 Adjust misc other padding issues with focus state"

This reverts commit f9bfaece62362223492be6f8199ddf8bcec20e21.

Revert "10427 Change padding to margin top & bottom for link style buttons"

This reverts commit d0a875efc05325d0c58ca10e59279acf1ab7e12c.