### PR TITLE
Opex: fix for automated glue jobs (to `test`)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -709,7 +709,7 @@ jobs:
       - run:
           name: Set Marker to Indicate Data is Finished Gluing
           command: |
-            JOB_NAME="wait-for-glued-data-to-index" ./scripts/migration/set-migration-complete-marker.sh
+            DEPLOYING_COLOR="$CURRENT_COLOR" JOB_NAME="wait-for-glued-data-to-index" ./scripts/migration/set-migration-complete-marker.sh
       - run:
           name: Enable Dynamodb Streams
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -709,7 +709,8 @@ jobs:
       - run:
           name: Set Marker to Indicate Data is Finished Gluing
           command: |
-            DEPLOYING_COLOR="$CURRENT_COLOR" ; JOB_NAME="wait-for-glued-data-to-index" ./scripts/migration/set-migration-complete-marker.sh
+            export DEPLOYING_COLOR="$CURRENT_COLOR"
+            JOB_NAME="wait-for-glued-data-to-index" ./scripts/migration/set-migration-complete-marker.sh
       - run:
           name: Enable Dynamodb Streams
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -709,7 +709,7 @@ jobs:
       - run:
           name: Set Marker to Indicate Data is Finished Gluing
           command: |
-            DEPLOYING_COLOR="$CURRENT_COLOR" JOB_NAME="wait-for-glued-data-to-index" ./scripts/migration/set-migration-complete-marker.sh
+            DEPLOYING_COLOR="$CURRENT_COLOR" ; JOB_NAME="wait-for-glued-data-to-index" ./scripts/migration/set-migration-complete-marker.sh
       - run:
           name: Enable Dynamodb Streams
           command: |


### PR DESCRIPTION
After we glue data into test, the already-deployed streams lambda handles indexing all of the glued data for us. Therefore, when we generate the `CompletionMarker` record that the indexer is looking for, the color needs to be the current color instead of the deploying color.