### PR TITLE
10074 bug: Auto Scroll Issues on Petitions Clerk Create Case Form

### DIFF
--- a/cypress/local-only/tests/integration/myAccount/respondent-modifies-contact-info.cy.ts
+++ b/cypress/local-only/tests/integration/myAccount/respondent-modifies-contact-info.cy.ts
@@ -7,7 +7,7 @@ import { respondentModifiesContactInfo } from '../../../../helpers/myAccount/res
 const BAR_NUMBER = 'WN7777';
 const USER = 'irspractitioner2';
 
-describe('a repondent modifies their address', () => {
+describe('a respondent modifies their address', () => {
   it('should generate a notice of change address for all cases associated with the respondent', function () {
     loginAsPetitioner();
     petitionerCreatesElectronicCase().then(docketNumber => {

--- a/web-client/src/presenter/actions/setValidationAlertErrorsAction.ts
+++ b/web-client/src/presenter/actions/setValidationAlertErrorsAction.ts
@@ -86,6 +86,7 @@ export const setValidationAlertErrorsAction = ({
           }
         }),
     ),
+    preventAutoScroll: props.preventAutoScroll || false,
     title: 'Please correct the following errors on the page:',
   };
   store.set(state.alertError, alertError);

--- a/web-client/src/presenter/computeds/alertHelper.ts
+++ b/web-client/src/presenter/computeds/alertHelper.ts
@@ -15,7 +15,6 @@ export const alertHelper = (get: Get): any => {
 
   return {
     messagesDeduped: uniq(alertError.messages).filter(Boolean),
-    preventAutoScroll: false,
     responseCode: alertError.responseCode,
     showErrorAlert:
       !!alertError.title || !!alertError.message || !!alertError.messages,

--- a/web-client/src/views/AddPetitionerToCase/AddPetitionerToCase.tsx
+++ b/web-client/src/views/AddPetitionerToCase/AddPetitionerToCase.tsx
@@ -51,7 +51,8 @@ export const AddPetitionerToCase = connect(
   }) {
     const type = 'contact';
     const bind = 'form';
-    const onBlur = 'validateAddPetitionerSequence';
+    const onBlur = () =>
+      validateAddPetitionerSequence({ preventAutoScroll: true });
 
     return (
       <>

--- a/web-client/src/views/CaseDetail/EditCaseDetails.tsx
+++ b/web-client/src/views/CaseDetail/EditCaseDetails.tsx
@@ -45,7 +45,7 @@ export const EditCaseDetails = connect(
               <h4 className="margin-bottom-2">IRS Notice/Case</h4>
               <IRSNotice
                 shouldStartWithBlankStatistic={false}
-                validationFunction={validateCaseDetailsSequence}
+                validateFormData={validateCaseDetailsSequence}
               />
 
               <ProcedureType
@@ -87,9 +87,9 @@ export const EditCaseDetails = connect(
 
             <PetitionPaymentForm
               bind="form"
+              validateFormData={validateCaseDetailsSequence}
               validationErrorsBind="validationErrors"
               onUpdate={updateFormValueSequence}
-              onValidate={validateCaseDetailsSequence}
             />
           </div>
 

--- a/web-client/src/views/CaseDetail/EditCaseDetails.tsx
+++ b/web-client/src/views/CaseDetail/EditCaseDetails.tsx
@@ -87,9 +87,9 @@ export const EditCaseDetails = connect(
 
             <PetitionPaymentForm
               bind="form"
-              updateSequence={updateFormValueSequence}
-              validateSequence={validateCaseDetailsSequence}
               validationErrorsBind="validationErrors"
+              onUpdate={updateFormValueSequence}
+              onValidate={validateCaseDetailsSequence}
             />
           </div>
 

--- a/web-client/src/views/CaseDetail/EditCaseDetails.tsx
+++ b/web-client/src/views/CaseDetail/EditCaseDetails.tsx
@@ -45,7 +45,7 @@ export const EditCaseDetails = connect(
               <h4 className="margin-bottom-2">IRS Notice/Case</h4>
               <IRSNotice
                 shouldStartWithBlankStatistic={false}
-                validationName="validateCaseDetailsSequence"
+                validationFunction={validateCaseDetailsSequence}
               />
 
               <ProcedureType

--- a/web-client/src/views/CaseDetail/PetitionPaymentForm.tsx
+++ b/web-client/src/views/CaseDetail/PetitionPaymentForm.tsx
@@ -6,6 +6,171 @@ import { sequences, state } from '@web-client/presenter/app.cerebral';
 import React from 'react';
 import classNames from 'classnames';
 
+interface ComponentProps {
+  onUpdate: (args: Record<string, any>) => void;
+  onValidate: (args: Record<string, any>) => void;
+}
+
+// It would be better to use ComponentProps & CerebralProps, but
+// typing won't work nicely with CerebralProps. Hence the & any.
+const PetitionPaymentFormComponent: React.FC<ComponentProps & any> = ({
+  bind,
+  DATE_FORMATS,
+  formatAndUpdateDateFromDatePickerSequence,
+  onUpdate,
+  onValidate,
+  paymentStatus,
+  validationErrors,
+}) => {
+  return (
+    <>
+      <h4 className="margin-bottom-2">Petition Fee</h4>
+      <FormGroup errorText={validationErrors.petitionPaymentStatus}>
+        <fieldset className="usa-fieldset">
+          <legend className="usa-legend" id="fee-paid-legend">
+            Fee paid?
+          </legend>
+          <div className="usa-radio usa-radio__inline">
+            <input
+              aria-describedby="fee-paid-legend"
+              checked={bind.petitionPaymentStatus === paymentStatus.PAID}
+              className="usa-radio__input"
+              id="payment-status-paid"
+              name="petitionPaymentStatus"
+              type="radio"
+              value={paymentStatus.PAID}
+              onChange={e => {
+                onUpdate({
+                  key: e.target.name,
+                  value: e.target.value,
+                });
+                onValidate({ preventAutoScroll: true });
+              }}
+            />
+            <label
+              className="usa-radio__label"
+              data-testid="payment-status-paid-radio"
+              htmlFor="payment-status-paid"
+            >
+              {paymentStatus.PAID}
+            </label>
+          </div>
+
+          <div className="usa-radio usa-radio__inline">
+            <input
+              aria-describedby="fee-paid-legend"
+              checked={bind.petitionPaymentStatus === paymentStatus.UNPAID}
+              className="usa-radio__input"
+              id="payment-status-unpaid"
+              name="petitionPaymentStatus"
+              type="radio"
+              value={paymentStatus.UNPAID}
+              onChange={e => {
+                onUpdate({
+                  key: e.target.name,
+                  value: e.target.value,
+                });
+                onValidate({ preventAutoScroll: true });
+              }}
+            />
+            <label
+              className="usa-radio__label"
+              data-testid="payment-status-unpaid-radio"
+              htmlFor="payment-status-unpaid"
+            >
+              {paymentStatus.UNPAID}
+            </label>
+          </div>
+
+          <div className="usa-radio usa-radio__inline">
+            <input
+              aria-describedby="fee-paid-legend"
+              checked={bind.petitionPaymentStatus === paymentStatus.WAIVED}
+              className="usa-radio__input"
+              id="payment-status-waived"
+              name="petitionPaymentStatus"
+              type="radio"
+              value={paymentStatus.WAIVED}
+              onChange={e => {
+                onUpdate({
+                  key: e.target.name,
+                  value: e.target.value,
+                });
+                onValidate({ preventAutoScroll: true });
+              }}
+            />
+            <label
+              className="usa-radio__label"
+              data-testid="payment-status-waived-radio"
+              htmlFor="payment-status-waived"
+            >
+              {paymentStatus.WAIVED}
+            </label>
+          </div>
+        </fieldset>
+      </FormGroup>
+
+      {bind.petitionPaymentStatus === paymentStatus.PAID && (
+        <>
+          <DateSelector
+            defaultValue={bind.petitionPaymentDate}
+            errorText={validationErrors.petitionPaymentDate}
+            id="payment-date"
+            label="Payment date"
+            onChange={e => {
+              formatAndUpdateDateFromDatePickerSequence({
+                key: 'petitionPaymentDate',
+                toFormat: DATE_FORMATS.ISO,
+                value: e.target.value,
+              });
+              onValidate({ preventAutoScroll: true });
+            }}
+          />
+
+          <FormGroup errorText={validationErrors.petitionPaymentMethod}>
+            <label className="usa-label" htmlFor="petition-payment-method">
+              Payment method
+            </label>
+            <input
+              className={classNames(
+                'usa-input',
+                validationErrors.petitionPaymentMethod && 'usa-input-error',
+              )}
+              id="petition-payment-method"
+              name="petitionPaymentMethod"
+              value={bind.petitionPaymentMethod || ''}
+              onBlur={() => onValidate({ preventAutoScroll: true })}
+              onChange={e => {
+                onUpdate({
+                  key: e.target.name,
+                  value: e.target.value,
+                });
+              }}
+            />
+          </FormGroup>
+        </>
+      )}
+
+      {bind.petitionPaymentStatus === paymentStatus.WAIVED && (
+        <DateSelector
+          defaultValue={bind.petitionPaymentWaivedDate}
+          errorText={validationErrors.petitionPaymentWaivedDate}
+          id="payment-date-waived"
+          label="Date waived"
+          onChange={e => {
+            formatAndUpdateDateFromDatePickerSequence({
+              key: 'petitionPaymentWaivedDate',
+              toFormat: DATE_FORMATS.ISO,
+              value: e.target.value,
+            });
+            onValidate({ preventAutoScroll: true });
+          }}
+        />
+      )}
+    </>
+  );
+};
+
 export const PetitionPaymentForm = connect(
   {
     DATE_FORMATS: state.constants.DATE_FORMATS,
@@ -15,163 +180,7 @@ export const PetitionPaymentForm = connect(
     paymentStatus: state.constants.PAYMENT_STATUS,
     validationErrors: state[props.validationErrorsBind],
   },
-  function PetitionPaymentForm({
-    bind,
-    DATE_FORMATS,
-    formatAndUpdateDateFromDatePickerSequence,
-    paymentStatus,
-    updateSequence,
-    validateSequence,
-    validationErrors,
-  }) {
-    return (
-      <>
-        <h4 className="margin-bottom-2">Petition Fee</h4>
-        <FormGroup errorText={validationErrors.petitionPaymentStatus}>
-          <fieldset className="usa-fieldset">
-            <legend className="usa-legend" id="fee-paid-legend">
-              Fee paid?
-            </legend>
-            <div className="usa-radio usa-radio__inline">
-              <input
-                aria-describedby="fee-paid-legend"
-                checked={bind.petitionPaymentStatus === paymentStatus.PAID}
-                className="usa-radio__input"
-                id="payment-status-paid"
-                name="petitionPaymentStatus"
-                type="radio"
-                value={paymentStatus.PAID}
-                onChange={e => {
-                  updateSequence({
-                    key: e.target.name,
-                    value: e.target.value,
-                  });
-                  validateSequence();
-                }}
-              />
-              <label
-                className="usa-radio__label"
-                data-testid="payment-status-paid-radio"
-                htmlFor="payment-status-paid"
-              >
-                {paymentStatus.PAID}
-              </label>
-            </div>
-
-            <div className="usa-radio usa-radio__inline">
-              <input
-                aria-describedby="fee-paid-legend"
-                checked={bind.petitionPaymentStatus === paymentStatus.UNPAID}
-                className="usa-radio__input"
-                id="payment-status-unpaid"
-                name="petitionPaymentStatus"
-                type="radio"
-                value={paymentStatus.UNPAID}
-                onChange={e => {
-                  updateSequence({
-                    key: e.target.name,
-                    value: e.target.value,
-                  });
-                  validateSequence();
-                }}
-              />
-              <label
-                className="usa-radio__label"
-                data-testid="payment-status-unpaid-radio"
-                htmlFor="payment-status-unpaid"
-              >
-                {paymentStatus.UNPAID}
-              </label>
-            </div>
-
-            <div className="usa-radio usa-radio__inline">
-              <input
-                aria-describedby="fee-paid-legend"
-                checked={bind.petitionPaymentStatus === paymentStatus.WAIVED}
-                className="usa-radio__input"
-                id="payment-status-waived"
-                name="petitionPaymentStatus"
-                type="radio"
-                value={paymentStatus.WAIVED}
-                onChange={e => {
-                  updateSequence({
-                    key: e.target.name,
-                    value: e.target.value,
-                  });
-                  validateSequence();
-                }}
-              />
-              <label
-                className="usa-radio__label"
-                data-testid="payment-status-waived-radio"
-                htmlFor="payment-status-waived"
-              >
-                {paymentStatus.WAIVED}
-              </label>
-            </div>
-          </fieldset>
-        </FormGroup>
-
-        {bind.petitionPaymentStatus === paymentStatus.PAID && (
-          <>
-            <DateSelector
-              defaultValue={bind.petitionPaymentDate}
-              errorText={validationErrors.petitionPaymentDate}
-              id="payment-date"
-              label="Payment date"
-              onChange={e => {
-                formatAndUpdateDateFromDatePickerSequence({
-                  key: 'petitionPaymentDate',
-                  toFormat: DATE_FORMATS.ISO,
-                  value: e.target.value,
-                });
-                validateSequence();
-              }}
-            />
-
-            <FormGroup errorText={validationErrors.petitionPaymentMethod}>
-              <label className="usa-label" htmlFor="petition-payment-method">
-                Payment method
-              </label>
-              <input
-                className={classNames(
-                  'usa-input',
-                  validationErrors.petitionPaymentMethod && 'usa-input-error',
-                )}
-                id="petition-payment-method"
-                name="petitionPaymentMethod"
-                value={bind.petitionPaymentMethod || ''}
-                onBlur={() => validateSequence()}
-                onChange={e => {
-                  updateSequence({
-                    key: e.target.name,
-                    value: e.target.value,
-                  });
-                }}
-              />
-            </FormGroup>
-          </>
-        )}
-
-        {bind.petitionPaymentStatus === paymentStatus.WAIVED && (
-          <DateSelector
-            defaultValue={bind.petitionPaymentWaivedDate}
-            errorText={validationErrors.petitionPaymentWaivedDate}
-            id="payment-date-waived"
-            label="Date waived"
-            onChange={e => {
-              formatAndUpdateDateFromDatePickerSequence({
-                key: 'petitionPaymentWaivedDate',
-                toFormat: DATE_FORMATS.ISO,
-                value: e.target.value,
-              });
-              validateSequence();
-            }}
-          />
-        )}
-      </>
-    );
-  },
+  PetitionPaymentFormComponent,
 );
 
 PetitionPaymentForm.displayName = 'PetitionPaymentForm';

--- a/web-client/src/views/CaseDetail/PetitionPaymentForm.tsx
+++ b/web-client/src/views/CaseDetail/PetitionPaymentForm.tsx
@@ -8,7 +8,7 @@ import classNames from 'classnames';
 
 interface ComponentProps {
   onUpdate: (args: Record<string, any>) => void;
-  onValidate: (args: Record<string, any>) => void;
+  validateFormData: (args: Record<string, any>) => void;
 }
 
 // It would be better to use ComponentProps & CerebralProps, but
@@ -18,8 +18,8 @@ const PetitionPaymentFormComponent: React.FC<ComponentProps & any> = ({
   DATE_FORMATS,
   formatAndUpdateDateFromDatePickerSequence,
   onUpdate,
-  onValidate,
   paymentStatus,
+  validateFormData,
   validationErrors,
 }) => {
   return (
@@ -44,7 +44,7 @@ const PetitionPaymentFormComponent: React.FC<ComponentProps & any> = ({
                   key: e.target.name,
                   value: e.target.value,
                 });
-                onValidate({ preventAutoScroll: true });
+                validateFormData({ preventAutoScroll: true });
               }}
             />
             <label
@@ -70,7 +70,7 @@ const PetitionPaymentFormComponent: React.FC<ComponentProps & any> = ({
                   key: e.target.name,
                   value: e.target.value,
                 });
-                onValidate({ preventAutoScroll: true });
+                validateFormData({ preventAutoScroll: true });
               }}
             />
             <label
@@ -96,7 +96,7 @@ const PetitionPaymentFormComponent: React.FC<ComponentProps & any> = ({
                   key: e.target.name,
                   value: e.target.value,
                 });
-                onValidate({ preventAutoScroll: true });
+                validateFormData({ preventAutoScroll: true });
               }}
             />
             <label
@@ -123,7 +123,7 @@ const PetitionPaymentFormComponent: React.FC<ComponentProps & any> = ({
                 toFormat: DATE_FORMATS.ISO,
                 value: e.target.value,
               });
-              onValidate({ preventAutoScroll: true });
+              validateFormData({ preventAutoScroll: true });
             }}
           />
 
@@ -139,7 +139,7 @@ const PetitionPaymentFormComponent: React.FC<ComponentProps & any> = ({
               id="petition-payment-method"
               name="petitionPaymentMethod"
               value={bind.petitionPaymentMethod || ''}
-              onBlur={() => onValidate({ preventAutoScroll: true })}
+              onBlur={() => validateFormData({ preventAutoScroll: true })}
               onChange={e => {
                 onUpdate({
                   allowEmptyString: true,
@@ -164,7 +164,7 @@ const PetitionPaymentFormComponent: React.FC<ComponentProps & any> = ({
               toFormat: DATE_FORMATS.ISO,
               value: e.target.value,
             });
-            onValidate({ preventAutoScroll: true });
+            validateFormData({ preventAutoScroll: true });
           }}
         />
       )}

--- a/web-client/src/views/CaseDetail/PetitionPaymentForm.tsx
+++ b/web-client/src/views/CaseDetail/PetitionPaymentForm.tsx
@@ -142,6 +142,7 @@ const PetitionPaymentFormComponent: React.FC<ComponentProps & any> = ({
               onBlur={() => onValidate({ preventAutoScroll: true })}
               onChange={e => {
                 onUpdate({
+                  allowEmptyString: true,
                   key: e.target.name,
                   value: e.target.value,
                 });

--- a/web-client/src/views/CaseDetailEdit/CaseDetailEdit.tsx
+++ b/web-client/src/views/CaseDetailEdit/CaseDetailEdit.tsx
@@ -48,7 +48,7 @@ export const CaseDetailEdit = connect(
             title="IRS Notice"
           >
             <div className="blue-container">
-              <IRSNotice validationFunction={validateCaseDetailSequence} />
+              <IRSNotice validateFormData={validateCaseDetailSequence} />
             </div>
           </Tab>
         </Tabs>

--- a/web-client/src/views/CaseDetailEdit/CaseDetailEdit.tsx
+++ b/web-client/src/views/CaseDetailEdit/CaseDetailEdit.tsx
@@ -14,11 +14,13 @@ export const CaseDetailEdit = connect(
     navigateBackSequence: sequences.navigateBackSequence,
     saveSavedCaseForLaterSequence: sequences.saveSavedCaseForLaterSequence,
     screenMetadata: state.screenMetadata,
+    validateCaseDetailSequence: sequences.validateCaseDetailSequence,
   },
   function CaseDetailEdit({
     navigateBackSequence,
     saveSavedCaseForLaterSequence,
     screenMetadata,
+    validateCaseDetailSequence,
   }) {
     return (
       <div noValidate id="case-edit-form" role="form">
@@ -46,7 +48,7 @@ export const CaseDetailEdit = connect(
             title="IRS Notice"
           >
             <div className="blue-container">
-              <IRSNotice validationName="validateCaseDetailSequence" />
+              <IRSNotice validationFunction={validateCaseDetailSequence} />
             </div>
           </Tab>
         </Tabs>

--- a/web-client/src/views/CaseDetailEdit/CaseInfo.tsx
+++ b/web-client/src/views/CaseDetailEdit/CaseInfo.tsx
@@ -222,9 +222,9 @@ export const CaseInfo = connect(
 
         <PetitionPaymentForm
           bind="form"
-          updateSequence={updatePetitionPaymentFormValueSequence}
-          validateSequence={validateCaseDetailSequence}
           validationErrorsBind="validationErrors"
+          onUpdate={updatePetitionPaymentFormValueSequence}
+          onValidate={validateCaseDetailSequence}
         />
 
         {caseDetailEditHelper.showOrderForFilingFee && (

--- a/web-client/src/views/CaseDetailEdit/CaseInfo.tsx
+++ b/web-client/src/views/CaseDetailEdit/CaseInfo.tsx
@@ -222,9 +222,9 @@ export const CaseInfo = connect(
 
         <PetitionPaymentForm
           bind="form"
+          validateFormData={validateCaseDetailSequence}
           validationErrorsBind="validationErrors"
           onUpdate={updatePetitionPaymentFormValueSequence}
-          onValidate={validateCaseDetailSequence}
         />
 
         {caseDetailEditHelper.showOrderForFilingFee && (

--- a/web-client/src/views/CaseDetailEdit/PartyInformation.tsx
+++ b/web-client/src/views/CaseDetailEdit/PartyInformation.tsx
@@ -11,12 +11,14 @@ export const PartyInformation = connect(
     form: state.form,
     updateCasePartyTypeSequence: sequences.updateCasePartyTypeSequence,
     updateFormValueSequence: sequences.updateFormValueSequence,
+    validateCaseDetailSequence: sequences.validateCaseDetailSequence,
   },
   function PartyInformation({
     caseDetailEditHelper,
     form,
     updateCasePartyTypeSequence,
     updateFormValueSequence,
+    validateCaseDetailSequence,
   }) {
     return (
       <div className="blue-container document-detail-one-third">
@@ -87,7 +89,7 @@ export const PartyInformation = connect(
               showPrimaryContact={caseDetailEditHelper.showPrimaryContact}
               showSecondaryContact={caseDetailEditHelper.showSecondaryContact}
               useSameAsPrimary={true}
-              onBlur="validateCaseDetailSequence"
+              onBlur={validateCaseDetailSequence}
               onChange="updateFormValueAndCaseCaptionSequence"
             />
           </div>

--- a/web-client/src/views/CaseDetailEdit/PartyInformation.tsx
+++ b/web-client/src/views/CaseDetailEdit/PartyInformation.tsx
@@ -89,7 +89,9 @@ export const PartyInformation = connect(
               showPrimaryContact={caseDetailEditHelper.showPrimaryContact}
               showSecondaryContact={caseDetailEditHelper.showSecondaryContact}
               useSameAsPrimary={true}
-              onBlur={validateCaseDetailSequence}
+              onBlur={() =>
+                validateCaseDetailSequence({ preventAutoScroll: true })
+              }
               onChange="updateFormValueAndCaseCaptionSequence"
             />
           </div>

--- a/web-client/src/views/EditPetitionerInformationInternal.tsx
+++ b/web-client/src/views/EditPetitionerInformationInternal.tsx
@@ -55,7 +55,8 @@ export const EditPetitionerInformationInternal = connect(
   }) {
     const type = 'contact';
     const bind = 'form';
-    const onBlur = 'validatePetitionerSequence';
+    const onBlur = () =>
+      validatePetitionerSequence({ preventAutoScroll: true });
 
     return (
       <>

--- a/web-client/src/views/ErrorNotification.tsx
+++ b/web-client/src/views/ErrorNotification.tsx
@@ -15,9 +15,9 @@ export const ErrorNotification = connect(
     alertError?: {
       title?: string;
       message?: string;
+      preventAutoScroll?: boolean;
     };
     alertHelper: {
-      preventAutoScroll?: boolean;
       showErrorAlert?: boolean;
       showSingleMessage?: boolean;
       showMultipleMessages?: boolean;
@@ -29,7 +29,7 @@ export const ErrorNotification = connect(
 
     useEffect(() => {
       const notification = notificationRef.current;
-      if (notification && !alertHelper.preventAutoScroll) {
+      if (notification && !alertError?.preventAutoScroll) {
         window.scrollTo(0, 0);
       }
     });

--- a/web-client/src/views/IRSNotice.tsx
+++ b/web-client/src/views/IRSNotice.tsx
@@ -21,8 +21,8 @@ export const IRSNotice = connect(
     showModal: state.modal.showModal,
     statisticsFormHelper: state.statisticsFormHelper,
     updateFormValueSequence: sequences.updateFormValueSequence,
+    validateFormData: props.validateFormData,
     validationErrors: state.validationErrors,
-    validationFunction: props.validationFunction,
   },
   function IRSNotice({
     caseDetailEditHelper,
@@ -35,8 +35,8 @@ export const IRSNotice = connect(
     showModal,
     statisticsFormHelper,
     updateFormValueSequence,
+    validateFormData,
     validationErrors,
-    validationFunction,
   }) {
     const renderIrsNoticeRadios = () => {
       return (
@@ -119,7 +119,7 @@ export const IRSNotice = connect(
               toFormat: constants.DATE_FORMATS.ISO,
               value: e.target.value,
             });
-            validationFunction({ preventAutoScroll: true });
+            validateFormData({ preventAutoScroll: true });
           }}
         />
       );
@@ -133,7 +133,7 @@ export const IRSNotice = connect(
           allowDefaultOption={true}
           caseTypes={constants.CASE_TYPES}
           legend="Type of case"
-          validationFunction={validationFunction}
+          validateFormData={validateFormData}
           value={form.caseType}
           onChange="updateFormValueSequence"
           onChangePreValidation="refreshStatisticsSequence"

--- a/web-client/src/views/IRSNotice.tsx
+++ b/web-client/src/views/IRSNotice.tsx
@@ -21,8 +21,8 @@ export const IRSNotice = connect(
     showModal: state.modal.showModal,
     statisticsFormHelper: state.statisticsFormHelper,
     updateFormValueSequence: sequences.updateFormValueSequence,
-    validation: sequences[props.validationName],
     validationErrors: state.validationErrors,
+    validationFunction: props.validationFunction,
   },
   function IRSNotice({
     caseDetailEditHelper,
@@ -35,9 +35,8 @@ export const IRSNotice = connect(
     showModal,
     statisticsFormHelper,
     updateFormValueSequence,
-    validation,
     validationErrors,
-    validationName,
+    validationFunction,
   }) {
     const renderIrsNoticeRadios = () => {
       return (
@@ -120,7 +119,7 @@ export const IRSNotice = connect(
               toFormat: constants.DATE_FORMATS.ISO,
               value: e.target.value,
             });
-            validation();
+            validationFunction({ preventAutoScroll: true });
           }}
         />
       );
@@ -134,7 +133,7 @@ export const IRSNotice = connect(
           allowDefaultOption={true}
           caseTypes={constants.CASE_TYPES}
           legend="Type of case"
-          validation={validationName}
+          validationFunction={validationFunction}
           value={form.caseType}
           onChange="updateFormValueSequence"
           onChangePreValidation="refreshStatisticsSequence"

--- a/web-client/src/views/Practitioners/PractitionerContactForm.tsx
+++ b/web-client/src/views/Practitioners/PractitionerContactForm.tsx
@@ -22,7 +22,6 @@ export const PractitionerContactForm = connect(
     changeCountryTypeSequence,
     COUNTRY_TYPES,
     form,
-    onBlurSequenceName,
     onBlurValidationSequence,
     onChangeSequenceName,
     onChangeUpdateSequence,
@@ -34,7 +33,7 @@ export const PractitionerContactForm = connect(
         <Country
           bind={bind}
           type={type}
-          onBlur={onBlurSequenceName}
+          onBlur={() => onBlurValidationSequence({ preventAutoScroll: true })}
           onChange={onChangeSequenceName}
           onChangeCountryType={changeCountryTypeSequence}
         />
@@ -42,14 +41,14 @@ export const PractitionerContactForm = connect(
           <Address
             bind={bind}
             type={type}
-            onBlur={onBlurSequenceName}
+            onBlur={() => onBlurValidationSequence({ preventAutoScroll: true })}
             onChange={onChangeSequenceName}
           />
         ) : (
           <InternationalAddress
             bind={bind}
             type={type}
-            onBlur={onBlurSequenceName}
+            onBlur={() => onBlurValidationSequence({ preventAutoScroll: true })}
             onChange={onChangeSequenceName}
           />
         )}
@@ -70,9 +69,9 @@ export const PractitionerContactForm = connect(
                 name="contact.phone"
                 type="text"
                 value={form.contact.phone || ''}
-                onBlur={() => {
-                  onBlurValidationSequence();
-                }}
+                onBlur={() =>
+                  onBlurValidationSequence({ preventAutoScroll: true })
+                }
                 onChange={e => {
                   onChangeUpdateSequence({
                     key: e.target.name,

--- a/web-client/src/views/StartCase/Address.tsx
+++ b/web-client/src/views/StartCase/Address.tsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 export const Address = connect(
   {
     data: state[props.bind],
-    onBlurSequence: sequences[props.onBlur],
+    onBlur: props.onBlur,
     registerRef: props.registerRef,
     type: props.type,
     updateFormValueAndSecondaryContactInfoSequence: sequences[props.onChange],
@@ -20,7 +20,7 @@ export const Address = connect(
   },
   function Address({
     data,
-    onBlurSequence,
+    onBlur,
     registerRef,
     type,
     updateFormValueAndSecondaryContactInfoSequence,
@@ -38,7 +38,7 @@ export const Address = connect(
               useFullStateName
               data={data}
               handleBlur={() =>
-                onBlurSequence({
+                onBlur({
                   validationKey: [type, 'state'],
                 })
               }
@@ -46,7 +46,7 @@ export const Address = connect(
               refProp={registerRef && registerRef(`${type}.state`)}
               type={type}
               onChangeValidationSequence={() =>
-                onBlurSequence({
+                onBlur({
                   validationKey: [type, 'state'],
                 })
               }
@@ -70,7 +70,7 @@ export const Address = connect(
               type="text"
               value={data[type].postalCode || ''}
               onBlur={() => {
-                onBlurSequence({
+                onBlur({
                   validationKey: [type, 'postalCode'],
                 });
               }}
@@ -109,7 +109,7 @@ export const Address = connect(
                   className="max-width-180"
                   data={data}
                   handleBlur={() =>
-                    onBlurSequence({
+                    onBlur({
                       validationKey: [type, 'state'],
                     })
                   }
@@ -117,7 +117,7 @@ export const Address = connect(
                   refProp={registerRef && registerRef(`${type}.state`)}
                   type={type}
                   onChangeValidationSequence={() =>
-                    onBlurSequence({
+                    onBlur({
                       validationKey: [type, 'state'],
                     })
                   }
@@ -152,7 +152,7 @@ export const Address = connect(
                   type="text"
                   value={data[type].postalCode || ''}
                   onBlur={() => {
-                    onBlurSequence({
+                    onBlur({
                       validationKey: [type, 'postalCode'],
                     });
                   }}
@@ -198,7 +198,7 @@ export const Address = connect(
             type="text"
             value={data[type].address1 || ''}
             onBlur={() => {
-              onBlurSequence({
+              onBlur({
                 validationKey: [type, 'address1'],
               });
             }}
@@ -222,7 +222,7 @@ export const Address = connect(
             type="text"
             value={data[type].address2 || ''}
             onBlur={() => {
-              onBlurSequence({
+              onBlur({
                 validationKey: [type, 'address2'],
               });
             }}
@@ -246,7 +246,7 @@ export const Address = connect(
             type="text"
             value={data[type].address3 || ''}
             onBlur={() => {
-              onBlurSequence({
+              onBlur({
                 validationKey: [type, 'address3'],
               });
             }}
@@ -275,7 +275,7 @@ export const Address = connect(
             type="text"
             value={data[type].city || ''}
             onBlur={() => {
-              onBlurSequence({
+              onBlur({
                 validationKey: [type, 'city'],
               });
             }}

--- a/web-client/src/views/StartCase/CaseTypeSelect.tsx
+++ b/web-client/src/views/StartCase/CaseTypeSelect.tsx
@@ -19,9 +19,9 @@ export const CaseTypeSelect = connect(
     onChangePreValidation: sequences[props.onChangePreValidation],
     rawOnChange: props.onChange,
     refProp: props.refProp,
+    validateFormData: props.validateFormData,
     validationError: props.validationError,
     validationErrors: state.validationErrors,
-    validationFunction: props.validationFunction,
     value: props.value,
   },
   function CaseTypeSelect({
@@ -37,9 +37,9 @@ export const CaseTypeSelect = connect(
     onChangePreValidation,
     rawOnChange,
     refProp,
+    validateFormData,
     validationError,
     validationErrors,
-    validationFunction,
     value,
   }) {
     return (
@@ -69,8 +69,8 @@ export const CaseTypeSelect = connect(
                   value: e.target.value,
                 });
                 if (onChangePreValidation) onChangePreValidation();
-                if (validationFunction)
-                  validationFunction({ preventAutoScroll: true });
+                if (validateFormData)
+                  validateFormData({ preventAutoScroll: true });
               }}
             >
               {allowDefaultOption && <option value="">-- Select --</option>}

--- a/web-client/src/views/StartCase/CaseTypeSelect.tsx
+++ b/web-client/src/views/StartCase/CaseTypeSelect.tsx
@@ -69,7 +69,8 @@ export const CaseTypeSelect = connect(
                   value: e.target.value,
                 });
                 if (onChangePreValidation) onChangePreValidation();
-                if (validationFunction) validationFunction();
+                if (validationFunction)
+                  validationFunction({ preventAutoScroll: true });
               }}
             >
               {allowDefaultOption && <option value="">-- Select --</option>}

--- a/web-client/src/views/StartCase/CaseTypeSelect.tsx
+++ b/web-client/src/views/StartCase/CaseTypeSelect.tsx
@@ -19,9 +19,9 @@ export const CaseTypeSelect = connect(
     onChangePreValidation: sequences[props.onChangePreValidation],
     rawOnChange: props.onChange,
     refProp: props.refProp,
-    validation: sequences[props.validation],
     validationError: props.validationError,
     validationErrors: state.validationErrors,
+    validationFunction: props.validationFunction,
     value: props.value,
   },
   function CaseTypeSelect({
@@ -37,9 +37,9 @@ export const CaseTypeSelect = connect(
     onChangePreValidation,
     rawOnChange,
     refProp,
-    validation,
     validationError,
     validationErrors,
+    validationFunction,
     value,
   }) {
     return (
@@ -69,7 +69,7 @@ export const CaseTypeSelect = connect(
                   value: e.target.value,
                 });
                 if (onChangePreValidation) onChangePreValidation();
-                if (validation) validation();
+                if (validationFunction) validationFunction();
               }}
             >
               {allowDefaultOption && <option value="">-- Select --</option>}

--- a/web-client/src/views/StartCase/ContactPrimary.tsx
+++ b/web-client/src/views/StartCase/ContactPrimary.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 const props = cerebralProps as unknown as {
   contactsHelper: string;
   bind: string;
-  onBlur: () => void;
+  onBlur: (args: Record<string, any>) => void;
   onChange: string;
   parentView: string;
 };

--- a/web-client/src/views/StartCase/ContactPrimary.tsx
+++ b/web-client/src/views/StartCase/ContactPrimary.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 const props = cerebralProps as unknown as {
   contactsHelper: string;
   bind: string;
-  onBlur: string;
+  onBlur: () => void;
   onChange: string;
   parentView: string;
 };
@@ -25,7 +25,6 @@ export const ContactPrimary = connect(
     contactsHelper: state[props.contactsHelper],
     data: state[props.bind],
     onBlur: props.onBlur,
-    onBlurSequence: sequences[props.onBlur],
     onChange: props.onChange,
     onChangeSequence: sequences[props.onChange],
     parentView: props.parentView,
@@ -39,7 +38,6 @@ export const ContactPrimary = connect(
     contactsHelper,
     data,
     onBlur,
-    onBlurSequence,
     onChange,
     onChangeSequence,
     parentView,
@@ -139,9 +137,7 @@ export const ContactPrimary = connect(
           name="contactPrimary.inCareOf"
           type="text"
           value={data.contactPrimary.inCareOf || ''}
-          onBlur={() => {
-            onBlurSequence();
-          }}
+          onBlur={onBlur}
           onChange={e => {
             onChangeSequence({
               key: e.target.name,
@@ -179,9 +175,7 @@ export const ContactPrimary = connect(
               name="contactPrimary.name"
               type="text"
               value={data.contactPrimary.name || ''}
-              onBlur={() => {
-                onBlurSequence();
-              }}
+              onBlur={onBlur}
               onChange={e => {
                 onChangeSequence({
                   key: e.target.name,
@@ -253,9 +247,7 @@ export const ContactPrimary = connect(
               name="contactPrimary.phone"
               type="text"
               value={data.contactPrimary.phone || ''}
-              onBlur={() => {
-                onBlurSequence();
-              }}
+              onBlur={onBlur}
               onChange={e => {
                 updateFormValueAndSecondaryContactInfoSequence({
                   key: e.target.name,

--- a/web-client/src/views/StartCase/ContactPrimary.tsx
+++ b/web-client/src/views/StartCase/ContactPrimary.tsx
@@ -69,6 +69,7 @@ export const ContactPrimary = connect(
           name="contactPrimary.secondaryName"
           type="text"
           value={data.contactPrimary.secondaryName || ''}
+          onBlur={onBlur}
           onChange={e => {
             onChangeSequence({
               key: e.target.name,

--- a/web-client/src/views/StartCase/ContactSecondary.tsx
+++ b/web-client/src/views/StartCase/ContactSecondary.tsx
@@ -17,7 +17,6 @@ export const ContactSecondary = connect(
     contactsHelper: state[props.contactsHelper],
     data: state[props.bind],
     onBlur: props.onBlur,
-    onBlurSequence: sequences[props.onBlur],
     onChange: props.onChange,
     onChangeSequence: sequences[props.onChange],
     parentView: props.parentView,
@@ -33,7 +32,6 @@ export const ContactSecondary = connect(
     contactsHelper,
     data,
     onBlur,
-    onBlurSequence,
     onChange,
     onChangeSequence,
     parentView,
@@ -70,9 +68,7 @@ export const ContactSecondary = connect(
               name="contactSecondary.name"
               type="text"
               value={data.contactSecondary.name || ''}
-              onBlur={() => {
-                onBlurSequence();
-              }}
+              onBlur={onBlur}
               onChange={e => {
                 onChangeSequence({
                   key: e.target.name,
@@ -137,9 +133,7 @@ export const ContactSecondary = connect(
                 name="contactSecondary.inCareOf"
                 type="text"
                 value={data.contactSecondary.inCareOf || ''}
-                onBlur={() => {
-                  onBlurSequence();
-                }}
+                onBlur={onBlur}
                 onChange={e => {
                   onChangeSequence({
                     key: e.target.name,
@@ -203,9 +197,7 @@ export const ContactSecondary = connect(
                 name="contactSecondary.phone"
                 type="text"
                 value={data.contactSecondary.phone || ''}
-                onBlur={() => {
-                  onBlurSequence();
-                }}
+                onBlur={onBlur}
                 onChange={e => {
                   onChangeSequence({
                     key: e.target.name,

--- a/web-client/src/views/StartCase/Country.tsx
+++ b/web-client/src/views/StartCase/Country.tsx
@@ -9,7 +9,7 @@ export const Country = connect(
   {
     constants: state.constants,
     data: state[props.bind],
-    onBlurSequence: sequences[props.onBlur],
+    onBlur: props.onBlur,
     onChangeCountryType: sequences[props.onChangeCountryType],
     registerRef: props.registerRef,
     type: props.type,
@@ -19,7 +19,7 @@ export const Country = connect(
   function Country({
     constants,
     data,
-    onBlurSequence,
+    onBlur,
     onChangeCountryType,
     registerRef,
     type,
@@ -50,8 +50,10 @@ export const Country = connect(
                   type,
                   value: e.target.value,
                 });
-                if (onBlurSequence) {
-                  onBlurSequence({ validationKey: [type, 'countryType'] });
+                if (onBlur) {
+                  onBlur({
+                    validationKey: [type, 'countryType'],
+                  });
                 }
               }}
             />
@@ -79,8 +81,8 @@ export const Country = connect(
                   type,
                   value: e.target.value,
                 });
-                if (onBlurSequence) {
-                  onBlurSequence({
+                if (onBlur) {
+                  onBlur({
                     validationKey: [type, 'countryType'],
                   });
                 }
@@ -114,8 +116,8 @@ export const Country = connect(
               type="text"
               value={data[type].country || ''}
               onBlur={() => {
-                if (onBlurSequence) {
-                  onBlurSequence({
+                if (onBlur) {
+                  onBlur({
                     validationKey: [type, 'country'],
                   });
                 }

--- a/web-client/src/views/StartCase/InternationalAddress.tsx
+++ b/web-client/src/views/StartCase/InternationalAddress.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 const props = cerebralProps as unknown as {
   bind: string;
-  onBlur: string;
+  onBlur: any;
   type: string;
   onChange: string;
   registerRef: (param: string) => void;
@@ -17,7 +17,6 @@ export const InternationalAddress = connect(
   {
     data: state[props.bind],
     onBlur: props.onBlur,
-    onBlurSequence: sequences[props.onBlur],
     registerRef: props.registerRef,
     type: props.type,
     updateFormValueSequence: sequences[props.onChange],
@@ -25,7 +24,7 @@ export const InternationalAddress = connect(
   },
   function InternationalAddress({
     data,
-    onBlurSequence,
+    onBlur,
     registerRef,
     type,
     updateFormValueSequence,
@@ -50,7 +49,7 @@ export const InternationalAddress = connect(
             type="text"
             value={data[type].address1 || ''}
             onBlur={() => {
-              onBlurSequence({
+              onBlur({
                 validationKey: [type, 'address1'],
               });
             }}
@@ -75,7 +74,7 @@ export const InternationalAddress = connect(
             type="text"
             value={data[type].address2 || ''}
             onBlur={() => {
-              onBlurSequence({
+              onBlur({
                 validationKey: [type, 'address2'],
               });
             }}
@@ -100,7 +99,7 @@ export const InternationalAddress = connect(
             type="text"
             value={data[type].address3 || ''}
             onBlur={() => {
-              onBlurSequence({
+              onBlur({
                 validationKey: [type, 'address3'],
               });
             }}
@@ -129,7 +128,7 @@ export const InternationalAddress = connect(
             type="text"
             value={data[type].state || ''}
             onBlur={() => {
-              onBlurSequence({
+              onBlur({
                 validationKey: [type, 'state'],
               });
             }}
@@ -158,7 +157,7 @@ export const InternationalAddress = connect(
             type="text"
             value={data[type].city || ''}
             onBlur={() => {
-              onBlurSequence({
+              onBlur({
                 validationKey: [type, 'city'],
               });
             }}
@@ -187,7 +186,7 @@ export const InternationalAddress = connect(
             type="text"
             value={data[type].postalCode || ''}
             onBlur={() => {
-              onBlurSequence({
+              onBlur({
                 validationKey: [type, 'postalCode'],
               });
             }}

--- a/web-client/src/views/StartCase/InternationalAddress.tsx
+++ b/web-client/src/views/StartCase/InternationalAddress.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 const props = cerebralProps as unknown as {
   bind: string;
-  onBlur: any;
+  onBlur: (args: Record<string, any>) => void;
   type: string;
   onChange: string;
   registerRef: (param: string) => void;

--- a/web-client/src/views/StartCase/StartCaseStep2.tsx
+++ b/web-client/src/views/StartCase/StartCaseStep2.tsx
@@ -145,7 +145,7 @@ export const StartCaseStep2 = connect(
                   allowDefaultOption={true}
                   caseTypes={caseTypeDescriptionHelper.caseTypes}
                   legend="Type of notice / case"
-                  validation="validateStartCaseWizardSequence"
+                  validationFunction={validateStartCaseWizardSequence}
                   value={form.caseType}
                   onChange="updateFormValueSequence"
                 />
@@ -193,7 +193,7 @@ export const StartCaseStep2 = connect(
                 className="margin-bottom-0"
                 legend="Which topic most closely matches your complaint with the
                 IRS?"
-                validation="validateStartCaseWizardSequence"
+                validationFunction={validateStartCaseWizardSequence}
                 value={form.caseType}
                 onChange="updateFormValueSequence"
               />

--- a/web-client/src/views/StartCase/StartCaseStep2.tsx
+++ b/web-client/src/views/StartCase/StartCaseStep2.tsx
@@ -145,7 +145,7 @@ export const StartCaseStep2 = connect(
                   allowDefaultOption={true}
                   caseTypes={caseTypeDescriptionHelper.caseTypes}
                   legend="Type of notice / case"
-                  validationFunction={validateStartCaseWizardSequence}
+                  validateFormData={validateStartCaseWizardSequence}
                   value={form.caseType}
                   onChange="updateFormValueSequence"
                 />
@@ -193,7 +193,7 @@ export const StartCaseStep2 = connect(
                 className="margin-bottom-0"
                 legend="Which topic most closely matches your complaint with the
                 IRS?"
-                validationFunction={validateStartCaseWizardSequence}
+                validateFormData={validateStartCaseWizardSequence}
                 value={form.caseType}
                 onChange="updateFormValueSequence"
               />

--- a/web-client/src/views/StartCase/StartCaseStep3.tsx
+++ b/web-client/src/views/StartCase/StartCaseStep3.tsx
@@ -349,7 +349,7 @@ export const StartCaseStep3 = connect(
           showPrimaryContact={startCaseHelper.showPrimaryContact}
           showSecondaryContact={startCaseHelper.showSecondaryContact}
           useSameAsPrimary={true}
-          onBlur="validateStartCaseWizardSequence"
+          onBlur={validateStartCaseWizardSequence}
           onChange="updateFormValueSequence"
         />
 

--- a/web-client/src/views/StartCaseInternal/CaseInformation.tsx
+++ b/web-client/src/views/StartCaseInternal/CaseInformation.tsx
@@ -181,11 +181,9 @@ export const CaseInformation = connect(
         </FormGroup>
         <PetitionPaymentForm
           bind="form"
-          updateSequence={updatePetitionPaymentFormValueSequence}
-          validateSequence={() =>
-            validatePetitionFromPaperSequence({ preventAutoScroll: true })
-          }
           validationErrorsBind="validationErrors"
+          onUpdate={updatePetitionPaymentFormValueSequence}
+          onValidate={validatePetitionFromPaperSequence}
         />
         {startCaseInternalHelper.showOrderForFilingFee && (
           <div className="order-checkbox">

--- a/web-client/src/views/StartCaseInternal/CaseInformation.tsx
+++ b/web-client/src/views/StartCaseInternal/CaseInformation.tsx
@@ -181,9 +181,9 @@ export const CaseInformation = connect(
         </FormGroup>
         <PetitionPaymentForm
           bind="form"
+          validateFormData={validatePetitionFromPaperSequence}
           validationErrorsBind="validationErrors"
           onUpdate={updatePetitionPaymentFormValueSequence}
-          onValidate={validatePetitionFromPaperSequence}
         />
         {startCaseInternalHelper.showOrderForFilingFee && (
           <div className="order-checkbox">

--- a/web-client/src/views/StartCaseInternal/CaseInformation.tsx
+++ b/web-client/src/views/StartCaseInternal/CaseInformation.tsx
@@ -53,7 +53,7 @@ export const CaseInformation = connect(
               toFormat: DATE_FORMATS.ISO,
               value: e.target.value,
             });
-            validatePetitionFromPaperSequence();
+            validatePetitionFromPaperSequence({ preventAutoScroll: true });
           }}
         />
         <FormGroup errorText={validationErrors.mailingDate}>
@@ -66,7 +66,9 @@ export const CaseInformation = connect(
             maxLength="25"
             name="mailingDate"
             value={form.mailingDate || ''}
-            onBlur={() => validatePetitionFromPaperSequence()}
+            onBlur={() =>
+              validatePetitionFromPaperSequence({ preventAutoScroll: true })
+            }
             onChange={e => {
               updateFormValueSequence({
                 key: e.target.name,
@@ -85,7 +87,7 @@ export const CaseInformation = connect(
             name="caseCaption"
             value={form.caseCaption}
             onBlur={() => {
-              validatePetitionFromPaperSequence();
+              validatePetitionFromPaperSequence({ preventAutoScroll: true });
             }}
             onChange={e => {
               updateFormValueSequence({
@@ -107,7 +109,7 @@ export const CaseInformation = connect(
               value: e.target.value,
             });
             clearPreferredTrialCitySequence();
-            validatePetitionFromPaperSequence();
+            validatePetitionFromPaperSequence({ preventAutoScroll: true });
           }}
         />
         <FormGroup>
@@ -148,7 +150,7 @@ export const CaseInformation = connect(
               key: e.target.name,
               value: e.target.value || null,
             });
-            validatePetitionFromPaperSequence();
+            validatePetitionFromPaperSequence({ preventAutoScroll: true });
           }}
         />
         <FormGroup errorText={validationErrors['object.missing']}>
@@ -165,7 +167,7 @@ export const CaseInformation = connect(
                   key: e.target.name,
                   value: e.target.checked,
                 });
-                validatePetitionFromPaperSequence();
+                validatePetitionFromPaperSequence({ preventAutoScroll: true });
               }}
             />
             <label
@@ -180,7 +182,9 @@ export const CaseInformation = connect(
         <PetitionPaymentForm
           bind="form"
           updateSequence={updatePetitionPaymentFormValueSequence}
-          validateSequence={validatePetitionFromPaperSequence}
+          validateSequence={() =>
+            validatePetitionFromPaperSequence({ preventAutoScroll: true })
+          }
           validationErrorsBind="validationErrors"
         />
         {startCaseInternalHelper.showOrderForFilingFee && (

--- a/web-client/src/views/StartCaseInternal/Parties.tsx
+++ b/web-client/src/views/StartCaseInternal/Parties.tsx
@@ -40,7 +40,7 @@ export const Parties = connect(
                 key: e.target.name,
                 value: e.target.value,
               });
-              validatePetitionFromPaperSequence();
+              validatePetitionFromPaperSequence({ preventAutoScroll: true });
             }}
           >
             <option value="">- Select -</option>
@@ -92,7 +92,9 @@ export const Parties = connect(
                 startCaseInternalHelper.showSecondaryContact
               }
               useSameAsPrimary={true}
-              onBlur="validatePetitionFromPaperSequence"
+              onBlur={() =>
+                validatePetitionFromPaperSequence({ preventAutoScroll: true })
+              }
               onChange="updateFormValueAndCaseCaptionSequence"
             />
           </div>

--- a/web-client/src/views/StartCaseInternal/StartCaseInternal.tsx
+++ b/web-client/src/views/StartCaseInternal/StartCaseInternal.tsx
@@ -23,6 +23,7 @@ export const StartCaseInternal = connect(
     showModal: state.modal.showModal,
     startCaseHelper: state.startCaseHelper,
     submitPetitionFromPaperSequence: sequences.submitPetitionFromPaperSequence,
+    validateCaseDetailSequence: sequences.validateCaseDetailSequence,
     validatePetitionFromPaperSequence:
       sequences.validatePetitionFromPaperSequence,
   },
@@ -33,6 +34,7 @@ export const StartCaseInternal = connect(
     showModal,
     startCaseHelper,
     submitPetitionFromPaperSequence,
+    validateCaseDetailSequence,
     validatePetitionFromPaperSequence,
   }) {
     return (
@@ -75,7 +77,13 @@ export const StartCaseInternal = connect(
                     title="IRS Notice"
                   >
                     <div className="blue-container">
-                      <IRSNotice validationName="validateCaseDetailSequence" />
+                      <IRSNotice
+                        validationFunction={() =>
+                          validateCaseDetailSequence({
+                            preventAutoScroll: true,
+                          })
+                        }
+                      />
                     </div>
                   </Tab>
                 </Tabs>
@@ -85,7 +93,11 @@ export const StartCaseInternal = connect(
                   documentTabs={startCaseHelper.documentTabs}
                   documentType={documentSelectedForScan}
                   title="Add Document(s)"
-                  validateSequence={validatePetitionFromPaperSequence}
+                  validateSequence={() =>
+                    validatePetitionFromPaperSequence({
+                      preventAutoScroll: true,
+                    })
+                  }
                 />
               </div>
             </div>

--- a/web-client/src/views/StartCaseInternal/StartCaseInternal.tsx
+++ b/web-client/src/views/StartCaseInternal/StartCaseInternal.tsx
@@ -78,11 +78,7 @@ export const StartCaseInternal = connect(
                   >
                     <div className="blue-container">
                       <IRSNotice
-                        validationFunction={() =>
-                          validateCaseDetailSequence({
-                            preventAutoScroll: true,
-                          })
-                        }
+                        validateFormData={validateCaseDetailSequence}
                       />
                     </div>
                   </Tab>
@@ -93,11 +89,7 @@ export const StartCaseInternal = connect(
                   documentTabs={startCaseHelper.documentTabs}
                   documentType={documentSelectedForScan}
                   title="Add Document(s)"
-                  validateSequence={() =>
-                    validatePetitionFromPaperSequence({
-                      preventAutoScroll: true,
-                    })
-                  }
+                  validateSequence={validatePetitionFromPaperSequence}
                 />
               </div>
             </div>

--- a/web-client/src/views/StartCaseInternal/StatisticsForm.tsx
+++ b/web-client/src/views/StartCaseInternal/StatisticsForm.tsx
@@ -49,7 +49,9 @@ export const StatisticsForm = connect(
           id={`deficiency-amount-${index}`}
           name={`statistics.${index}.irsDeficiencyAmount`}
           value={form.statistics[index].irsDeficiencyAmount || ''}
-          onBlur={() => validatePetitionFromPaperSequence()}
+          onBlur={() =>
+            validatePetitionFromPaperSequence({ preventAutoScroll: true })
+          }
           onValueChange={values => {
             updateStatisticsFormValueSequence({
               key: `statistics.${index}.irsDeficiencyAmount`,
@@ -132,7 +134,11 @@ export const StatisticsForm = connect(
                     name={`statistics.${index}.year`}
                     placeholder="YYYY"
                     value={form.statistics[index].year || ''}
-                    onBlur={() => validatePetitionFromPaperSequence()}
+                    onBlur={() =>
+                      validatePetitionFromPaperSequence({
+                        preventAutoScroll: true,
+                      })
+                    }
                     onChange={e => {
                       updateStatisticsFormValueSequence({
                         key: e.target.name,

--- a/web-client/src/views/UserContactEditForm.tsx
+++ b/web-client/src/views/UserContactEditForm.tsx
@@ -30,7 +30,9 @@ export const UserContactEditForm = connect(
         <Country
           bind={bind}
           type={type}
-          onBlur={'validateUserContactSequence'}
+          onBlur={() =>
+            validateUserContactSequence({ preventAutoScroll: true })
+          }
           onChange={'updateFormValueSequence'}
           onChangeCountryType={'changeCountryTypeSequence'}
         />
@@ -38,14 +40,18 @@ export const UserContactEditForm = connect(
           <Address
             bind={bind}
             type={type}
-            onBlur={'validateUserContactSequence'}
+            onBlur={() =>
+              validateUserContactSequence({ preventAutoScroll: true })
+            }
             onChange={'updateFormValueSequence'}
           />
         ) : (
           <InternationalAddress
             bind={bind}
             type={type}
-            onBlur={'validateUserContactSequence'}
+            onBlur={() =>
+              validateUserContactSequence({ preventAutoScroll: true })
+            }
             onChange={'updateFormValueSequence'}
           />
         )}
@@ -64,9 +70,9 @@ export const UserContactEditForm = connect(
             name="contact.phone"
             type="text"
             value={form.contact.phone || ''}
-            onBlur={() => {
-              validateUserContactSequence();
-            }}
+            onBlur={() =>
+              validateUserContactSequence({ preventAutoScroll: true })
+            }
             onChange={e => {
               updateFormValueSequence({
                 key: e.target.name,


### PR DESCRIPTION
On the form for petitions clerk creating a case, we validated on blur, on change, etc., and this validation would automatically (and disruptively) scroll to the top to show the validation errors message box. This PR adds a `preventAutoScroll` flag (or rather revises an existing flag that was not fully implemented) in order to prevent this scrolling behavior.

---

A couple of notes:

1. It would be very easy to get carried away refactoring. I tried to find a middle ground: I updated onBlur and onChange to take in functions rather than strings as needed, updated a few components that caused typing issues as needed, but otherwise kept things the same.
2. I decided that `preventAutoScroll: false` would be the default even if it turns out that we need `preventAutoScroll: true` in most instances. (The only time it makes sense to scroll, I think, is on submission.) This was to keep behavior the same so that developers are not surprised about new behavior.