### PR TITLE
10261 Story: Update to sealed icon hover text

### DIFF
--- a/shared/src/business/utilities/getSealedDocketEntryTooltip.ts
+++ b/shared/src/business/utilities/getSealedDocketEntryTooltip.ts
@@ -1,3 +1,4 @@
+// This applies only to docket entries, not to full cases
 export const getSealedDocketEntryTooltip = (applicationContext, entry) => {
   const { DOCKET_ENTRY_SEALED_TO_TYPES } = applicationContext.getConstants();
 

--- a/web-client/src/presenter/computeds/practitionerInformationHelper.ts
+++ b/web-client/src/presenter/computeds/practitionerInformationHelper.ts
@@ -5,25 +5,17 @@ import { state } from '@web-client/presenter/app.cerebral';
 
 import { Get } from 'cerebral';
 import { PractitionerCaseDetail } from '@web-client/presenter/state';
-import { getSealedDocketEntryTooltip } from '@shared/business/utilities/getSealedDocketEntryTooltip';
 
 const PAGE_SIZE = 100;
 
 const getPagesToDisplay = ({
-  applicationContext,
   cases,
   pageNumber,
 }: {
   pageNumber: number;
   cases: PractitionerCaseDetail[];
-  applicationContext: ClientApplicationContext;
 }) => {
-  return cases
-    .slice(pageNumber * PAGE_SIZE, (pageNumber + 1) * PAGE_SIZE)
-    .map(c => {
-      c.sealedToTooltip = getSealedDocketEntryTooltip(applicationContext, c);
-      return c;
-    });
+  return cases.slice(pageNumber * PAGE_SIZE, (pageNumber + 1) * PAGE_SIZE);
 };
 
 export const practitionerInformationHelper = (
@@ -64,13 +56,11 @@ export const practitionerInformationHelper = (
   const showClosedCasesPagination = totalClosedCasesPages > 1;
 
   const openCasesToDisplay = getPagesToDisplay({
-    applicationContext,
     cases: practitionerDetail.openCaseInfo?.allCases || [],
     pageNumber: practitionerDetail.openCaseInfo?.currentPage || 0,
   });
 
   const closedCasesToDisplay = getPagesToDisplay({
-    applicationContext,
     cases: practitionerDetail.closedCaseInfo?.allCases || [],
     pageNumber: practitionerDetail.closedCaseInfo?.currentPage || 0,
   });

--- a/web-client/src/styles/custom.scss
+++ b/web-client/src/styles/custom.scss
@@ -1794,7 +1794,8 @@ button.change-scanner-button {
   margin-right: 4px;
 }
 
-.sealed-docket-entry {
+.sealed-docket-entry,
+.sealed-case-entry {
   color: color($theme-color-secondary-dark);
 }
 

--- a/web-client/src/views/Practitioners/PractitionerCaseIcons.tsx
+++ b/web-client/src/views/Practitioners/PractitionerCaseIcons.tsx
@@ -11,8 +11,8 @@ export function PractitionerCaseIcons({
     <div className="multi-filing-type-icon">
       {formattedCase.isSealed && (
         <Icon
-          aria-label={formattedCase.sealedToTooltip}
-          className="sealed-docket-entry"
+          aria-label="sealed"
+          className="sealed-case-entry"
           icon="lock"
           title={formattedCase.sealedToTooltip}
         />

--- a/web-client/src/views/Practitioners/PractitionerCaseIcons.tsx
+++ b/web-client/src/views/Practitioners/PractitionerCaseIcons.tsx
@@ -14,7 +14,7 @@ export function PractitionerCaseIcons({
           aria-label="sealed"
           className="sealed-case-entry"
           icon="lock"
-          title={formattedCase.sealedToTooltip}
+          title="sealed"
         />
       )}
       {formattedCase.inConsolidatedGroup && (


### PR DESCRIPTION
The sealed case icon hover text I was using was only valid for _docket entries_, not full cases. I have changed the code to mimic other places where _cases_ are sealed. I also added a comment to the code just to help other developers avoid the same mistake.