### PR TITLE
Opex: fix setup-glued-judges (to test)

### DIFF
--- a/scripts/user/setup-glued-judges.ts
+++ b/scripts/user/setup-glued-judges.ts
@@ -62,7 +62,6 @@ const createOrUpdateCognitoUser = async ({
     const { code }: any = err;
     if (code !== 'UserNotFoundException') {
       console.error(`ERROR checking for cognito user for ${name}:`, err);
-      return;
     }
   }
 


### PR DESCRIPTION
Don't bail if we couldn't find a cognito user for a newly-glued judge, just create one.