### PR TITLE
More 10001 (and 10002 and 10003) Updates: skip file type validation for PractitionerAddEditDocoment

### DIFF
--- a/web-client/src/views/FileDocument/StateDrivenFileInput.tsx
+++ b/web-client/src/views/FileDocument/StateDrivenFileInput.tsx
@@ -20,6 +20,7 @@ type StateDriveFileInputProps = {
   name: string;
   accept?: string;
   ignoreSizeKey?: boolean;
+  skipFileTypeValidation?: boolean;
 };
 
 const deps = {
@@ -49,6 +50,7 @@ export const StateDrivenFileInput = connect<
     setIsLoadingSequence,
     setIsNotLoadingSequence,
     showFileUploadErrorModalSequence,
+    skipFileTypeValidation = false, // skipFileTypeValidation is only here to support PractitionerAddEditDocument "accepting" certain file types but not enforcing that acceptance
     updateFormValueSequence,
     validationSequence,
     ...remainingProps
@@ -100,6 +102,7 @@ export const StateDrivenFileInput = connect<
               /* no-op */
             });
         },
+        skipFileTypeValidation,
       });
       setIsNotLoadingSequence();
     };

--- a/web-client/src/views/Practitioners/PractitionerAddEditDocument.tsx
+++ b/web-client/src/views/Practitioners/PractitionerAddEditDocument.tsx
@@ -93,6 +93,7 @@ export const PractitionerAddEditDocument = connect(
                         aria-describedby="practitioner-document-file-label"
                         id="practitioner-document-file"
                         name="practitionerDocumentFile"
+                        skipFileTypeValidation={true}
                         updateFormValueSequence="updateFormValueSequence"
                         validationSequence="validateAddPractitionerDocumentSequence"
                       />


### PR DESCRIPTION
We want to keep behavior of PractitionerAddEditDocoment exactly the same (i.e., no file validation except for a size limit).