### PR TITLE
10001 (and 10002 and 10003): File Validation Updates

### DIFF
--- a/cypress/helpers/file/upload-file.ts
+++ b/cypress/helpers/file/upload-file.ts
@@ -15,6 +15,7 @@ export function attachSamplePdfFile(testId: string) {
 }
 
 export function attachFile({
+  encoding,
   filePath,
   selector,
   selectorToAwaitOnSuccess,
@@ -22,8 +23,9 @@ export function attachFile({
   selector: string;
   filePath: string;
   selectorToAwaitOnSuccess?: string;
+  encoding?: 'binary'; // Default to binary, which better mimics PDF data handling on the browser
 }) {
-  cy.get(selector).attachFile(filePath);
+  cy.get(selector).attachFile({ encoding, filePath });
   if (selectorToAwaitOnSuccess) {
     cy.get('[data-testid="loading-overlay"]').should('not.exist');
     cy.get(selectorToAwaitOnSuccess).should('exist');

--- a/web-client/src/presenter/actions/setupCurrentPageAction.ts
+++ b/web-client/src/presenter/actions/setupCurrentPageAction.ts
@@ -20,7 +20,6 @@ export const setupCurrentPageAction =
           .getAllFeatureFlagsInteractor(applicationContext);
         store.set(state.featureFlags, featureFlags);
       } catch (err) {
-        console.log(err);
         page = 'ErrorView500';
       }
     }

--- a/web-client/src/presenter/actions/setupCurrentPageAction.ts
+++ b/web-client/src/presenter/actions/setupCurrentPageAction.ts
@@ -20,6 +20,7 @@ export const setupCurrentPageAction =
           .getAllFeatureFlagsInteractor(applicationContext);
         store.set(state.featureFlags, featureFlags);
       } catch (err) {
+        console.log(err);
         page = 'ErrorView500';
       }
     }

