### PR TITLE
Opex: revoke a petitioner's e-access

### DIFF
--- a/scripts/user/revoke-e-access.ts
+++ b/scripts/user/revoke-e-access.ts
@@ -1,0 +1,57 @@
+// Usage: npx ts-node --transpile-only scripts/user/revoke-e-access.ts 432143213-4321-1234-4321-432143214321 101-23
+
+import { Case } from '@shared/business/entities/cases/Case';
+import { createApplicationContext } from '@web-api/applicationContext';
+import { getCaseByDocketNumber } from '@web-api/persistence/dynamo/cases/getCaseByDocketNumber';
+
+const userId = process.argv[2];
+const docketNumber = process.argv[3];
+
+if (!userId || !docketNumber) {
+  console.error('Error: missing docket number or user id.');
+  console.log(
+    'Usage:\nnpx ts-node --transpile-only scripts/user/revoke-e-access.ts 432143213-4321-1234-4321-432143214321 101-23',
+  );
+  process.exit(1);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+(async () => {
+  const applicationContext = createApplicationContext({});
+
+  const rawCase = await getCaseByDocketNumber({
+    applicationContext,
+    docketNumber,
+  });
+  if (!rawCase.docketNumber) {
+    console.error(`Error: Unable to find case ${docketNumber}.`);
+    process.exit(1);
+  }
+
+  const offendingPetitioner = rawCase.petitioners.find(
+    p => p.contactId === userId,
+  );
+  if (!offendingPetitioner) {
+    console.error(
+      `Error: Unable to find petitioner with id ${userId} in case ${docketNumber}.`,
+    );
+    process.exit(1);
+  }
+
+  offendingPetitioner.serviceIndicator = 'Paper';
+  delete offendingPetitioner.email;
+  const caseToUpdate = new Case(rawCase, { authorizedUser: undefined })
+    .validate()
+    .toRawObject();
+
+  await applicationContext
+    .getPersistenceGateway()
+    .updateCase({ applicationContext, caseToUpdate });
+  await applicationContext
+    .getPersistenceGateway()
+    .deleteUserFromCase({ applicationContext, docketNumber, userId });
+
+  console.log(
+    `Electronic access to case ${docketNumber} has been revoked for ${offendingPetitioner.name}.`,
+  );
+})();

--- a/scripts/user/revoke-e-access.ts
+++ b/scripts/user/revoke-e-access.ts
@@ -3,6 +3,7 @@
 import { Case } from '@shared/business/entities/cases/Case';
 import { createApplicationContext } from '@web-api/applicationContext';
 import { getCaseByDocketNumber } from '@web-api/persistence/dynamo/cases/getCaseByDocketNumber';
+import { requireEnvVars } from '../../shared/admin-tools/util';
 
 const userId = process.argv[2];
 const docketNumber = process.argv[3];
@@ -14,6 +15,7 @@ if (!userId || !docketNumber) {
   );
   process.exit(1);
 }
+requireEnvVars(['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'ENV']);
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 (async () => {

--- a/scripts/user/revoke-e-access.ts
+++ b/scripts/user/revoke-e-access.ts
@@ -3,6 +3,7 @@
 import { Case } from '@shared/business/entities/cases/Case';
 import { createApplicationContext } from '@web-api/applicationContext';
 import { getCaseByDocketNumber } from '@web-api/persistence/dynamo/cases/getCaseByDocketNumber';
+import { getUniqueId } from '@shared/sharedAppContext';
 import { requireEnvVars } from '../../shared/admin-tools/util';
 
 const userId = process.argv[2];
@@ -40,6 +41,7 @@ requireEnvVars(['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'ENV']);
     process.exit(1);
   }
 
+  offendingPetitioner.contactId = getUniqueId();
   offendingPetitioner.serviceIndicator = 'Paper';
   delete offendingPetitioner.email;
   const caseToUpdate = new Case(rawCase, { authorizedUser: undefined })


### PR DESCRIPTION
This script will revoke a petitioner's e-access to a given case.

Backstory: occasionally petitioners will abuse their e-access by e-filing large volumes of unrelated or nonsensical documents, overwhelming the Court's QC processes, which have to look at all documents as if they were filed in good faith.

This script is only to be executed after a Judge's order revoking a petitioner's e-access is served.