### PR TITLE
10261 Story: Practitioner Case List (Updates based on UX feedback)

### DIFF
--- a/shared/src/business/useCases/getPractitionerCasesInteractor.ts
+++ b/shared/src/business/useCases/getPractitionerCasesInteractor.ts
@@ -7,6 +7,7 @@ import {
 import { ServerApplicationContext } from '@web-api/applicationContext';
 import { UnauthorizedError } from '@web-api/errors/errors';
 import { UnknownAuthUser } from '@shared/business/entities/authUser/AuthUser';
+import { formatCase } from '@shared/business/utilities/getFormattedCaseDetail';
 import { partition } from 'lodash';
 
 export const getPractitionerCasesInteractor = async (
@@ -31,11 +32,8 @@ export const getPractitionerCasesInteractor = async (
     .getPersistenceGateway()
     .getCasesByDocketNumbers({ applicationContext, docketNumbers });
 
-  cases.forEach(
-    aCase => (aCase.caseTitle = Case.getCaseTitle(aCase.caseCaption)),
-  );
-
   const caseDetails: PractitionerCaseDetail[] = cases.map(c => {
+    c = formatCase(applicationContext, c, authorizedUser);
     return {
       caseTitle: c.caseTitle,
       consolidatedIconTooltipText: c.consolidatedIconTooltipText,
@@ -44,9 +42,6 @@ export const getPractitionerCasesInteractor = async (
       inConsolidatedGroup: c.inConsolidatedGroup,
       isLeadCase: c.isLeadCase,
       isSealed: c.isSealed,
-      leadDocketNumber: c.leadDocketNumber,
-      sealedDate: c.sealedDate,
-      sealedToTooltip: c.sealedToToolTip,
       status: c.status,
     };
   });

--- a/shared/src/business/useCases/getPractitionerCasesInteractor.ts
+++ b/shared/src/business/useCases/getPractitionerCasesInteractor.ts
@@ -33,16 +33,28 @@ export const getPractitionerCasesInteractor = async (
     .getCasesByDocketNumbers({ applicationContext, docketNumbers });
 
   const caseDetails: PractitionerCaseDetail[] = cases.map(c => {
-    c = formatCase(applicationContext, c, authorizedUser);
+    const formattedCase = formatCase(applicationContext, c, authorizedUser);
+
+    const {
+      caseTitle,
+      consolidatedIconTooltipText,
+      docketNumber,
+      docketNumberWithSuffix,
+      inConsolidatedGroup,
+      isLeadCase,
+      isSealed,
+      status,
+    } = formattedCase;
+
     return {
-      caseTitle: c.caseTitle,
-      consolidatedIconTooltipText: c.consolidatedIconTooltipText,
-      docketNumber: c.docketNumber,
-      docketNumberWithSuffix: c.docketNumberWithSuffix,
-      inConsolidatedGroup: c.inConsolidatedGroup,
-      isLeadCase: c.isLeadCase,
-      isSealed: c.isSealed,
-      status: c.status,
+      caseTitle,
+      consolidatedIconTooltipText,
+      docketNumber,
+      docketNumberWithSuffix,
+      inConsolidatedGroup,
+      isLeadCase,
+      isSealed,
+      status,
     };
   });
 

--- a/shared/src/business/useCases/getPractitionerCasesInteractor.ts
+++ b/shared/src/business/useCases/getPractitionerCasesInteractor.ts
@@ -1,4 +1,5 @@
 import { Case, isClosed } from '../entities/cases/Case';
+import { PractitionerCaseDetail } from '@web-client/presenter/state';
 import {
   ROLE_PERMISSIONS,
   isAuthorized,
@@ -34,8 +35,24 @@ export const getPractitionerCasesInteractor = async (
     aCase => (aCase.caseTitle = Case.getCaseTitle(aCase.caseCaption)),
   );
 
+  const caseDetails: PractitionerCaseDetail[] = cases.map(c => {
+    return {
+      caseTitle: c.caseTitle,
+      consolidatedIconTooltipText: c.consolidatedIconTooltipText,
+      docketNumber: c.docketNumber,
+      docketNumberWithSuffix: c.docketNumberWithSuffix,
+      inConsolidatedGroup: c.inConsolidatedGroup,
+      isLeadCase: c.isLeadCase,
+      isSealed: c.isSealed,
+      leadDocketNumber: c.leadDocketNumber,
+      sealedDate: c.sealedDate,
+      sealedToTooltip: c.sealedToToolTip,
+      status: c.status,
+    };
+  });
+
   const [closedCases, openCases] = partition(
-    Case.sortByDocketNumber(cases).reverse(),
+    Case.sortByDocketNumber(caseDetails).reverse(),
     theCase => isClosed(theCase),
   );
 

--- a/web-client/src/presenter/actions/getPractitionerDetailAction.ts
+++ b/web-client/src/presenter/actions/getPractitionerDetailAction.ts
@@ -7,7 +7,7 @@
  */
 
 import {
-  PractitionerCaseInfo,
+  PractitionerAllCasesInfo,
   PractitionerDetail,
 } from '@web-client/presenter/state';
 import { state } from '@web-client/presenter/app.cerebral';
@@ -36,11 +36,11 @@ export const getPractitionerDetailAction = async ({
         userId: practitionerDetail.userId,
       });
 
-    const openCaseInfo: PractitionerCaseInfo = {
+    const openCaseInfo: PractitionerAllCasesInfo = {
       allCases: openCases,
       currentPage: 0,
     };
-    const closedCaseInfo: PractitionerCaseInfo = {
+    const closedCaseInfo: PractitionerAllCasesInfo = {
       allCases: closedCases,
       currentPage: 0,
     };

--- a/web-client/src/presenter/computeds/practitionerInformationHelper.ts
+++ b/web-client/src/presenter/computeds/practitionerInformationHelper.ts
@@ -1,10 +1,8 @@
 /* eslint-disable complexity */
 
 import { ClientApplicationContext } from '@web-client/applicationContext';
-import { formatCase } from '@shared/business/utilities/getFormattedCaseDetail';
 import { state } from '@web-client/presenter/app.cerebral';
 
-import { AuthUser } from '@shared/business/entities/authUser/AuthUser';
 import { Get } from 'cerebral';
 import { PractitionerCaseDetail } from '@web-client/presenter/state';
 import { getSealedDocketEntryTooltip } from '@shared/business/utilities/getSealedDocketEntryTooltip';
@@ -15,17 +13,14 @@ const getPagesToDisplay = ({
   applicationContext,
   cases,
   pageNumber,
-  user,
 }: {
   pageNumber: number;
   cases: PractitionerCaseDetail[];
   applicationContext: ClientApplicationContext;
-  user: AuthUser;
 }) => {
   return cases
     .slice(pageNumber * PAGE_SIZE, (pageNumber + 1) * PAGE_SIZE)
     .map(c => {
-      c = formatCase(applicationContext, c, user);
       c.sealedToTooltip = getSealedDocketEntryTooltip(applicationContext, c);
       return c;
     });
@@ -72,14 +67,12 @@ export const practitionerInformationHelper = (
     applicationContext,
     cases: practitionerDetail.openCaseInfo?.allCases || [],
     pageNumber: practitionerDetail.openCaseInfo?.currentPage || 0,
-    user,
   });
 
   const closedCasesToDisplay = getPagesToDisplay({
     applicationContext,
     cases: practitionerDetail.closedCaseInfo?.allCases || [],
     pageNumber: practitionerDetail.closedCaseInfo?.currentPage || 0,
-    user,
   });
 
   return {

--- a/web-client/src/presenter/state.ts
+++ b/web-client/src/presenter/state.ts
@@ -911,8 +911,8 @@ export type PractitionerDetail = {
   practitionerType?: string;
   middleName?: string;
   contact?: Partial<UserContact>;
-  openCaseInfo?: PractitionerCaseInfo; // Only for internal users
-  closedCaseInfo?: PractitionerCaseInfo; // Only for internal users
+  openCaseInfo?: PractitionerAllCasesInfo; // Only for internal users
+  closedCaseInfo?: PractitionerAllCasesInfo; // Only for internal users
   email?: string;
   pendingEmail?: string;
   additionalPhone?: string;
@@ -920,17 +920,20 @@ export type PractitionerDetail = {
   hasEAccess?: boolean;
 };
 
-export type PractitionerCaseInfo = {
+export type PractitionerAllCasesInfo = {
   allCases: PractitionerCaseDetail[];
   currentPage: number;
 };
 
 export type PractitionerCaseDetail = {
   docketNumberWithSuffix: string;
+  docketNumber: string;
   caseTitle: string;
   inConsolidatedGroup: boolean;
   isLeadCase: boolean;
   isSealed: boolean;
+  leadDocketNumber?: string;
+  sealedDate?: string;
   status: string;
   sealedToTooltip?: string;
   consolidatedIconTooltipText?: string;

--- a/web-client/src/presenter/state.ts
+++ b/web-client/src/presenter/state.ts
@@ -926,14 +926,12 @@ export type PractitionerAllCasesInfo = {
 };
 
 export type PractitionerCaseDetail = {
-  docketNumberWithSuffix: string;
   docketNumber: string;
+  docketNumberWithSuffix: string;
   caseTitle: string;
   inConsolidatedGroup: boolean;
   isLeadCase: boolean;
   isSealed: boolean;
-  leadDocketNumber?: string;
-  sealedDate?: string;
   status: string;
   sealedToTooltip?: string;
   consolidatedIconTooltipText?: string;

--- a/web-client/src/styles/tabs.scss
+++ b/web-client/src/styles/tabs.scss
@@ -244,3 +244,7 @@
     margin-bottom: 0 !important;
   }
 }
+
+.tab-content-with-top-margin {
+  margin-top: 2.5rem;
+}

--- a/web-client/src/views/Practitioners/PractitionerCaseList.tsx
+++ b/web-client/src/views/Practitioners/PractitionerCaseList.tsx
@@ -32,7 +32,7 @@ export function PractitionerCaseList({
             <thead>
               <tr>
                 <th aria-hidden="true" className="icon-column" />
-                <th>Docket No.</th>
+                <th className="no-wrap">Docket No.</th>
                 <th>Case Title</th>
                 {showStatus && <th>Case Status</th>}
               </tr>

--- a/web-client/src/views/Practitioners/PractitionerInformation.tsx
+++ b/web-client/src/views/Practitioners/PractitionerInformation.tsx
@@ -91,6 +91,7 @@ export const PractitionerInformation = connect(
             bind="currentViewMetadata.tab"
             className="classic-horizontal-header3 tab-border"
             defaultActiveTab="practitioner-details"
+            marginBottom={false}
             onSelect={tabName => {
               onPractitionerInformationTabSelectSequence({
                 tabName,
@@ -127,23 +128,27 @@ export const PractitionerInformation = connect(
               tabName="practitioner-open-cases"
               title={`Open Cases (${numOpenCases})`}
             >
-              {openPagesPaginator()}
-              <PractitionerCaseList
-                caseType={'open'}
-                cases={practitionerInformationHelper.openCasesToDisplay}
-              />
-              {openPagesPaginator()}
+              <div className="tab-content-with-top-margin">
+                {openPagesPaginator()}
+                <PractitionerCaseList
+                  caseType={'open'}
+                  cases={practitionerInformationHelper.openCasesToDisplay}
+                />
+                {openPagesPaginator()}
+              </div>
             </Tab>
             <Tab
               tabName="practitioner-closed-cases"
               title={`Closed Cases (${numClosedCases})`}
             >
-              {closedPagesPaginator()}
-              <PractitionerCaseList
-                caseType={'closed'}
-                cases={practitionerInformationHelper.closedCasesToDisplay}
-              />
-              {closedPagesPaginator()}
+              <div className="tab-content-with-top-margin">
+                {closedPagesPaginator()}
+                <PractitionerCaseList
+                  caseType={'closed'}
+                  cases={practitionerInformationHelper.closedCasesToDisplay}
+                />
+                {closedPagesPaginator()}
+              </div>
             </Tab>
           </Tabs>
         </section>


### PR DESCRIPTION
- Large case numbers can trigger a 502. This PR (theoretically) fixes that.
- The Docket No. column no longer wraps.
- The old top margin is preserved for the non-case-list tab contents; the new top margin is applied only for the case-list tab contents.