--- a/web-client/src/views/FileHandlingHelpers/pdfValidation.test.ts
+++ b/web-client/src/views/FileHandlingHelpers/pdfValidation.test.ts
@@ -8,7 +8,7 @@ import {
 import { applicationContext } from '@web-client/applicationContext';
 
 const VALID_PDF_HEADER_BYTES = [0x25, 0x50, 0x44, 0x46, 0x2d]; // %PDF-
-const INVALID_PDF_HEADER_BYTES = [0x50, 0x44, 0x46, 0x25, 0x2d]; // %PDF-
+const INVALID_PDF_HEADER_BYTES = [0x50, 0x44, 0x46, 0x25, 0x2d]; // PFD%-
 
 describe('validatePdfHeader', () => {
   it('should return true for valid PDF header', () => {

--- a/web-client/src/views/FileHandlingHelpers/pdfValidation.test.ts
+++ b/web-client/src/views/FileHandlingHelpers/pdfValidation.test.ts
@@ -34,8 +34,6 @@ describe('validatePdf', () => {
   let mockFileReader: any;
 
   beforeEach(() => {
-    jest.restoreAllMocks();
-
     mockFileReader = {
       onerror: null,
       onload: null,

--- a/web-client/src/views/FileHandlingHelpers/pdfValidation.test.ts
+++ b/web-client/src/views/FileHandlingHelpers/pdfValidation.test.ts
@@ -3,8 +3,30 @@ import {
   PDF_CORRUPTED_ERROR_MESSAGE,
   PDF_PASSWORD_PROTECTED_ERROR_MESSAGE,
   validatePdf,
+  validatePdfHeader,
 } from './pdfValidation';
 import { applicationContext } from '@web-client/applicationContext';
+
+const VALID_PDF_HEADER_BYTES = [0x25, 0x50, 0x44, 0x46, 0x2d]; // %PDF-
+const INVALID_PDF_HEADER_BYTES = [0x50, 0x44, 0x46, 0x25, 0x2d]; // %PDF-
+
+describe('validatePdfHeader', () => {
+  it('should return true for valid PDF header', () => {
+    const validPdfData = new Uint8Array(VALID_PDF_HEADER_BYTES);
+
+    const result = validatePdfHeader(validPdfData);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return false for invalid PDF header', () => {
+    const invalidPdfData = new Uint8Array(INVALID_PDF_HEADER_BYTES);
+
+    const result = validatePdfHeader(invalidPdfData);
+
+    expect(result).toBe(false);
+  });
+});
 
 describe('validatePdf', () => {
   let mockFile: File;
@@ -12,11 +34,13 @@ describe('validatePdf', () => {
   let mockFileReader: any;
 
   beforeEach(() => {
+    jest.restoreAllMocks();
+
     mockFileReader = {
       onerror: null,
       onload: null,
       readAsArrayBuffer: jest.fn(),
-      result: new ArrayBuffer(8),
+      result: VALID_PDF_HEADER_BYTES,
     };
 
     (global as any).FileReader = jest.fn(() => mockFileReader);
@@ -63,6 +87,23 @@ describe('validatePdf', () => {
     });
   });
 
+  it('should return error message for PDF with invalid header', async () => {
+    const resultPromise = validatePdf({ file: mockFile });
+    mockFileReader.result = INVALID_PDF_HEADER_BYTES;
+    mockFileReader.onload();
+
+    const result = await resultPromise;
+
+    expect(result).toEqual({
+      errorInformation: {
+        errorMessageToDisplay: PDF_CORRUPTED_ERROR_MESSAGE,
+        errorMessageToLog: `${PDF_CORRUPTED_ERROR_MESSAGE} (CorruptPDFHeaderException)`,
+        errorType: ErrorTypes.CORRUPT_FILE,
+      },
+      isValid: false,
+    });
+  });
+
   it('should return error message for corrupted PDF', async () => {
     const error = new Error();
     error.name = 'InvalidPDFException';
@@ -77,6 +118,7 @@ describe('validatePdf', () => {
     expect(result).toEqual({
       errorInformation: {
         errorMessageToDisplay: PDF_CORRUPTED_ERROR_MESSAGE,
+        errorMessageToLog: `${PDF_CORRUPTED_ERROR_MESSAGE} (InvalidPDFException)`,
         errorType: ErrorTypes.CORRUPT_FILE,
       },
       isValid: false,


### PR DESCRIPTION
TL;DR: This PR adds some updates to make sure that 1) Cypress attachments are mimicking actual browser behavior and 2) we validate pdf headers on the front end just like we do on the back end.

---

This PR addresses two things

1) PDFs with incorrect headers were accepted on the front end but rejected on the back end. While there might be slight differences between front-end and back-end validation, this was a particularly large and unnecessary difference.
2) The validation in [the original PR for 10001 et al.](https://github.com/ustaxcourt/ef-cms/pull/5365) correctly caught that [corrupt-pdf](https://github.com/ustaxcourt/ef-cms/blob/staging/cypress/helpers/file/corrupt-pdf.pdf) is corrupt in [the Cypress test](https://github.com/ustaxcourt/ef-cms/blob/2ffbdef46f2ca79333f27f4005978cd30f7c6018/cypress/local-only/tests/integration/fileUpload/upload-court-issued-pdf-validation.cy.ts#L34-L47) but did _not_ catch it outside of Cypress. This was because we attached files in Cypress with a different encoding than what occurs in the browser. (More details: in Cypress, because the file was loaded [with a non-binary encoding](https://www.npmjs.com/package/cypress-file-upload#working-with-file-encodings), pdfjs happened to fail to parse the PDF and therefore marked it as corrupt. Outside of Cypress, where the file bytes were loaded as a binary array, pdfjs happened to be able to parse the PDF and therefore did not mark it as corrupt. To avoid this divergence between the test environment and actual environment, I defaulted to uploading files in Cypress via binary encoding.)