### PR TITLE
10518 Bug: Override problematic default Quill styles

### DIFF
--- a/web-client/src/styles/_index.scss
+++ b/web-client/src/styles/_index.scss
@@ -10,6 +10,7 @@
 @forward './print';
 @forward './progress';
 @forward './public';
+@forward './quill';
 @forward './tables';
 @forward './tabs';
 @forward './typography';

--- a/web-client/src/styles/custom.scss
+++ b/web-client/src/styles/custom.scss
@@ -1230,10 +1230,6 @@ hr.lighter {
   right: -7px;
 }
 
-.quill {
-  background: $color-white;
-}
-
 .sign-pdf-control {
   .icon-button {
     color: color($theme-color-primary);
@@ -1322,67 +1318,6 @@ hr.lighter {
       0 4px 8px 0 rgb(0 0 0 / 20%),
       0 6px 20px 0 rgb(0 0 0 / 19%);
   }
-}
-
-.ql-editor {
-  min-height: 640px;
-  max-height: 640px;
-  font-family: 'Times New Roman', Times, serif;
-  font-size: 16px;
-
-  p {
-    max-width: 100%;
-  }
-}
-
-.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='10px']::before,
-.ql-snow
-  .ql-picker.ql-size
-  .ql-picker-label.ql-active[data-value='10px']::before {
-  content: '10px';
-  font-size: 10px !important;
-}
-
-.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='12px']::before,
-.ql-snow
-  .ql-picker.ql-size
-  .ql-picker-label.ql-active[data-value='12px']::before {
-  content: '12px';
-  font-size: 12px !important;
-}
-
-/* default */
-.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='14px']::before,
-.ql-snow
-  .ql-picker.ql-size
-  .ql-picker-label.ql-active[data-value='14px']::before {
-  content: '14px';
-  font-size: 14px !important;
-}
-
-.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='16px']::before,
-.ql-snow
-  .ql-picker.ql-size
-  .ql-picker-label.ql-active[data-value='16px']::before,
-.ql-snow .ql-picker.ql-size .ql-picker-label:not(.ql-active)::before {
-  content: '16px';
-  font-size: 16px !important;
-}
-
-.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='18px']::before,
-.ql-snow
-  .ql-picker.ql-size
-  .ql-picker-label.ql-active[data-value='18px']::before {
-  content: '18px';
-  font-size: 18px !important;
-}
-
-.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='20px']::before,
-.ql-snow
-  .ql-picker.ql-size
-  .ql-picker-label.ql-active[data-value='20px']::before {
-  content: '20px';
-  font-size: 20px !important;
 }
 
 .usa-accordion__heading:not(:first-child) {

--- a/web-client/src/styles/quill.scss
+++ b/web-client/src/styles/quill.scss
@@ -1,0 +1,155 @@
+.ql-editor {
+  min-height: 640px;
+  max-height: 640px;
+  font-family: 'Times New Roman', Times, serif;
+  font-size: 16px;
+
+  p {
+    max-width: 100%;
+  }
+}
+
+.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='10px']::before,
+.ql-snow
+  .ql-picker.ql-size
+  .ql-picker-label.ql-active[data-value='10px']::before {
+  content: '10px';
+  font-size: 10px !important;
+}
+
+.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='12px']::before,
+.ql-snow
+  .ql-picker.ql-size
+  .ql-picker-label.ql-active[data-value='12px']::before {
+  content: '12px';
+  font-size: 12px !important;
+}
+
+/* default */
+.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='14px']::before,
+.ql-snow
+  .ql-picker.ql-size
+  .ql-picker-label.ql-active[data-value='14px']::before {
+  content: '14px';
+  font-size: 14px !important;
+}
+
+.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='16px']::before,
+.ql-snow
+  .ql-picker.ql-size
+  .ql-picker-label.ql-active[data-value='16px']::before,
+.ql-snow .ql-picker.ql-size .ql-picker-label:not(.ql-active)::before {
+  content: '16px';
+  font-size: 16px !important;
+}
+
+.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='18px']::before,
+.ql-snow
+  .ql-picker.ql-size
+  .ql-picker-label.ql-active[data-value='18px']::before {
+  content: '18px';
+  font-size: 18px !important;
+}
+
+.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='20px']::before,
+.ql-snow
+  .ql-picker.ql-size
+  .ql-picker-label.ql-active[data-value='20px']::before {
+  content: '20px';
+  font-size: 20px !important;
+}
+
+// Quill's default <ol> styling uses counters with names list-1, list-2, etc.
+// Unfortunately, these names conflict with CSS keywords and cause unexpected behavior.
+// Below, we have simply copied Quill's styling but overridden some names to avoid the issue.
+.ql-editor ol li {
+  counter-increment: ql-list-0 !important;
+  counter-reset: ql-list-1 ql-list-2 ql-list-3 ql-list-4 ql-list-5 ql-list-6
+    ql-list-7 ql-list-8 ql-list-9 !important;
+}
+
+.ql-editor ol li::before {
+  content: counter(ql-list-0, decimal) '. ' !important;
+}
+
+.ql-editor ol li.ql-indent-1 {
+  counter-increment: ql-list-1 !important;
+  counter-reset: ql-list-2 ql-list-3 ql-list-4 ql-list-5 ql-list-6 ql-list-7
+    ql-list-8 ql-list-9 !important;
+}
+
+.ql-editor ol li.ql-indent-1::before {
+  content: counter(ql-list-1, lower-alpha) '. ' !important;
+}
+
+.ql-editor ol li.ql-indent-2 {
+  counter-increment: ql-list-2 !important;
+  counter-reset: ql-list-3 ql-list-4 ql-list-5 ql-list-6 ql-list-7 ql-list-8
+    ql-list-9 !important;
+}
+
+.ql-editor ol li.ql-indent-2::before {
+  content: counter(ql-list-2, lower-roman) '. ' !important;
+}
+
+.ql-editor ol li.ql-indent-3 {
+  counter-increment: ql-list-3 !important;
+  counter-reset: ql-list-4 ql-list-5 ql-list-6 ql-list-7 ql-list-8 ql-list-9 !important;
+}
+
+.ql-editor ol li.ql-indent-3::before {
+  content: counter(ql-list-3, decimal) '. ' !important;
+}
+
+.ql-editor ol li.ql-indent-4 {
+  counter-increment: ql-list-4 !important;
+  counter-reset: ql-list-5 ql-list-6 ql-list-7 ql-list-8 ql-list-9 !important;
+}
+
+.ql-editor ol li.ql-indent-4::before {
+  content: counter(ql-list-4, lower-alpha) '. ' !important;
+}
+
+.ql-editor ol li.ql-indent-5 {
+  counter-increment: ql-list-5 !important;
+  counter-reset: ql-list-6 ql-list-7 ql-list-8 ql-list-9 !important;
+}
+
+.ql-editor ol li.ql-indent-5::before {
+  content: counter(ql-list-5, lower-roman) '. ' !important;
+}
+
+.ql-editor ol li.ql-indent-6 {
+  counter-increment: ql-list-6 !important;
+  counter-reset: ql-list-7 ql-list-8 ql-list-9 !important;
+}
+
+.ql-editor ol li.ql-indent-6::before {
+  content: counter(ql-list-6, decimal) '. ' !important;
+}
+
+.ql-editor ol li.ql-indent-7 {
+  counter-increment: ql-list-7 !important;
+  counter-reset: ql-list-8 ql-list-9 !important;
+}
+
+.ql-editor ol li.ql-indent-7::before {
+  content: counter(ql-list-7, lower-alpha) '. ' !important;
+}
+
+.ql-editor ol li.ql-indent-8 {
+  counter-increment: ql-list-8 !important;
+  counter-reset: ql-list-9 !important;
+}
+
+.ql-editor ol li.ql-indent-8::before {
+  content: counter(ql-list-8, lower-roman) '. ' !important;
+}
+
+.ql-editor ol li.ql-indent-9 {
+  counter-increment: ql-list-9 !important;
+}
+
+.ql-editor ol li.ql-indent-9::before {
+  content: counter(ql-list-9, decimal) '. ' !important;
+}

