### PR TITLE
10001 (and 10002 and 10003) Design Debt Updates

### DIFF
--- a/cypress/helpers/file/upload-file.ts
+++ b/cypress/helpers/file/upload-file.ts
@@ -15,6 +15,7 @@ export function attachSamplePdfFile(testId: string) {
 }
 
 export function attachFile({
+  encoding,
   filePath,
   selector,
   selectorToAwaitOnSuccess,
@@ -22,8 +23,9 @@ export function attachFile({
   selector: string;
   filePath: string;
   selectorToAwaitOnSuccess?: string;
+  encoding?: 'binary'; // Use binary for non-text files because it better mimics, e.g., readAsArrayBuffer
 }) {
-  cy.get(selector).attachFile(filePath);
+  cy.get(selector).attachFile({ encoding, filePath });
   if (selectorToAwaitOnSuccess) {
     cy.get('[data-testid="loading-overlay"]').should('not.exist');
     cy.get(selectorToAwaitOnSuccess).should('exist');


### PR DESCRIPTION
The validation in the original PR for 10001 et al. correctly caught that [corrupt-pdf](https://github.com/ustaxcourt/ef-cms/blob/staging/cypress/helpers/file/corrupt-pdf.pdf) is corrupt in [the Cypress test](https://github.com/ustaxcourt/ef-cms/blob/2ffbdef46f2ca79333f27f4005978cd30f7c6018/cypress/local-only/tests/integration/fileUpload/upload-court-issued-pdf-validation.cy.ts#L34-L47) but did _not_ catch it outside of Cypress.

This PR thus does two things:

1. Ensures that our PDF file uploads within Cypress mimic the file uploads outside of Cypress by specifying that the upload is in binary format.
2. Implements an unfortunate solution--but as far as I can tell the only viable solution, unless we use something other than pdfjs--to catch corrupt but not fully invalid PDFs.