### PR TITLE
Bugfix: Do not attempt to sign user out if clientNeedsToRefresh is true

### DIFF
--- a/web-client/src/presenter/sequences/signOutUserInitiatedSequence.ts
+++ b/web-client/src/presenter/sequences/signOutUserInitiatedSequence.ts
@@ -1,13 +1,20 @@
 import { BROADCAST_MESSAGES } from '@shared/business/entities/EntityConstants';
+import { checkClientNeedsToRefresh } from '@web-client/presenter/actions/checkClientNeedsToRefresh';
 import { navigateToLoginSequence } from '@web-client/presenter/sequences/Login/navigateToLoginSequence';
 import { setLogoutTypeAction } from '@web-client/presenter/actions/setLogoutTypeAction';
 import { signOutSequence } from '@web-client/presenter/sequences/signOutSequence';
 
 // The sequence to call when the user voluntarily decides to sign out
 export const signOutUserInitiatedSequence = [
-  setLogoutTypeAction(BROADCAST_MESSAGES.userLogout),
-  signOutSequence,
-  navigateToLoginSequence,
+  checkClientNeedsToRefresh,
+  {
+    no: [
+      setLogoutTypeAction(BROADCAST_MESSAGES.userLogout),
+      signOutSequence,
+      navigateToLoginSequence,
+    ],
+    yes: [],
+  },
 ] as unknown as (props: {
   skipBroadcast?: boolean;
   fromModal?: boolean;

--- a/web-client/src/presenter/sequences/signOutUserInitiatedSequence.ts
+++ b/web-client/src/presenter/sequences/signOutUserInitiatedSequence.ts
@@ -8,12 +8,12 @@ import { signOutSequence } from '@web-client/presenter/sequences/signOutSequence
 export const signOutUserInitiatedSequence = [
   checkClientNeedsToRefresh,
   {
-    no: [
+    clientDoesNotNeedToRefresh: [
       setLogoutTypeAction(BROADCAST_MESSAGES.userLogout),
       signOutSequence,
       navigateToLoginSequence,
     ],
-    yes: [],
+    clientNeedsToRefresh: [],
   },
 ] as unknown as (props: {
   skipBroadcast?: boolean;


### PR DESCRIPTION
I ran into an error today on test. I had two tabs open:

1. Old tab needed to refresh (due to a deploy to test)
2. Current tab needed to refresh (due to that same deploy to test)
3. I refreshed the current tab. All good!
4. I [signed out of the current tab](https://github.com/ustaxcourt/ef-cms/blob/staging/web-client/src/presenter/sequences/signOutUserInitiatedSequence.ts). This [sent a broadcast message](https://github.com/ustaxcourt/ef-cms/blob/staging/web-client/src/presenter/actions/broadcastLogoutAction.ts) to sign out all tabs.
5. The old tab [got that broadcast message and tried to send a backend request as part of signing out](https://github.com/ustaxcourt/ef-cms/blob/06436b36fd1bcb9eb9a7256574c0c09ada219e9d/web-client/src/AppInstanceManager.tsx#L51). The [request failed because of a backend color change](https://github.com/ustaxcourt/ef-cms/blob/06436b36fd1bcb9eb9a7256574c0c09ada219e9d/web-api/src/app.ts#L270-L275), so the app in that tab said, "[Looks like I need to refresh](https://github.com/ustaxcourt/ef-cms/blob/06436b36fd1bcb9eb9a7256574c0c09ada219e9d/web-client/src/app.tsx#L271-L273)--better [let the other tabs know too!](https://github.com/ustaxcourt/ef-cms/blob/06436b36fd1bcb9eb9a7256574c0c09ada219e9d/web-client/src/presenter/sequences/handleAppHasUpdatedSequence.ts#L9)"
6. The current tab [got a "you need to refresh" message and acted accordingly](https://github.com/ustaxcourt/ef-cms/blob/06436b36fd1bcb9eb9a7256574c0c09ada219e9d/web-client/src/AppInstanceManager.tsx#L56).
7. Repeat indefinitely.

This PR is effectively an imperfect patch. A stale client should avoid sending _any_ backend request, otherwise we will broadcast to other tabs that they need to refresh. (Alternatively, we can choose not to broadcast, but that feels like the less-good, less-user-friendly, more convenient solution. _Alternatively_ alternatively, upon getting a "need to refresh" broadcast message, a tab could ping for a backend health check.) I don't believe we have any other "background tab" requests being sent to the back end at this time.

This was something I _should_ have caught as part of my work on [10349](https://app.zenhub.com/workspaces/flexionef-cms-5bbe4bed4b5806bc2bec65d3/issues/gh/flexion/ef-cms/10349), but I was focused on idle logout at the expense of user-initiated logout.