### PR TITLE
10501 Bugfix: Fix judges chambers not populating in certain message modals

### DIFF
--- a/web-client/src/presenter/sequences/openCompleteAndSendMessageModalSequence.ts
+++ b/web-client/src/presenter/sequences/openCompleteAndSendMessageModalSequence.ts
@@ -1,6 +1,7 @@
 import { clearModalStateAction } from '../actions/clearModalStateAction';
 import { generateTitleAction } from '../actions/FileDocument/generateTitleAction';
 import { getCaseAction } from '../actions/getCaseAction';
+import { getJudgesChambersSequence } from '@web-client/presenter/sequences/getJudgesChambersSequence';
 import { isWorkItemAlreadyCompletedAction } from '../actions/isWorkItemAlreadyCompletedAction';
 import { refreshExternalDocumentTitleFromEventCodeAction } from '../actions/FileDocument/refreshExternalDocumentTitleFromEventCodeAction';
 import { setAlertErrorAction } from '../actions/setAlertErrorAction';
@@ -29,6 +30,7 @@ export const openCompleteAndSendMessageModalSequence = [
         ],
         success: [
           clearModalStateAction,
+          getJudgesChambersSequence,
           refreshExternalDocumentTitleFromEventCodeAction,
           setPreviousDocumentDocketEntryAction,
           generateTitleAction,

--- a/web-client/src/presenter/sequences/openForwardMessageModalSequence.ts
+++ b/web-client/src/presenter/sequences/openForwardMessageModalSequence.ts
@@ -1,4 +1,5 @@
 import { clearModalStateAction } from '../actions/clearModalStateAction';
+import { getJudgesChambersSequence } from '@web-client/presenter/sequences/getJudgesChambersSequence';
 import { getMostRecentMessageInThreadAction } from '../actions/getMostRecentMessageInThreadAction';
 import { setForwardMessageModalDialogModalStateAction } from '../actions/WorkItem/setForwardMessageModalDialogModalStateAction';
 import { setShowModalFactoryAction } from '../actions/setShowModalFactoryAction';
@@ -6,6 +7,7 @@ import { setShowModalFactoryAction } from '../actions/setShowModalFactoryAction'
 export const openForwardMessageModalSequence = [
   clearModalStateAction,
   getMostRecentMessageInThreadAction,
+  getJudgesChambersSequence,
   setForwardMessageModalDialogModalStateAction,
   setShowModalFactoryAction('ForwardMessageModal'),
 ];


### PR DESCRIPTION
[10455](https://app.zenhub.com/workspaces/flexionef-cms-5bbe4bed4b5806bc2bec65d3/issues/gh/flexion/ef-cms/10455) pulled hard-coded judge chambers information out of the codebase. While the main send message sequence was getting judges chambers information, there were other message sequences that were not. This PR addresses the issue.