### PR TITLE
10261 Story: Practitioner Case List -- UX Updates (Show multiple pages in pagination, and fix sort)

### DIFF
--- a/shared/src/business/entities/cases/Case.sortByDocketNumber.test.ts
+++ b/shared/src/business/entities/cases/Case.sortByDocketNumber.test.ts
@@ -39,11 +39,17 @@ describe('sortByDocketNumber', () => {
         docketNumber: '120-19',
       },
       {
+        docketNumber: '120-95',
+      },
+      {
         docketNumber: '120-18',
       },
     ]);
 
     expect(result).toEqual([
+      {
+        docketNumber: '120-95',
+      },
       {
         docketNumber: '110-18',
       },

--- a/shared/src/business/entities/cases/Case.ts
+++ b/shared/src/business/entities/cases/Case.ts
@@ -232,15 +232,15 @@ export class Case extends JoiValidationEntity {
    */
   static sortByDocketNumber(cases) {
     return cases.sort((a, b) => {
-      return this.docketNumberSort(a.docketNumber, b.docketNumber);
+      return Case.docketNumberSort(a.docketNumber, b.docketNumber);
     });
   }
 
   // This will not take into account [19]95 vs [20]95
   static docketNumberSort(docketNumberA, docketNumberB) {
     return (
-      (this.getSortableDocketNumber(docketNumberA) || 0) -
-      (this.getSortableDocketNumber(docketNumberB) || 0)
+      (Case.getSortableDocketNumber(docketNumberA) || 0) -
+      (Case.getSortableDocketNumber(docketNumberB) || 0)
     );
   }
 

--- a/shared/src/business/entities/cases/Case.ts
+++ b/shared/src/business/entities/cases/Case.ts
@@ -232,22 +232,16 @@ export class Case extends JoiValidationEntity {
    */
   static sortByDocketNumber(cases) {
     return cases.sort((a, b) => {
-      return Case.docketNumberSort(a.docketNumber, b.docketNumber);
+      return this.docketNumberSort(a.docketNumber, b.docketNumber);
     });
   }
 
+  // This will not take into account [19]95 vs [20]95
   static docketNumberSort(docketNumberA, docketNumberB) {
-    const aSplit = docketNumberA.split('-');
-    const bSplit = docketNumberB.split('-');
-
-    if (aSplit[1] !== bSplit[1]) {
-      // compare years if they aren't the same;
-      // compare as strings, because they *might* have suffix
-      return aSplit[1].localeCompare(bSplit[1]);
-    } else {
-      // compare index if years are the same, compare as integers
-      return +aSplit[0] - +bSplit[0];
-    }
+    return (
+      (this.getSortableDocketNumber(docketNumberA) || 0) -
+      (this.getSortableDocketNumber(docketNumberB) || 0)
+    );
   }
 
   /**

--- a/shared/src/business/entities/cases/Case.ts
+++ b/shared/src/business/entities/cases/Case.ts
@@ -236,7 +236,6 @@ export class Case extends JoiValidationEntity {
     });
   }
 
-  // This will not take into account [19]95 vs [20]95
   static docketNumberSort(docketNumberA, docketNumberB) {
     return (
       (Case.getSortableDocketNumber(docketNumberA) || 0) -

--- a/web-client/src/views/Practitioners/PractitionerInformation.tsx
+++ b/web-client/src/views/Practitioners/PractitionerInformation.tsx
@@ -42,7 +42,6 @@ export const PractitionerInformation = connect(
         practitionerInformationHelper.showOpenCasesPagination && (
           <Paginator
             currentPageIndex={practitionerInformationHelper.openCasesPageNumber}
-            showSinglePage={true}
             totalPages={practitionerInformationHelper.totalOpenCasesPages}
             onPageChange={selectedPage => {
               setPractitionerOpenCasesPageSequence({
@@ -61,7 +60,6 @@ export const PractitionerInformation = connect(
             currentPageIndex={
               practitionerInformationHelper.closedCasesPageNumber
             }
-            showSinglePage={true}
             totalPages={practitionerInformationHelper.totalClosedCasesPages}
             onPageChange={selectedPage => {
               setPractitionerClosedCasesPageSequence({


### PR DESCRIPTION
We want the paginator to show more pages (when applicable) for the practitioner case lists. Also, UX discovered an existing bug pertaining to out-of-order docket numbers. This PR addresses these two issues.