--- a/web-client/src/styles/quill.scss
+++ b/web-client/src/styles/quill.scss
@@ -1,3 +1,9 @@
+@use '../variables' as *;
+
+.quill {
+  background: $color-white;
+}
+
 .ql-editor {
   min-height: 640px;
   max-height: 640px;


### PR DESCRIPTION
`react-quill` uses CSS styles that cause issues. In this PR, we override these styles.

**Before (note the d):**
<img width="498" alt="Screenshot 2024-10-16 at 3 50 52 PM" src="https://github.com/user-attachments/assets/21482636-dbea-4171-8585-7a1487a2dab9">


**After:**
<img width="775" alt="Screenshot 2024-10-16 at 3 50 30 PM" src="https://github.com/user-attachments/assets/5cef23fd-b36d-4b0c-930d-a04b02ad0947">

----

### Notes:

The error is essentially the same as the one recorded [here](https://github.com/slab/quill/issues/3309).

This is a "minimal" fix for the bug. There are "better" ways to fix this, but they are more involved. (Example: use `Quill` directly, which does not have the same style issue as `react-quill`, which is no longer maintained.) This PR also does not address a related bug: saving an order with a nested list and then editing that order will cause the re-loaded list to be rendered incorrectly. Ultimately, this is because Quill uses its own data structure, the Quill Delta, and that--not the HTML--is what Quill needs to save/reload its state. All of our "save-and-edit-mismatch" bugs boil down to this misuse of Quill. However, since the court is moving towards a Word/Microsoft solution, we decided using Quill properly (or switching to a different editor without a separate data structure) was not worth the investment.