### PR TITLE
10412 Design Debt: Improving Messages Table

### DIFF
--- a/web-client/src/ustc-ui/Table/SortableColumn.tsx
+++ b/web-client/src/ustc-ui/Table/SortableColumn.tsx
@@ -62,27 +62,34 @@ export const SortableColumn = ({
       }}
     >
       <span
-        className={classNames('margin-right-105', {
+        className={classNames('margin-right-1', {
           sortActive: isActive,
         })}
       >
         {title}
       </span>
-      {isLoading && (
-        <FontAwesomeIcon
-          className="fa-spin spinner"
-          icon="sync"
-          size="sm"
-          title="sorting results"
-        />
-      )}
-      {!isLoading &&
-        getFontAwesomeIcon({
-          ascText,
-          descText,
-          direction: currentlySortedOrder,
-          isActiveColumn: isActive,
-        })}
+      <span className="text-no-wrap">
+        {/* We use a non-breaking space to force the icon to wrap with the text, not independently */}
+        &nbsp;
+        {/* We fix the icon width so that switching from double arrow to smaller single arrow icon does not affect line-breaking behavior */}
+        <span className="display-inline-block width-205">
+          {isLoading && (
+            <FontAwesomeIcon
+              className="fa-spin spinner"
+              icon="sync"
+              size="sm"
+              title="sorting results"
+            />
+          )}
+          {!isLoading &&
+            getFontAwesomeIcon({
+              ascText,
+              descText,
+              direction: currentlySortedOrder,
+              isActiveColumn: isActive,
+            })}
+        </span>
+      </span>
     </Button>
   );
 };

--- a/web-client/src/views/DocketRecord/DocketRecord.tsx
+++ b/web-client/src/views/DocketRecord/DocketRecord.tsx
@@ -55,7 +55,7 @@ export const DocketRecord = connect(
         <DocketRecordHeader />
 
         <NonPhone>
-          <div style={{ overflowX: 'scroll', width: '100%' }}>
+          <div className="width-full overflow-x-auto">
             <table
               aria-label="docket record"
               className="usa-table ustc-table usa-table--stacked"

--- a/web-client/src/views/Messages/MessagesIndividualCompleted.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualCompleted.tsx
@@ -21,135 +21,140 @@ export const MessagesIndividualCompleted = connect(
   }) {
     return (
       <>
-        <table className="usa-table ustc-table subsection">
-          <thead>
-            <tr>
-              <th aria-hidden="true" className="consolidated-case-column"></th>
-              <th aria-label="Docket Number" className="small" colSpan={2}>
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-docket-number-header-button"
-                  defaultSortOrder={constants.DESCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="docketNumber"
-                  title="Docket No."
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th className="medium">
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-completed-at-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="completedAt"
-                  title="Completed"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-subject-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="subject"
-                  title="Last Message"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-comment-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="completedMessage"
-                  title="Comment"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-case-title-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="caseTitle"
-                  title="Case Title"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-            </tr>
-          </thead>
-          {formattedMessages.completedMessages.map(message => {
-            return (
-              <tbody key={`message-individual-${message.messageId}`}>
-                <tr>
-                  <td className="consolidated-case-column">
-                    <ConsolidatedCaseIcon
-                      consolidatedIconTooltipText={
-                        message.consolidatedIconTooltipText
-                      }
-                      inConsolidatedGroup={message.inConsolidatedGroup}
-                      showLeadCaseIcon={message.isLeadCase}
-                    />
-                  </td>
-                  <td
-                    className="message-queue-row small"
-                    colSpan={2}
-                    data-testid="individual-message-completed-docket-number-cell"
-                  >
-                    {message.docketNumberWithSuffix}
-                  </td>
-                  <td
-                    className="message-queue-row small"
-                    data-testid="individual-message-completed-completed-at-cell"
-                  >
-                    <span className="no-wrap">
-                      {message.completedAtFormatted}
-                    </span>
-                  </td>
-                  <td className="message-queue-row">
-                    <div className="message-document-title">
-                      <Button
-                        link
-                        className="padding-0"
-                        data-testid="individual-message-completed-subject-cell"
-                        href={message.messageDetailLink}
-                      >
-                        {message.subject}
-                      </Button>
-                    </div>
-                    <div className="message-document-detail">
-                      {message.message}
-                    </div>
-                  </td>
-                  <td className="message-queue-row">
-                    {message.completedMessage}
-                  </td>
-                  <td className="message-queue-row">{message.caseTitle}</td>
-                </tr>
-              </tbody>
-            );
-          })}
-        </table>
-        {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+        <div className="overflow-x-auto">
+          <table className="usa-table ustc-table subsection">
+            <thead>
+              <tr>
+                <th
+                  aria-hidden="true"
+                  className="consolidated-case-column"
+                ></th>
+                <th aria-label="Docket Number" className="small" colSpan={2}>
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-docket-number-header-button"
+                    defaultSortOrder={constants.DESCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="docketNumber"
+                    title="Docket No."
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th className="medium">
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-completed-at-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="completedAt"
+                    title="Completed"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-subject-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="subject"
+                    title="Last Message"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-comment-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="completedMessage"
+                    title="Comment"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-case-title-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="caseTitle"
+                    title="Case Title"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+              </tr>
+            </thead>
+            {formattedMessages.completedMessages.map(message => {
+              return (
+                <tbody key={`message-individual-${message.messageId}`}>
+                  <tr>
+                    <td className="consolidated-case-column">
+                      <ConsolidatedCaseIcon
+                        consolidatedIconTooltipText={
+                          message.consolidatedIconTooltipText
+                        }
+                        inConsolidatedGroup={message.inConsolidatedGroup}
+                        showLeadCaseIcon={message.isLeadCase}
+                      />
+                    </td>
+                    <td
+                      className="message-queue-row small"
+                      colSpan={2}
+                      data-testid="individual-message-completed-docket-number-cell"
+                    >
+                      {message.docketNumberWithSuffix}
+                    </td>
+                    <td
+                      className="message-queue-row small"
+                      data-testid="individual-message-completed-completed-at-cell"
+                    >
+                      <span className="no-wrap">
+                        {message.completedAtFormatted}
+                      </span>
+                    </td>
+                    <td className="message-queue-row">
+                      <div className="message-document-title">
+                        <Button
+                          link
+                          className="padding-0"
+                          data-testid="individual-message-completed-subject-cell"
+                          href={message.messageDetailLink}
+                        >
+                          {message.subject}
+                        </Button>
+                      </div>
+                      <div className="message-document-detail">
+                        {message.message}
+                      </div>
+                    </td>
+                    <td className="message-queue-row">
+                      {message.completedMessage}
+                    </td>
+                    <td className="message-queue-row">{message.caseTitle}</td>
+                  </tr>
+                </tbody>
+              );
+            })}
+          </table>
+          {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+        </div>
       </>
     );
   },

--- a/web-client/src/views/Messages/MessagesIndividualInbox.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualInbox.tsx
@@ -65,268 +65,273 @@ export const MessagesIndividualInbox = connect(
             </div>
           </div>
         )}
-        <div className="grid-row grid-gap">
-          <div className="desktop:grid-col-8 tablet:grid-col-12 display-flex flex-align-center">
-            <TableFilters
-              filters={[
-                {
-                  isSelected: screenMetadata.caseStatus,
-                  key: 'caseStatus',
-                  label: 'Case Status',
-                  options: formattedMessages.caseStatuses,
-                },
-                {
-                  isSelected: screenMetadata.fromUser,
-                  key: 'fromUser',
-                  label: 'From',
-                  options: formattedMessages.fromUsers,
-                },
-                {
-                  isSelected: screenMetadata.fromSection,
-                  key: 'fromSection',
-                  label: 'Section',
-                  options: formattedMessages.fromSections,
-                },
-              ]}
-              onSelect={updateMessageFilterSequence}
-            ></TableFilters>
+        <div className="overflow-x-auto">
+          <div className="grid-row grid-gap">
+            <div className="desktop:grid-col-8 tablet:grid-col-12 display-flex flex-align-center">
+              <TableFilters
+                filters={[
+                  {
+                    isSelected: screenMetadata.caseStatus,
+                    key: 'caseStatus',
+                    label: 'Case Status',
+                    options: formattedMessages.caseStatuses,
+                  },
+                  {
+                    isSelected: screenMetadata.fromUser,
+                    key: 'fromUser',
+                    label: 'From',
+                    options: formattedMessages.fromUsers,
+                  },
+                  {
+                    isSelected: screenMetadata.fromSection,
+                    key: 'fromSection',
+                    label: 'Section',
+                    options: formattedMessages.fromSections,
+                  },
+                ]}
+                onSelect={updateMessageFilterSequence}
+              ></TableFilters>
+            </div>
+
+            <div className="desktop:grid-col-4 tablet:grid-col-12 tablet:margin-top-2 text-right">
+              <Button
+                link
+                className="action-button"
+                data-testid="message-batch-mark-as-complete"
+                disabled={
+                  !messagesIndividualInboxHelper.isCompletionButtonEnabled
+                }
+                icon="check-circle"
+                id="button-batch-complete"
+                onClick={() => {
+                  batchCompleteMessageSequence();
+                }}
+              >
+                Complete
+              </Button>
+            </div>
           </div>
 
-          <div className="desktop:grid-col-4 tablet:grid-col-12 tablet:margin-top-2 text-right">
-            <Button
-              link
-              className="action-button"
-              data-testid="message-batch-mark-as-complete"
-              disabled={
-                !messagesIndividualInboxHelper.isCompletionButtonEnabled
-              }
-              icon="check-circle"
-              id="button-batch-complete"
-              onClick={() => {
-                batchCompleteMessageSequence();
-              }}
-            >
-              Complete
-            </Button>
-          </div>
-        </div>
-
-        <table className="usa-table ustc-table subsection">
-          <thead>
-            <tr>
-              <th>
-                <input
-                  aria-label="all-messages-checkbox"
-                  checked={messagesIndividualInboxHelper.allMessagesSelected}
-                  data-testid="all-messages-checkbox"
-                  disabled={
-                    !messagesIndividualInboxHelper.allMessagesCheckboxEnabled
-                  }
-                  id="all-messages-checkbox"
-                  ref={selectAllCheckboxRef}
-                  type="checkbox"
-                  onChange={() => {
-                    const selectAll = formattedMessages.messages.map(
-                      message => ({
-                        messageId: message.messageId,
-                        parentMessageId: message.parentMessageId,
-                      }),
-                    );
-                    setSelectedMessagesSequence({ messages: selectAll });
-                  }}
-                />
-              </th>
-              <th aria-hidden="true" className="consolidated-case-column"></th>
-              <th aria-label="Docket Number" className="small" colSpan={2}>
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-docket-number-header-button"
-                  defaultSortOrder={constants.DESCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="docketNumber"
-                  title="Docket No."
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-received-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="createdAt"
-                  title="Received"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th className="message-unread-column"></th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-subject-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="subject"
-                  title="Message"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-case-title-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="caseTitle"
-                  title="Case Title"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-case-status-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="caseStatus"
-                  title="Case Status"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-from-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="from"
-                  title="From"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th className="small">
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-section-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="fromSectionFormatted"
-                  title="Section"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-            </tr>
-          </thead>
-          {formattedMessages.messages.map(message => {
-            return (
-              <tbody key={message.messageId}>
-                <tr key={message.messageId}>
-                  <td>
-                    <input
-                      aria-label={`${message.caseTitle}-${message.subject}-checkbox`}
-                      checked={message.isSelected}
-                      id={`${message.caseTitle}-message-checkbox`}
-                      type="checkbox"
-                      onChange={() => {
-                        setSelectedMessagesSequence({
-                          messages: [
-                            {
-                              messageId: message.messageId,
-                              parentMessageId: message.parentMessageId,
-                            },
-                          ],
-                        });
-                      }}
-                    />
-                  </td>
-                  <td className="consolidated-case-column">
-                    <ConsolidatedCaseIcon
-                      consolidatedIconTooltipText={
-                        message.consolidatedIconTooltipText
-                      }
-                      inConsolidatedGroup={message.inConsolidatedGroup}
-                      showLeadCaseIcon={message.isLeadCase}
-                    />
-                  </td>
-                  <td
-                    className="message-queue-row small"
-                    colSpan={2}
-                    data-testid="individual-message-inbox-docket-number-cell"
-                  >
-                    {message.docketNumberWithSuffix}
-                  </td>
-                  <td
-                    className="message-queue-row small"
-                    data-testid="individual-message-inbox-received-at-cell"
-                  >
-                    <span className="no-wrap">
-                      {message.createdAtFormatted}
-                    </span>
-                  </td>
-                  <td className="message-unread-column">
-                    {!message.isRead && (
-                      <Icon
-                        aria-label="unread message"
-                        className="fa-icon-blue"
-                        icon="envelope"
-                        size="1x"
+          <table className="usa-table ustc-table subsection">
+            <thead>
+              <tr>
+                <th>
+                  <input
+                    aria-label="all-messages-checkbox"
+                    checked={messagesIndividualInboxHelper.allMessagesSelected}
+                    data-testid="all-messages-checkbox"
+                    disabled={
+                      !messagesIndividualInboxHelper.allMessagesCheckboxEnabled
+                    }
+                    id="all-messages-checkbox"
+                    ref={selectAllCheckboxRef}
+                    type="checkbox"
+                    onChange={() => {
+                      const selectAll = formattedMessages.messages.map(
+                        message => ({
+                          messageId: message.messageId,
+                          parentMessageId: message.parentMessageId,
+                        }),
+                      );
+                      setSelectedMessagesSequence({ messages: selectAll });
+                    }}
+                  />
+                </th>
+                <th
+                  aria-hidden="true"
+                  className="consolidated-case-column"
+                ></th>
+                <th aria-label="Docket Number" colSpan={2}>
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-docket-number-header-button"
+                    defaultSortOrder={constants.DESCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="docketNumber"
+                    title="Docket No."
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-received-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="createdAt"
+                    title="Received"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th className="message-unread-column"></th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-subject-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="subject"
+                    title="Message"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-case-title-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="caseTitle"
+                    title="Case Title"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-case-status-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="caseStatus"
+                    title="Case Status"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-from-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="from"
+                    title="From"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-section-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="fromSectionFormatted"
+                    title="Section"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+              </tr>
+            </thead>
+            {formattedMessages.messages.map(message => {
+              return (
+                <tbody key={message.messageId}>
+                  <tr key={message.messageId}>
+                    <td>
+                      <input
+                        aria-label={`${message.caseTitle}-${message.subject}-checkbox`}
+                        checked={message.isSelected}
+                        id={`${message.caseTitle}-message-checkbox`}
+                        type="checkbox"
+                        onChange={() => {
+                          setSelectedMessagesSequence({
+                            messages: [
+                              {
+                                messageId: message.messageId,
+                                parentMessageId: message.parentMessageId,
+                              },
+                            ],
+                          });
+                        }}
                       />
-                    )}
-                  </td>
-                  <td className="message-queue-row message-subject">
-                    <div className="message-document-title">
-                      <Button
-                        link
-                        className={classNames(
-                          'padding-0',
-                          message.isRead ? '' : 'text-bold',
-                        )}
-                        data-testid="individual-message-inbox-subject-cell"
-                        href={message.messageDetailLink}
-                      >
-                        {message.subject}
-                      </Button>
-                    </div>
+                    </td>
+                    <td className="consolidated-case-column">
+                      <ConsolidatedCaseIcon
+                        consolidatedIconTooltipText={
+                          message.consolidatedIconTooltipText
+                        }
+                        inConsolidatedGroup={message.inConsolidatedGroup}
+                        showLeadCaseIcon={message.isLeadCase}
+                      />
+                    </td>
+                    <td
+                      className="message-queue-row"
+                      colSpan={2}
+                      data-testid="individual-message-inbox-docket-number-cell"
+                    >
+                      {message.docketNumberWithSuffix}
+                    </td>
+                    <td
+                      className="message-queue-row"
+                      data-testid="individual-message-inbox-received-at-cell"
+                    >
+                      <span className="no-wrap">
+                        {message.createdAtFormatted}
+                      </span>
+                    </td>
+                    <td className="message-unread-column">
+                      {!message.isRead && (
+                        <Icon
+                          aria-label="unread message"
+                          className="fa-icon-blue"
+                          icon="envelope"
+                          size="1x"
+                        />
+                      )}
+                    </td>
+                    <td className="message-queue-row message-subject">
+                      <div className="message-document-title">
+                        <Button
+                          link
+                          className={classNames(
+                            'padding-0',
+                            message.isRead ? '' : 'text-bold',
+                          )}
+                          data-testid="individual-message-inbox-subject-cell"
+                          href={message.messageDetailLink}
+                        >
+                          {message.subject}
+                        </Button>
+                      </div>
 
-                    <div className="message-document-detail">
-                      {message.message}
-                    </div>
-                  </td>
-                  <td className="message-queue-row max-width-25">
-                    {message.caseTitle}
-                  </td>
-                  <td className="message-queue-row">{message.caseStatus}</td>
-                  <td className="message-queue-row from">{message.from}</td>
-                  <td className="message-queue-row small">
-                    {message.fromSectionFormatted}
-                  </td>
-                </tr>
-              </tbody>
-            );
-          })}
-        </table>
-        {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+                      <div className="message-document-detail">
+                        {message.message}
+                      </div>
+                    </td>
+                    <td className="message-queue-row max-width-25">
+                      {message.caseTitle}
+                    </td>
+                    <td className="message-queue-row">{message.caseStatus}</td>
+                    <td className="message-queue-row from">{message.from}</td>
+                    <td className="message-queue-row">
+                      {message.fromSectionFormatted}
+                    </td>
+                  </tr>
+                </tbody>
+              );
+            })}
+          </table>
+          {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+        </div>
       </>
     );
   },

--- a/web-client/src/views/Messages/MessagesIndividualOutbox.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualOutbox.tsx
@@ -26,194 +26,197 @@ export const MessagesIndividualOutbox = connect(
   }) {
     return (
       <>
-        <TableFilters
-          filters={[
-            {
-              isSelected: screenMetadata.caseStatus,
-              key: 'caseStatus',
-              label: 'Case Status',
-              options: formattedMessages.caseStatuses,
-            },
-            {
-              isSelected: screenMetadata.toUser,
-              key: 'toUser',
-              label: 'To',
-              options: formattedMessages.toUsers,
-            },
-            {
-              isSelected: screenMetadata.toSection,
-              key: 'toSection',
-              label: 'Section',
-              options: formattedMessages.toSections,
-            },
-          ]}
-          onSelect={updateScreenMetadataSequence}
-        ></TableFilters>
+        <div className="overflow-x-auto">
+          <TableFilters
+            filters={[
+              {
+                isSelected: screenMetadata.caseStatus,
+                key: 'caseStatus',
+                label: 'Case Status',
+                options: formattedMessages.caseStatuses,
+              },
+              {
+                isSelected: screenMetadata.toUser,
+                key: 'toUser',
+                label: 'To',
+                options: formattedMessages.toUsers,
+              },
+              {
+                isSelected: screenMetadata.toSection,
+                key: 'toSection',
+                label: 'Section',
+                options: formattedMessages.toSections,
+              },
+            ]}
+            onSelect={updateScreenMetadataSequence}
+          ></TableFilters>
 
-        <table className="usa-table ustc-table subsection">
-          <thead>
-            <tr>
-              <th aria-hidden="true" className="consolidated-case-column"></th>
-              <th aria-label="Docket Number" className="small" colSpan={2}>
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-outbox-docket-number-header-button"
-                  defaultSortOrder={constants.DESCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="docketNumber"
-                  title="Docket No."
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th className="small">
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-outbox-completed-at-header-button"
-                  defaultSortOrder={constants.DESCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="createdAt"
-                  title="Sent"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-outbox-subject-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="subject"
-                  title="Message"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-case-title-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="caseTitle"
-                  title="Case Title"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-case-status-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="caseStatus"
-                  title="Case Status"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-to-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="to"
-                  title="To"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th className="small">
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-section-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="toSection"
-                  title="Section"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-            </tr>
-          </thead>
-          {formattedMessages.messages.map(message => {
-            return (
-              <tbody key={`message-${message.messageId}`}>
-                <tr>
-                  <td className="consolidated-case-column">
-                    <ConsolidatedCaseIcon
-                      consolidatedIconTooltipText={
-                        message.consolidatedIconTooltipText
-                      }
-                      inConsolidatedGroup={message.inConsolidatedGroup}
-                      showLeadCaseIcon={message.isLeadCase}
-                    />
-                  </td>
-                  <td
-                    className="message-queue-row small"
-                    colSpan={2}
-                    data-testid="individual-message-outbox-docket-number-cell"
-                  >
-                    {message.docketNumberWithSuffix}
-                  </td>
-                  <td
-                    className="message-queue-row small"
-                    data-testid="individual-message-outbox-completed-at-cell"
-                  >
-                    <span className="no-wrap">
-                      {message.createdAtFormatted}
-                    </span>
-                  </td>
-                  <td
-                    className="message-queue-row message-subject"
-                    data-testid="individual-message-outbox-subject-cell"
-                  >
-                    <div className="message-document-title">
-                      <Button
-                        link
-                        className="padding-0"
-                        href={message.messageDetailLink}
-                      >
-                        {message.subject}
-                      </Button>
-                    </div>
+          <table className="usa-table ustc-table subsection">
+            <thead>
+              <tr>
+                <th
+                  aria-hidden="true"
+                  className="consolidated-case-column"
+                ></th>
+                <th aria-label="Docket Number" colSpan={2}>
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-outbox-docket-number-header-button"
+                    defaultSortOrder={constants.DESCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="docketNumber"
+                    title="Docket No."
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-outbox-completed-at-header-button"
+                    defaultSortOrder={constants.DESCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="createdAt"
+                    title="Sent"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-outbox-subject-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="subject"
+                    title="Message"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-case-title-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="caseTitle"
+                    title="Case Title"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-case-status-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="caseStatus"
+                    title="Case Status"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-to-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="to"
+                    title="To"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-section-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="toSection"
+                    title="Section"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+              </tr>
+            </thead>
+            {formattedMessages.messages.map(message => {
+              return (
+                <tbody key={`message-${message.messageId}`}>
+                  <tr>
+                    <td className="consolidated-case-column">
+                      <ConsolidatedCaseIcon
+                        consolidatedIconTooltipText={
+                          message.consolidatedIconTooltipText
+                        }
+                        inConsolidatedGroup={message.inConsolidatedGroup}
+                        showLeadCaseIcon={message.isLeadCase}
+                      />
+                    </td>
+                    <td
+                      className="message-queue-row"
+                      colSpan={2}
+                      data-testid="individual-message-outbox-docket-number-cell"
+                    >
+                      {message.docketNumberWithSuffix}
+                    </td>
+                    <td
+                      className="message-queue-row"
+                      data-testid="individual-message-outbox-completed-at-cell"
+                    >
+                      <span className="no-wrap">
+                        {message.createdAtFormatted}
+                      </span>
+                    </td>
+                    <td
+                      className="message-queue-row message-subject"
+                      data-testid="individual-message-outbox-subject-cell"
+                    >
+                      <div className="message-document-title">
+                        <Button
+                          link
+                          className="padding-0"
+                          href={message.messageDetailLink}
+                        >
+                          {message.subject}
+                        </Button>
+                      </div>
 
-                    <div className="message-document-detail">
-                      {message.message}
-                    </div>
-                  </td>
-                  <td className="message-queue-row max-width-25">
-                    {message.caseTitle}
-                  </td>
-                  <td className="message-queue-row">{message.caseStatus}</td>
-                  <td className="message-queue-row to">{message.to}</td>
-                  <td className="message-queue-row small">
-                    {message.toSection}
-                  </td>
-                </tr>
-              </tbody>
-            );
-          })}
-        </table>
-        {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+                      <div className="message-document-detail">
+                        {message.message}
+                      </div>
+                    </td>
+                    <td className="message-queue-row max-width-25">
+                      {message.caseTitle}
+                    </td>
+                    <td className="message-queue-row">{message.caseStatus}</td>
+                    <td className="message-queue-row to">{message.to}</td>
+                    <td className="message-queue-row">{message.toSection}</td>
+                  </tr>
+                </tbody>
+              );
+            })}
+          </table>
+          {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+        </div>
       </>
     );
   },

--- a/web-client/src/views/Messages/MessagesSectionCompleted.tsx
+++ b/web-client/src/views/Messages/MessagesSectionCompleted.tsx
@@ -26,114 +26,119 @@ export const MessagesSectionCompleted = connect(
   }) {
     return (
       <>
-        <TableFilters
-          filters={[
-            {
-              isSelected: screenMetadata.completedBy,
-              key: 'completedBy',
-              label: 'Completed By',
-              options: formattedMessages.completedByUsers,
-              useInlineSelect: false,
-            },
-          ]}
-          onSelect={updateScreenMetadataSequence}
-        ></TableFilters>
+        <div className="overflow-x-auto">
+          <TableFilters
+            filters={[
+              {
+                isSelected: screenMetadata.completedBy,
+                key: 'completedBy',
+                label: 'Completed By',
+                options: formattedMessages.completedByUsers,
+                useInlineSelect: false,
+              },
+            ]}
+            onSelect={updateScreenMetadataSequence}
+          ></TableFilters>
 
-        <table className="usa-table ustc-table subsection">
-          <thead>
-            <tr>
-              <th aria-hidden="true" className="consolidated-case-column"></th>
-              <th aria-label="Docket Number" className="small" colSpan={2}>
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-docket-number-header-button"
-                  defaultSortOrder={constants.DESCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="docketNumber"
-                  title="Docket No."
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th className="medium">
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-completed-at-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="completedAt"
-                  title="Completed"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-subject-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="subject"
-                  title="Last Message"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-comment-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="completedMessage"
-                  title="Comment"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-completed-by-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="completedBy"
-                  title="Completed By"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-completed-by-section-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="completedBySection"
-                  title="Section"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-            </tr>
-          </thead>
-          {formattedMessages.completedMessages.map(message => (
-            <CompletedMessageRow key={message.messageId} message={message} />
-          ))}
-        </table>
-        {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+          <table className="usa-table ustc-table subsection">
+            <thead>
+              <tr>
+                <th
+                  aria-hidden="true"
+                  className="consolidated-case-column"
+                ></th>
+                <th aria-label="Docket Number" colSpan={2}>
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-docket-number-header-button"
+                    defaultSortOrder={constants.DESCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="docketNumber"
+                    title="Docket No."
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th className="medium">
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-completed-at-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="completedAt"
+                    title="Completed"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-subject-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="subject"
+                    title="Last Message"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-comment-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="completedMessage"
+                    title="Comment"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-completed-by-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="completedBy"
+                    title="Completed By"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-completed-by-section-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="completedBySection"
+                    title="Section"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+              </tr>
+            </thead>
+            {formattedMessages.completedMessages.map(message => (
+              <CompletedMessageRow key={message.messageId} message={message} />
+            ))}
+          </table>
+          {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+        </div>
       </>
     );
   },
@@ -155,14 +160,14 @@ const CompletedMessageRow = React.memo(function CompletedMessageRow({
           />
         </td>
         <td
-          className="message-queue-row small"
+          className="message-queue-row"
           colSpan={2}
           data-testid="section-message-completed-docket-number-cell"
         >
           {message.docketNumberWithSuffix}
         </td>
         <td
-          className="message-queue-row small"
+          className="message-queue-row"
           data-testid="section-message-completed-completed-at-cell"
         >
           <span className="no-wrap">{message.completedAtFormatted}</span>

--- a/web-client/src/views/Messages/MessagesSectionInbox.tsx
+++ b/web-client/src/views/Messages/MessagesSectionInbox.tsx
@@ -26,159 +26,164 @@ export const MessagesSectionInbox = connect(
   }) {
     return (
       <>
-        <TableFilters
-          filters={[
-            {
-              isSelected: screenMetadata.caseStatus,
-              key: 'caseStatus',
-              label: 'Case Status',
-              options: formattedMessages.caseStatuses,
-            },
-            {
-              isSelected: screenMetadata.toUser,
-              key: 'toUser',
-              label: 'To',
-              options: formattedMessages.toUsers,
-            },
-            {
-              isSelected: screenMetadata.fromUser,
-              key: 'fromUser',
-              label: 'From',
-              options: formattedMessages.fromUsers,
-            },
-            {
-              isSelected: screenMetadata.fromSection,
-              key: 'fromSection',
-              label: 'Section',
-              options: formattedMessages.fromSections,
-            },
-          ]}
-          onSelect={updateScreenMetadataSequence}
-        ></TableFilters>
+        <div className="overflow-x-auto">
+          <TableFilters
+            filters={[
+              {
+                isSelected: screenMetadata.caseStatus,
+                key: 'caseStatus',
+                label: 'Case Status',
+                options: formattedMessages.caseStatuses,
+              },
+              {
+                isSelected: screenMetadata.toUser,
+                key: 'toUser',
+                label: 'To',
+                options: formattedMessages.toUsers,
+              },
+              {
+                isSelected: screenMetadata.fromUser,
+                key: 'fromUser',
+                label: 'From',
+                options: formattedMessages.fromUsers,
+              },
+              {
+                isSelected: screenMetadata.fromSection,
+                key: 'fromSection',
+                label: 'Section',
+                options: formattedMessages.fromSections,
+              },
+            ]}
+            onSelect={updateScreenMetadataSequence}
+          ></TableFilters>
 
-        <table className="usa-table ustc-table subsection">
-          <thead>
-            <tr>
-              <th aria-hidden="true" className="consolidated-case-column"></th>
-              <th aria-label="Docket Number" className="small" colSpan={2}>
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-docket-number-header-button"
-                  defaultSortOrder={constants.DESCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="docketNumber"
-                  title="Docket No."
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th className="medium">
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-received-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="createdAt"
-                  title="Received"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-subject-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="subject"
-                  title="Message"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-case-title-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="caseTitle"
-                  title="Case Title"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-case-status-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="caseStatus"
-                  title="Case Status"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-to-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="to"
-                  title="To"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-from-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="from"
-                  title="From"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th className="small">
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-from-section-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="fromSectionFormatted"
-                  title="Section"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-            </tr>
-          </thead>
-          {formattedMessages.messages.map(message => (
-            <MessageInboxRow key={message.messageId} message={message} />
-          ))}
-        </table>
-        {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+          <table className="usa-table ustc-table subsection">
+            <thead>
+              <tr>
+                <th
+                  aria-hidden="true"
+                  className="consolidated-case-column"
+                ></th>
+                <th aria-label="Docket Number" colSpan={2}>
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-docket-number-header-button"
+                    defaultSortOrder={constants.DESCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="docketNumber"
+                    title="Docket No."
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th className="medium">
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-received-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="createdAt"
+                    title="Received"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-subject-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="subject"
+                    title="Message"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-case-title-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="caseTitle"
+                    title="Case Title"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-case-status-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="caseStatus"
+                    title="Case Status"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-to-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="to"
+                    title="To"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-from-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="from"
+                    title="From"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-from-section-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="fromSectionFormatted"
+                    title="Section"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+              </tr>
+            </thead>
+            {formattedMessages.messages.map(message => (
+              <MessageInboxRow key={message.messageId} message={message} />
+            ))}
+          </table>
+          {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+        </div>
       </>
     );
   },
@@ -198,14 +203,14 @@ const MessageInboxRow = React.memo(function MessageInboxRow({ message }) {
           />
         </td>
         <td
-          className="message-queue-row small"
+          className="message-queue-row"
           colSpan={2}
           data-testid="section-message-inbox-docket-number-cell"
         >
           {message.docketNumberWithSuffix}
         </td>
         <td
-          className="message-queue-row small"
+          className="message-queue-row"
           data-testid="section-message-inbox-received-at-cell"
         >
           <span className="no-wrap">{message.createdAtFormatted}</span>
@@ -228,9 +233,7 @@ const MessageInboxRow = React.memo(function MessageInboxRow({ message }) {
         <td className="message-queue-row">{message.caseStatus}</td>
         <td className="message-queue-row to">{message.to}</td>
         <td className="message-queue-row from">{message.from}</td>
-        <td className="message-queue-row small">
-          {message.fromSectionFormatted}
-        </td>
+        <td className="message-queue-row">{message.fromSectionFormatted}</td>
       </tr>
     </tbody>
   );

--- a/web-client/src/views/Messages/MessagesSectionOutbox.tsx
+++ b/web-client/src/views/Messages/MessagesSectionOutbox.tsx
@@ -26,159 +26,164 @@ export const MessagesSectionOutbox = connect(
   }) {
     return (
       <>
-        <TableFilters
-          filters={[
-            {
-              isSelected: screenMetadata.caseStatus,
-              key: 'caseStatus',
-              label: 'Case Status',
-              options: formattedMessages.caseStatuses,
-            },
-            {
-              isSelected: screenMetadata.toUser,
-              key: 'toUser',
-              label: 'To',
-              options: formattedMessages.toUsers,
-            },
-            {
-              isSelected: screenMetadata.fromUser,
-              key: 'fromUser',
-              label: 'From',
-              options: formattedMessages.fromUsers,
-            },
-            {
-              isSelected: screenMetadata.toSection,
-              key: 'toSection',
-              label: 'Section',
-              options: formattedMessages.toSections,
-            },
-          ]}
-          onSelect={updateScreenMetadataSequence}
-        ></TableFilters>
+        <div className="overflow-x-auto">
+          <TableFilters
+            filters={[
+              {
+                isSelected: screenMetadata.caseStatus,
+                key: 'caseStatus',
+                label: 'Case Status',
+                options: formattedMessages.caseStatuses,
+              },
+              {
+                isSelected: screenMetadata.toUser,
+                key: 'toUser',
+                label: 'To',
+                options: formattedMessages.toUsers,
+              },
+              {
+                isSelected: screenMetadata.fromUser,
+                key: 'fromUser',
+                label: 'From',
+                options: formattedMessages.fromUsers,
+              },
+              {
+                isSelected: screenMetadata.toSection,
+                key: 'toSection',
+                label: 'Section',
+                options: formattedMessages.toSections,
+              },
+            ]}
+            onSelect={updateScreenMetadataSequence}
+          ></TableFilters>
 
-        <table className="usa-table ustc-table subsection">
-          <thead>
-            <tr>
-              <th aria-hidden="true" className="consolidated-case-column"></th>
-              <th aria-label="Docket Number" className="small" colSpan={2}>
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-outbox-docket-number-header-button"
-                  defaultSortOrder={constants.DESCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="docketNumber"
-                  title="Docket No."
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th className="small">
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-outbox-created-at-header-button"
-                  defaultSortOrder={constants.DESCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="createdAt"
-                  title="Sent"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-outbox-subject-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="subject"
-                  title="Message"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-case-title-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="caseTitle"
-                  title="Case Title"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-case-status-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="caseStatus"
-                  title="Case Status"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-to-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="to"
-                  title="To"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-from-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="from"
-                  title="From"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-to-section-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="toSection"
-                  title="Section"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-            </tr>
-          </thead>
-          {formattedMessages.messages.map(message => (
-            <MessageOutboxRow key={message.messageId} message={message} />
-          ))}
-        </table>
-        {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+          <table className="usa-table ustc-table subsection">
+            <thead>
+              <tr>
+                <th
+                  aria-hidden="true"
+                  className="consolidated-case-column"
+                ></th>
+                <th aria-label="Docket Number" colSpan={2}>
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-outbox-docket-number-header-button"
+                    defaultSortOrder={constants.DESCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="docketNumber"
+                    title="Docket No."
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-outbox-created-at-header-button"
+                    defaultSortOrder={constants.DESCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="createdAt"
+                    title="Sent"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-outbox-subject-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="subject"
+                    title="Message"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-case-title-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="caseTitle"
+                    title="Case Title"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-case-status-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="caseStatus"
+                    title="Case Status"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-to-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="to"
+                    title="To"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-from-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="from"
+                    title="From"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-to-section-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="toSection"
+                    title="Section"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+              </tr>
+            </thead>
+            {formattedMessages.messages.map(message => (
+              <MessageOutboxRow key={message.messageId} message={message} />
+            ))}
+          </table>
+          {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+        </div>
       </>
     );
   },
@@ -198,14 +203,14 @@ const MessageOutboxRow = React.memo(function MessageOutboxRow({ message }) {
           />
         </td>
         <td
-          className="message-queue-row small"
+          className="message-queue-row"
           colSpan={2}
           data-testid="section-message-outbox-docket-number-cell"
         >
           {message.docketNumberWithSuffix}
         </td>
         <td
-          className="message-queue-row small"
+          className="message-queue-row"
           data-testid="section-message-outbox-created-at-cell"
         >
           <span className="no-wrap">{message.createdAtFormatted}</span>
@@ -228,7 +233,7 @@ const MessageOutboxRow = React.memo(function MessageOutboxRow({ message }) {
         <td className="message-queue-row">{message.caseStatus}</td>
         <td className="message-queue-row to">{message.to}</td>
         <td className="message-queue-row from">{message.from}</td>
-        <td className="message-queue-row small">{message.toSection}</td>
+        <td className="message-queue-row">{message.toSection}</td>
       </tr>
     </tbody>
   );

--- a/web-client/src/views/Public/PublicDocketRecord.tsx
+++ b/web-client/src/views/Public/PublicDocketRecord.tsx
@@ -20,7 +20,7 @@ export const PublicDocketRecord = connect(
         <PublicDocketRecordHeader />
 
         <NonPhone>
-          <div style={{ overflowX: 'scroll', width: '100%' }}>
+          <div className="width-full overflow-x-auto">
             <table
               aria-label="docket record"
               className="usa-table ustc-table usa-table--stacked"


### PR DESCRIPTION
The diff is not nearly so heavy as it looks. It comes from wrapping multiple tsx components in a div so that they can be horizontally scrollable.

I do not like that there are six very similar message table components (the Cartesian product of individual or section and inbox, outbox, or completed). I think there should one with some config passed in. I am going to try refactoring this but will stop if it isn't straightforward.