### PR TITLE
10412 Design Debt: Message Table Updates

### DIFF
--- a/cypress/deployed-and-local/integration/documentQC/complete-docket-qc.cy.ts
+++ b/cypress/deployed-and-local/integration/documentQC/complete-docket-qc.cy.ts
@@ -212,7 +212,7 @@ function assertMessageRecordCountForDocketNumberAndSubject(
   count: number,
   inboxType: string,
 ) {
-  cy.get(`[data-testid="${inboxType}-message-inbox-docket-number-cell"]`).then(
+  cy.get(`[data-testid="messages-${inboxType}-inbox-docketNumber-cell"]`).then(
     $elements => {
       const parentElements = $elements.map((index, element) =>
         Cypress.$(element).parent(),
@@ -238,7 +238,7 @@ function assertMessageRecordCountForDocketNumberAndSubjectEscapeHatch(
 ) {
   return cy.get('body').then(body => {
     const $elements = body.find(
-      `[data-testid="${inboxType}-message-inbox-docket-number-cell"]`,
+      `[data-testid="messages-${inboxType}-inbox-docketNumber-cell"]`,
     );
 
     const parentElements = $elements.map((index, element) =>

--- a/cypress/local-only/tests/integration/messages/messages.cy.ts
+++ b/cypress/local-only/tests/integration/messages/messages.cy.ts
@@ -80,7 +80,7 @@ describe('Messages', () => {
       createAndServePaperPetition().then(({ docketNumber }) => {
         cy.wrap(docketNumber).as('DOCKET_NUMBER');
         goToCase(docketNumber);
-        sendMessagesToCompletedTab(DOCKET_CLERK_ID, docketNumber);
+        sendMessagesToCompletedTab(DOCKET_CLERK_ID);
         loginAsPetitionsClerk();
         goToCase(docketNumber);
         sendMessages(DOCKET_CLERK_ID);
@@ -92,79 +92,18 @@ describe('Messages', () => {
     });
 
     describe('Individual Message Boxes', () => {
-      describe('Sorting on the Individual Message Inbox', () => {
-        it('individual inbox subject column', () => {
-          loginAsDocketClerk();
-          cy.get(
-            '[data-testid="message-individual-subject-header-button"]',
-          ).click();
-          verifySubjectTitleOrder({
-            boxType: 'inbox',
-            isAscending: true,
-            prefix: 'Subject Line',
-            queueType: 'individual',
-          });
-          cy.get(
-            '[data-testid="message-individual-subject-header-button"]',
-          ).click();
-          verifySubjectTitleOrder({
-            boxType: 'inbox',
-            isAscending: false,
-            prefix: 'Subject Line',
-            queueType: 'individual',
-          });
-        });
+      before(() => {
+        loginAsDocketClerk();
+      });
 
-        it('individual inbox received at column when defaulted to sort ascending', () => {
-          loginAsDocketClerk();
-          cy.get(
-            '[data-testid="message-individual-received-header-button"]',
-          ).click();
-          verifySubjectTitleOrder({
-            boxType: 'inbox',
-            isAscending: false,
-            prefix: 'Subject Line',
-            queueType: 'individual',
-          });
-          cy.get(
-            '[data-testid="message-individual-received-header-button"]',
-          ).click();
-          verifySubjectTitleOrder({
-            boxType: 'inbox',
-            isAscending: true,
-            prefix: 'Subject Line',
-            queueType: 'individual',
-          });
-        });
-
-        it('individual inbox docket number column', () => {
-          loginAsDocketClerk();
-          cy.get(
-            '[data-testid="message-individual-docket-number-header-button"]',
-          ).click();
-          verifySubjectTitleOrder({
-            boxType: 'inbox',
-            isAscending: false,
-            prefix: 'Subject Line',
-            queueType: 'individual',
-          });
-          cy.get(
-            '[data-testid="message-individual-docket-number-header-button"]',
-          ).click();
-          verifySubjectTitleOrder({
-            boxType: 'inbox',
-            isAscending: false,
-            prefix: 'Subject Line',
-            queueType: 'individual',
-          });
-        });
+      beforeEach(() => {
+        cy.visit('/');
       });
 
       describe('Sorting on the Individual Message Inbox', () => {
         it('individual inbox subject column', () => {
-          loginAsDocketClerk();
           cy.get(
-            '[data-testid="message-individual-subject-header-button"]',
+            '[data-testid="messages-individual-inbox-subject-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'inbox',
@@ -173,7 +112,7 @@ describe('Messages', () => {
             queueType: 'individual',
           });
           cy.get(
-            '[data-testid="message-individual-subject-header-button"]',
+            '[data-testid="messages-individual-inbox-subject-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'inbox',
@@ -184,9 +123,8 @@ describe('Messages', () => {
         });
 
         it('individual inbox received at column when defaulted to sort ascending', () => {
-          loginAsDocketClerk();
           cy.get(
-            '[data-testid="message-individual-received-header-button"]',
+            '[data-testid="messages-individual-inbox-createdAt-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'inbox',
@@ -195,7 +133,7 @@ describe('Messages', () => {
             queueType: 'individual',
           });
           cy.get(
-            '[data-testid="message-individual-received-header-button"]',
+            '[data-testid="messages-individual-inbox-createdAt-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'inbox',
@@ -206,9 +144,8 @@ describe('Messages', () => {
         });
 
         it('individual inbox docket number column', () => {
-          loginAsDocketClerk();
           cy.get(
-            '[data-testid="message-individual-docket-number-header-button"]',
+            '[data-testid="messages-individual-inbox-docketNumber-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'inbox',
@@ -217,7 +154,7 @@ describe('Messages', () => {
             queueType: 'individual',
           });
           cy.get(
-            '[data-testid="message-individual-docket-number-header-button"]',
+            '[data-testid="messages-individual-inbox-docketNumber-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'inbox',
@@ -230,10 +167,9 @@ describe('Messages', () => {
 
       describe('Sorting on the Individual Message Completed', () => {
         it('individual completed subject column', () => {
-          loginAsDocketClerk();
           cy.get('[data-testid="messages-completed-tab"]').click();
           cy.get(
-            '[data-testid="message-individual-subject-header-button"]',
+            '[data-testid="messages-individual-completed-subject-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'completed',
@@ -242,7 +178,7 @@ describe('Messages', () => {
             queueType: 'individual',
           });
           cy.get(
-            '[data-testid="message-individual-subject-header-button"]',
+            '[data-testid="messages-individual-completed-subject-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'completed',
@@ -252,11 +188,10 @@ describe('Messages', () => {
           });
         });
 
-        it('individual completed completed-at column when defaulted to sort ascending', () => {
-          loginAsDocketClerk();
+        it('individual completed completedAt column when defaulted to sort ascending', () => {
           cy.get('[data-testid="messages-completed-tab"]').click();
           cy.get(
-            '[data-testid="message-individual-completed-at-header-button"]',
+            '[data-testid="messages-individual-completed-completedAt-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'completed',
@@ -265,7 +200,7 @@ describe('Messages', () => {
             queueType: 'individual',
           });
           cy.get(
-            '[data-testid="message-individual-completed-at-header-button"]',
+            '[data-testid="messages-individual-completed-completedAt-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'completed',
@@ -276,10 +211,9 @@ describe('Messages', () => {
         });
 
         it('individual completed docket number column', () => {
-          loginAsDocketClerk();
           cy.get('[data-testid="messages-completed-tab"]').click();
           cy.get(
-            '[data-testid="message-individual-docket-number-header-button"]',
+            '[data-testid="messages-individual-completed-docketNumber-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'completed',
@@ -288,7 +222,7 @@ describe('Messages', () => {
             queueType: 'individual',
           });
           cy.get(
-            '[data-testid="message-individual-docket-number-header-button"]',
+            '[data-testid="messages-individual-completed-docketNumber-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'completed',
@@ -300,11 +234,18 @@ describe('Messages', () => {
       });
 
       describe('Sorting on the Individual Message Outbox', () => {
-        it('individual outbox subject column', () => {
+        before(() => {
           loginAsPetitionsClerk();
+        });
+
+        beforeEach(() => {
+          cy.visit('/');
+        });
+
+        it('individual outbox subject column', () => {
           cy.get('[data-testid="messages-outbox-tab"]').click();
           cy.get(
-            '[data-testid="message-individual-outbox-subject-header-button"]',
+            '[data-testid="messages-individual-outbox-subject-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'outbox',
@@ -313,7 +254,7 @@ describe('Messages', () => {
             queueType: 'individual',
           });
           cy.get(
-            '[data-testid="message-individual-outbox-subject-header-button"]',
+            '[data-testid="messages-individual-outbox-subject-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'outbox',
@@ -323,11 +264,10 @@ describe('Messages', () => {
           });
         });
 
-        it('individual outbox completed-at column when defaulted to sort ascending', () => {
-          loginAsPetitionsClerk();
+        it('individual outbox createdAt column when defaulted to sort ascending', () => {
           cy.get('[data-testid="messages-outbox-tab"]').click();
           cy.get(
-            '[data-testid="message-individual-outbox-completed-at-header-button"]',
+            '[data-testid="messages-individual-outbox-createdAt-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'outbox',
@@ -336,7 +276,7 @@ describe('Messages', () => {
             queueType: 'individual',
           });
           cy.get(
-            '[data-testid="message-individual-outbox-completed-at-header-button"]',
+            '[data-testid="messages-individual-outbox-createdAt-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'outbox',
@@ -347,10 +287,9 @@ describe('Messages', () => {
         });
 
         it('individual outbox docket number column', () => {
-          loginAsPetitionsClerk();
           cy.get('[data-testid="messages-outbox-tab"]').click();
           cy.get(
-            '[data-testid="message-individual-outbox-docket-number-header-button"]',
+            '[data-testid="messages-individual-outbox-docketNumber-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'outbox',
@@ -359,7 +298,7 @@ describe('Messages', () => {
             queueType: 'individual',
           });
           cy.get(
-            '[data-testid="message-individual-outbox-docket-number-header-button"]',
+            '[data-testid="messages-individual-outbox-docketNumber-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'outbox',
@@ -372,12 +311,19 @@ describe('Messages', () => {
     });
 
     describe('Section Message Boxes', () => {
+      before(() => {
+        loginAsDocketClerk();
+      });
+
+      beforeEach(() => {
+        cy.visit('/');
+      });
+
       describe('Sorting on the Section Message Inbox', () => {
         it('Section inbox subject column', () => {
-          loginAsDocketClerk();
           cy.get('[data-testid="switch-to-section-messages-button"]').click();
           cy.get(
-            '[data-testid="message-section-subject-header-button"]',
+            '[data-testid="messages-section-inbox-subject-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'inbox',
@@ -385,7 +331,7 @@ describe('Messages', () => {
             prefix: 'Subject Line',
           });
           cy.get(
-            '[data-testid="message-section-subject-header-button"]',
+            '[data-testid="messages-section-inbox-subject-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'inbox',
@@ -395,11 +341,12 @@ describe('Messages', () => {
         });
 
         it('Section inbox received at column when defaulted to sort ascending', () => {
-          loginAsDocketClerk();
           cy.get('[data-testid="switch-to-section-messages-button"]').click();
-          cy.get('[data-testid="message-section-subject-header-button"]');
           cy.get(
-            '[data-testid="message-section-received-header-button"]',
+            '[data-testid="messages-section-inbox-subject-header-button"]',
+          );
+          cy.get(
+            '[data-testid="messages-section-inbox-createdAt-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'inbox',
@@ -407,7 +354,7 @@ describe('Messages', () => {
             prefix: 'Subject Line',
           });
           cy.get(
-            '[data-testid="message-section-received-header-button"]',
+            '[data-testid="messages-section-inbox-createdAt-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'inbox',
@@ -417,11 +364,12 @@ describe('Messages', () => {
         });
 
         it('Section inbox docket number column', () => {
-          loginAsDocketClerk();
           cy.get('[data-testid="switch-to-section-messages-button"]').click();
-          cy.get('[data-testid="message-section-subject-header-button"]');
           cy.get(
-            '[data-testid="message-section-docket-number-header-button"]',
+            '[data-testid="messages-section-inbox-subject-header-button"]',
+          );
+          cy.get(
+            '[data-testid="messages-section-inbox-docketNumber-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'inbox',
@@ -429,7 +377,7 @@ describe('Messages', () => {
             prefix: 'Subject Line',
           });
           cy.get(
-            '[data-testid="message-section-docket-number-header-button"]',
+            '[data-testid="messages-section-inbox-docketNumber-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'inbox',
@@ -441,12 +389,13 @@ describe('Messages', () => {
 
       describe('Sorting on the Section Message Completed', () => {
         it('section completed subject column', () => {
-          loginAsDocketClerk();
           cy.get('[data-testid="switch-to-section-messages-button"]').click();
-          cy.get('[data-testid="message-section-subject-header-button"]');
+          cy.get(
+            '[data-testid="messages-section-inbox-subject-header-button"]',
+          );
           cy.get('[data-testid="messages-completed-tab"]').click();
           cy.get(
-            '[data-testid="message-section-subject-header-button"]',
+            '[data-testid="messages-section-completed-subject-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'completed',
@@ -454,7 +403,7 @@ describe('Messages', () => {
             prefix: 'Complete',
           });
           cy.get(
-            '[data-testid="message-section-subject-header-button"]',
+            '[data-testid="messages-section-completed-subject-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'completed',
@@ -463,13 +412,14 @@ describe('Messages', () => {
           });
         });
 
-        it('section completed completed-at column when defaulted to sort ascending', () => {
-          loginAsDocketClerk();
+        it('section completed completedAt column when defaulted to sort ascending', () => {
           cy.get('[data-testid="switch-to-section-messages-button"]').click();
-          cy.get('[data-testid="message-section-subject-header-button"]');
+          cy.get(
+            '[data-testid="messages-section-inbox-subject-header-button"]',
+          );
           cy.get('[data-testid="messages-completed-tab"]').click();
           cy.get(
-            '[data-testid="message-section-completed-at-header-button"]',
+            '[data-testid="messages-section-completed-completedAt-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'completed',
@@ -477,7 +427,7 @@ describe('Messages', () => {
             prefix: 'Complete',
           });
           cy.get(
-            '[data-testid="message-section-completed-at-header-button"]',
+            '[data-testid="messages-section-completed-completedAt-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'completed',
@@ -487,12 +437,13 @@ describe('Messages', () => {
         });
 
         it('section completed docket number column', () => {
-          loginAsDocketClerk();
           cy.get('[data-testid="switch-to-section-messages-button"]').click();
-          cy.get('[data-testid="message-section-subject-header-button"]');
+          cy.get(
+            '[data-testid="messages-section-inbox-subject-header-button"]',
+          );
           cy.get('[data-testid="messages-completed-tab"]').click();
           cy.get(
-            '[data-testid="message-section-docket-number-header-button"]',
+            '[data-testid="messages-section-completed-docketNumber-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'completed',
@@ -500,7 +451,7 @@ describe('Messages', () => {
             prefix: 'Complete',
           });
           cy.get(
-            '[data-testid="message-section-docket-number-header-button"]',
+            '[data-testid="messages-section-completed-docketNumber-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'completed',
@@ -511,13 +462,22 @@ describe('Messages', () => {
       });
 
       describe('Sorting on the Section Message Outbox', () => {
-        it('section outbox subject column', () => {
+        before(() => {
           loginAsPetitionsClerk();
+        });
+
+        beforeEach(() => {
+          cy.visit('/');
+        });
+
+        it('section outbox subject column', () => {
           cy.get('[data-testid="switch-to-section-messages-button"]').click();
-          cy.get('[data-testid="message-section-subject-header-button"]');
+          cy.get(
+            '[data-testid="messages-section-inbox-subject-header-button"]',
+          );
           cy.get('[data-testid="messages-outbox-tab"]').click();
           cy.get(
-            '[data-testid="message-section-outbox-subject-header-button"]',
+            '[data-testid="messages-section-outbox-subject-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'outbox',
@@ -525,7 +485,7 @@ describe('Messages', () => {
             prefix: 'Subject Line',
           });
           cy.get(
-            '[data-testid="message-section-outbox-subject-header-button"]',
+            '[data-testid="messages-section-outbox-subject-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'outbox',
@@ -537,10 +497,12 @@ describe('Messages', () => {
         it('section outbox created-at column when defaulted to sort ascending', () => {
           loginAsPetitionsClerk();
           cy.get('[data-testid="switch-to-section-messages-button"]').click();
-          cy.get('[data-testid="message-section-subject-header-button"]');
+          cy.get(
+            '[data-testid="messages-section-inbox-subject-header-button"]',
+          );
           cy.get('[data-testid="messages-outbox-tab"]').click();
           cy.get(
-            '[data-testid="message-section-outbox-created-at-header-button"]',
+            '[data-testid="messages-section-outbox-createdAt-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'outbox',
@@ -548,7 +510,7 @@ describe('Messages', () => {
             prefix: 'Subject Line',
           });
           cy.get(
-            '[data-testid="message-section-outbox-created-at-header-button"]',
+            '[data-testid="messages-section-outbox-createdAt-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'outbox',
@@ -560,10 +522,12 @@ describe('Messages', () => {
         it('section outbox docket number column', () => {
           loginAsPetitionsClerk();
           cy.get('[data-testid="switch-to-section-messages-button"]').click();
-          cy.get('[data-testid="message-section-subject-header-button"]');
+          cy.get(
+            '[data-testid="messages-section-inbox-subject-header-button"]',
+          );
           cy.get('[data-testid="messages-outbox-tab"]').click();
           cy.get(
-            '[data-testid="message-section-outbox-docket-number-header-button"]',
+            '[data-testid="messages-section-outbox-docketNumber-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'outbox',
@@ -571,7 +535,7 @@ describe('Messages', () => {
             prefix: 'Subject Line',
           });
           cy.get(
-            '[data-testid="message-section-outbox-docket-number-header-button"]',
+            '[data-testid="messages-section-outbox-docketNumber-header-button"]',
           ).click();
           verifySubjectTitleOrder({
             boxType: 'outbox',
@@ -644,7 +608,7 @@ function verifySubjectTitleOrder({
   cy.get('@DOCKET_NUMBER').then(docketNumber => {
     const rows: string[] = [];
     cy.get(
-      `[data-testid="${queueType}-message-${boxType}-docket-number-cell"]:contains("${docketNumber}")`,
+      `[data-testid="messages-${queueType}-${boxType}-docketNumber-cell"]:contains("${docketNumber}")`,
     ).each(el => {
       cy.wrap(el.parent())
         .find('.message-document-title')

--- a/cypress/local-only/tests/integration/messages/messages.cy.ts
+++ b/cypress/local-only/tests/integration/messages/messages.cy.ts
@@ -264,7 +264,7 @@ describe('Messages', () => {
           });
         });
 
-        it('individual outbox createdAt column when defaulted to sort ascending', () => {
+        it('individual outbox sent column when defaulted to sort ascending', () => {
           cy.get('[data-testid="messages-outbox-tab"]').click();
           cy.get(
             '[data-testid="messages-individual-outbox-createdAt-header-button"]',
@@ -412,7 +412,7 @@ describe('Messages', () => {
           });
         });
 
-        it('section completed completedAt column when defaulted to sort ascending', () => {
+        it('section completed completed at column when defaulted to sort ascending', () => {
           cy.get('[data-testid="switch-to-section-messages-button"]').click();
           cy.get(
             '[data-testid="messages-section-inbox-subject-header-button"]',
@@ -494,7 +494,7 @@ describe('Messages', () => {
           });
         });
 
-        it('section outbox created-at column when defaulted to sort ascending', () => {
+        it('section outbox sent column when defaulted to sort ascending', () => {
           loginAsPetitionsClerk();
           cy.get('[data-testid="switch-to-section-messages-button"]').click();
           cy.get(

--- a/web-client/src/styles/tables.scss
+++ b/web-client/src/styles/tables.scss
@@ -134,6 +134,8 @@ table,
 
     &.message-queue-row {
       padding-top: 14px;
+      overflow-wrap: break-word;
+      word-break: break-word; // fallback
     }
 
     &.message-queue-case-title {

--- a/web-client/src/ustc-ui/Table/SortableColumn.tsx
+++ b/web-client/src/ustc-ui/Table/SortableColumn.tsx
@@ -62,27 +62,34 @@ export const SortableColumn = ({
       }}
     >
       <span
-        className={classNames('margin-right-105', {
+        className={classNames('margin-right-1', {
           sortActive: isActive,
         })}
       >
         {title}
       </span>
-      {isLoading && (
-        <FontAwesomeIcon
-          className="fa-spin spinner"
-          icon="sync"
-          size="sm"
-          title="sorting results"
-        />
-      )}
-      {!isLoading &&
-        getFontAwesomeIcon({
-          ascText,
-          descText,
-          direction: currentlySortedOrder,
-          isActiveColumn: isActive,
-        })}
+      <span className="text-no-wrap">
+        {/* We use a non-breaking space to force the icon to wrap with the text, not independently */}
+        &nbsp;
+        {/* We fix the icon width so that switching from double arrow to smaller single arrow icon does not affect line-breaking behavior */}
+        <span className="display-inline-block width-205">
+          {isLoading && (
+            <FontAwesomeIcon
+              className="fa-spin spinner"
+              icon="sync"
+              size="sm"
+              title="sorting results"
+            />
+          )}
+          {!isLoading &&
+            getFontAwesomeIcon({
+              ascText,
+              descText,
+              direction: currentlySortedOrder,
+              isActiveColumn: isActive,
+            })}
+        </span>
+      </span>
     </Button>
   );
 };

--- a/web-client/src/views/DocketRecord/DocketRecord.tsx
+++ b/web-client/src/views/DocketRecord/DocketRecord.tsx
@@ -55,7 +55,7 @@ export const DocketRecord = connect(
         <DocketRecordHeader />
 
         <NonPhone>
-          <div style={{ overflowX: 'scroll', width: '100%' }}>
+          <div className="width-full overflow-x-auto">
             <table
               aria-label="docket record"
               className="usa-table ustc-table usa-table--stacked"

--- a/web-client/src/views/Messages/MessageColumns.test.ts
+++ b/web-client/src/views/Messages/MessageColumns.test.ts
@@ -1,0 +1,31 @@
+import {
+  ALPHABETICALLY_ASCENDING,
+  ALPHABETICALLY_DESCENDING,
+  CHRONOLOGICALLY_ASCENDING,
+  CHRONOLOGICALLY_DESCENDING,
+} from '@shared/business/entities/EntityConstants';
+import {
+  getAscendingTextForSortType,
+  getDescendingTextForSortType,
+} from '@web-client/views/Messages/MessageColumns';
+
+describe('Ascending and descending text for sort types', () => {
+  it('should use chronologically ascending for date when ascending', () => {
+    expect(getAscendingTextForSortType('date')).toBe(CHRONOLOGICALLY_ASCENDING);
+  });
+  it('should use chronologically descending for date when descending', () => {
+    expect(getDescendingTextForSortType('date')).toBe(
+      CHRONOLOGICALLY_DESCENDING,
+    );
+  });
+  it('should use alphabetically ascending for string when ascending', () => {
+    expect(getAscendingTextForSortType('string')).toBe(
+      ALPHABETICALLY_ASCENDING,
+    );
+  });
+  it('should use alphabetically descending for string when descending', () => {
+    expect(getDescendingTextForSortType('string')).toBe(
+      ALPHABETICALLY_DESCENDING,
+    );
+  });
+});

--- a/web-client/src/views/Messages/MessageColumns.ts
+++ b/web-client/src/views/Messages/MessageColumns.ts
@@ -1,0 +1,101 @@
+export interface MessageColumnData {
+  columnName: string;
+  sortField: string;
+  sortFieldDisplay?: string;
+  sortType?: 'string' | 'date';
+  className?: string;
+  dataTestId?: string;
+  iconClassName?: string;
+}
+
+export const COLUMN_NAMES = {
+  CASE_STATUS: 'Case Status',
+  CASE_TITLE: 'Case Title',
+  COMMENT: 'Comment',
+  COMPLETED: 'Completed',
+  DOCKET_NUMBER: 'Docket No.',
+  FROM: 'From',
+  LAST_MESSAGE: 'Last Message',
+  MESSAGE: 'Message',
+  RECEIVED: 'Received',
+  SECTION: 'Section',
+  SENT: 'Sent',
+  TO: 'To',
+};
+
+const getOneColumnData = (columnName: string) => {
+  return columns.find(column => column.columnName === columnName)!;
+};
+
+export const getColumnData = (columnNames: string[]) => {
+  return columnNames.map(field => getOneColumnData(field));
+};
+
+export const columns: MessageColumnData[] = [
+  {
+    columnName: COLUMN_NAMES.DOCKET_NUMBER,
+    dataTestId: 'message-individual-docket-number',
+    iconClassName: 'consolidated-case-column',
+    sortField: 'docketNumber',
+  },
+  {
+    columnName: COLUMN_NAMES.RECEIVED,
+    dataTestId: 'message-individual-received',
+    sortField: 'createdAt',
+    sortFieldDisplay: 'createdAtFormatted',
+  },
+  {
+    columnName: COLUMN_NAMES.SENT,
+    dataTestId: 'message-individual-received',
+    sortField: 'createdAt',
+    sortFieldDisplay: 'createdAtFormatted',
+  },
+  {
+    columnName: COLUMN_NAMES.COMPLETED,
+    dataTestId: 'message-individual-received',
+    sortField: 'completedAt',
+    sortFieldDisplay: 'completedAtFormatted',
+  },
+  {
+    columnName: COLUMN_NAMES.LAST_MESSAGE,
+    dataTestId: 'message-individual-subject',
+    iconClassName: 'message-unread-column',
+    sortField: 'subject',
+  },
+  {
+    columnName: COLUMN_NAMES.MESSAGE,
+    dataTestId: 'message-individual-subject',
+    iconClassName: 'message-unread-column',
+    sortField: 'subject',
+  },
+  {
+    columnName: COLUMN_NAMES.CASE_TITLE,
+    dataTestId: 'message-individual-case-title',
+    sortField: 'caseTitle',
+  },
+  {
+    columnName: COLUMN_NAMES.CASE_STATUS,
+    dataTestId: 'message-individual-case-status',
+    sortField: 'caseStatus',
+  },
+  {
+    columnName: COLUMN_NAMES.TO,
+    dataTestId: 'message-individual-from',
+    sortField: 'to',
+  },
+  {
+    columnName: COLUMN_NAMES.FROM,
+    dataTestId: 'message-individual-from',
+    sortField: 'from',
+  },
+  {
+    columnName: COLUMN_NAMES.SECTION,
+    dataTestId: 'message-individual-section',
+    sortField: 'fromSectionFormatted',
+  },
+  {
+    columnName: COLUMN_NAMES.COMMENT,
+    dataTestId: 'message-individual-comment',
+    sortField: 'completedMessage',
+  },
+];

--- a/web-client/src/views/Messages/MessageColumns.ts
+++ b/web-client/src/views/Messages/MessageColumns.ts
@@ -87,8 +87,8 @@ export const SORTABLE_COLUMNS: Record<string, MessageColumnData> = {
     sortFieldInfo: SORT_FIELDS.FROM_SECTION,
   },
   LAST_MESSAGE: {
+    // For completed message threads
     columnName: 'Last Message',
-    headerIconClassName: 'message-unread-column',
     sortFieldInfo: SORT_FIELDS.SUBJECT,
   },
   MESSAGE: {

--- a/web-client/src/views/Messages/MessageColumns.ts
+++ b/web-client/src/views/Messages/MessageColumns.ts
@@ -1,7 +1,13 @@
+import {
+  ALPHABETICALLY_ASCENDING,
+  ALPHABETICALLY_DESCENDING,
+  CHRONOLOGICALLY_ASCENDING,
+  CHRONOLOGICALLY_DESCENDING,
+} from '@shared/business/entities/EntityConstants';
+
 export type MessageColumnData = {
   columnName: string;
   sortFieldInfo: SortFieldInfo;
-  sortType?: 'string' | 'date';
   headerClassName?: string;
   headerIconClassName?: string;
 };
@@ -9,29 +15,36 @@ export type MessageColumnData = {
 type SortFieldInfo = {
   sortField: string; // What we are actually sorting by (e.g., a timestamp)
   displayField?: string; // What we are displaying (e.g., a formatted timestamp)
+  sortType: 'string' | 'date';
 };
 
 // The fields that messages can be sorted by.
 export const SORT_FIELDS: Record<string, SortFieldInfo> = {
-  CASE_STATUS: { sortField: 'caseStatus' },
-  CASE_TITLE: { sortField: 'caseTitle' },
+  CASE_STATUS: { sortField: 'caseStatus', sortType: 'string' },
+  CASE_TITLE: { sortField: 'caseTitle', sortType: 'string' },
   COMPLETED_AT: {
     displayField: 'completedAtFormatted',
     sortField: 'completedAt',
+    sortType: 'date',
   },
-  COMPLETED_BY: { sortField: 'completedBy' },
-  COMPLETED_BY_SECTION: { sortField: 'completedBySection' },
-  COMPLETED_MESSAGE: { sortField: 'completedMessage' },
-  CREATED_AT: { displayField: 'createdAtFormatted', sortField: 'createdAt' },
+  COMPLETED_BY: { sortField: 'completedBy', sortType: 'date' },
+  COMPLETED_BY_SECTION: { sortField: 'completedBySection', sortType: 'string' },
+  COMPLETED_MESSAGE: { sortField: 'completedMessage', sortType: 'string' },
+  CREATED_AT: {
+    displayField: 'createdAtFormatted',
+    sortField: 'createdAt',
+    sortType: 'date',
+  },
   DOCKET_NUMBER: {
     displayField: 'docketNumberWithSuffix',
     sortField: 'docketNumber',
+    sortType: 'string',
   },
-  FROM: { sortField: 'from' },
-  FROM_SECTION: { sortField: 'fromSectionFormatted' },
-  SUBJECT: { sortField: 'subject' },
-  TO: { sortField: 'to' },
-  TO_SECTION: { sortField: 'toSection' },
+  FROM: { sortField: 'from', sortType: 'string' },
+  FROM_SECTION: { sortField: 'fromSectionFormatted', sortType: 'string' },
+  SUBJECT: { sortField: 'subject', sortType: 'string' },
+  TO: { sortField: 'to', sortType: 'string' },
+  TO_SECTION: { sortField: 'toSection', sortType: 'string' },
 };
 
 // The columns we have available for any message queue.
@@ -99,4 +112,18 @@ export const SORTABLE_COLUMNS: Record<string, MessageColumnData> = {
     columnName: 'Section',
     sortFieldInfo: SORT_FIELDS.TO_SECTION,
   },
+};
+
+export const getAscendingTextForSortType = (sortType: 'string' | 'date') => {
+  if (sortType === 'date') {
+    return CHRONOLOGICALLY_ASCENDING;
+  }
+  return ALPHABETICALLY_ASCENDING;
+};
+
+export const getDescendingTextForSortType = (sortType: 'string' | 'date') => {
+  if (sortType === 'date') {
+    return CHRONOLOGICALLY_DESCENDING;
+  }
+  return ALPHABETICALLY_DESCENDING;
 };

--- a/web-client/src/views/Messages/MessageColumns.ts
+++ b/web-client/src/views/Messages/MessageColumns.ts
@@ -1,11 +1,10 @@
-export interface MessageColumnData {
+export type MessageColumnData = {
   columnName: string;
   sortFieldInfo: SortFieldInfo;
   sortType?: 'string' | 'date';
   headerClassName?: string;
-  dataTestId?: string;
   headerIconClassName?: string;
-}
+};
 
 type SortFieldInfo = {
   sortField: string; // What we are actually sorting by (e.g., a timestamp)
@@ -39,80 +38,65 @@ export const SORT_FIELDS: Record<string, SortFieldInfo> = {
 export const SORTABLE_COLUMNS: Record<string, MessageColumnData> = {
   CASE_STATUS: {
     columnName: 'Case Status',
-    dataTestId: 'message-individual-case-status',
     sortFieldInfo: SORT_FIELDS.CASE_STATUS,
   },
   CASE_TITLE: {
     columnName: 'Case Title',
-    dataTestId: 'message-individual-case-title',
     sortFieldInfo: SORT_FIELDS.CASE_TITLE,
   },
   COMMENT: {
     columnName: 'Comment',
-    dataTestId: 'message-individual-comment',
     sortFieldInfo: SORT_FIELDS.COMPLETED_MESSAGE,
   },
   COMPLETED_AT: {
     columnName: 'Completed',
-    dataTestId: 'message-individual-completed',
     sortFieldInfo: SORT_FIELDS.COMPLETED_AT,
   },
   COMPLETED_BY: {
     columnName: 'Completed By',
-    dataTestId: 'message-individual-completed',
     sortFieldInfo: SORT_FIELDS.COMPLETED_BY,
   },
   COMPLETED_BY_SECTION: {
     columnName: 'Section',
-    dataTestId: 'message-individual-completed',
     sortFieldInfo: SORT_FIELDS.COMPLETED_BY_SECTION,
   },
   DOCKET_NUMBER: {
     columnName: 'Docket No.',
-    dataTestId: 'message-individual-docket-number',
     headerIconClassName: 'consolidated-case-column',
     sortFieldInfo: SORT_FIELDS.DOCKET_NUMBER,
   },
   FROM: {
     columnName: 'From',
-    dataTestId: 'message-individual-from',
     sortFieldInfo: SORT_FIELDS.FROM,
   },
   FROM_SECTION: {
     columnName: 'Section',
-    dataTestId: 'message-individual-section',
     sortFieldInfo: SORT_FIELDS.FROM_SECTION,
   },
   LAST_MESSAGE: {
     columnName: 'Last Message',
-    dataTestId: 'message-individual-subject',
     headerIconClassName: 'message-unread-column',
     sortFieldInfo: SORT_FIELDS.SUBJECT,
   },
   MESSAGE: {
     columnName: 'Message',
-    dataTestId: 'message-individual-subject',
     headerIconClassName: 'message-unread-column',
     sortFieldInfo: SORT_FIELDS.SUBJECT,
   },
   RECEIVED: {
     columnName: 'Received',
-    dataTestId: 'message-individual-received',
     sortFieldInfo: SORT_FIELDS.CREATED_AT,
   },
   SENT: {
     columnName: 'Sent',
-    dataTestId: 'message-individual-sent',
     sortFieldInfo: SORT_FIELDS.CREATED_AT,
   },
   TO: {
     columnName: 'To',
-    dataTestId: 'message-individual-from',
     sortFieldInfo: SORT_FIELDS.TO,
   },
   TO_SECTION: {
     columnName: 'Section',
-    dataTestId: 'message-section-to-section',
     sortFieldInfo: SORT_FIELDS.TO_SECTION,
   },
 };

--- a/web-client/src/views/Messages/MessageColumns.ts
+++ b/web-client/src/views/Messages/MessageColumns.ts
@@ -1,101 +1,118 @@
 export interface MessageColumnData {
   columnName: string;
-  sortField: string;
-  sortFieldDisplay?: string;
+  sortFieldInfo: SortFieldInfo;
   sortType?: 'string' | 'date';
-  className?: string;
+  headerClassName?: string;
   dataTestId?: string;
-  iconClassName?: string;
+  headerIconClassName?: string;
 }
 
-export const COLUMN_NAMES = {
-  CASE_STATUS: 'Case Status',
-  CASE_TITLE: 'Case Title',
-  COMMENT: 'Comment',
-  COMPLETED: 'Completed',
-  DOCKET_NUMBER: 'Docket No.',
-  FROM: 'From',
-  LAST_MESSAGE: 'Last Message',
-  MESSAGE: 'Message',
-  RECEIVED: 'Received',
-  SECTION: 'Section',
-  SENT: 'Sent',
-  TO: 'To',
+type SortFieldInfo = {
+  sortField: string; // What we are actually sorting by (e.g., a timestamp)
+  displayField?: string; // What we are displaying (e.g., a formatted timestamp)
 };
 
-const getOneColumnData = (columnName: string) => {
-  return columns.find(column => column.columnName === columnName)!;
-};
-
-export const getColumnData = (columnNames: string[]) => {
-  return columnNames.map(field => getOneColumnData(field));
-};
-
-export const columns: MessageColumnData[] = [
-  {
-    columnName: COLUMN_NAMES.DOCKET_NUMBER,
-    dataTestId: 'message-individual-docket-number',
-    iconClassName: 'consolidated-case-column',
+// The fields that messages can be sorted by.
+export const SORT_FIELDS: Record<string, SortFieldInfo> = {
+  CASE_STATUS: { sortField: 'caseStatus' },
+  CASE_TITLE: { sortField: 'caseTitle' },
+  COMPLETED_AT: {
+    displayField: 'completedAtFormatted',
+    sortField: 'completedAt',
+  },
+  COMPLETED_BY: { sortField: 'completedBy' },
+  COMPLETED_BY_SECTION: { sortField: 'completedBySection' },
+  COMPLETED_MESSAGE: { sortField: 'completedMessage' },
+  CREATED_AT: { displayField: 'createdAtFormatted', sortField: 'createdAt' },
+  DOCKET_NUMBER: {
+    displayField: 'docketNumberWithSuffix',
     sortField: 'docketNumber',
   },
-  {
-    columnName: COLUMN_NAMES.RECEIVED,
-    dataTestId: 'message-individual-received',
-    sortField: 'createdAt',
-    sortFieldDisplay: 'createdAtFormatted',
-  },
-  {
-    columnName: COLUMN_NAMES.SENT,
-    dataTestId: 'message-individual-received',
-    sortField: 'createdAt',
-    sortFieldDisplay: 'createdAtFormatted',
-  },
-  {
-    columnName: COLUMN_NAMES.COMPLETED,
-    dataTestId: 'message-individual-received',
-    sortField: 'completedAt',
-    sortFieldDisplay: 'completedAtFormatted',
-  },
-  {
-    columnName: COLUMN_NAMES.LAST_MESSAGE,
-    dataTestId: 'message-individual-subject',
-    iconClassName: 'message-unread-column',
-    sortField: 'subject',
-  },
-  {
-    columnName: COLUMN_NAMES.MESSAGE,
-    dataTestId: 'message-individual-subject',
-    iconClassName: 'message-unread-column',
-    sortField: 'subject',
-  },
-  {
-    columnName: COLUMN_NAMES.CASE_TITLE,
-    dataTestId: 'message-individual-case-title',
-    sortField: 'caseTitle',
-  },
-  {
-    columnName: COLUMN_NAMES.CASE_STATUS,
+  FROM: { sortField: 'from' },
+  FROM_SECTION: { sortField: 'fromSectionFormatted' },
+  SUBJECT: { sortField: 'subject' },
+  TO: { sortField: 'to' },
+  TO_SECTION: { sortField: 'toSection' },
+};
+
+// The columns we have available for any message queue.
+export const SORTABLE_COLUMNS: Record<string, MessageColumnData> = {
+  CASE_STATUS: {
+    columnName: 'Case Status',
     dataTestId: 'message-individual-case-status',
-    sortField: 'caseStatus',
+    sortFieldInfo: SORT_FIELDS.CASE_STATUS,
   },
-  {
-    columnName: COLUMN_NAMES.TO,
-    dataTestId: 'message-individual-from',
-    sortField: 'to',
+  CASE_TITLE: {
+    columnName: 'Case Title',
+    dataTestId: 'message-individual-case-title',
+    sortFieldInfo: SORT_FIELDS.CASE_TITLE,
   },
-  {
-    columnName: COLUMN_NAMES.FROM,
-    dataTestId: 'message-individual-from',
-    sortField: 'from',
-  },
-  {
-    columnName: COLUMN_NAMES.SECTION,
-    dataTestId: 'message-individual-section',
-    sortField: 'fromSectionFormatted',
-  },
-  {
-    columnName: COLUMN_NAMES.COMMENT,
+  COMMENT: {
+    columnName: 'Comment',
     dataTestId: 'message-individual-comment',
-    sortField: 'completedMessage',
+    sortFieldInfo: SORT_FIELDS.COMPLETED_MESSAGE,
   },
-];
+  COMPLETED_AT: {
+    columnName: 'Completed',
+    dataTestId: 'message-individual-completed',
+    sortFieldInfo: SORT_FIELDS.COMPLETED_AT,
+  },
+  COMPLETED_BY: {
+    columnName: 'Completed By',
+    dataTestId: 'message-individual-completed',
+    sortFieldInfo: SORT_FIELDS.COMPLETED_BY,
+  },
+  COMPLETED_BY_SECTION: {
+    columnName: 'Section',
+    dataTestId: 'message-individual-completed',
+    sortFieldInfo: SORT_FIELDS.COMPLETED_BY_SECTION,
+  },
+  DOCKET_NUMBER: {
+    columnName: 'Docket No.',
+    dataTestId: 'message-individual-docket-number',
+    headerIconClassName: 'consolidated-case-column',
+    sortFieldInfo: SORT_FIELDS.DOCKET_NUMBER,
+  },
+  FROM: {
+    columnName: 'From',
+    dataTestId: 'message-individual-from',
+    sortFieldInfo: SORT_FIELDS.FROM,
+  },
+  FROM_SECTION: {
+    columnName: 'Section',
+    dataTestId: 'message-individual-section',
+    sortFieldInfo: SORT_FIELDS.FROM_SECTION,
+  },
+  LAST_MESSAGE: {
+    columnName: 'Last Message',
+    dataTestId: 'message-individual-subject',
+    headerIconClassName: 'message-unread-column',
+    sortFieldInfo: SORT_FIELDS.SUBJECT,
+  },
+  MESSAGE: {
+    columnName: 'Message',
+    dataTestId: 'message-individual-subject',
+    headerIconClassName: 'message-unread-column',
+    sortFieldInfo: SORT_FIELDS.SUBJECT,
+  },
+  RECEIVED: {
+    columnName: 'Received',
+    dataTestId: 'message-individual-received',
+    sortFieldInfo: SORT_FIELDS.CREATED_AT,
+  },
+  SENT: {
+    columnName: 'Sent',
+    dataTestId: 'message-individual-sent',
+    sortFieldInfo: SORT_FIELDS.CREATED_AT,
+  },
+  TO: {
+    columnName: 'To',
+    dataTestId: 'message-individual-from',
+    sortFieldInfo: SORT_FIELDS.TO,
+  },
+  TO_SECTION: {
+    columnName: 'Section',
+    dataTestId: 'message-section-to-section',
+    sortFieldInfo: SORT_FIELDS.TO_SECTION,
+  },
+};

--- a/web-client/src/views/Messages/MessageColumns.ts
+++ b/web-client/src/views/Messages/MessageColumns.ts
@@ -93,6 +93,10 @@ export const SORTABLE_COLUMNS: Record<string, MessageColumnData> = {
   },
   MESSAGE: {
     columnName: 'Message',
+    sortFieldInfo: SORT_FIELDS.SUBJECT,
+  },
+  MESSAGE_WITH_UNREAD_ICON: {
+    columnName: 'Message',
     headerIconClassName: 'message-unread-column',
     sortFieldInfo: SORT_FIELDS.SUBJECT,
   },

--- a/web-client/src/views/Messages/MessageList.tsx
+++ b/web-client/src/views/Messages/MessageList.tsx
@@ -1,0 +1,289 @@
+import { Button } from '../../ustc-ui/Button/Button';
+import { ConsolidatedCaseIcon } from '../../ustc-ui/Icon/ConsolidatedCaseIcon';
+import { ErrorNotification } from '../ErrorNotification';
+import { Icon } from '../../ustc-ui/Icon/Icon';
+import { SortableColumn } from '../../ustc-ui/Table/SortableColumn';
+import { SuccessNotification } from '../SuccessNotification';
+import { TableFilters } from '../../ustc-ui/Table/TableFilters';
+import { connect } from '@web-client/presenter/shared.cerebral';
+import { sequences } from '@web-client/presenter/app.cerebral';
+import { state } from '@web-client/presenter/app.cerebral';
+import React, { useEffect, useRef } from 'react';
+import classNames from 'classnames';
+
+export interface MessageColumnData {
+  columnName: string;
+  sortField: string;
+  sortType?: 'string' | 'date';
+  className?: string;
+  dataTestId?: string;
+  iconClassName?: string;
+}
+
+export interface MessageFilterData {
+  isSelected: any;
+  key: string;
+  label: string;
+  options: any[];
+}
+
+type MessageListProps = {
+  selectable: boolean;
+  messageColumns: MessageColumnData[];
+  messageFilters: MessageFilterData[];
+};
+
+const MessageListCerebralDependencies = {
+  batchCompleteMessageSequence: sequences.batchCompleteMessageSequence,
+  constants: state.constants,
+  formattedMessages: state.formattedMessages,
+  messagesIndividualInboxHelper: state.messagesIndividualInboxHelper,
+  screenMetadata: state.screenMetadata,
+  setSelectedMessagesSequence: sequences.setSelectedMessagesSequence,
+  sortTableSequence: sequences.sortTableSequence,
+  tableSort: state.tableSort,
+  updateMessageFilterSequence: sequences.updateMessageFilterSequence,
+};
+
+export const MessageList = connect<
+  MessageListProps,
+  typeof MessageListCerebralDependencies
+>(
+  MessageListCerebralDependencies,
+  function MessageList({
+    batchCompleteMessageSequence,
+    constants,
+    formattedMessages,
+    messageColumns,
+    messageFilters,
+    messagesIndividualInboxHelper,
+    screenMetadata,
+    selectable,
+    setSelectedMessagesSequence,
+    sortTableSequence,
+    tableSort,
+    updateMessageFilterSequence,
+  }) {
+    const selectAllCheckboxRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+      if (!selectAllCheckboxRef.current) return;
+
+      selectAllCheckboxRef.current.indeterminate =
+        messagesIndividualInboxHelper.someMessagesSelected &&
+        !messagesIndividualInboxHelper.allMessagesSelected;
+    }, [
+      selectAllCheckboxRef.current,
+      messagesIndividualInboxHelper.someMessagesSelected,
+      messagesIndividualInboxHelper.allMessagesSelected,
+    ]);
+    return (
+      <>
+        <SuccessNotification />
+        <ErrorNotification />
+        {screenMetadata.completionSuccess && (
+          <div
+            aria-live="polite"
+            className="usa-alert usa-alert--success"
+            data-testid="message-detail-success-alert"
+            role="alert"
+          >
+            <div className="usa-alert__body">
+              Message(s) completed at{' '}
+              {messagesIndividualInboxHelper.messagesCompletedAt} by{' '}
+              {messagesIndividualInboxHelper.messagesCompletedBy}
+            </div>
+          </div>
+        )}
+        <div className="grid-row grid-gap">
+          <div className="desktop:grid-col-8 tablet:grid-col-12 display-flex flex-align-center">
+            <TableFilters
+              filters={messageFilters}
+              onSelect={updateMessageFilterSequence}
+            ></TableFilters>
+          </div>
+
+          {selectable && (
+            <div className="desktop:grid-col-4 tablet:grid-col-12 tablet:margin-top-2 text-right">
+              <Button
+                link
+                className="action-button"
+                data-testid="message-batch-mark-as-complete"
+                disabled={
+                  !messagesIndividualInboxHelper.isCompletionButtonEnabled
+                }
+                icon="check-circle"
+                id="button-batch-complete"
+                onClick={() => {
+                  batchCompleteMessageSequence();
+                }}
+              >
+                Complete
+              </Button>
+            </div>
+          )}
+        </div>
+
+        <table className="usa-table ustc-table subsection">
+          <thead>
+            <tr>
+              {selectable && (
+                <th>
+                  <input
+                    aria-label="all-messages-checkbox"
+                    checked={messagesIndividualInboxHelper.allMessagesSelected}
+                    data-testid="all-messages-checkbox"
+                    disabled={
+                      !messagesIndividualInboxHelper.allMessagesCheckboxEnabled
+                    }
+                    id="all-messages-checkbox"
+                    ref={selectAllCheckboxRef}
+                    type="checkbox"
+                    onChange={() => {
+                      const selectAll = formattedMessages.messages.map(
+                        message => ({
+                          messageId: message.messageId,
+                          parentMessageId: message.parentMessageId,
+                        }),
+                      );
+                      setSelectedMessagesSequence({ messages: selectAll });
+                    }}
+                  />
+                </th>
+              )}
+              {messageColumns.map((data, index) => {
+                return (
+                  <>
+                    {data.iconClassName && (
+                      <th className={data.iconClassName}></th>
+                    )}
+                    <th
+                      aria-label={data.columnName}
+                      className={data.className}
+                      colSpan={index === 0 ? 2 : undefined}
+                      key={data.sortField}
+                      // TODO: probably should use aria-sort, but USWDS has default styles for this we may not want
+                    >
+                      <SortableColumn
+                        ascText={
+                          data.sortType === 'string'
+                            ? constants.CHRONOLOGICALLY_ASCENDING
+                            : constants.ALPHABETICALLY_ASCENDING
+                        }
+                        currentlySortedField={tableSort.sortField}
+                        currentlySortedOrder={tableSort.sortOrder}
+                        data-testid={`${data.dataTestId}-header-button`}
+                        defaultSortOrder={constants.DESCENDING}
+                        descText={
+                          data.sortType === 'date'
+                            ? constants.CHRONOLOGICALLY_DESCENDING
+                            : constants.ALPHABETICALLY_DESCENDING
+                        }
+                        hasRows={formattedMessages.hasMessages}
+                        sortField={data.sortField}
+                        title={data.columnName}
+                        onClickSequence={sortTableSequence}
+                      />
+                    </th>
+                  </>
+                );
+              })}
+            </tr>
+          </thead>
+          {formattedMessages.messages.map(message => {
+            return (
+              <tbody key={message.messageId}>
+                <tr key={message.messageId}>
+                  {selectable && (
+                    <td>
+                      <input
+                        aria-label={`${message.caseTitle}-${message.subject}-checkbox`}
+                        checked={message.isSelected}
+                        id={`${message.caseTitle}-message-checkbox`}
+                        type="checkbox"
+                        onChange={() => {
+                          setSelectedMessagesSequence({
+                            messages: [
+                              {
+                                messageId: message.messageId,
+                                parentMessageId: message.parentMessageId,
+                              },
+                            ],
+                          });
+                        }}
+                      />
+                    </td>
+                  )}
+                  <td className="consolidated-case-column">
+                    <ConsolidatedCaseIcon
+                      consolidatedIconTooltipText={
+                        message.consolidatedIconTooltipText
+                      }
+                      inConsolidatedGroup={message.inConsolidatedGroup}
+                      showLeadCaseIcon={message.isLeadCase}
+                    />
+                  </td>
+                  <td
+                    className="message-queue-row small"
+                    colSpan={2}
+                    data-testid="individual-message-inbox-docket-number-cell"
+                  >
+                    {message.docketNumberWithSuffix}
+                  </td>
+                  <td
+                    className="message-queue-row small"
+                    data-testid="individual-message-inbox-received-at-cell"
+                  >
+                    <span className="no-wrap">
+                      {message.createdAtFormatted}
+                    </span>
+                  </td>
+                  <td className="message-unread-column">
+                    {!message.isRead && (
+                      <Icon
+                        aria-label="unread message"
+                        className="fa-icon-blue"
+                        icon="envelope"
+                        size="1x"
+                      />
+                    )}
+                  </td>
+                  <td className="message-queue-row message-subject">
+                    <div className="message-document-title">
+                      <Button
+                        link
+                        className={classNames(
+                          'padding-0',
+                          message.isRead ? '' : 'text-bold',
+                        )}
+                        data-testid="individual-message-inbox-subject-cell"
+                        href={message.messageDetailLink}
+                      >
+                        {message.subject}
+                      </Button>
+                    </div>
+
+                    <div className="message-document-detail">
+                      {message.message}
+                    </div>
+                  </td>
+                  <td className="message-queue-row max-width-25">
+                    {message.caseTitle}
+                  </td>
+                  <td className="message-queue-row">{message.caseStatus}</td>
+                  <td className="message-queue-row from">{message.from}</td>
+                  <td className="message-queue-row small">
+                    {message.fromSectionFormatted}
+                  </td>
+                </tr>
+              </tbody>
+            );
+          })}
+        </table>
+        {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+      </>
+    );
+  },
+);
+
+MessageList.displayName = 'MessageList';

--- a/web-client/src/views/Messages/MessageList.tsx
+++ b/web-client/src/views/Messages/MessageList.tsx
@@ -2,6 +2,7 @@ import { Button } from '../../ustc-ui/Button/Button';
 import { ConsolidatedCaseIcon } from '../../ustc-ui/Icon/ConsolidatedCaseIcon';
 import { ErrorNotification } from '../ErrorNotification';
 import { Icon } from '../../ustc-ui/Icon/Icon';
+import { MessageColumnData } from '@web-client/views/Messages/MessageColumns';
 import { SortableColumn } from '../../ustc-ui/Table/SortableColumn';
 import { SuccessNotification } from '../SuccessNotification';
 import { TableFilters } from '../../ustc-ui/Table/TableFilters';
@@ -10,15 +11,6 @@ import { sequences } from '@web-client/presenter/app.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
 import React, { useEffect, useRef } from 'react';
 import classNames from 'classnames';
-
-export interface MessageColumnData {
-  columnName: string;
-  sortField: string;
-  sortType?: 'string' | 'date';
-  className?: string;
-  dataTestId?: string;
-  iconClassName?: string;
-}
 
 export interface MessageFilterData {
   isSelected: any;
@@ -66,6 +58,82 @@ export const MessageList = connect<
   }) {
     const selectAllCheckboxRef = useRef<HTMLInputElement>(null);
 
+    const getOneCell = (message: any, data: MessageColumnData) => {
+      if (data.sortField === 'docketNumber') {
+        return (
+          <>
+            <td className="consolidated-case-column">
+              <ConsolidatedCaseIcon
+                consolidatedIconTooltipText={
+                  message.consolidatedIconTooltipText
+                }
+                inConsolidatedGroup={message.inConsolidatedGroup}
+                showLeadCaseIcon={message.isLeadCase}
+              />
+            </td>
+            <td
+              className="message-queue-row small"
+              colSpan={2}
+              data-testid="individual-message-inbox-docket-number-cell"
+            >
+              {message.docketNumberWithSuffix}
+            </td>
+          </>
+        );
+      }
+      if (data.sortField === 'subject') {
+        return (
+          <>
+            <td className="message-unread-column">
+              {!message.isRead && (
+                <Icon
+                  aria-label="unread message"
+                  className="fa-icon-blue"
+                  icon="envelope"
+                  size="1x"
+                />
+              )}
+            </td>
+            <td className="message-queue-row message-subject">
+              <div className="message-document-title">
+                <Button
+                  link
+                  className={classNames(
+                    'padding-0',
+                    message.isRead ? '' : 'text-bold',
+                  )}
+                  data-testid="individual-message-inbox-subject-cell"
+                  href={message.messageDetailLink}
+                >
+                  {message.subject}
+                </Button>
+              </div>
+
+              <div className="message-document-detail">{message.message}</div>
+            </td>
+          </>
+        );
+      }
+      if (data.sortField === 'createdAt') {
+        return (
+          <td
+            className="message-queue-row no-wrap"
+            data-testid={`${data.dataTestId}-cell`}
+          >
+            {message[data.sortFieldDisplay || data.sortField]}
+          </td>
+        );
+      }
+      return (
+        <td
+          className="message-queue-row"
+          data-testid={`${data.dataTestId}-cell`}
+        >
+          {message[data.sortFieldDisplay || data.sortField]}
+        </td>
+      );
+    };
+
     useEffect(() => {
       if (!selectAllCheckboxRef.current) return;
 
@@ -95,192 +163,138 @@ export const MessageList = connect<
             </div>
           </div>
         )}
-        <div className="grid-row grid-gap">
-          <div className="desktop:grid-col-8 tablet:grid-col-12 display-flex flex-align-center">
-            <TableFilters
-              filters={messageFilters}
-              onSelect={updateMessageFilterSequence}
-            ></TableFilters>
+        <div className="overflow-x-auto">
+          <div className="grid-row grid-gap">
+            <div className="desktop:grid-col-8 tablet:grid-col-12 display-flex flex-align-center">
+              <TableFilters
+                filters={messageFilters}
+                onSelect={updateMessageFilterSequence}
+              ></TableFilters>
+            </div>
+
+            {selectable && (
+              <div className="desktop:grid-col-4 tablet:grid-col-12 tablet:margin-top-2 text-right">
+                <Button
+                  link
+                  className="action-button"
+                  data-testid="message-batch-mark-as-complete"
+                  disabled={
+                    !messagesIndividualInboxHelper.isCompletionButtonEnabled
+                  }
+                  icon="check-circle"
+                  id="button-batch-complete"
+                  onClick={() => {
+                    batchCompleteMessageSequence();
+                  }}
+                >
+                  Complete
+                </Button>
+              </div>
+            )}
           </div>
 
-          {selectable && (
-            <div className="desktop:grid-col-4 tablet:grid-col-12 tablet:margin-top-2 text-right">
-              <Button
-                link
-                className="action-button"
-                data-testid="message-batch-mark-as-complete"
-                disabled={
-                  !messagesIndividualInboxHelper.isCompletionButtonEnabled
-                }
-                icon="check-circle"
-                id="button-batch-complete"
-                onClick={() => {
-                  batchCompleteMessageSequence();
-                }}
-              >
-                Complete
-              </Button>
-            </div>
-          )}
-        </div>
-
-        <table className="usa-table ustc-table subsection">
-          <thead>
-            <tr>
-              {selectable && (
-                <th>
-                  <input
-                    aria-label="all-messages-checkbox"
-                    checked={messagesIndividualInboxHelper.allMessagesSelected}
-                    data-testid="all-messages-checkbox"
-                    disabled={
-                      !messagesIndividualInboxHelper.allMessagesCheckboxEnabled
-                    }
-                    id="all-messages-checkbox"
-                    ref={selectAllCheckboxRef}
-                    type="checkbox"
-                    onChange={() => {
-                      const selectAll = formattedMessages.messages.map(
-                        message => ({
-                          messageId: message.messageId,
-                          parentMessageId: message.parentMessageId,
-                        }),
-                      );
-                      setSelectedMessagesSequence({ messages: selectAll });
-                    }}
-                  />
-                </th>
-              )}
-              {messageColumns.map((data, index) => {
-                return (
-                  <>
-                    {data.iconClassName && (
-                      <th className={data.iconClassName}></th>
-                    )}
-                    <th
-                      aria-label={data.columnName}
-                      className={data.className}
-                      colSpan={index === 0 ? 2 : undefined}
-                      key={data.sortField}
-                      // TODO: probably should use aria-sort, but USWDS has default styles for this we may not want
-                    >
-                      <SortableColumn
-                        ascText={
-                          data.sortType === 'string'
-                            ? constants.CHRONOLOGICALLY_ASCENDING
-                            : constants.ALPHABETICALLY_ASCENDING
-                        }
-                        currentlySortedField={tableSort.sortField}
-                        currentlySortedOrder={tableSort.sortOrder}
-                        data-testid={`${data.dataTestId}-header-button`}
-                        defaultSortOrder={constants.DESCENDING}
-                        descText={
-                          data.sortType === 'date'
-                            ? constants.CHRONOLOGICALLY_DESCENDING
-                            : constants.ALPHABETICALLY_DESCENDING
-                        }
-                        hasRows={formattedMessages.hasMessages}
-                        sortField={data.sortField}
-                        title={data.columnName}
-                        onClickSequence={sortTableSequence}
-                      />
-                    </th>
-                  </>
-                );
-              })}
-            </tr>
-          </thead>
-          {formattedMessages.messages.map(message => {
-            return (
-              <tbody key={message.messageId}>
-                <tr key={message.messageId}>
-                  {selectable && (
-                    <td>
-                      <input
-                        aria-label={`${message.caseTitle}-${message.subject}-checkbox`}
-                        checked={message.isSelected}
-                        id={`${message.caseTitle}-message-checkbox`}
-                        type="checkbox"
-                        onChange={() => {
-                          setSelectedMessagesSequence({
-                            messages: [
-                              {
-                                messageId: message.messageId,
-                                parentMessageId: message.parentMessageId,
-                              },
-                            ],
-                          });
-                        }}
-                      />
-                    </td>
-                  )}
-                  <td className="consolidated-case-column">
-                    <ConsolidatedCaseIcon
-                      consolidatedIconTooltipText={
-                        message.consolidatedIconTooltipText
+          <table className="usa-table ustc-table subsection">
+            <thead>
+              <tr>
+                {selectable && (
+                  <th>
+                    <input
+                      aria-label="all-messages-checkbox"
+                      checked={
+                        messagesIndividualInboxHelper.allMessagesSelected
                       }
-                      inConsolidatedGroup={message.inConsolidatedGroup}
-                      showLeadCaseIcon={message.isLeadCase}
+                      data-testid="all-messages-checkbox"
+                      disabled={
+                        !messagesIndividualInboxHelper.allMessagesCheckboxEnabled
+                      }
+                      id="all-messages-checkbox"
+                      ref={selectAllCheckboxRef}
+                      type="checkbox"
+                      onChange={() => {
+                        const selectAll = formattedMessages.messages.map(
+                          message => ({
+                            messageId: message.messageId,
+                            parentMessageId: message.parentMessageId,
+                          }),
+                        );
+                        setSelectedMessagesSequence({ messages: selectAll });
+                      }}
                     />
-                  </td>
-                  <td
-                    className="message-queue-row small"
-                    colSpan={2}
-                    data-testid="individual-message-inbox-docket-number-cell"
-                  >
-                    {message.docketNumberWithSuffix}
-                  </td>
-                  <td
-                    className="message-queue-row small"
-                    data-testid="individual-message-inbox-received-at-cell"
-                  >
-                    <span className="no-wrap">
-                      {message.createdAtFormatted}
-                    </span>
-                  </td>
-                  <td className="message-unread-column">
-                    {!message.isRead && (
-                      <Icon
-                        aria-label="unread message"
-                        className="fa-icon-blue"
-                        icon="envelope"
-                        size="1x"
-                      />
-                    )}
-                  </td>
-                  <td className="message-queue-row message-subject">
-                    <div className="message-document-title">
-                      <Button
-                        link
-                        className={classNames(
-                          'padding-0',
-                          message.isRead ? '' : 'text-bold',
-                        )}
-                        data-testid="individual-message-inbox-subject-cell"
-                        href={message.messageDetailLink}
+                  </th>
+                )}
+                {messageColumns.map((data, index) => {
+                  return (
+                    <>
+                      {data.iconClassName && (
+                        <th className={data.iconClassName}></th>
+                      )}
+                      <th
+                        aria-label={data.columnName}
+                        className={data.className}
+                        colSpan={index === 0 ? 2 : undefined}
+                        key={data.sortField}
+                        // TODO: probably should use aria-sort, but USWDS has default styles for this we may not want
                       >
-                        {message.subject}
-                      </Button>
-                    </div>
-
-                    <div className="message-document-detail">
-                      {message.message}
-                    </div>
-                  </td>
-                  <td className="message-queue-row max-width-25">
-                    {message.caseTitle}
-                  </td>
-                  <td className="message-queue-row">{message.caseStatus}</td>
-                  <td className="message-queue-row from">{message.from}</td>
-                  <td className="message-queue-row small">
-                    {message.fromSectionFormatted}
-                  </td>
-                </tr>
-              </tbody>
-            );
-          })}
-        </table>
-        {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+                        <SortableColumn
+                          ascText={
+                            data.sortType === 'string'
+                              ? constants.CHRONOLOGICALLY_ASCENDING
+                              : constants.ALPHABETICALLY_ASCENDING
+                          }
+                          currentlySortedField={tableSort.sortField}
+                          currentlySortedOrder={tableSort.sortOrder}
+                          data-testid={`${data.dataTestId}-header-button`}
+                          defaultSortOrder={constants.DESCENDING}
+                          descText={
+                            data.sortType === 'date'
+                              ? constants.CHRONOLOGICALLY_DESCENDING
+                              : constants.ALPHABETICALLY_DESCENDING
+                          }
+                          hasRows={formattedMessages.hasMessages}
+                          sortField={data.sortField}
+                          title={data.columnName}
+                          onClickSequence={sortTableSequence}
+                        />
+                      </th>
+                    </>
+                  );
+                })}
+              </tr>
+            </thead>
+            {formattedMessages.messages.map(message => {
+              return (
+                <tbody key={message.messageId}>
+                  <tr key={message.messageId}>
+                    {selectable && (
+                      <td>
+                        <input
+                          aria-label={`${message.caseTitle}-${message.subject}-checkbox`}
+                          checked={message.isSelected}
+                          id={`${message.caseTitle}-message-checkbox`}
+                          type="checkbox"
+                          onChange={() => {
+                            setSelectedMessagesSequence({
+                              messages: [
+                                {
+                                  messageId: message.messageId,
+                                  parentMessageId: message.parentMessageId,
+                                },
+                              ],
+                            });
+                          }}
+                        />
+                      </td>
+                    )}
+                    {messageColumns.map(data => {
+                      return getOneCell(message, data);
+                    })}
+                  </tr>
+                </tbody>
+              );
+            })}
+          </table>
+          {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+        </div>
       </>
     );
   },

--- a/web-client/src/views/Messages/MessageList.tsx
+++ b/web-client/src/views/Messages/MessageList.tsx
@@ -1,3 +1,7 @@
+import {
+  ASCENDING,
+  DESCENDING,
+} from '@shared/business/entities/EntityConstants';
 import { Button } from '../../ustc-ui/Button/Button';
 import { ConsolidatedCaseIcon } from '../../ustc-ui/Icon/ConsolidatedCaseIcon';
 import { ErrorNotification } from '../ErrorNotification';
@@ -5,6 +9,8 @@ import { Icon } from '../../ustc-ui/Icon/Icon';
 import {
   MessageColumnData,
   SORT_FIELDS,
+  getAscendingTextForSortType,
+  getDescendingTextForSortType,
 } from '@web-client/views/Messages/MessageColumns';
 import { SortableColumn } from '../../ustc-ui/Table/SortableColumn';
 import { SuccessNotification } from '../SuccessNotification';
@@ -31,7 +37,6 @@ type MessageListProps = {
 
 const MessageListCerebralDependencies = {
   batchCompleteMessageSequence: sequences.batchCompleteMessageSequence,
-  constants: state.constants,
   formattedMessages: state.formattedMessages,
   messagesIndividualInboxHelper: state.messagesIndividualInboxHelper,
   screenMetadata: state.screenMetadata,
@@ -48,7 +53,6 @@ export const MessageList = connect<
   MessageListCerebralDependencies,
   function MessageList({
     batchCompleteMessageSequence,
-    constants,
     formattedMessages,
     id,
     messageColumns,
@@ -63,82 +67,6 @@ export const MessageList = connect<
   }) {
     const selectAllCheckboxRef = useRef<HTMLInputElement>(null);
 
-    const getMessageDocketNumberCell = (message: any) => {
-      return (
-        <>
-          <td className="consolidated-case-column">
-            <ConsolidatedCaseIcon
-              consolidatedIconTooltipText={message.consolidatedIconTooltipText}
-              inConsolidatedGroup={message.inConsolidatedGroup}
-              showLeadCaseIcon={message.isLeadCase}
-            />
-          </td>
-          <td
-            className="message-queue-row"
-            colSpan={2}
-            data-testid={`${id}-docketNumber-cell`}
-          >
-            {message.docketNumberWithSuffix}
-          </td>
-        </>
-      );
-    };
-
-    const getMessageSubjectCell = (message: any) => {
-      return (
-        <>
-          <td className="message-unread-column">
-            {!message.isRead && (
-              <Icon
-                aria-label="unread message"
-                className="fa-icon-blue"
-                icon="envelope"
-                size="1x"
-              />
-            )}
-          </td>
-          <td className="message-queue-row message-subject">
-            <div className="message-document-title">
-              <Button
-                link
-                className={classNames(
-                  'padding-0',
-                  message.isRead ? '' : 'text-bold',
-                )}
-                data-testid={`${id}-subject-cell`}
-                href={message.messageDetailLink}
-              >
-                {message.subject}
-              </Button>
-            </div>
-
-            <div className="message-document-detail">{message.message}</div>
-          </td>
-        </>
-      );
-    };
-
-    const getOneCell = (message: any, data: MessageColumnData) => {
-      if (data.sortFieldInfo === SORT_FIELDS.DOCKET_NUMBER) {
-        return getMessageDocketNumberCell(message);
-      }
-      if (data.sortFieldInfo === SORT_FIELDS.SUBJECT) {
-        return getMessageSubjectCell(message);
-      }
-      return (
-        <td
-          className={`message-queue-row ${data.sortFieldInfo === SORT_FIELDS.CREATED_AT && 'no-wrap'}`}
-          data-testid={`${id}-${data.sortFieldInfo.sortField}-cell`}
-        >
-          {
-            message[
-              data.sortFieldInfo.displayField || data.sortFieldInfo.sortField
-            ]
-          }
-        </td>
-      );
-    };
-
     useEffect(() => {
       if (!selectAllCheckboxRef.current) return;
 
@@ -150,6 +78,52 @@ export const MessageList = connect<
       messagesIndividualInboxHelper.someMessagesSelected,
       messagesIndividualInboxHelper.allMessagesSelected,
     ]);
+
+    // For cases when messages can be selected in the given view
+    const getSelectAllCheckbox = () => {
+      return (
+        <th>
+          <input
+            aria-label="all-messages-checkbox"
+            checked={messagesIndividualInboxHelper.allMessagesSelected}
+            data-testid="all-messages-checkbox"
+            disabled={!messagesIndividualInboxHelper.allMessagesCheckboxEnabled}
+            id="all-messages-checkbox"
+            ref={selectAllCheckboxRef}
+            type="checkbox"
+            onChange={() => {
+              const selectAll = formattedMessages.messages.map(message => ({
+                messageId: message.messageId,
+                parentMessageId: message.parentMessageId,
+              }));
+              setSelectedMessagesSequence({ messages: selectAll });
+            }}
+          />
+        </th>
+      );
+    };
+
+    // For cases when messages can be completed in the given view
+    const getCompleteAllButton = () => {
+      return (
+        <div className="desktop:grid-col-4 tablet:grid-col-12 tablet:margin-top-2 text-right">
+          <Button
+            link
+            className="action-button"
+            data-testid="message-batch-mark-as-complete"
+            disabled={!messagesIndividualInboxHelper.isCompletionButtonEnabled}
+            icon="check-circle"
+            id="button-batch-complete"
+            onClick={() => {
+              batchCompleteMessageSequence();
+            }}
+          >
+            Complete
+          </Button>
+        </div>
+      );
+    };
+
     return (
       <>
         <SuccessNotification />
@@ -178,128 +152,37 @@ export const MessageList = connect<
                 ></TableFilters>
               </div>
             )}
-            {selectable && (
-              <div className="desktop:grid-col-4 tablet:grid-col-12 tablet:margin-top-2 text-right">
-                <Button
-                  link
-                  className="action-button"
-                  data-testid="message-batch-mark-as-complete"
-                  disabled={
-                    !messagesIndividualInboxHelper.isCompletionButtonEnabled
-                  }
-                  icon="check-circle"
-                  id="button-batch-complete"
-                  onClick={() => {
-                    batchCompleteMessageSequence();
-                  }}
-                >
-                  Complete
-                </Button>
-              </div>
-            )}
+            {selectable && getCompleteAllButton()}
           </div>
 
           <table className="usa-table ustc-table subsection">
             <thead>
               <tr>
-                {selectable && (
-                  <th>
-                    <input
-                      aria-label="all-messages-checkbox"
-                      checked={
-                        messagesIndividualInboxHelper.allMessagesSelected
-                      }
-                      data-testid="all-messages-checkbox"
-                      disabled={
-                        !messagesIndividualInboxHelper.allMessagesCheckboxEnabled
-                      }
-                      id="all-messages-checkbox"
-                      ref={selectAllCheckboxRef}
-                      type="checkbox"
-                      onChange={() => {
-                        const selectAll = formattedMessages.messages.map(
-                          message => ({
-                            messageId: message.messageId,
-                            parentMessageId: message.parentMessageId,
-                          }),
-                        );
-                        setSelectedMessagesSequence({ messages: selectAll });
-                      }}
-                    />
-                  </th>
-                )}
-                {messageColumns.map((data, index) => {
+                {selectable && getSelectAllCheckbox()}
+                {messageColumns.map(columnData => {
                   return (
-                    <>
-                      {data.headerIconClassName && (
-                        <th className={data.headerIconClassName}></th>
-                      )}
-                      <th
-                        aria-label={data.columnName}
-                        className={data.headerClassName}
-                        colSpan={index === 0 ? 2 : undefined}
-                        key={data.sortFieldInfo.sortField}
-                        // TODO: probably should use aria-sort, but USWDS has default styles for this we may not want
-                      >
-                        <SortableColumn
-                          ascText={
-                            data.sortType === 'string'
-                              ? constants.CHRONOLOGICALLY_ASCENDING
-                              : constants.ALPHABETICALLY_ASCENDING
-                          }
-                          currentlySortedField={tableSort.sortField}
-                          currentlySortedOrder={tableSort.sortOrder}
-                          data-testid={`${id}-${data.sortFieldInfo.sortField}-header-button`}
-                          defaultSortOrder={
-                            data.sortFieldInfo === SORT_FIELDS.DOCKET_NUMBER
-                              ? constants.DESCENDING
-                              : constants.ASCENDING
-                          }
-                          descText={
-                            data.sortType === 'date'
-                              ? constants.CHRONOLOGICALLY_DESCENDING
-                              : constants.ALPHABETICALLY_DESCENDING
-                          }
-                          hasRows={formattedMessages.hasMessages}
-                          sortField={data.sortFieldInfo.sortField}
-                          title={data.columnName}
-                          onClickSequence={sortTableSequence}
-                        />
-                      </th>
-                    </>
+                    <MessageColumnHeader
+                      columnData={columnData}
+                      formattedMessages={formattedMessages}
+                      key={columnData.sortFieldInfo.sortField}
+                      messageListId={id}
+                      tableSort={tableSort}
+                      onSort={sortTableSequence}
+                    />
                   );
                 })}
               </tr>
             </thead>
             {formattedMessages.messages.map(message => {
               return (
-                <tbody key={message.messageId}>
-                  <tr key={message.messageId}>
-                    {selectable && (
-                      <td>
-                        <input
-                          aria-label={`${message.caseTitle}-${message.subject}-checkbox`}
-                          checked={message.isSelected}
-                          id={`${message.caseTitle}-message-checkbox`}
-                          type="checkbox"
-                          onChange={() => {
-                            setSelectedMessagesSequence({
-                              messages: [
-                                {
-                                  messageId: message.messageId,
-                                  parentMessageId: message.parentMessageId,
-                                },
-                              ],
-                            });
-                          }}
-                        />
-                      </td>
-                    )}
-                    {messageColumns.map(data => {
-                      return getOneCell(message, data);
-                    })}
-                  </tr>
-                </tbody>
+                <MessageRow
+                  columns={messageColumns}
+                  key={message.messageId}
+                  message={message}
+                  messageListId={id}
+                  selectable={selectable}
+                  onSelect={setSelectedMessagesSequence}
+                />
               );
             })}
           </table>
@@ -311,3 +194,203 @@ export const MessageList = connect<
 );
 
 MessageList.displayName = 'MessageList';
+
+const MessageColumnHeader = ({
+  columnData,
+  formattedMessages,
+  messageListId,
+  onSort,
+  tableSort,
+}: {
+  messageListId: string;
+  columnData: MessageColumnData;
+  tableSort: any;
+  formattedMessages: any;
+  onSort: ({
+    sortField,
+    sortOrder,
+  }: {
+    sortField: string;
+    sortOrder: 'asc' | 'desc';
+  }) => void;
+}) => {
+  return (
+    <>
+      {columnData.headerIconClassName && (
+        <th className={columnData.headerIconClassName}></th>
+      )}
+      <th
+        aria-label={columnData.columnName}
+        className={columnData.headerClassName}
+        colSpan={
+          columnData.sortFieldInfo === SORT_FIELDS.DOCKET_NUMBER ? 2 : undefined
+        }
+        // TODO: probably should use aria-sort, but USWDS has default styles for this we may not want
+      >
+        <SortableColumn
+          ascText={getAscendingTextForSortType(
+            columnData.sortFieldInfo.sortType,
+          )}
+          currentlySortedField={tableSort.sortField}
+          currentlySortedOrder={tableSort.sortOrder}
+          data-testid={`${messageListId}-${columnData.sortFieldInfo.sortField}-header-button`}
+          defaultSortOrder={
+            columnData.sortFieldInfo === SORT_FIELDS.DOCKET_NUMBER
+              ? DESCENDING
+              : ASCENDING
+          }
+          descText={getDescendingTextForSortType(
+            columnData.sortFieldInfo.sortType,
+          )}
+          hasRows={formattedMessages.hasMessages}
+          sortField={columnData.sortFieldInfo.sortField}
+          title={columnData.columnName}
+          onClickSequence={onSort}
+        />
+      </th>
+    </>
+  );
+};
+
+const MessageRow = ({
+  columns,
+  message,
+  messageListId,
+  onSelect,
+  selectable,
+}: {
+  message: any;
+  messageListId: string;
+  selectable: boolean;
+  onSelect: (messages: any) => void;
+  columns: MessageColumnData[];
+}) => {
+  return (
+    <tbody>
+      <tr>
+        {selectable && (
+          <td>
+            <input
+              aria-label={`${message.caseTitle}-${message.subject}-checkbox`}
+              checked={message.isSelected}
+              id={`${message.caseTitle}-message-checkbox`}
+              type="checkbox"
+              onChange={() => {
+                onSelect({
+                  messages: [
+                    {
+                      messageId: message.messageId,
+                      parentMessageId: message.parentMessageId,
+                    },
+                  ],
+                });
+              }}
+            />
+          </td>
+        )}
+        {columns.map(columnData => {
+          return getOneCell({ columnData, message, messageListId });
+        })}
+      </tr>
+    </tbody>
+  );
+};
+
+const getOneCell = ({
+  columnData,
+  message,
+  messageListId,
+}: {
+  messageListId: string;
+  message: any;
+  columnData: MessageColumnData;
+}) => {
+  // If the cell requires special handling (e.g., an icon, formatting, etc.), do that
+  if (columnData.sortFieldInfo === SORT_FIELDS.DOCKET_NUMBER) {
+    return getMessageDocketNumberCell({ message, messageListId });
+  }
+  if (columnData.sortFieldInfo === SORT_FIELDS.SUBJECT) {
+    return getMessageSubjectCell({ message, messageListId });
+  }
+  // Otherwise, return a generic cell
+  return (
+    <td
+      className={`message-queue-row ${columnData.sortFieldInfo === SORT_FIELDS.CREATED_AT && 'no-wrap'}`}
+      data-testid={`${messageListId}-${columnData.sortFieldInfo.sortField}-cell`}
+    >
+      {
+        message[
+          columnData.sortFieldInfo.displayField ||
+            columnData.sortFieldInfo.sortField
+        ]
+      }
+    </td>
+  );
+};
+
+const getMessageDocketNumberCell = ({
+  message,
+  messageListId,
+}: {
+  messageListId: string;
+  message: any;
+}) => {
+  return (
+    <>
+      <td className="consolidated-case-column">
+        <ConsolidatedCaseIcon
+          consolidatedIconTooltipText={message.consolidatedIconTooltipText}
+          inConsolidatedGroup={message.inConsolidatedGroup}
+          showLeadCaseIcon={message.isLeadCase}
+        />
+      </td>
+      <td
+        className="message-queue-row"
+        colSpan={2}
+        data-testid={`${messageListId}-docketNumber-cell`}
+      >
+        {message.docketNumberWithSuffix}
+      </td>
+    </>
+  );
+};
+
+const getMessageSubjectCell = ({
+  message,
+  messageListId,
+}: {
+  messageListId: string;
+  message: any;
+}) => {
+  return (
+    <>
+      <td className="message-unread-column">
+        {!message.isRead && (
+          <Icon
+            aria-label="unread message"
+            className="fa-icon-blue"
+            icon="envelope"
+            size="1x"
+          />
+        )}
+      </td>
+      <td className="message-queue-row message-subject">
+        <div className="message-document-title">
+          <Button
+            link
+            className={classNames(
+              'padding-0',
+              message.isRead ? '' : 'text-bold',
+            )}
+            data-testid={`${messageListId}-subject-cell`}
+            href={message.messageDetailLink}
+          >
+            {message.subject}
+          </Button>
+        </div>
+
+        <div className="message-document-detail">{message.message}</div>
+      </td>
+    </>
+  );
+};

--- a/web-client/src/views/Messages/MessageList.tsx
+++ b/web-client/src/views/Messages/MessageList.tsx
@@ -74,9 +74,9 @@ export const MessageList = connect<
             />
           </td>
           <td
-            className="message-queue-rowl"
+            className="message-queue-row"
             colSpan={2}
-            data-testid="individual-message-inbox-docket-number-cell"
+            data-testid={`${id}-docketNumber-cell`}
           >
             {message.docketNumberWithSuffix}
           </td>
@@ -105,7 +105,7 @@ export const MessageList = connect<
                   'padding-0',
                   message.isRead ? '' : 'text-bold',
                 )}
-                data-testid="individual-message-inbox-subject-cell"
+                data-testid={`${id}-subject-cell`}
                 href={message.messageDetailLink}
               >
                 {message.subject}
@@ -128,7 +128,7 @@ export const MessageList = connect<
       return (
         <td
           className={`message-queue-row ${data.sortFieldInfo === SORT_FIELDS.CREATED_AT && 'no-wrap'}`}
-          data-testid={`${data.dataTestId}-cell`}
+          data-testid={`${id}-${data.sortFieldInfo.sortField}-cell`}
         >
           {
             message[
@@ -170,13 +170,14 @@ export const MessageList = connect<
         )}
         <div className="overflow-x-auto" id={id}>
           <div className="grid-row grid-gap">
-            <div className="desktop:grid-col-8 tablet:grid-col-12 display-flex flex-align-center">
-              <TableFilters
-                filters={messageFilters}
-                onSelect={updateMessageFilterSequence}
-              ></TableFilters>
-            </div>
-
+            {messageFilters.length > 0 && (
+              <div className="desktop:grid-col-8 tablet:grid-col-12 display-flex flex-align-center">
+                <TableFilters
+                  filters={messageFilters}
+                  onSelect={updateMessageFilterSequence}
+                ></TableFilters>
+              </div>
+            )}
             {selectable && (
               <div className="desktop:grid-col-4 tablet:grid-col-12 tablet:margin-top-2 text-right">
                 <Button
@@ -248,8 +249,12 @@ export const MessageList = connect<
                           }
                           currentlySortedField={tableSort.sortField}
                           currentlySortedOrder={tableSort.sortOrder}
-                          data-testid={`${data.dataTestId}-header-button`}
-                          defaultSortOrder={constants.DESCENDING}
+                          data-testid={`${id}-${data.sortFieldInfo.sortField}-header-button`}
+                          defaultSortOrder={
+                            data.sortFieldInfo === SORT_FIELDS.DOCKET_NUMBER
+                              ? constants.DESCENDING
+                              : constants.ASCENDING
+                          }
                           descText={
                             data.sortType === 'date'
                               ? constants.CHRONOLOGICALLY_DESCENDING

--- a/web-client/src/views/Messages/MessageList.tsx
+++ b/web-client/src/views/Messages/MessageList.tsx
@@ -2,7 +2,10 @@ import { Button } from '../../ustc-ui/Button/Button';
 import { ConsolidatedCaseIcon } from '../../ustc-ui/Icon/ConsolidatedCaseIcon';
 import { ErrorNotification } from '../ErrorNotification';
 import { Icon } from '../../ustc-ui/Icon/Icon';
-import { MessageColumnData } from '@web-client/views/Messages/MessageColumns';
+import {
+  MessageColumnData,
+  SORT_FIELDS,
+} from '@web-client/views/Messages/MessageColumns';
 import { SortableColumn } from '../../ustc-ui/Table/SortableColumn';
 import { SuccessNotification } from '../SuccessNotification';
 import { TableFilters } from '../../ustc-ui/Table/TableFilters';
@@ -58,78 +61,78 @@ export const MessageList = connect<
   }) {
     const selectAllCheckboxRef = useRef<HTMLInputElement>(null);
 
-    const getOneCell = (message: any, data: MessageColumnData) => {
-      if (data.sortField === 'docketNumber') {
-        return (
-          <>
-            <td className="consolidated-case-column">
-              <ConsolidatedCaseIcon
-                consolidatedIconTooltipText={
-                  message.consolidatedIconTooltipText
-                }
-                inConsolidatedGroup={message.inConsolidatedGroup}
-                showLeadCaseIcon={message.isLeadCase}
-              />
-            </td>
-            <td
-              className="message-queue-row small"
-              colSpan={2}
-              data-testid="individual-message-inbox-docket-number-cell"
-            >
-              {message.docketNumberWithSuffix}
-            </td>
-          </>
-        );
-      }
-      if (data.sortField === 'subject') {
-        return (
-          <>
-            <td className="message-unread-column">
-              {!message.isRead && (
-                <Icon
-                  aria-label="unread message"
-                  className="fa-icon-blue"
-                  icon="envelope"
-                  size="1x"
-                />
-              )}
-            </td>
-            <td className="message-queue-row message-subject">
-              <div className="message-document-title">
-                <Button
-                  link
-                  className={classNames(
-                    'padding-0',
-                    message.isRead ? '' : 'text-bold',
-                  )}
-                  data-testid="individual-message-inbox-subject-cell"
-                  href={message.messageDetailLink}
-                >
-                  {message.subject}
-                </Button>
-              </div>
-
-              <div className="message-document-detail">{message.message}</div>
-            </td>
-          </>
-        );
-      }
-      if (data.sortField === 'createdAt') {
-        return (
-          <td
-            className="message-queue-row no-wrap"
-            data-testid={`${data.dataTestId}-cell`}
-          >
-            {message[data.sortFieldDisplay || data.sortField]}
+    const getMessageDocketNumberCell = (message: any) => {
+      return (
+        <>
+          <td className="consolidated-case-column">
+            <ConsolidatedCaseIcon
+              consolidatedIconTooltipText={message.consolidatedIconTooltipText}
+              inConsolidatedGroup={message.inConsolidatedGroup}
+              showLeadCaseIcon={message.isLeadCase}
+            />
           </td>
-        );
+          <td
+            className="message-queue-rowl"
+            colSpan={2}
+            data-testid="individual-message-inbox-docket-number-cell"
+          >
+            {message.docketNumberWithSuffix}
+          </td>
+        </>
+      );
+    };
+
+    const getMessageSubjectCell = (message: any) => {
+      return (
+        <>
+          <td className="message-unread-column">
+            {!message.isRead && (
+              <Icon
+                aria-label="unread message"
+                className="fa-icon-blue"
+                icon="envelope"
+                size="1x"
+              />
+            )}
+          </td>
+          <td className="message-queue-row message-subject">
+            <div className="message-document-title">
+              <Button
+                link
+                className={classNames(
+                  'padding-0',
+                  message.isRead ? '' : 'text-bold',
+                )}
+                data-testid="individual-message-inbox-subject-cell"
+                href={message.messageDetailLink}
+              >
+                {message.subject}
+              </Button>
+            </div>
+
+            <div className="message-document-detail">{message.message}</div>
+          </td>
+        </>
+      );
+    };
+
+    const getOneCell = (message: any, data: MessageColumnData) => {
+      if (data.sortFieldInfo === SORT_FIELDS.DOCKET_NUMBER) {
+        return getMessageDocketNumberCell(message);
+      }
+      if (data.sortFieldInfo === SORT_FIELDS.SUBJECT) {
+        return getMessageSubjectCell(message);
       }
       return (
         <td
-          className="message-queue-row"
+          className={`message-queue-row ${data.sortFieldInfo === SORT_FIELDS.CREATED_AT && 'no-wrap'}`}
           data-testid={`${data.dataTestId}-cell`}
         >
-          {message[data.sortFieldDisplay || data.sortField]}
+          {
+            message[
+              data.sortFieldInfo.displayField || data.sortFieldInfo.sortField
+            ]
+          }
         </td>
       );
     };
@@ -225,14 +228,14 @@ export const MessageList = connect<
                 {messageColumns.map((data, index) => {
                   return (
                     <>
-                      {data.iconClassName && (
-                        <th className={data.iconClassName}></th>
+                      {data.headerIconClassName && (
+                        <th className={data.headerIconClassName}></th>
                       )}
                       <th
                         aria-label={data.columnName}
-                        className={data.className}
+                        className={data.headerClassName}
                         colSpan={index === 0 ? 2 : undefined}
-                        key={data.sortField}
+                        key={data.sortFieldInfo.sortField}
                         // TODO: probably should use aria-sort, but USWDS has default styles for this we may not want
                       >
                         <SortableColumn
@@ -251,7 +254,7 @@ export const MessageList = connect<
                               : constants.ALPHABETICALLY_DESCENDING
                           }
                           hasRows={formattedMessages.hasMessages}
-                          sortField={data.sortField}
+                          sortField={data.sortFieldInfo.sortField}
                           title={data.columnName}
                           onClickSequence={sortTableSequence}
                         />

--- a/web-client/src/views/Messages/MessageList.tsx
+++ b/web-client/src/views/Messages/MessageList.tsx
@@ -23,6 +23,7 @@ export interface MessageFilterData {
 }
 
 type MessageListProps = {
+  id: string;
   selectable: boolean;
   messageColumns: MessageColumnData[];
   messageFilters: MessageFilterData[];
@@ -49,6 +50,7 @@ export const MessageList = connect<
     batchCompleteMessageSequence,
     constants,
     formattedMessages,
+    id,
     messageColumns,
     messageFilters,
     messagesIndividualInboxHelper,
@@ -166,7 +168,7 @@ export const MessageList = connect<
             </div>
           </div>
         )}
-        <div className="overflow-x-auto">
+        <div className="overflow-x-auto" id={id}>
           <div className="grid-row grid-gap">
             <div className="desktop:grid-col-8 tablet:grid-col-12 display-flex flex-align-center">
               <TableFilters

--- a/web-client/src/views/Messages/MessageTable.tsx
+++ b/web-client/src/views/Messages/MessageTable.tsx
@@ -33,7 +33,6 @@ type MessageListProps = {
   selectable: boolean;
   messageColumns: MessageColumnData[];
   messageFilters: MessageFilterData[];
-  showUnreadIcon?: boolean;
 };
 
 const MessageListCerebralDependencies = {
@@ -47,12 +46,12 @@ const MessageListCerebralDependencies = {
   updateMessageFilterSequence: sequences.updateMessageFilterSequence,
 };
 
-export const MessagesTable = connect<
+export const MessageTable = connect<
   MessageListProps,
   typeof MessageListCerebralDependencies
 >(
   MessageListCerebralDependencies,
-  function MessagesTable({
+  function MessageTable({
     batchCompleteMessageSequence,
     formattedMessages,
     id,
@@ -62,7 +61,6 @@ export const MessagesTable = connect<
     screenMetadata,
     selectable,
     setSelectedMessagesSequence,
-    showUnreadIcon = false,
     sortTableSequence,
     tableSort,
     updateMessageFilterSequence,
@@ -168,7 +166,6 @@ export const MessagesTable = connect<
                       formattedMessages={formattedMessages}
                       key={columnData.sortFieldInfo.sortField}
                       messageListId={id}
-                      showUnreadIcon={showUnreadIcon}
                       tableSort={tableSort}
                       onSort={sortTableSequence}
                     />
@@ -184,7 +181,6 @@ export const MessagesTable = connect<
                   message={message}
                   messageListId={id}
                   selectable={selectable}
-                  showUnreadIcon={showUnreadIcon}
                   onSelect={setSelectedMessagesSequence}
                 />
               );
@@ -202,14 +198,12 @@ const MessageColumnHeader = ({
   formattedMessages,
   messageListId,
   onSort,
-  showUnreadIcon,
   tableSort,
 }: {
   messageListId: string;
   columnData: MessageColumnData;
   tableSort: any;
   formattedMessages: any;
-  showUnreadIcon: boolean;
   onSort: ({
     sortField,
     sortOrder,
@@ -218,23 +212,16 @@ const MessageColumnHeader = ({
     sortOrder: 'asc' | 'desc';
   }) => void;
 }) => {
-  let columnNeedsIcon = false;
-  if (columnData.headerIconClassName) {
-    if (columnData.sortFieldInfo === SORT_FIELDS.SUBJECT) {
-      columnNeedsIcon = !!showUnreadIcon;
-    } else {
-      columnNeedsIcon = true;
-    }
-  }
-  console.log(columnNeedsIcon, columnData.headerIconClassName);
   return (
     <>
-      {columnNeedsIcon && <th className={columnData.headerIconClassName}></th>}
+      {columnData.headerIconClassName && (
+        <th className={columnData.headerIconClassName}></th>
+      )}
       <th
         aria-label={columnData.columnName}
         className={columnData.headerClassName}
         colSpan={
-          columnData.sortFieldInfo === SORT_FIELDS.DOCKET_NUMBER ? 2 : undefined
+          columnData.sortFieldInfo === SORT_FIELDS.DOCKET_NUMBER ? 2 : undefined // Takes into account the consolidated case icon
         }
         // TODO: probably should use aria-sort, but USWDS has default styles for this we may not want
       >
@@ -269,14 +256,12 @@ const MessageRow = ({
   messageListId,
   onSelect,
   selectable,
-  showUnreadIcon,
 }: {
   message: any;
   messageListId: string;
   selectable: boolean;
   onSelect: (messages: any) => void;
   columns: MessageColumnData[];
-  showUnreadIcon: boolean;
 }) => {
   return (
     <tbody>
@@ -306,7 +291,6 @@ const MessageRow = ({
             columnData,
             message,
             messageListId,
-            showUnreadIcon,
           });
         })}
       </tr>
@@ -318,19 +302,17 @@ const getOneCell = ({
   columnData,
   message,
   messageListId,
-  showUnreadIcon,
 }: {
   messageListId: string;
   message: any;
   columnData: MessageColumnData;
-  showUnreadIcon: boolean;
 }) => {
   // If the cell requires special handling (e.g., an icon, formatting, etc.), do that
   if (columnData.sortFieldInfo === SORT_FIELDS.DOCKET_NUMBER) {
     return getMessageDocketNumberCell({ message, messageListId });
   }
   if (columnData.sortFieldInfo === SORT_FIELDS.SUBJECT) {
-    return getMessageSubjectCell({ message, messageListId, showUnreadIcon });
+    return getMessageSubjectCell({ columnData, message, messageListId });
   }
   // Otherwise, return a generic cell
   return (
@@ -376,35 +358,35 @@ const getMessageDocketNumberCell = ({
 };
 
 const getMessageSubjectCell = ({
+  columnData,
   message,
   messageListId,
-  showUnreadIcon,
 }: {
   messageListId: string;
   message: any;
-  showUnreadIcon: boolean;
+  columnData: MessageColumnData;
 }) => {
-  console.log('showUnreadIcon', showUnreadIcon);
+  const hasIconRow = !!columnData.headerIconClassName;
+  const boldText = !message.isRead && hasIconRow;
   return (
     <>
-      {!message.isRead && showUnreadIcon && (
+      {hasIconRow && (
         <td className="message-unread-column">
-          <Icon
-            aria-label="unread message"
-            className="fa-icon-blue"
-            icon="envelope"
-            size="1x"
-          />
+          {!message.isRead && (
+            <Icon
+              aria-label="unread message"
+              className="fa-icon-blue"
+              icon="envelope"
+              size="1x"
+            />
+          )}
         </td>
       )}
       <td className="message-queue-row message-subject">
         <div className="message-document-title">
           <Button
             link
-            className={classNames(
-              'padding-0',
-              !message.isRead && showUnreadIcon ? 'text-bold' : '',
-            )}
+            className={classNames('padding-0', boldText ? 'text-bold' : '')}
             data-testid={`${messageListId}-subject-cell`}
             href={message.messageDetailLink}
           >

--- a/web-client/src/views/Messages/MessageTable.tsx
+++ b/web-client/src/views/Messages/MessageTable.tsx
@@ -46,12 +46,12 @@ const MessageListCerebralDependencies = {
   updateMessageFilterSequence: sequences.updateMessageFilterSequence,
 };
 
-export const MessageList = connect<
+export const MessagesTable = connect<
   MessageListProps,
   typeof MessageListCerebralDependencies
 >(
   MessageListCerebralDependencies,
-  function MessageList({
+  function MessagesTable({
     batchCompleteMessageSequence,
     formattedMessages,
     id,
@@ -192,8 +192,6 @@ export const MessageList = connect<
     );
   },
 );
-
-MessageList.displayName = 'MessageList';
 
 const MessageColumnHeader = ({
   columnData,

--- a/web-client/src/views/Messages/MessageTable.tsx
+++ b/web-client/src/views/Messages/MessageTable.tsx
@@ -366,11 +366,11 @@ const getMessageSubjectCell = ({
   message: any;
   columnData: MessageColumnData;
 }) => {
-  const hasIconRow = !!columnData.headerIconClassName;
-  const boldText = !message.isRead && hasIconRow;
+  const hasIconColumn = !!columnData.headerIconClassName;
+  const boldText = !message.isRead && hasIconColumn;
   return (
     <>
-      {hasIconRow && (
+      {hasIconColumn && (
         <td className="message-unread-column">
           {!message.isRead && (
             <Icon

--- a/web-client/src/views/Messages/MessageTable.tsx
+++ b/web-client/src/views/Messages/MessageTable.tsx
@@ -33,6 +33,7 @@ type MessageListProps = {
   selectable: boolean;
   messageColumns: MessageColumnData[];
   messageFilters: MessageFilterData[];
+  showUnreadIcon?: boolean;
 };
 
 const MessageListCerebralDependencies = {
@@ -61,6 +62,7 @@ export const MessagesTable = connect<
     screenMetadata,
     selectable,
     setSelectedMessagesSequence,
+    showUnreadIcon = false,
     sortTableSequence,
     tableSort,
     updateMessageFilterSequence,
@@ -166,6 +168,7 @@ export const MessagesTable = connect<
                       formattedMessages={formattedMessages}
                       key={columnData.sortFieldInfo.sortField}
                       messageListId={id}
+                      showUnreadIcon={showUnreadIcon}
                       tableSort={tableSort}
                       onSort={sortTableSequence}
                     />
@@ -181,6 +184,7 @@ export const MessagesTable = connect<
                   message={message}
                   messageListId={id}
                   selectable={selectable}
+                  showUnreadIcon={showUnreadIcon}
                   onSelect={setSelectedMessagesSequence}
                 />
               );
@@ -198,12 +202,14 @@ const MessageColumnHeader = ({
   formattedMessages,
   messageListId,
   onSort,
+  showUnreadIcon,
   tableSort,
 }: {
   messageListId: string;
   columnData: MessageColumnData;
   tableSort: any;
   formattedMessages: any;
+  showUnreadIcon: boolean;
   onSort: ({
     sortField,
     sortOrder,
@@ -212,11 +218,18 @@ const MessageColumnHeader = ({
     sortOrder: 'asc' | 'desc';
   }) => void;
 }) => {
+  let columnNeedsIcon = false;
+  if (columnData.headerIconClassName) {
+    if (columnData.sortFieldInfo === SORT_FIELDS.SUBJECT) {
+      columnNeedsIcon = !!showUnreadIcon;
+    } else {
+      columnNeedsIcon = true;
+    }
+  }
+  console.log(columnNeedsIcon, columnData.headerIconClassName);
   return (
     <>
-      {columnData.headerIconClassName && (
-        <th className={columnData.headerIconClassName}></th>
-      )}
+      {columnNeedsIcon && <th className={columnData.headerIconClassName}></th>}
       <th
         aria-label={columnData.columnName}
         className={columnData.headerClassName}
@@ -256,12 +269,14 @@ const MessageRow = ({
   messageListId,
   onSelect,
   selectable,
+  showUnreadIcon,
 }: {
   message: any;
   messageListId: string;
   selectable: boolean;
   onSelect: (messages: any) => void;
   columns: MessageColumnData[];
+  showUnreadIcon: boolean;
 }) => {
   return (
     <tbody>
@@ -287,7 +302,12 @@ const MessageRow = ({
           </td>
         )}
         {columns.map(columnData => {
-          return getOneCell({ columnData, message, messageListId });
+          return getOneCell({
+            columnData,
+            message,
+            messageListId,
+            showUnreadIcon,
+          });
         })}
       </tr>
     </tbody>
@@ -298,17 +318,19 @@ const getOneCell = ({
   columnData,
   message,
   messageListId,
+  showUnreadIcon,
 }: {
   messageListId: string;
   message: any;
   columnData: MessageColumnData;
+  showUnreadIcon: boolean;
 }) => {
   // If the cell requires special handling (e.g., an icon, formatting, etc.), do that
   if (columnData.sortFieldInfo === SORT_FIELDS.DOCKET_NUMBER) {
     return getMessageDocketNumberCell({ message, messageListId });
   }
   if (columnData.sortFieldInfo === SORT_FIELDS.SUBJECT) {
-    return getMessageSubjectCell({ message, messageListId });
+    return getMessageSubjectCell({ message, messageListId, showUnreadIcon });
   }
   // Otherwise, return a generic cell
   return (
@@ -356,29 +378,32 @@ const getMessageDocketNumberCell = ({
 const getMessageSubjectCell = ({
   message,
   messageListId,
+  showUnreadIcon,
 }: {
   messageListId: string;
   message: any;
+  showUnreadIcon: boolean;
 }) => {
+  console.log('showUnreadIcon', showUnreadIcon);
   return (
     <>
-      <td className="message-unread-column">
-        {!message.isRead && (
+      {!message.isRead && showUnreadIcon && (
+        <td className="message-unread-column">
           <Icon
             aria-label="unread message"
             className="fa-icon-blue"
             icon="envelope"
             size="1x"
           />
-        )}
-      </td>
+        </td>
+      )}
       <td className="message-queue-row message-subject">
         <div className="message-document-title">
           <Button
             link
             className={classNames(
               'padding-0',
-              message.isRead ? '' : 'text-bold',
+              !message.isRead && showUnreadIcon ? 'text-bold' : '',
             )}
             data-testid={`${messageListId}-subject-cell`}
             href={message.messageDetailLink}

--- a/web-client/src/views/Messages/MessagesIndividualCompleted.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualCompleted.tsx
@@ -21,135 +21,140 @@ export const MessagesIndividualCompleted = connect(
   }) {
     return (
       <>
-        <table className="usa-table ustc-table subsection">
-          <thead>
-            <tr>
-              <th aria-hidden="true" className="consolidated-case-column"></th>
-              <th aria-label="Docket Number" className="small" colSpan={2}>
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-docket-number-header-button"
-                  defaultSortOrder={constants.DESCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="docketNumber"
-                  title="Docket No."
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th className="medium">
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-completed-at-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="completedAt"
-                  title="Completed"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-subject-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="subject"
-                  title="Last Message"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-comment-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="completedMessage"
-                  title="Comment"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-case-title-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="caseTitle"
-                  title="Case Title"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-            </tr>
-          </thead>
-          {formattedMessages.completedMessages.map(message => {
-            return (
-              <tbody key={`message-individual-${message.messageId}`}>
-                <tr>
-                  <td className="consolidated-case-column">
-                    <ConsolidatedCaseIcon
-                      consolidatedIconTooltipText={
-                        message.consolidatedIconTooltipText
-                      }
-                      inConsolidatedGroup={message.inConsolidatedGroup}
-                      showLeadCaseIcon={message.isLeadCase}
-                    />
-                  </td>
-                  <td
-                    className="message-queue-row small"
-                    colSpan={2}
-                    data-testid="individual-message-completed-docket-number-cell"
-                  >
-                    {message.docketNumberWithSuffix}
-                  </td>
-                  <td
-                    className="message-queue-row small"
-                    data-testid="individual-message-completed-completed-at-cell"
-                  >
-                    <span className="no-wrap">
-                      {message.completedAtFormatted}
-                    </span>
-                  </td>
-                  <td className="message-queue-row">
-                    <div className="message-document-title">
-                      <Button
-                        link
-                        className="padding-0"
-                        data-testid="individual-message-completed-subject-cell"
-                        href={message.messageDetailLink}
-                      >
-                        {message.subject}
-                      </Button>
-                    </div>
-                    <div className="message-document-detail">
-                      {message.message}
-                    </div>
-                  </td>
-                  <td className="message-queue-row">
-                    {message.completedMessage}
-                  </td>
-                  <td className="message-queue-row">{message.caseTitle}</td>
-                </tr>
-              </tbody>
-            );
-          })}
-        </table>
-        {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+        <div className="overflow-x-auto">
+          <table className="usa-table ustc-table subsection">
+            <thead>
+              <tr>
+                <th
+                  aria-hidden="true"
+                  className="consolidated-case-column"
+                ></th>
+                <th aria-label="Docket Number" className="small" colSpan={2}>
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-docket-number-header-button"
+                    defaultSortOrder={constants.DESCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="docketNumber"
+                    title="Docket No."
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th className="medium">
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-completed-at-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="completedAt"
+                    title="Completed"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-subject-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="subject"
+                    title="Last Message"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-comment-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="completedMessage"
+                    title="Comment"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-case-title-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="caseTitle"
+                    title="Case Title"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+              </tr>
+            </thead>
+            {formattedMessages.completedMessages.map(message => {
+              return (
+                <tbody key={`message-individual-${message.messageId}`}>
+                  <tr>
+                    <td className="consolidated-case-column">
+                      <ConsolidatedCaseIcon
+                        consolidatedIconTooltipText={
+                          message.consolidatedIconTooltipText
+                        }
+                        inConsolidatedGroup={message.inConsolidatedGroup}
+                        showLeadCaseIcon={message.isLeadCase}
+                      />
+                    </td>
+                    <td
+                      className="message-queue-row small"
+                      colSpan={2}
+                      data-testid="individual-message-completed-docket-number-cell"
+                    >
+                      {message.docketNumberWithSuffix}
+                    </td>
+                    <td
+                      className="message-queue-row small"
+                      data-testid="individual-message-completed-completed-at-cell"
+                    >
+                      <span className="no-wrap">
+                        {message.completedAtFormatted}
+                      </span>
+                    </td>
+                    <td className="message-queue-row">
+                      <div className="message-document-title">
+                        <Button
+                          link
+                          className="padding-0"
+                          data-testid="individual-message-completed-subject-cell"
+                          href={message.messageDetailLink}
+                        >
+                          {message.subject}
+                        </Button>
+                      </div>
+                      <div className="message-document-detail">
+                        {message.message}
+                      </div>
+                    </td>
+                    <td className="message-queue-row">
+                      {message.completedMessage}
+                    </td>
+                    <td className="message-queue-row">{message.caseTitle}</td>
+                  </tr>
+                </tbody>
+              );
+            })}
+          </table>
+          {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+        </div>
       </>
     );
   },

--- a/web-client/src/views/Messages/MessagesIndividualCompleted.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualCompleted.tsx
@@ -1,161 +1,29 @@
-import { Button } from '../../ustc-ui/Button/Button';
-import { ConsolidatedCaseIcon } from '../../ustc-ui/Icon/ConsolidatedCaseIcon';
-import { SortableColumn } from '../../ustc-ui/Table/SortableColumn';
+import {
+  COLUMN_NAMES,
+  MessageColumnData,
+  getColumnData,
+} from '@web-client/views/Messages/MessageColumns';
+import { MessageList } from '@web-client/views/Messages/MessageList';
 import { connect } from '@web-client/presenter/shared.cerebral';
-import { sequences } from '@web-client/presenter/app.cerebral';
-import { state } from '@web-client/presenter/app.cerebral';
 import React from 'react';
 
+const columns: MessageColumnData[] = getColumnData([
+  COLUMN_NAMES.DOCKET_NUMBER,
+  COLUMN_NAMES.COMPLETED,
+  COLUMN_NAMES.LAST_MESSAGE,
+  COLUMN_NAMES.COMMENT,
+  COLUMN_NAMES.CASE_TITLE,
+]);
+
 export const MessagesIndividualCompleted = connect(
-  {
-    constants: state.constants,
-    formattedMessages: state.formattedMessages,
-    sortTableSequence: sequences.sortTableSequence,
-    tableSort: state.tableSort,
-  },
-  function MessagesIndividualCompleted({
-    constants,
-    formattedMessages,
-    sortTableSequence,
-    tableSort,
-  }) {
+  {},
+  function MessagesIndividualCompleted() {
     return (
-      <>
-        <div className="overflow-x-auto">
-          <table className="usa-table ustc-table subsection">
-            <thead>
-              <tr>
-                <th
-                  aria-hidden="true"
-                  className="consolidated-case-column"
-                ></th>
-                <th aria-label="Docket Number" className="small" colSpan={2}>
-                  <SortableColumn
-                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-individual-docket-number-header-button"
-                    defaultSortOrder={constants.DESCENDING}
-                    descText={constants.CHRONOLOGICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="docketNumber"
-                    title="Docket No."
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th className="medium">
-                  <SortableColumn
-                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-individual-completed-at-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.CHRONOLOGICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="completedAt"
-                    title="Completed"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-individual-subject-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="subject"
-                    title="Last Message"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-individual-comment-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="completedMessage"
-                    title="Comment"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-individual-case-title-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="caseTitle"
-                    title="Case Title"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-              </tr>
-            </thead>
-            {formattedMessages.completedMessages.map(message => {
-              return (
-                <tbody key={`message-individual-${message.messageId}`}>
-                  <tr>
-                    <td className="consolidated-case-column">
-                      <ConsolidatedCaseIcon
-                        consolidatedIconTooltipText={
-                          message.consolidatedIconTooltipText
-                        }
-                        inConsolidatedGroup={message.inConsolidatedGroup}
-                        showLeadCaseIcon={message.isLeadCase}
-                      />
-                    </td>
-                    <td
-                      className="message-queue-row small"
-                      colSpan={2}
-                      data-testid="individual-message-completed-docket-number-cell"
-                    >
-                      {message.docketNumberWithSuffix}
-                    </td>
-                    <td
-                      className="message-queue-row small"
-                      data-testid="individual-message-completed-completed-at-cell"
-                    >
-                      <span className="no-wrap">
-                        {message.completedAtFormatted}
-                      </span>
-                    </td>
-                    <td className="message-queue-row">
-                      <div className="message-document-title">
-                        <Button
-                          link
-                          className="padding-0"
-                          data-testid="individual-message-completed-subject-cell"
-                          href={message.messageDetailLink}
-                        >
-                          {message.subject}
-                        </Button>
-                      </div>
-                      <div className="message-document-detail">
-                        {message.message}
-                      </div>
-                    </td>
-                    <td className="message-queue-row">
-                      {message.completedMessage}
-                    </td>
-                    <td className="message-queue-row">{message.caseTitle}</td>
-                  </tr>
-                </tbody>
-              );
-            })}
-          </table>
-          {!formattedMessages.hasMessages && <div>There are no messages.</div>}
-        </div>
-      </>
+      <MessageList
+        messageColumns={columns}
+        messageFilters={[]}
+        selectable={false}
+      />
     );
   },
 );

--- a/web-client/src/views/Messages/MessagesIndividualCompleted.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualCompleted.tsx
@@ -1,19 +1,18 @@
 import {
-  COLUMN_NAMES,
   MessageColumnData,
-  getColumnData,
+  SORTABLE_COLUMNS,
 } from '@web-client/views/Messages/MessageColumns';
 import { MessageList } from '@web-client/views/Messages/MessageList';
 import { connect } from '@web-client/presenter/shared.cerebral';
 import React from 'react';
 
-const columns: MessageColumnData[] = getColumnData([
-  COLUMN_NAMES.DOCKET_NUMBER,
-  COLUMN_NAMES.COMPLETED,
-  COLUMN_NAMES.LAST_MESSAGE,
-  COLUMN_NAMES.COMMENT,
-  COLUMN_NAMES.CASE_TITLE,
-]);
+const columns: MessageColumnData[] = [
+  SORTABLE_COLUMNS.DOCKET_NUMBER,
+  SORTABLE_COLUMNS.COMPLETED_AT,
+  SORTABLE_COLUMNS.LAST_MESSAGE,
+  SORTABLE_COLUMNS.COMMENT,
+  SORTABLE_COLUMNS.CASE_TITLE,
+];
 
 export const MessagesIndividualCompleted = connect(
   {},

--- a/web-client/src/views/Messages/MessagesIndividualCompleted.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualCompleted.tsx
@@ -19,6 +19,7 @@ export const MessagesIndividualCompleted = connect(
   function MessagesIndividualCompleted() {
     return (
       <MessageList
+        id="messages-individual-completed"
         messageColumns={columns}
         messageFilters={[]}
         selectable={false}

--- a/web-client/src/views/Messages/MessagesIndividualCompleted.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualCompleted.tsx
@@ -2,7 +2,7 @@ import {
   MessageColumnData,
   SORTABLE_COLUMNS,
 } from '@web-client/views/Messages/MessageColumns';
-import { MessageList } from '@web-client/views/Messages/MessageList';
+import { MessagesTable } from '@web-client/views/Messages/MessageTable';
 import { connect } from '@web-client/presenter/shared.cerebral';
 import React from 'react';
 
@@ -18,7 +18,7 @@ export const MessagesIndividualCompleted = connect(
   {},
   function MessagesIndividualCompleted() {
     return (
-      <MessageList
+      <MessagesTable
         id="messages-individual-completed"
         messageColumns={columns}
         messageFilters={[]}

--- a/web-client/src/views/Messages/MessagesIndividualCompleted.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualCompleted.tsx
@@ -2,7 +2,7 @@ import {
   MessageColumnData,
   SORTABLE_COLUMNS,
 } from '@web-client/views/Messages/MessageColumns';
-import { MessagesTable } from '@web-client/views/Messages/MessageTable';
+import { MessageTable } from '@web-client/views/Messages/MessageTable';
 import { connect } from '@web-client/presenter/shared.cerebral';
 import React from 'react';
 
@@ -18,7 +18,7 @@ export const MessagesIndividualCompleted = connect(
   {},
   function MessagesIndividualCompleted() {
     return (
-      <MessagesTable
+      <MessageTable
         id="messages-individual-completed"
         messageColumns={columns}
         messageFilters={[]}

--- a/web-client/src/views/Messages/MessagesIndividualInbox.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualInbox.tsx
@@ -65,268 +65,273 @@ export const MessagesIndividualInbox = connect(
             </div>
           </div>
         )}
-        <div className="grid-row grid-gap">
-          <div className="desktop:grid-col-8 tablet:grid-col-12 display-flex flex-align-center">
-            <TableFilters
-              filters={[
-                {
-                  isSelected: screenMetadata.caseStatus,
-                  key: 'caseStatus',
-                  label: 'Case Status',
-                  options: formattedMessages.caseStatuses,
-                },
-                {
-                  isSelected: screenMetadata.fromUser,
-                  key: 'fromUser',
-                  label: 'From',
-                  options: formattedMessages.fromUsers,
-                },
-                {
-                  isSelected: screenMetadata.fromSection,
-                  key: 'fromSection',
-                  label: 'Section',
-                  options: formattedMessages.fromSections,
-                },
-              ]}
-              onSelect={updateMessageFilterSequence}
-            ></TableFilters>
+        <div className="overflow-x-auto">
+          <div className="grid-row grid-gap">
+            <div className="desktop:grid-col-8 tablet:grid-col-12 display-flex flex-align-center">
+              <TableFilters
+                filters={[
+                  {
+                    isSelected: screenMetadata.caseStatus,
+                    key: 'caseStatus',
+                    label: 'Case Status',
+                    options: formattedMessages.caseStatuses,
+                  },
+                  {
+                    isSelected: screenMetadata.fromUser,
+                    key: 'fromUser',
+                    label: 'From',
+                    options: formattedMessages.fromUsers,
+                  },
+                  {
+                    isSelected: screenMetadata.fromSection,
+                    key: 'fromSection',
+                    label: 'Section',
+                    options: formattedMessages.fromSections,
+                  },
+                ]}
+                onSelect={updateMessageFilterSequence}
+              ></TableFilters>
+            </div>
+
+            <div className="desktop:grid-col-4 tablet:grid-col-12 tablet:margin-top-2 text-right">
+              <Button
+                link
+                className="action-button"
+                data-testid="message-batch-mark-as-complete"
+                disabled={
+                  !messagesIndividualInboxHelper.isCompletionButtonEnabled
+                }
+                icon="check-circle"
+                id="button-batch-complete"
+                onClick={() => {
+                  batchCompleteMessageSequence();
+                }}
+              >
+                Complete
+              </Button>
+            </div>
           </div>
 
-          <div className="desktop:grid-col-4 tablet:grid-col-12 tablet:margin-top-2 text-right">
-            <Button
-              link
-              className="action-button"
-              data-testid="message-batch-mark-as-complete"
-              disabled={
-                !messagesIndividualInboxHelper.isCompletionButtonEnabled
-              }
-              icon="check-circle"
-              id="button-batch-complete"
-              onClick={() => {
-                batchCompleteMessageSequence();
-              }}
-            >
-              Complete
-            </Button>
-          </div>
-        </div>
-
-        <table className="usa-table ustc-table subsection">
-          <thead>
-            <tr>
-              <th>
-                <input
-                  aria-label="all-messages-checkbox"
-                  checked={messagesIndividualInboxHelper.allMessagesSelected}
-                  data-testid="all-messages-checkbox"
-                  disabled={
-                    !messagesIndividualInboxHelper.allMessagesCheckboxEnabled
-                  }
-                  id="all-messages-checkbox"
-                  ref={selectAllCheckboxRef}
-                  type="checkbox"
-                  onChange={() => {
-                    const selectAll = formattedMessages.messages.map(
-                      message => ({
-                        messageId: message.messageId,
-                        parentMessageId: message.parentMessageId,
-                      }),
-                    );
-                    setSelectedMessagesSequence({ messages: selectAll });
-                  }}
-                />
-              </th>
-              <th aria-hidden="true" className="consolidated-case-column"></th>
-              <th aria-label="Docket Number" className="small" colSpan={2}>
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-docket-number-header-button"
-                  defaultSortOrder={constants.DESCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="docketNumber"
-                  title="Docket No."
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-received-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="createdAt"
-                  title="Received"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th className="message-unread-column"></th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-subject-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="subject"
-                  title="Message"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-case-title-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="caseTitle"
-                  title="Case Title"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-case-status-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="caseStatus"
-                  title="Case Status"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-from-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="from"
-                  title="From"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th className="small">
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-section-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="fromSectionFormatted"
-                  title="Section"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-            </tr>
-          </thead>
-          {formattedMessages.messages.map(message => {
-            return (
-              <tbody key={message.messageId}>
-                <tr key={message.messageId}>
-                  <td>
-                    <input
-                      aria-label={`${message.caseTitle}-${message.subject}-checkbox`}
-                      checked={message.isSelected}
-                      id={`${message.caseTitle}-message-checkbox`}
-                      type="checkbox"
-                      onChange={() => {
-                        setSelectedMessagesSequence({
-                          messages: [
-                            {
-                              messageId: message.messageId,
-                              parentMessageId: message.parentMessageId,
-                            },
-                          ],
-                        });
-                      }}
-                    />
-                  </td>
-                  <td className="consolidated-case-column">
-                    <ConsolidatedCaseIcon
-                      consolidatedIconTooltipText={
-                        message.consolidatedIconTooltipText
-                      }
-                      inConsolidatedGroup={message.inConsolidatedGroup}
-                      showLeadCaseIcon={message.isLeadCase}
-                    />
-                  </td>
-                  <td
-                    className="message-queue-row small"
-                    colSpan={2}
-                    data-testid="individual-message-inbox-docket-number-cell"
-                  >
-                    {message.docketNumberWithSuffix}
-                  </td>
-                  <td
-                    className="message-queue-row small"
-                    data-testid="individual-message-inbox-received-at-cell"
-                  >
-                    <span className="no-wrap">
-                      {message.createdAtFormatted}
-                    </span>
-                  </td>
-                  <td className="message-unread-column">
-                    {!message.isRead && (
-                      <Icon
-                        aria-label="unread message"
-                        className="fa-icon-blue"
-                        icon="envelope"
-                        size="1x"
+          <table className="usa-table ustc-table subsection">
+            <thead>
+              <tr>
+                <th>
+                  <input
+                    aria-label="all-messages-checkbox"
+                    checked={messagesIndividualInboxHelper.allMessagesSelected}
+                    data-testid="all-messages-checkbox"
+                    disabled={
+                      !messagesIndividualInboxHelper.allMessagesCheckboxEnabled
+                    }
+                    id="all-messages-checkbox"
+                    ref={selectAllCheckboxRef}
+                    type="checkbox"
+                    onChange={() => {
+                      const selectAll = formattedMessages.messages.map(
+                        message => ({
+                          messageId: message.messageId,
+                          parentMessageId: message.parentMessageId,
+                        }),
+                      );
+                      setSelectedMessagesSequence({ messages: selectAll });
+                    }}
+                  />
+                </th>
+                <th
+                  aria-hidden="true"
+                  className="consolidated-case-column"
+                ></th>
+                <th aria-label="Docket Number" colSpan={2}>
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-docket-number-header-button"
+                    defaultSortOrder={constants.DESCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="docketNumber"
+                    title="Docket No."
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-received-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="createdAt"
+                    title="Received"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th className="message-unread-column"></th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-subject-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="subject"
+                    title="Message"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-case-title-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="caseTitle"
+                    title="Case Title"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-case-status-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="caseStatus"
+                    title="Case Status"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-from-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="from"
+                    title="From"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-section-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="fromSectionFormatted"
+                    title="Section"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+              </tr>
+            </thead>
+            {formattedMessages.messages.map(message => {
+              return (
+                <tbody key={message.messageId}>
+                  <tr key={message.messageId}>
+                    <td>
+                      <input
+                        aria-label={`${message.caseTitle}-${message.subject}-checkbox`}
+                        checked={message.isSelected}
+                        id={`${message.caseTitle}-message-checkbox`}
+                        type="checkbox"
+                        onChange={() => {
+                          setSelectedMessagesSequence({
+                            messages: [
+                              {
+                                messageId: message.messageId,
+                                parentMessageId: message.parentMessageId,
+                              },
+                            ],
+                          });
+                        }}
                       />
-                    )}
-                  </td>
-                  <td className="message-queue-row message-subject">
-                    <div className="message-document-title">
-                      <Button
-                        link
-                        className={classNames(
-                          'padding-0',
-                          message.isRead ? '' : 'text-bold',
-                        )}
-                        data-testid="individual-message-inbox-subject-cell"
-                        href={message.messageDetailLink}
-                      >
-                        {message.subject}
-                      </Button>
-                    </div>
+                    </td>
+                    <td className="consolidated-case-column">
+                      <ConsolidatedCaseIcon
+                        consolidatedIconTooltipText={
+                          message.consolidatedIconTooltipText
+                        }
+                        inConsolidatedGroup={message.inConsolidatedGroup}
+                        showLeadCaseIcon={message.isLeadCase}
+                      />
+                    </td>
+                    <td
+                      className="message-queue-row"
+                      colSpan={2}
+                      data-testid="individual-message-inbox-docket-number-cell"
+                    >
+                      {message.docketNumberWithSuffix}
+                    </td>
+                    <td
+                      className="message-queue-row"
+                      data-testid="individual-message-inbox-received-at-cell"
+                    >
+                      <span className="no-wrap">
+                        {message.createdAtFormatted}
+                      </span>
+                    </td>
+                    <td className="message-unread-column">
+                      {!message.isRead && (
+                        <Icon
+                          aria-label="unread message"
+                          className="fa-icon-blue"
+                          icon="envelope"
+                          size="1x"
+                        />
+                      )}
+                    </td>
+                    <td className="message-queue-row message-subject">
+                      <div className="message-document-title">
+                        <Button
+                          link
+                          className={classNames(
+                            'padding-0',
+                            message.isRead ? '' : 'text-bold',
+                          )}
+                          data-testid="individual-message-inbox-subject-cell"
+                          href={message.messageDetailLink}
+                        >
+                          {message.subject}
+                        </Button>
+                      </div>
 
-                    <div className="message-document-detail">
-                      {message.message}
-                    </div>
-                  </td>
-                  <td className="message-queue-row max-width-25">
-                    {message.caseTitle}
-                  </td>
-                  <td className="message-queue-row">{message.caseStatus}</td>
-                  <td className="message-queue-row from">{message.from}</td>
-                  <td className="message-queue-row small">
-                    {message.fromSectionFormatted}
-                  </td>
-                </tr>
-              </tbody>
-            );
-          })}
-        </table>
-        {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+                      <div className="message-document-detail">
+                        {message.message}
+                      </div>
+                    </td>
+                    <td className="message-queue-row max-width-25">
+                      {message.caseTitle}
+                    </td>
+                    <td className="message-queue-row">{message.caseStatus}</td>
+                    <td className="message-queue-row from">{message.from}</td>
+                    <td className="message-queue-row">
+                      {message.fromSectionFormatted}
+                    </td>
+                  </tr>
+                </tbody>
+              );
+            })}
+          </table>
+          {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+        </div>
       </>
     );
   },

--- a/web-client/src/views/Messages/MessagesIndividualInbox.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualInbox.tsx
@@ -1,64 +1,30 @@
 import {
+  COLUMN_NAMES,
   MessageColumnData,
+  getColumnData,
+} from '@web-client/views/Messages/MessageColumns';
+import {
   MessageFilterData,
   MessageList,
 } from '@web-client/views/Messages/MessageList';
 import { connect } from '@web-client/presenter/shared.cerebral';
-import { sequences } from '@web-client/presenter/app.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
 import React from 'react';
 
-const columns: MessageColumnData[] = [
-  {
-    columnName: 'Docket No.',
-    dataTestId: 'message-individual-docket-number',
-    iconClassName: 'consolidated-case-column',
-    sortField: 'docketNumber',
-  },
-  {
-    columnName: 'Received',
-    dataTestId: 'message-individual-received',
-    sortField: 'createdAt',
-  },
-  {
-    columnName: 'Message',
-    dataTestId: 'message-individual-subject',
-    iconClassName: 'message-unread-column',
-    sortField: 'subject',
-  },
-  {
-    columnName: 'Case Title',
-    dataTestId: 'message-individual-case-title',
-    sortField: 'caseTitle',
-  },
-  {
-    columnName: 'Case Status',
-    dataTestId: 'message-individual-case-status',
-    sortField: 'caseStatus',
-  },
-  {
-    columnName: 'From',
-    dataTestId: 'message-individual-from',
-    sortField: 'from',
-  },
-  {
-    columnName: 'Section',
-    dataTestId: 'message-individual-section',
-    sortField: 'fromSectionFormatted',
-  },
-];
+const columns: MessageColumnData[] = getColumnData([
+  COLUMN_NAMES.DOCKET_NUMBER,
+  COLUMN_NAMES.RECEIVED,
+  COLUMN_NAMES.MESSAGE,
+  COLUMN_NAMES.CASE_TITLE,
+  COLUMN_NAMES.CASE_STATUS,
+  COLUMN_NAMES.FROM,
+  COLUMN_NAMES.SECTION,
+]);
 
 export const MessagesIndividualInbox = connect(
   {
-    batchCompleteMessageSequence: sequences.batchCompleteMessageSequence,
-    constants: state.constants,
     formattedMessages: state.formattedMessages,
-    messagesIndividualInboxHelper: state.messagesIndividualInboxHelper,
     screenMetadata: state.screenMetadata,
-    setSelectedMessagesSequence: sequences.setSelectedMessagesSequence,
-    sortTableSequence: sequences.sortTableSequence,
-    tableSort: state.tableSort,
-    updateMessageFilterSequence: sequences.updateMessageFilterSequence,
   },
   function MessagesIndividualInbox({ formattedMessages, screenMetadata }) {
     const filters: MessageFilterData[] = [

--- a/web-client/src/views/Messages/MessagesIndividualInbox.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualInbox.tsx
@@ -1,15 +1,52 @@
-import { Button } from '../../ustc-ui/Button/Button';
-import { ConsolidatedCaseIcon } from '../../ustc-ui/Icon/ConsolidatedCaseIcon';
-import { ErrorNotification } from '../ErrorNotification';
-import { Icon } from '../../ustc-ui/Icon/Icon';
-import { SortableColumn } from '../../ustc-ui/Table/SortableColumn';
-import { SuccessNotification } from '../SuccessNotification';
-import { TableFilters } from '../../ustc-ui/Table/TableFilters';
+import {
+  MessageColumnData,
+  MessageFilterData,
+  MessageList,
+} from '@web-client/views/Messages/MessageList';
 import { connect } from '@web-client/presenter/shared.cerebral';
 import { sequences } from '@web-client/presenter/app.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
-import React, { useEffect, useRef } from 'react';
-import classNames from 'classnames';
+import React from 'react';
+
+const columns: MessageColumnData[] = [
+  {
+    columnName: 'Docket No.',
+    dataTestId: 'message-individual-docket-number',
+    iconClassName: 'consolidated-case-column',
+    sortField: 'docketNumber',
+  },
+  {
+    columnName: 'Received',
+    dataTestId: 'message-individual-received',
+    sortField: 'createdAt',
+  },
+  {
+    columnName: 'Message',
+    dataTestId: 'message-individual-subject',
+    iconClassName: 'message-unread-column',
+    sortField: 'subject',
+  },
+  {
+    columnName: 'Case Title',
+    dataTestId: 'message-individual-case-title',
+    sortField: 'caseTitle',
+  },
+  {
+    columnName: 'Case Status',
+    dataTestId: 'message-individual-case-status',
+    sortField: 'caseStatus',
+  },
+  {
+    columnName: 'From',
+    dataTestId: 'message-individual-from',
+    sortField: 'from',
+  },
+  {
+    columnName: 'Section',
+    dataTestId: 'message-individual-section',
+    sortField: 'fromSectionFormatted',
+  },
+];
 
 export const MessagesIndividualInbox = connect(
   {
@@ -23,316 +60,34 @@ export const MessagesIndividualInbox = connect(
     tableSort: state.tableSort,
     updateMessageFilterSequence: sequences.updateMessageFilterSequence,
   },
-  function MessagesIndividualInbox({
-    batchCompleteMessageSequence,
-    constants,
-    formattedMessages,
-    messagesIndividualInboxHelper,
-    screenMetadata,
-    setSelectedMessagesSequence,
-    sortTableSequence,
-    tableSort,
-    updateMessageFilterSequence,
-  }) {
-    const selectAllCheckboxRef = useRef<HTMLInputElement>(null);
+  function MessagesIndividualInbox({ formattedMessages, screenMetadata }) {
+    const filters: MessageFilterData[] = [
+      {
+        isSelected: screenMetadata.caseStatus,
+        key: 'caseStatus',
+        label: 'Case Status',
+        options: formattedMessages.caseStatuses,
+      },
+      {
+        isSelected: screenMetadata.fromUser,
+        key: 'fromUser',
+        label: 'From',
+        options: formattedMessages.fromUsers,
+      },
+      {
+        isSelected: screenMetadata.fromSection,
+        key: 'fromSection',
+        label: 'Section',
+        options: formattedMessages.fromSections,
+      },
+    ];
 
-    useEffect(() => {
-      if (!selectAllCheckboxRef.current) return;
-
-      selectAllCheckboxRef.current.indeterminate =
-        messagesIndividualInboxHelper.someMessagesSelected &&
-        !messagesIndividualInboxHelper.allMessagesSelected;
-    }, [
-      selectAllCheckboxRef.current,
-      messagesIndividualInboxHelper.someMessagesSelected,
-      messagesIndividualInboxHelper.allMessagesSelected,
-    ]);
     return (
-      <>
-        <SuccessNotification />
-        <ErrorNotification />
-        {screenMetadata.completionSuccess && (
-          <div
-            aria-live="polite"
-            className="usa-alert usa-alert--success"
-            data-testid="message-detail-success-alert"
-            role="alert"
-          >
-            <div className="usa-alert__body">
-              Message(s) completed at{' '}
-              {messagesIndividualInboxHelper.messagesCompletedAt} by{' '}
-              {messagesIndividualInboxHelper.messagesCompletedBy}
-            </div>
-          </div>
-        )}
-        <div className="overflow-x-auto">
-          <div className="grid-row grid-gap">
-            <div className="desktop:grid-col-8 tablet:grid-col-12 display-flex flex-align-center">
-              <TableFilters
-                filters={[
-                  {
-                    isSelected: screenMetadata.caseStatus,
-                    key: 'caseStatus',
-                    label: 'Case Status',
-                    options: formattedMessages.caseStatuses,
-                  },
-                  {
-                    isSelected: screenMetadata.fromUser,
-                    key: 'fromUser',
-                    label: 'From',
-                    options: formattedMessages.fromUsers,
-                  },
-                  {
-                    isSelected: screenMetadata.fromSection,
-                    key: 'fromSection',
-                    label: 'Section',
-                    options: formattedMessages.fromSections,
-                  },
-                ]}
-                onSelect={updateMessageFilterSequence}
-              ></TableFilters>
-            </div>
-
-            <div className="desktop:grid-col-4 tablet:grid-col-12 tablet:margin-top-2 text-right">
-              <Button
-                link
-                className="action-button"
-                data-testid="message-batch-mark-as-complete"
-                disabled={
-                  !messagesIndividualInboxHelper.isCompletionButtonEnabled
-                }
-                icon="check-circle"
-                id="button-batch-complete"
-                onClick={() => {
-                  batchCompleteMessageSequence();
-                }}
-              >
-                Complete
-              </Button>
-            </div>
-          </div>
-
-          <table className="usa-table ustc-table subsection">
-            <thead>
-              <tr>
-                <th>
-                  <input
-                    aria-label="all-messages-checkbox"
-                    checked={messagesIndividualInboxHelper.allMessagesSelected}
-                    data-testid="all-messages-checkbox"
-                    disabled={
-                      !messagesIndividualInboxHelper.allMessagesCheckboxEnabled
-                    }
-                    id="all-messages-checkbox"
-                    ref={selectAllCheckboxRef}
-                    type="checkbox"
-                    onChange={() => {
-                      const selectAll = formattedMessages.messages.map(
-                        message => ({
-                          messageId: message.messageId,
-                          parentMessageId: message.parentMessageId,
-                        }),
-                      );
-                      setSelectedMessagesSequence({ messages: selectAll });
-                    }}
-                  />
-                </th>
-                <th
-                  aria-hidden="true"
-                  className="consolidated-case-column"
-                ></th>
-                <th aria-label="Docket Number" colSpan={2}>
-                  <SortableColumn
-                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-individual-docket-number-header-button"
-                    defaultSortOrder={constants.DESCENDING}
-                    descText={constants.CHRONOLOGICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="docketNumber"
-                    title="Docket No."
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-individual-received-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.CHRONOLOGICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="createdAt"
-                    title="Received"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th className="message-unread-column"></th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-individual-subject-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="subject"
-                    title="Message"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-individual-case-title-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="caseTitle"
-                    title="Case Title"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-individual-case-status-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="caseStatus"
-                    title="Case Status"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-individual-from-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="from"
-                    title="From"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-individual-section-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="fromSectionFormatted"
-                    title="Section"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-              </tr>
-            </thead>
-            {formattedMessages.messages.map(message => {
-              return (
-                <tbody key={message.messageId}>
-                  <tr key={message.messageId}>
-                    <td>
-                      <input
-                        aria-label={`${message.caseTitle}-${message.subject}-checkbox`}
-                        checked={message.isSelected}
-                        id={`${message.caseTitle}-message-checkbox`}
-                        type="checkbox"
-                        onChange={() => {
-                          setSelectedMessagesSequence({
-                            messages: [
-                              {
-                                messageId: message.messageId,
-                                parentMessageId: message.parentMessageId,
-                              },
-                            ],
-                          });
-                        }}
-                      />
-                    </td>
-                    <td className="consolidated-case-column">
-                      <ConsolidatedCaseIcon
-                        consolidatedIconTooltipText={
-                          message.consolidatedIconTooltipText
-                        }
-                        inConsolidatedGroup={message.inConsolidatedGroup}
-                        showLeadCaseIcon={message.isLeadCase}
-                      />
-                    </td>
-                    <td
-                      className="message-queue-row"
-                      colSpan={2}
-                      data-testid="individual-message-inbox-docket-number-cell"
-                    >
-                      {message.docketNumberWithSuffix}
-                    </td>
-                    <td
-                      className="message-queue-row"
-                      data-testid="individual-message-inbox-received-at-cell"
-                    >
-                      <span className="no-wrap">
-                        {message.createdAtFormatted}
-                      </span>
-                    </td>
-                    <td className="message-unread-column">
-                      {!message.isRead && (
-                        <Icon
-                          aria-label="unread message"
-                          className="fa-icon-blue"
-                          icon="envelope"
-                          size="1x"
-                        />
-                      )}
-                    </td>
-                    <td className="message-queue-row message-subject">
-                      <div className="message-document-title">
-                        <Button
-                          link
-                          className={classNames(
-                            'padding-0',
-                            message.isRead ? '' : 'text-bold',
-                          )}
-                          data-testid="individual-message-inbox-subject-cell"
-                          href={message.messageDetailLink}
-                        >
-                          {message.subject}
-                        </Button>
-                      </div>
-
-                      <div className="message-document-detail">
-                        {message.message}
-                      </div>
-                    </td>
-                    <td className="message-queue-row max-width-25">
-                      {message.caseTitle}
-                    </td>
-                    <td className="message-queue-row">{message.caseStatus}</td>
-                    <td className="message-queue-row from">{message.from}</td>
-                    <td className="message-queue-row">
-                      {message.fromSectionFormatted}
-                    </td>
-                  </tr>
-                </tbody>
-              );
-            })}
-          </table>
-          {!formattedMessages.hasMessages && <div>There are no messages.</div>}
-        </div>
-      </>
+      <MessageList
+        messageColumns={columns}
+        messageFilters={filters}
+        selectable={true}
+      />
     );
   },
 );

--- a/web-client/src/views/Messages/MessagesIndividualInbox.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualInbox.tsx
@@ -1,7 +1,6 @@
 import {
-  COLUMN_NAMES,
   MessageColumnData,
-  getColumnData,
+  SORTABLE_COLUMNS,
 } from '@web-client/views/Messages/MessageColumns';
 import {
   MessageFilterData,
@@ -11,15 +10,15 @@ import { connect } from '@web-client/presenter/shared.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
 import React from 'react';
 
-const columns: MessageColumnData[] = getColumnData([
-  COLUMN_NAMES.DOCKET_NUMBER,
-  COLUMN_NAMES.RECEIVED,
-  COLUMN_NAMES.MESSAGE,
-  COLUMN_NAMES.CASE_TITLE,
-  COLUMN_NAMES.CASE_STATUS,
-  COLUMN_NAMES.FROM,
-  COLUMN_NAMES.SECTION,
-]);
+const columns: MessageColumnData[] = [
+  SORTABLE_COLUMNS.DOCKET_NUMBER,
+  SORTABLE_COLUMNS.RECEIVED,
+  SORTABLE_COLUMNS.MESSAGE,
+  SORTABLE_COLUMNS.CASE_TITLE,
+  SORTABLE_COLUMNS.CASE_STATUS,
+  SORTABLE_COLUMNS.FROM,
+  SORTABLE_COLUMNS.FROM_SECTION,
+];
 
 export const MessagesIndividualInbox = connect(
   {

--- a/web-client/src/views/Messages/MessagesIndividualInbox.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualInbox.tsx
@@ -4,7 +4,7 @@ import {
 } from '@web-client/views/Messages/MessageColumns';
 import {
   MessageFilterData,
-  MessagesTable,
+  MessageTable,
 } from '@web-client/views/Messages/MessageTable';
 import { connect } from '@web-client/presenter/shared.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
@@ -13,7 +13,7 @@ import React from 'react';
 const columns: MessageColumnData[] = [
   SORTABLE_COLUMNS.DOCKET_NUMBER,
   SORTABLE_COLUMNS.RECEIVED,
-  SORTABLE_COLUMNS.MESSAGE,
+  SORTABLE_COLUMNS.MESSAGE_WITH_UNREAD_ICON,
   SORTABLE_COLUMNS.CASE_TITLE,
   SORTABLE_COLUMNS.CASE_STATUS,
   SORTABLE_COLUMNS.FROM,
@@ -48,12 +48,11 @@ export const MessagesIndividualInbox = connect(
     ];
 
     return (
-      <MessagesTable
+      <MessageTable
         id="messages-individual-inbox"
         messageColumns={columns}
         messageFilters={filters}
         selectable={true}
-        showUnreadIcon={true}
       />
     );
   },

--- a/web-client/src/views/Messages/MessagesIndividualInbox.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualInbox.tsx
@@ -53,6 +53,7 @@ export const MessagesIndividualInbox = connect(
         messageColumns={columns}
         messageFilters={filters}
         selectable={true}
+        showUnreadIcon={true}
       />
     );
   },

--- a/web-client/src/views/Messages/MessagesIndividualInbox.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualInbox.tsx
@@ -4,8 +4,8 @@ import {
 } from '@web-client/views/Messages/MessageColumns';
 import {
   MessageFilterData,
-  MessageList,
-} from '@web-client/views/Messages/MessageList';
+  MessagesTable,
+} from '@web-client/views/Messages/MessageTable';
 import { connect } from '@web-client/presenter/shared.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
 import React from 'react';
@@ -48,7 +48,7 @@ export const MessagesIndividualInbox = connect(
     ];
 
     return (
-      <MessageList
+      <MessagesTable
         id="messages-individual-inbox"
         messageColumns={columns}
         messageFilters={filters}

--- a/web-client/src/views/Messages/MessagesIndividualInbox.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualInbox.tsx
@@ -49,6 +49,7 @@ export const MessagesIndividualInbox = connect(
 
     return (
       <MessageList
+        id="messages-individual-inbox"
         messageColumns={columns}
         messageFilters={filters}
         selectable={true}

--- a/web-client/src/views/Messages/MessagesIndividualOutbox.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualOutbox.tsx
@@ -26,194 +26,197 @@ export const MessagesIndividualOutbox = connect(
   }) {
     return (
       <>
-        <TableFilters
-          filters={[
-            {
-              isSelected: screenMetadata.caseStatus,
-              key: 'caseStatus',
-              label: 'Case Status',
-              options: formattedMessages.caseStatuses,
-            },
-            {
-              isSelected: screenMetadata.toUser,
-              key: 'toUser',
-              label: 'To',
-              options: formattedMessages.toUsers,
-            },
-            {
-              isSelected: screenMetadata.toSection,
-              key: 'toSection',
-              label: 'Section',
-              options: formattedMessages.toSections,
-            },
-          ]}
-          onSelect={updateScreenMetadataSequence}
-        ></TableFilters>
+        <div className="overflow-x-auto">
+          <TableFilters
+            filters={[
+              {
+                isSelected: screenMetadata.caseStatus,
+                key: 'caseStatus',
+                label: 'Case Status',
+                options: formattedMessages.caseStatuses,
+              },
+              {
+                isSelected: screenMetadata.toUser,
+                key: 'toUser',
+                label: 'To',
+                options: formattedMessages.toUsers,
+              },
+              {
+                isSelected: screenMetadata.toSection,
+                key: 'toSection',
+                label: 'Section',
+                options: formattedMessages.toSections,
+              },
+            ]}
+            onSelect={updateScreenMetadataSequence}
+          ></TableFilters>
 
-        <table className="usa-table ustc-table subsection">
-          <thead>
-            <tr>
-              <th aria-hidden="true" className="consolidated-case-column"></th>
-              <th aria-label="Docket Number" className="small" colSpan={2}>
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-outbox-docket-number-header-button"
-                  defaultSortOrder={constants.DESCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="docketNumber"
-                  title="Docket No."
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th className="small">
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-outbox-completed-at-header-button"
-                  defaultSortOrder={constants.DESCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="createdAt"
-                  title="Sent"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-outbox-subject-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="subject"
-                  title="Message"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-case-title-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="caseTitle"
-                  title="Case Title"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-case-status-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="caseStatus"
-                  title="Case Status"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-to-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="to"
-                  title="To"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th className="small">
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-individual-section-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="toSection"
-                  title="Section"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-            </tr>
-          </thead>
-          {formattedMessages.messages.map(message => {
-            return (
-              <tbody key={`message-${message.messageId}`}>
-                <tr>
-                  <td className="consolidated-case-column">
-                    <ConsolidatedCaseIcon
-                      consolidatedIconTooltipText={
-                        message.consolidatedIconTooltipText
-                      }
-                      inConsolidatedGroup={message.inConsolidatedGroup}
-                      showLeadCaseIcon={message.isLeadCase}
-                    />
-                  </td>
-                  <td
-                    className="message-queue-row small"
-                    colSpan={2}
-                    data-testid="individual-message-outbox-docket-number-cell"
-                  >
-                    {message.docketNumberWithSuffix}
-                  </td>
-                  <td
-                    className="message-queue-row small"
-                    data-testid="individual-message-outbox-completed-at-cell"
-                  >
-                    <span className="no-wrap">
-                      {message.createdAtFormatted}
-                    </span>
-                  </td>
-                  <td
-                    className="message-queue-row message-subject"
-                    data-testid="individual-message-outbox-subject-cell"
-                  >
-                    <div className="message-document-title">
-                      <Button
-                        link
-                        className="padding-0"
-                        href={message.messageDetailLink}
-                      >
-                        {message.subject}
-                      </Button>
-                    </div>
+          <table className="usa-table ustc-table subsection">
+            <thead>
+              <tr>
+                <th
+                  aria-hidden="true"
+                  className="consolidated-case-column"
+                ></th>
+                <th aria-label="Docket Number" colSpan={2}>
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-outbox-docket-number-header-button"
+                    defaultSortOrder={constants.DESCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="docketNumber"
+                    title="Docket No."
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-outbox-completed-at-header-button"
+                    defaultSortOrder={constants.DESCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="createdAt"
+                    title="Sent"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-outbox-subject-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="subject"
+                    title="Message"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-case-title-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="caseTitle"
+                    title="Case Title"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-case-status-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="caseStatus"
+                    title="Case Status"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-to-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="to"
+                    title="To"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-individual-section-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="toSection"
+                    title="Section"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+              </tr>
+            </thead>
+            {formattedMessages.messages.map(message => {
+              return (
+                <tbody key={`message-${message.messageId}`}>
+                  <tr>
+                    <td className="consolidated-case-column">
+                      <ConsolidatedCaseIcon
+                        consolidatedIconTooltipText={
+                          message.consolidatedIconTooltipText
+                        }
+                        inConsolidatedGroup={message.inConsolidatedGroup}
+                        showLeadCaseIcon={message.isLeadCase}
+                      />
+                    </td>
+                    <td
+                      className="message-queue-row"
+                      colSpan={2}
+                      data-testid="individual-message-outbox-docket-number-cell"
+                    >
+                      {message.docketNumberWithSuffix}
+                    </td>
+                    <td
+                      className="message-queue-row"
+                      data-testid="individual-message-outbox-completed-at-cell"
+                    >
+                      <span className="no-wrap">
+                        {message.createdAtFormatted}
+                      </span>
+                    </td>
+                    <td
+                      className="message-queue-row message-subject"
+                      data-testid="individual-message-outbox-subject-cell"
+                    >
+                      <div className="message-document-title">
+                        <Button
+                          link
+                          className="padding-0"
+                          href={message.messageDetailLink}
+                        >
+                          {message.subject}
+                        </Button>
+                      </div>
 
-                    <div className="message-document-detail">
-                      {message.message}
-                    </div>
-                  </td>
-                  <td className="message-queue-row max-width-25">
-                    {message.caseTitle}
-                  </td>
-                  <td className="message-queue-row">{message.caseStatus}</td>
-                  <td className="message-queue-row to">{message.to}</td>
-                  <td className="message-queue-row small">
-                    {message.toSection}
-                  </td>
-                </tr>
-              </tbody>
-            );
-          })}
-        </table>
-        {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+                      <div className="message-document-detail">
+                        {message.message}
+                      </div>
+                    </td>
+                    <td className="message-queue-row max-width-25">
+                      {message.caseTitle}
+                    </td>
+                    <td className="message-queue-row">{message.caseStatus}</td>
+                    <td className="message-queue-row to">{message.to}</td>
+                    <td className="message-queue-row">{message.toSection}</td>
+                  </tr>
+                </tbody>
+              );
+            })}
+          </table>
+          {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+        </div>
       </>
     );
   },

--- a/web-client/src/views/Messages/MessagesIndividualOutbox.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualOutbox.tsx
@@ -1,60 +1,27 @@
 import {
+  COLUMN_NAMES,
   MessageColumnData,
-  MessageList,
-} from '@web-client/views/Messages/MessageList';
+  getColumnData,
+} from '@web-client/views/Messages/MessageColumns';
+import { MessageList } from '@web-client/views/Messages/MessageList';
 import { connect } from '@web-client/presenter/shared.cerebral';
-import { sequences } from '@web-client/presenter/app.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
 import React from 'react';
 
-const columns: MessageColumnData[] = [
-  {
-    columnName: 'Docket No.',
-    dataTestId: 'message-individual-docket-number-header-button',
-    iconClassName: 'consolidated-case-column',
-    sortField: 'docketNumber',
-  },
-  {
-    columnName: 'Sent',
-    dataTestId: 'message-individual-received-header-button',
-    sortField: 'createdAt',
-  },
-  {
-    columnName: 'Message',
-    dataTestId: 'message-individual-subject-header-button',
-    iconClassName: 'message-unread-column',
-    sortField: 'subject',
-  },
-  {
-    columnName: 'Case Title',
-    dataTestId: 'message-individual-case-title-header-button',
-    sortField: 'caseTitle',
-  },
-  {
-    columnName: 'Case Status',
-    dataTestId: 'message-individual-case-status-header-button',
-    sortField: 'caseStatus',
-  },
-  {
-    columnName: 'To',
-    dataTestId: 'message-individual-from-header-button',
-    sortField: 'to',
-  },
-  {
-    columnName: 'Section',
-    dataTestId: 'message-individual-section-header-button',
-    sortField: 'toSection',
-  },
-];
+const columns: MessageColumnData[] = getColumnData([
+  COLUMN_NAMES.DOCKET_NUMBER,
+  COLUMN_NAMES.SENT,
+  COLUMN_NAMES.MESSAGE,
+  COLUMN_NAMES.CASE_TITLE,
+  COLUMN_NAMES.CASE_STATUS,
+  COLUMN_NAMES.TO,
+  COLUMN_NAMES.SECTION,
+]);
 
 export const MessagesIndividualOutbox = connect(
   {
-    constants: state.constants,
     formattedMessages: state.formattedMessages,
     screenMetadata: state.screenMetadata,
-    sortTableSequence: sequences.sortTableSequence,
-    tableSort: state.tableSort,
-    updateScreenMetadataSequence: sequences.updateScreenMetadataSequence,
   },
   function MessagesIndividualOutbox({ formattedMessages, screenMetadata }) {
     const filters = [

--- a/web-client/src/views/Messages/MessagesIndividualOutbox.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualOutbox.tsx
@@ -1,11 +1,51 @@
-import { Button } from '../../ustc-ui/Button/Button';
-import { ConsolidatedCaseIcon } from '../../ustc-ui/Icon/ConsolidatedCaseIcon';
-import { SortableColumn } from '../../ustc-ui/Table/SortableColumn';
-import { TableFilters } from '../../ustc-ui/Table/TableFilters';
+import {
+  MessageColumnData,
+  MessageList,
+} from '@web-client/views/Messages/MessageList';
 import { connect } from '@web-client/presenter/shared.cerebral';
 import { sequences } from '@web-client/presenter/app.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
 import React from 'react';
+
+const columns: MessageColumnData[] = [
+  {
+    columnName: 'Docket No.',
+    dataTestId: 'message-individual-docket-number-header-button',
+    iconClassName: 'consolidated-case-column',
+    sortField: 'docketNumber',
+  },
+  {
+    columnName: 'Sent',
+    dataTestId: 'message-individual-received-header-button',
+    sortField: 'createdAt',
+  },
+  {
+    columnName: 'Message',
+    dataTestId: 'message-individual-subject-header-button',
+    iconClassName: 'message-unread-column',
+    sortField: 'subject',
+  },
+  {
+    columnName: 'Case Title',
+    dataTestId: 'message-individual-case-title-header-button',
+    sortField: 'caseTitle',
+  },
+  {
+    columnName: 'Case Status',
+    dataTestId: 'message-individual-case-status-header-button',
+    sortField: 'caseStatus',
+  },
+  {
+    columnName: 'To',
+    dataTestId: 'message-individual-from-header-button',
+    sortField: 'to',
+  },
+  {
+    columnName: 'Section',
+    dataTestId: 'message-individual-section-header-button',
+    sortField: 'toSection',
+  },
+];
 
 export const MessagesIndividualOutbox = connect(
   {
@@ -16,208 +56,33 @@ export const MessagesIndividualOutbox = connect(
     tableSort: state.tableSort,
     updateScreenMetadataSequence: sequences.updateScreenMetadataSequence,
   },
-  function MessagesIndividualOutbox({
-    constants,
-    formattedMessages,
-    screenMetadata,
-    sortTableSequence,
-    tableSort,
-    updateScreenMetadataSequence,
-  }) {
+  function MessagesIndividualOutbox({ formattedMessages, screenMetadata }) {
+    const filters = [
+      {
+        isSelected: screenMetadata.caseStatus,
+        key: 'caseStatus',
+        label: 'Case Status',
+        options: formattedMessages.caseStatuses,
+      },
+      {
+        isSelected: screenMetadata.toUser,
+        key: 'toUser',
+        label: 'To',
+        options: formattedMessages.toUsers,
+      },
+      {
+        isSelected: screenMetadata.toSection,
+        key: 'toSection',
+        label: 'Section',
+        options: formattedMessages.toSections,
+      },
+    ];
     return (
-      <>
-        <div className="overflow-x-auto">
-          <TableFilters
-            filters={[
-              {
-                isSelected: screenMetadata.caseStatus,
-                key: 'caseStatus',
-                label: 'Case Status',
-                options: formattedMessages.caseStatuses,
-              },
-              {
-                isSelected: screenMetadata.toUser,
-                key: 'toUser',
-                label: 'To',
-                options: formattedMessages.toUsers,
-              },
-              {
-                isSelected: screenMetadata.toSection,
-                key: 'toSection',
-                label: 'Section',
-                options: formattedMessages.toSections,
-              },
-            ]}
-            onSelect={updateScreenMetadataSequence}
-          ></TableFilters>
-
-          <table className="usa-table ustc-table subsection">
-            <thead>
-              <tr>
-                <th
-                  aria-hidden="true"
-                  className="consolidated-case-column"
-                ></th>
-                <th aria-label="Docket Number" colSpan={2}>
-                  <SortableColumn
-                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-individual-outbox-docket-number-header-button"
-                    defaultSortOrder={constants.DESCENDING}
-                    descText={constants.CHRONOLOGICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="docketNumber"
-                    title="Docket No."
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-individual-outbox-completed-at-header-button"
-                    defaultSortOrder={constants.DESCENDING}
-                    descText={constants.CHRONOLOGICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="createdAt"
-                    title="Sent"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-individual-outbox-subject-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="subject"
-                    title="Message"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-individual-case-title-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="caseTitle"
-                    title="Case Title"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-individual-case-status-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="caseStatus"
-                    title="Case Status"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-individual-to-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="to"
-                    title="To"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-individual-section-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="toSection"
-                    title="Section"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-              </tr>
-            </thead>
-            {formattedMessages.messages.map(message => {
-              return (
-                <tbody key={`message-${message.messageId}`}>
-                  <tr>
-                    <td className="consolidated-case-column">
-                      <ConsolidatedCaseIcon
-                        consolidatedIconTooltipText={
-                          message.consolidatedIconTooltipText
-                        }
-                        inConsolidatedGroup={message.inConsolidatedGroup}
-                        showLeadCaseIcon={message.isLeadCase}
-                      />
-                    </td>
-                    <td
-                      className="message-queue-row"
-                      colSpan={2}
-                      data-testid="individual-message-outbox-docket-number-cell"
-                    >
-                      {message.docketNumberWithSuffix}
-                    </td>
-                    <td
-                      className="message-queue-row"
-                      data-testid="individual-message-outbox-completed-at-cell"
-                    >
-                      <span className="no-wrap">
-                        {message.createdAtFormatted}
-                      </span>
-                    </td>
-                    <td
-                      className="message-queue-row message-subject"
-                      data-testid="individual-message-outbox-subject-cell"
-                    >
-                      <div className="message-document-title">
-                        <Button
-                          link
-                          className="padding-0"
-                          href={message.messageDetailLink}
-                        >
-                          {message.subject}
-                        </Button>
-                      </div>
-
-                      <div className="message-document-detail">
-                        {message.message}
-                      </div>
-                    </td>
-                    <td className="message-queue-row max-width-25">
-                      {message.caseTitle}
-                    </td>
-                    <td className="message-queue-row">{message.caseStatus}</td>
-                    <td className="message-queue-row to">{message.to}</td>
-                    <td className="message-queue-row">{message.toSection}</td>
-                  </tr>
-                </tbody>
-              );
-            })}
-          </table>
-          {!formattedMessages.hasMessages && <div>There are no messages.</div>}
-        </div>
-      </>
+      <MessageList
+        messageColumns={columns}
+        messageFilters={filters}
+        selectable={false}
+      />
     );
   },
 );

--- a/web-client/src/views/Messages/MessagesIndividualOutbox.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualOutbox.tsx
@@ -45,6 +45,7 @@ export const MessagesIndividualOutbox = connect(
     ];
     return (
       <MessageList
+        id="messages-individual-outbox"
         messageColumns={columns}
         messageFilters={filters}
         selectable={false}

--- a/web-client/src/views/Messages/MessagesIndividualOutbox.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualOutbox.tsx
@@ -1,22 +1,21 @@
 import {
-  COLUMN_NAMES,
   MessageColumnData,
-  getColumnData,
+  SORTABLE_COLUMNS,
 } from '@web-client/views/Messages/MessageColumns';
 import { MessageList } from '@web-client/views/Messages/MessageList';
 import { connect } from '@web-client/presenter/shared.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
 import React from 'react';
 
-const columns: MessageColumnData[] = getColumnData([
-  COLUMN_NAMES.DOCKET_NUMBER,
-  COLUMN_NAMES.SENT,
-  COLUMN_NAMES.MESSAGE,
-  COLUMN_NAMES.CASE_TITLE,
-  COLUMN_NAMES.CASE_STATUS,
-  COLUMN_NAMES.TO,
-  COLUMN_NAMES.SECTION,
-]);
+const columns: MessageColumnData[] = [
+  SORTABLE_COLUMNS.DOCKET_NUMBER,
+  SORTABLE_COLUMNS.SENT,
+  SORTABLE_COLUMNS.MESSAGE,
+  SORTABLE_COLUMNS.CASE_TITLE,
+  SORTABLE_COLUMNS.CASE_STATUS,
+  SORTABLE_COLUMNS.TO,
+  SORTABLE_COLUMNS.TO_SECTION,
+];
 
 export const MessagesIndividualOutbox = connect(
   {

--- a/web-client/src/views/Messages/MessagesIndividualOutbox.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualOutbox.tsx
@@ -2,7 +2,7 @@ import {
   MessageColumnData,
   SORTABLE_COLUMNS,
 } from '@web-client/views/Messages/MessageColumns';
-import { MessagesTable } from '@web-client/views/Messages/MessageTable';
+import { MessageTable } from '@web-client/views/Messages/MessageTable';
 import { connect } from '@web-client/presenter/shared.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
 import React from 'react';
@@ -44,7 +44,7 @@ export const MessagesIndividualOutbox = connect(
       },
     ];
     return (
-      <MessagesTable
+      <MessageTable
         id="messages-individual-outbox"
         messageColumns={columns}
         messageFilters={filters}

--- a/web-client/src/views/Messages/MessagesIndividualOutbox.tsx
+++ b/web-client/src/views/Messages/MessagesIndividualOutbox.tsx
@@ -2,7 +2,7 @@ import {
   MessageColumnData,
   SORTABLE_COLUMNS,
 } from '@web-client/views/Messages/MessageColumns';
-import { MessageList } from '@web-client/views/Messages/MessageList';
+import { MessagesTable } from '@web-client/views/Messages/MessageTable';
 import { connect } from '@web-client/presenter/shared.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
 import React from 'react';
@@ -44,7 +44,7 @@ export const MessagesIndividualOutbox = connect(
       },
     ];
     return (
-      <MessageList
+      <MessagesTable
         id="messages-individual-outbox"
         messageColumns={columns}
         messageFilters={filters}

--- a/web-client/src/views/Messages/MessagesSectionCompleted.tsx
+++ b/web-client/src/views/Messages/MessagesSectionCompleted.tsx
@@ -26,114 +26,119 @@ export const MessagesSectionCompleted = connect(
   }) {
     return (
       <>
-        <TableFilters
-          filters={[
-            {
-              isSelected: screenMetadata.completedBy,
-              key: 'completedBy',
-              label: 'Completed By',
-              options: formattedMessages.completedByUsers,
-              useInlineSelect: false,
-            },
-          ]}
-          onSelect={updateScreenMetadataSequence}
-        ></TableFilters>
+        <div className="overflow-x-auto">
+          <TableFilters
+            filters={[
+              {
+                isSelected: screenMetadata.completedBy,
+                key: 'completedBy',
+                label: 'Completed By',
+                options: formattedMessages.completedByUsers,
+                useInlineSelect: false,
+              },
+            ]}
+            onSelect={updateScreenMetadataSequence}
+          ></TableFilters>
 
-        <table className="usa-table ustc-table subsection">
-          <thead>
-            <tr>
-              <th aria-hidden="true" className="consolidated-case-column"></th>
-              <th aria-label="Docket Number" className="small" colSpan={2}>
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-docket-number-header-button"
-                  defaultSortOrder={constants.DESCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="docketNumber"
-                  title="Docket No."
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th className="medium">
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-completed-at-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="completedAt"
-                  title="Completed"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-subject-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="subject"
-                  title="Last Message"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-comment-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="completedMessage"
-                  title="Comment"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-completed-by-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="completedBy"
-                  title="Completed By"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-completed-by-section-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="completedBySection"
-                  title="Section"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-            </tr>
-          </thead>
-          {formattedMessages.completedMessages.map(message => (
-            <CompletedMessageRow key={message.messageId} message={message} />
-          ))}
-        </table>
-        {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+          <table className="usa-table ustc-table subsection">
+            <thead>
+              <tr>
+                <th
+                  aria-hidden="true"
+                  className="consolidated-case-column"
+                ></th>
+                <th aria-label="Docket Number" colSpan={2}>
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-docket-number-header-button"
+                    defaultSortOrder={constants.DESCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="docketNumber"
+                    title="Docket No."
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th className="medium">
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-completed-at-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="completedAt"
+                    title="Completed"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-subject-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="subject"
+                    title="Last Message"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-comment-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="completedMessage"
+                    title="Comment"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-completed-by-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="completedBy"
+                    title="Completed By"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-completed-by-section-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="completedBySection"
+                    title="Section"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+              </tr>
+            </thead>
+            {formattedMessages.completedMessages.map(message => (
+              <CompletedMessageRow key={message.messageId} message={message} />
+            ))}
+          </table>
+          {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+        </div>
       </>
     );
   },
@@ -155,14 +160,14 @@ const CompletedMessageRow = React.memo(function CompletedMessageRow({
           />
         </td>
         <td
-          className="message-queue-row small"
+          className="message-queue-row"
           colSpan={2}
           data-testid="section-message-completed-docket-number-cell"
         >
           {message.docketNumberWithSuffix}
         </td>
         <td
-          className="message-queue-row small"
+          className="message-queue-row"
           data-testid="section-message-completed-completed-at-cell"
         >
           <span className="no-wrap">{message.completedAtFormatted}</span>

--- a/web-client/src/views/Messages/MessagesSectionCompleted.tsx
+++ b/web-client/src/views/Messages/MessagesSectionCompleted.tsx
@@ -33,6 +33,7 @@ export const MessagesSectionCompleted = connect(
     ];
     return (
       <MessageList
+        id="messages-section-completed"
         messageColumns={columns}
         messageFilters={filters}
         selectable={false}

--- a/web-client/src/views/Messages/MessagesSectionCompleted.tsx
+++ b/web-client/src/views/Messages/MessagesSectionCompleted.tsx
@@ -2,7 +2,7 @@ import {
   MessageColumnData,
   SORTABLE_COLUMNS,
 } from '@web-client/views/Messages/MessageColumns';
-import { MessagesTable } from '@web-client/views/Messages/MessageTable';
+import { MessageTable } from '@web-client/views/Messages/MessageTable';
 import { connect } from '@web-client/presenter/shared.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
 import React from 'react';
@@ -32,7 +32,7 @@ export const MessagesSectionCompleted = connect(
       },
     ];
     return (
-      <MessagesTable
+      <MessageTable
         id="messages-section-completed"
         messageColumns={columns}
         messageFilters={filters}

--- a/web-client/src/views/Messages/MessagesSectionCompleted.tsx
+++ b/web-client/src/views/Messages/MessagesSectionCompleted.tsx
@@ -2,7 +2,7 @@ import {
   MessageColumnData,
   SORTABLE_COLUMNS,
 } from '@web-client/views/Messages/MessageColumns';
-import { MessageList } from '@web-client/views/Messages/MessageList';
+import { MessagesTable } from '@web-client/views/Messages/MessageTable';
 import { connect } from '@web-client/presenter/shared.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
 import React from 'react';
@@ -32,7 +32,7 @@ export const MessagesSectionCompleted = connect(
       },
     ];
     return (
-      <MessageList
+      <MessagesTable
         id="messages-section-completed"
         messageColumns={columns}
         messageFilters={filters}

--- a/web-client/src/views/Messages/MessagesSectionCompleted.tsx
+++ b/web-client/src/views/Messages/MessagesSectionCompleted.tsx
@@ -1,193 +1,44 @@
-import { Button } from '../../ustc-ui/Button/Button';
-import { ConsolidatedCaseIcon } from '../../ustc-ui/Icon/ConsolidatedCaseIcon';
-import { SortableColumn } from '../../ustc-ui/Table/SortableColumn';
-import { TableFilters } from '../../ustc-ui/Table/TableFilters';
+import {
+  MessageColumnData,
+  SORTABLE_COLUMNS,
+} from '@web-client/views/Messages/MessageColumns';
+import { MessageList } from '@web-client/views/Messages/MessageList';
 import { connect } from '@web-client/presenter/shared.cerebral';
-import { sequences } from '@web-client/presenter/app.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
 import React from 'react';
 
+const columns: MessageColumnData[] = [
+  SORTABLE_COLUMNS.DOCKET_NUMBER,
+  SORTABLE_COLUMNS.COMPLETED_AT,
+  SORTABLE_COLUMNS.LAST_MESSAGE,
+  SORTABLE_COLUMNS.COMMENT,
+  SORTABLE_COLUMNS.COMPLETED_BY,
+  SORTABLE_COLUMNS.COMPLETED_BY_SECTION,
+];
+
 export const MessagesSectionCompleted = connect(
   {
-    constants: state.constants,
     formattedMessages: state.formattedMessages,
     screenMetadata: state.screenMetadata,
-    sortTableSequence: sequences.sortTableSequence,
-    tableSort: state.tableSort,
-    updateScreenMetadataSequence: sequences.updateScreenMetadataSequence,
   },
-  function MessagesSectionCompleted({
-    constants,
-    formattedMessages,
-    screenMetadata,
-    sortTableSequence,
-    tableSort,
-    updateScreenMetadataSequence,
-  }) {
+  function MessagesSectionCompleted({ formattedMessages, screenMetadata }) {
+    const filters = [
+      {
+        isSelected: screenMetadata.completedBy,
+        key: 'completedBy',
+        label: 'Completed By',
+        options: formattedMessages.completedByUsers,
+        useInlineSelect: false,
+      },
+    ];
     return (
-      <>
-        <div className="overflow-x-auto">
-          <TableFilters
-            filters={[
-              {
-                isSelected: screenMetadata.completedBy,
-                key: 'completedBy',
-                label: 'Completed By',
-                options: formattedMessages.completedByUsers,
-                useInlineSelect: false,
-              },
-            ]}
-            onSelect={updateScreenMetadataSequence}
-          ></TableFilters>
-
-          <table className="usa-table ustc-table subsection">
-            <thead>
-              <tr>
-                <th
-                  aria-hidden="true"
-                  className="consolidated-case-column"
-                ></th>
-                <th aria-label="Docket Number" colSpan={2}>
-                  <SortableColumn
-                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-section-docket-number-header-button"
-                    defaultSortOrder={constants.DESCENDING}
-                    descText={constants.CHRONOLOGICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="docketNumber"
-                    title="Docket No."
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th className="medium">
-                  <SortableColumn
-                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-section-completed-at-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.CHRONOLOGICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="completedAt"
-                    title="Completed"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-section-subject-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="subject"
-                    title="Last Message"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-section-comment-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="completedMessage"
-                    title="Comment"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-section-completed-by-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="completedBy"
-                    title="Completed By"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-section-completed-by-section-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="completedBySection"
-                    title="Section"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-              </tr>
-            </thead>
-            {formattedMessages.completedMessages.map(message => (
-              <CompletedMessageRow key={message.messageId} message={message} />
-            ))}
-          </table>
-          {!formattedMessages.hasMessages && <div>There are no messages.</div>}
-        </div>
-      </>
+      <MessageList
+        messageColumns={columns}
+        messageFilters={filters}
+        selectable={false}
+      />
     );
   },
 );
 
 MessagesSectionCompleted.displayName = 'MessagesSectionCompleted';
-
-const CompletedMessageRow = React.memo(function CompletedMessageRow({
-  message,
-}) {
-  return (
-    <tbody>
-      <tr>
-        <td className="consolidated-case-column">
-          <ConsolidatedCaseIcon
-            consolidatedIconTooltipText={message.consolidatedIconTooltipText}
-            inConsolidatedGroup={message.inConsolidatedGroup}
-            showLeadCaseIcon={message.isLeadCase}
-          />
-        </td>
-        <td
-          className="message-queue-row"
-          colSpan={2}
-          data-testid="section-message-completed-docket-number-cell"
-        >
-          {message.docketNumberWithSuffix}
-        </td>
-        <td
-          className="message-queue-row"
-          data-testid="section-message-completed-completed-at-cell"
-        >
-          <span className="no-wrap">{message.completedAtFormatted}</span>
-        </td>
-        <td className="message-queue-row">
-          <div
-            className="message-document-title"
-            data-testid="section-message-completed-subject-cell"
-          >
-            <Button link className="padding-0" href={message.messageDetailLink}>
-              {message.subject}
-            </Button>
-          </div>
-
-          <div className="message-document-detail">{message.message}</div>
-        </td>
-        <td className="message-queue-row">{message.completedMessage}</td>
-        <td className="message-queue-row">{message.completedBy}</td>
-        <td className="message-queue-row">{message.completedBySection}</td>
-      </tr>
-    </tbody>
-  );
-});

--- a/web-client/src/views/Messages/MessagesSectionInbox.tsx
+++ b/web-client/src/views/Messages/MessagesSectionInbox.tsx
@@ -26,159 +26,164 @@ export const MessagesSectionInbox = connect(
   }) {
     return (
       <>
-        <TableFilters
-          filters={[
-            {
-              isSelected: screenMetadata.caseStatus,
-              key: 'caseStatus',
-              label: 'Case Status',
-              options: formattedMessages.caseStatuses,
-            },
-            {
-              isSelected: screenMetadata.toUser,
-              key: 'toUser',
-              label: 'To',
-              options: formattedMessages.toUsers,
-            },
-            {
-              isSelected: screenMetadata.fromUser,
-              key: 'fromUser',
-              label: 'From',
-              options: formattedMessages.fromUsers,
-            },
-            {
-              isSelected: screenMetadata.fromSection,
-              key: 'fromSection',
-              label: 'Section',
-              options: formattedMessages.fromSections,
-            },
-          ]}
-          onSelect={updateScreenMetadataSequence}
-        ></TableFilters>
+        <div className="overflow-x-auto">
+          <TableFilters
+            filters={[
+              {
+                isSelected: screenMetadata.caseStatus,
+                key: 'caseStatus',
+                label: 'Case Status',
+                options: formattedMessages.caseStatuses,
+              },
+              {
+                isSelected: screenMetadata.toUser,
+                key: 'toUser',
+                label: 'To',
+                options: formattedMessages.toUsers,
+              },
+              {
+                isSelected: screenMetadata.fromUser,
+                key: 'fromUser',
+                label: 'From',
+                options: formattedMessages.fromUsers,
+              },
+              {
+                isSelected: screenMetadata.fromSection,
+                key: 'fromSection',
+                label: 'Section',
+                options: formattedMessages.fromSections,
+              },
+            ]}
+            onSelect={updateScreenMetadataSequence}
+          ></TableFilters>
 
-        <table className="usa-table ustc-table subsection">
-          <thead>
-            <tr>
-              <th aria-hidden="true" className="consolidated-case-column"></th>
-              <th aria-label="Docket Number" className="small" colSpan={2}>
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-docket-number-header-button"
-                  defaultSortOrder={constants.DESCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="docketNumber"
-                  title="Docket No."
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th className="medium">
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-received-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="createdAt"
-                  title="Received"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-subject-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="subject"
-                  title="Message"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-case-title-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="caseTitle"
-                  title="Case Title"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-case-status-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="caseStatus"
-                  title="Case Status"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-to-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="to"
-                  title="To"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-from-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="from"
-                  title="From"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th className="small">
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-from-section-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="fromSectionFormatted"
-                  title="Section"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-            </tr>
-          </thead>
-          {formattedMessages.messages.map(message => (
-            <MessageInboxRow key={message.messageId} message={message} />
-          ))}
-        </table>
-        {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+          <table className="usa-table ustc-table subsection">
+            <thead>
+              <tr>
+                <th
+                  aria-hidden="true"
+                  className="consolidated-case-column"
+                ></th>
+                <th aria-label="Docket Number" colSpan={2}>
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-docket-number-header-button"
+                    defaultSortOrder={constants.DESCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="docketNumber"
+                    title="Docket No."
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th className="medium">
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-received-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="createdAt"
+                    title="Received"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-subject-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="subject"
+                    title="Message"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-case-title-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="caseTitle"
+                    title="Case Title"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-case-status-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="caseStatus"
+                    title="Case Status"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-to-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="to"
+                    title="To"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-from-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="from"
+                    title="From"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-from-section-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="fromSectionFormatted"
+                    title="Section"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+              </tr>
+            </thead>
+            {formattedMessages.messages.map(message => (
+              <MessageInboxRow key={message.messageId} message={message} />
+            ))}
+          </table>
+          {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+        </div>
       </>
     );
   },
@@ -198,14 +203,14 @@ const MessageInboxRow = React.memo(function MessageInboxRow({ message }) {
           />
         </td>
         <td
-          className="message-queue-row small"
+          className="message-queue-row"
           colSpan={2}
           data-testid="section-message-inbox-docket-number-cell"
         >
           {message.docketNumberWithSuffix}
         </td>
         <td
-          className="message-queue-row small"
+          className="message-queue-row"
           data-testid="section-message-inbox-received-at-cell"
         >
           <span className="no-wrap">{message.createdAtFormatted}</span>
@@ -228,9 +233,7 @@ const MessageInboxRow = React.memo(function MessageInboxRow({ message }) {
         <td className="message-queue-row">{message.caseStatus}</td>
         <td className="message-queue-row to">{message.to}</td>
         <td className="message-queue-row from">{message.from}</td>
-        <td className="message-queue-row small">
-          {message.fromSectionFormatted}
-        </td>
+        <td className="message-queue-row">{message.fromSectionFormatted}</td>
       </tr>
     </tbody>
   );

--- a/web-client/src/views/Messages/MessagesSectionInbox.tsx
+++ b/web-client/src/views/Messages/MessagesSectionInbox.tsx
@@ -219,7 +219,6 @@ const MessageInboxRow = React.memo(function MessageInboxRow({ message }) {
           <div className="message-document-title">
             <Button
               link
-              section-message-inbox-subject-cell
               className="padding-0"
               data-testid="section-message-inbox-subject-cell"
               href={message.messageDetailLink}

--- a/web-client/src/views/Messages/MessagesSectionInbox.tsx
+++ b/web-client/src/views/Messages/MessagesSectionInbox.tsx
@@ -1,239 +1,63 @@
-import { Button } from '../../ustc-ui/Button/Button';
-import { ConsolidatedCaseIcon } from '../../ustc-ui/Icon/ConsolidatedCaseIcon';
-import { SortableColumn } from '../../ustc-ui/Table/SortableColumn';
-import { TableFilters } from '../../ustc-ui/Table/TableFilters';
+import {
+  MessageColumnData,
+  SORTABLE_COLUMNS,
+} from '@web-client/views/Messages/MessageColumns';
+import { MessageList } from '@web-client/views/Messages/MessageList';
 import { connect } from '@web-client/presenter/shared.cerebral';
-import { sequences } from '@web-client/presenter/app.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
 import React from 'react';
 
+const columns: MessageColumnData[] = [
+  SORTABLE_COLUMNS.DOCKET_NUMBER,
+  SORTABLE_COLUMNS.RECEIVED,
+  SORTABLE_COLUMNS.MESSAGE,
+  SORTABLE_COLUMNS.CASE_TITLE,
+  SORTABLE_COLUMNS.CASE_STATUS,
+  SORTABLE_COLUMNS.TO,
+  SORTABLE_COLUMNS.FROM,
+  SORTABLE_COLUMNS.FROM_SECTION,
+];
+
 export const MessagesSectionInbox = connect(
   {
-    constants: state.constants,
     formattedMessages: state.formattedMessages,
     screenMetadata: state.screenMetadata,
-    sortTableSequence: sequences.sortTableSequence,
-    tableSort: state.tableSort,
-    updateScreenMetadataSequence: sequences.updateScreenMetadataSequence,
   },
-  function MessagesSectionInbox({
-    constants,
-    formattedMessages,
-    screenMetadata,
-    sortTableSequence,
-    tableSort,
-    updateScreenMetadataSequence,
-  }) {
+  function MessagesSectionInbox({ formattedMessages, screenMetadata }) {
+    const filters = [
+      {
+        isSelected: screenMetadata.caseStatus,
+        key: 'caseStatus',
+        label: 'Case Status',
+        options: formattedMessages.caseStatuses,
+      },
+      {
+        isSelected: screenMetadata.toUser,
+        key: 'toUser',
+        label: 'To',
+        options: formattedMessages.toUsers,
+      },
+      {
+        isSelected: screenMetadata.fromUser,
+        key: 'fromUser',
+        label: 'From',
+        options: formattedMessages.fromUsers,
+      },
+      {
+        isSelected: screenMetadata.fromSection,
+        key: 'fromSection',
+        label: 'Section',
+        options: formattedMessages.fromSections,
+      },
+    ];
     return (
-      <>
-        <div className="overflow-x-auto">
-          <TableFilters
-            filters={[
-              {
-                isSelected: screenMetadata.caseStatus,
-                key: 'caseStatus',
-                label: 'Case Status',
-                options: formattedMessages.caseStatuses,
-              },
-              {
-                isSelected: screenMetadata.toUser,
-                key: 'toUser',
-                label: 'To',
-                options: formattedMessages.toUsers,
-              },
-              {
-                isSelected: screenMetadata.fromUser,
-                key: 'fromUser',
-                label: 'From',
-                options: formattedMessages.fromUsers,
-              },
-              {
-                isSelected: screenMetadata.fromSection,
-                key: 'fromSection',
-                label: 'Section',
-                options: formattedMessages.fromSections,
-              },
-            ]}
-            onSelect={updateScreenMetadataSequence}
-          ></TableFilters>
-
-          <table className="usa-table ustc-table subsection">
-            <thead>
-              <tr>
-                <th
-                  aria-hidden="true"
-                  className="consolidated-case-column"
-                ></th>
-                <th aria-label="Docket Number" colSpan={2}>
-                  <SortableColumn
-                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-section-docket-number-header-button"
-                    defaultSortOrder={constants.DESCENDING}
-                    descText={constants.CHRONOLOGICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="docketNumber"
-                    title="Docket No."
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th className="medium">
-                  <SortableColumn
-                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-section-received-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.CHRONOLOGICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="createdAt"
-                    title="Received"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-section-subject-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="subject"
-                    title="Message"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-section-case-title-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="caseTitle"
-                    title="Case Title"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-section-case-status-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="caseStatus"
-                    title="Case Status"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-section-to-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="to"
-                    title="To"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-section-from-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="from"
-                    title="From"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-section-from-section-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="fromSectionFormatted"
-                    title="Section"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-              </tr>
-            </thead>
-            {formattedMessages.messages.map(message => (
-              <MessageInboxRow key={message.messageId} message={message} />
-            ))}
-          </table>
-          {!formattedMessages.hasMessages && <div>There are no messages.</div>}
-        </div>
-      </>
+      <MessageList
+        messageColumns={columns}
+        messageFilters={filters}
+        selectable={false}
+      />
     );
   },
 );
 
 MessagesSectionInbox.displayName = 'MessagesSectionInbox';
-
-const MessageInboxRow = React.memo(function MessageInboxRow({ message }) {
-  return (
-    <tbody>
-      <tr>
-        <td className="consolidated-case-column">
-          <ConsolidatedCaseIcon
-            consolidatedIconTooltipText={message.consolidatedIconTooltipText}
-            inConsolidatedGroup={message.inConsolidatedGroup}
-            showLeadCaseIcon={message.isLeadCase}
-          />
-        </td>
-        <td
-          className="message-queue-row"
-          colSpan={2}
-          data-testid="section-message-inbox-docket-number-cell"
-        >
-          {message.docketNumberWithSuffix}
-        </td>
-        <td
-          className="message-queue-row"
-          data-testid="section-message-inbox-received-at-cell"
-        >
-          <span className="no-wrap">{message.createdAtFormatted}</span>
-        </td>
-        <td className="message-queue-row message-subject">
-          <div className="message-document-title">
-            <Button
-              link
-              className="padding-0"
-              data-testid="section-message-inbox-subject-cell"
-              href={message.messageDetailLink}
-            >
-              {message.subject}
-            </Button>
-          </div>
-          <div className="message-document-detail">{message.message}</div>
-        </td>
-        <td className="message-queue-row max-width-25">{message.caseTitle}</td>
-        <td className="message-queue-row">{message.caseStatus}</td>
-        <td className="message-queue-row to">{message.to}</td>
-        <td className="message-queue-row from">{message.from}</td>
-        <td className="message-queue-row">{message.fromSectionFormatted}</td>
-      </tr>
-    </tbody>
-  );
-});

--- a/web-client/src/views/Messages/MessagesSectionInbox.tsx
+++ b/web-client/src/views/Messages/MessagesSectionInbox.tsx
@@ -2,7 +2,7 @@ import {
   MessageColumnData,
   SORTABLE_COLUMNS,
 } from '@web-client/views/Messages/MessageColumns';
-import { MessageList } from '@web-client/views/Messages/MessageList';
+import { MessagesTable } from '@web-client/views/Messages/MessageTable';
 import { connect } from '@web-client/presenter/shared.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
 import React from 'react';
@@ -51,7 +51,7 @@ export const MessagesSectionInbox = connect(
       },
     ];
     return (
-      <MessageList
+      <MessagesTable
         id="messages-section-inbox"
         messageColumns={columns}
         messageFilters={filters}

--- a/web-client/src/views/Messages/MessagesSectionInbox.tsx
+++ b/web-client/src/views/Messages/MessagesSectionInbox.tsx
@@ -52,6 +52,7 @@ export const MessagesSectionInbox = connect(
     ];
     return (
       <MessageList
+        id="messages-section-inbox"
         messageColumns={columns}
         messageFilters={filters}
         selectable={false}

--- a/web-client/src/views/Messages/MessagesSectionInbox.tsx
+++ b/web-client/src/views/Messages/MessagesSectionInbox.tsx
@@ -2,7 +2,7 @@ import {
   MessageColumnData,
   SORTABLE_COLUMNS,
 } from '@web-client/views/Messages/MessageColumns';
-import { MessagesTable } from '@web-client/views/Messages/MessageTable';
+import { MessageTable } from '@web-client/views/Messages/MessageTable';
 import { connect } from '@web-client/presenter/shared.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
 import React from 'react';
@@ -51,7 +51,7 @@ export const MessagesSectionInbox = connect(
       },
     ];
     return (
-      <MessagesTable
+      <MessageTable
         id="messages-section-inbox"
         messageColumns={columns}
         messageFilters={filters}

--- a/web-client/src/views/Messages/MessagesSectionOutbox.tsx
+++ b/web-client/src/views/Messages/MessagesSectionOutbox.tsx
@@ -26,159 +26,164 @@ export const MessagesSectionOutbox = connect(
   }) {
     return (
       <>
-        <TableFilters
-          filters={[
-            {
-              isSelected: screenMetadata.caseStatus,
-              key: 'caseStatus',
-              label: 'Case Status',
-              options: formattedMessages.caseStatuses,
-            },
-            {
-              isSelected: screenMetadata.toUser,
-              key: 'toUser',
-              label: 'To',
-              options: formattedMessages.toUsers,
-            },
-            {
-              isSelected: screenMetadata.fromUser,
-              key: 'fromUser',
-              label: 'From',
-              options: formattedMessages.fromUsers,
-            },
-            {
-              isSelected: screenMetadata.toSection,
-              key: 'toSection',
-              label: 'Section',
-              options: formattedMessages.toSections,
-            },
-          ]}
-          onSelect={updateScreenMetadataSequence}
-        ></TableFilters>
+        <div className="overflow-x-auto">
+          <TableFilters
+            filters={[
+              {
+                isSelected: screenMetadata.caseStatus,
+                key: 'caseStatus',
+                label: 'Case Status',
+                options: formattedMessages.caseStatuses,
+              },
+              {
+                isSelected: screenMetadata.toUser,
+                key: 'toUser',
+                label: 'To',
+                options: formattedMessages.toUsers,
+              },
+              {
+                isSelected: screenMetadata.fromUser,
+                key: 'fromUser',
+                label: 'From',
+                options: formattedMessages.fromUsers,
+              },
+              {
+                isSelected: screenMetadata.toSection,
+                key: 'toSection',
+                label: 'Section',
+                options: formattedMessages.toSections,
+              },
+            ]}
+            onSelect={updateScreenMetadataSequence}
+          ></TableFilters>
 
-        <table className="usa-table ustc-table subsection">
-          <thead>
-            <tr>
-              <th aria-hidden="true" className="consolidated-case-column"></th>
-              <th aria-label="Docket Number" className="small" colSpan={2}>
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-outbox-docket-number-header-button"
-                  defaultSortOrder={constants.DESCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="docketNumber"
-                  title="Docket No."
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th className="small">
-                <SortableColumn
-                  ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-outbox-created-at-header-button"
-                  defaultSortOrder={constants.DESCENDING}
-                  descText={constants.CHRONOLOGICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="createdAt"
-                  title="Sent"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-outbox-subject-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="subject"
-                  title="Message"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-case-title-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="caseTitle"
-                  title="Case Title"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-case-status-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="caseStatus"
-                  title="Case Status"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-to-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="to"
-                  title="To"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-from-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="from"
-                  title="From"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-              <th>
-                <SortableColumn
-                  ascText={constants.ALPHABETICALLY_ASCENDING}
-                  currentlySortedField={tableSort.sortField}
-                  currentlySortedOrder={tableSort.sortOrder}
-                  data-testid="message-section-to-section-header-button"
-                  defaultSortOrder={constants.ASCENDING}
-                  descText={constants.ALPHABETICALLY_DESCENDING}
-                  hasRows={formattedMessages.hasMessages}
-                  sortField="toSection"
-                  title="Section"
-                  onClickSequence={sortTableSequence}
-                />
-              </th>
-            </tr>
-          </thead>
-          {formattedMessages.messages.map(message => (
-            <MessageOutboxRow key={message.messageId} message={message} />
-          ))}
-        </table>
-        {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+          <table className="usa-table ustc-table subsection">
+            <thead>
+              <tr>
+                <th
+                  aria-hidden="true"
+                  className="consolidated-case-column"
+                ></th>
+                <th aria-label="Docket Number" colSpan={2}>
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-outbox-docket-number-header-button"
+                    defaultSortOrder={constants.DESCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="docketNumber"
+                    title="Docket No."
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-outbox-created-at-header-button"
+                    defaultSortOrder={constants.DESCENDING}
+                    descText={constants.CHRONOLOGICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="createdAt"
+                    title="Sent"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-outbox-subject-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="subject"
+                    title="Message"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-case-title-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="caseTitle"
+                    title="Case Title"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-case-status-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="caseStatus"
+                    title="Case Status"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-to-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="to"
+                    title="To"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-from-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="from"
+                    title="From"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+                <th>
+                  <SortableColumn
+                    ascText={constants.ALPHABETICALLY_ASCENDING}
+                    currentlySortedField={tableSort.sortField}
+                    currentlySortedOrder={tableSort.sortOrder}
+                    data-testid="message-section-to-section-header-button"
+                    defaultSortOrder={constants.ASCENDING}
+                    descText={constants.ALPHABETICALLY_DESCENDING}
+                    hasRows={formattedMessages.hasMessages}
+                    sortField="toSection"
+                    title="Section"
+                    onClickSequence={sortTableSequence}
+                  />
+                </th>
+              </tr>
+            </thead>
+            {formattedMessages.messages.map(message => (
+              <MessageOutboxRow key={message.messageId} message={message} />
+            ))}
+          </table>
+          {!formattedMessages.hasMessages && <div>There are no messages.</div>}
+        </div>
       </>
     );
   },
@@ -198,14 +203,14 @@ const MessageOutboxRow = React.memo(function MessageOutboxRow({ message }) {
           />
         </td>
         <td
-          className="message-queue-row small"
+          className="message-queue-row"
           colSpan={2}
           data-testid="section-message-outbox-docket-number-cell"
         >
           {message.docketNumberWithSuffix}
         </td>
         <td
-          className="message-queue-row small"
+          className="message-queue-row"
           data-testid="section-message-outbox-created-at-cell"
         >
           <span className="no-wrap">{message.createdAtFormatted}</span>
@@ -228,7 +233,7 @@ const MessageOutboxRow = React.memo(function MessageOutboxRow({ message }) {
         <td className="message-queue-row">{message.caseStatus}</td>
         <td className="message-queue-row to">{message.to}</td>
         <td className="message-queue-row from">{message.from}</td>
-        <td className="message-queue-row small">{message.toSection}</td>
+        <td className="message-queue-row">{message.toSection}</td>
       </tr>
     </tbody>
   );

--- a/web-client/src/views/Messages/MessagesSectionOutbox.tsx
+++ b/web-client/src/views/Messages/MessagesSectionOutbox.tsx
@@ -52,6 +52,7 @@ export const MessagesSectionOutbox = connect(
     ];
     return (
       <MessageList
+        id="messages-section-outbox"
         messageColumns={columns}
         messageFilters={filters}
         selectable={false}

--- a/web-client/src/views/Messages/MessagesSectionOutbox.tsx
+++ b/web-client/src/views/Messages/MessagesSectionOutbox.tsx
@@ -2,7 +2,7 @@ import {
   MessageColumnData,
   SORTABLE_COLUMNS,
 } from '@web-client/views/Messages/MessageColumns';
-import { MessagesTable } from '@web-client/views/Messages/MessageTable';
+import { MessageTable } from '@web-client/views/Messages/MessageTable';
 import { connect } from '@web-client/presenter/shared.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
 import React from 'react';
@@ -51,7 +51,7 @@ export const MessagesSectionOutbox = connect(
       },
     ];
     return (
-      <MessagesTable
+      <MessageTable
         id="messages-section-outbox"
         messageColumns={columns}
         messageFilters={filters}

--- a/web-client/src/views/Messages/MessagesSectionOutbox.tsx
+++ b/web-client/src/views/Messages/MessagesSectionOutbox.tsx
@@ -2,7 +2,7 @@ import {
   MessageColumnData,
   SORTABLE_COLUMNS,
 } from '@web-client/views/Messages/MessageColumns';
-import { MessageList } from '@web-client/views/Messages/MessageList';
+import { MessagesTable } from '@web-client/views/Messages/MessageTable';
 import { connect } from '@web-client/presenter/shared.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
 import React from 'react';
@@ -51,7 +51,7 @@ export const MessagesSectionOutbox = connect(
       },
     ];
     return (
-      <MessageList
+      <MessagesTable
         id="messages-section-outbox"
         messageColumns={columns}
         messageFilters={filters}

--- a/web-client/src/views/Messages/MessagesSectionOutbox.tsx
+++ b/web-client/src/views/Messages/MessagesSectionOutbox.tsx
@@ -1,240 +1,63 @@
-import { Button } from '../../ustc-ui/Button/Button';
-import { ConsolidatedCaseIcon } from '../../ustc-ui/Icon/ConsolidatedCaseIcon';
-import { SortableColumn } from '../../ustc-ui/Table/SortableColumn';
-import { TableFilters } from '../../ustc-ui/Table/TableFilters';
+import {
+  MessageColumnData,
+  SORTABLE_COLUMNS,
+} from '@web-client/views/Messages/MessageColumns';
+import { MessageList } from '@web-client/views/Messages/MessageList';
 import { connect } from '@web-client/presenter/shared.cerebral';
-import { sequences } from '@web-client/presenter/app.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
 import React from 'react';
 
+const columns: MessageColumnData[] = [
+  SORTABLE_COLUMNS.DOCKET_NUMBER,
+  SORTABLE_COLUMNS.SENT,
+  SORTABLE_COLUMNS.MESSAGE,
+  SORTABLE_COLUMNS.CASE_TITLE,
+  SORTABLE_COLUMNS.CASE_STATUS,
+  SORTABLE_COLUMNS.TO,
+  SORTABLE_COLUMNS.FROM,
+  SORTABLE_COLUMNS.TO_SECTION,
+];
+
 export const MessagesSectionOutbox = connect(
   {
-    constants: state.constants,
     formattedMessages: state.formattedMessages,
     screenMetadata: state.screenMetadata,
-    sortTableSequence: sequences.sortTableSequence,
-    tableSort: state.tableSort,
-    updateScreenMetadataSequence: sequences.updateScreenMetadataSequence,
   },
-  function MessagesSectionOutbox({
-    constants,
-    formattedMessages,
-    screenMetadata,
-    sortTableSequence,
-    tableSort,
-    updateScreenMetadataSequence,
-  }) {
+  function MessagesSectionOutbox({ formattedMessages, screenMetadata }) {
+    const filters = [
+      {
+        isSelected: screenMetadata.caseStatus,
+        key: 'caseStatus',
+        label: 'Case Status',
+        options: formattedMessages.caseStatuses,
+      },
+      {
+        isSelected: screenMetadata.toUser,
+        key: 'toUser',
+        label: 'To',
+        options: formattedMessages.toUsers,
+      },
+      {
+        isSelected: screenMetadata.fromUser,
+        key: 'fromUser',
+        label: 'From',
+        options: formattedMessages.fromUsers,
+      },
+      {
+        isSelected: screenMetadata.toSection,
+        key: 'toSection',
+        label: 'Section',
+        options: formattedMessages.toSections,
+      },
+    ];
     return (
-      <>
-        <div className="overflow-x-auto">
-          <TableFilters
-            filters={[
-              {
-                isSelected: screenMetadata.caseStatus,
-                key: 'caseStatus',
-                label: 'Case Status',
-                options: formattedMessages.caseStatuses,
-              },
-              {
-                isSelected: screenMetadata.toUser,
-                key: 'toUser',
-                label: 'To',
-                options: formattedMessages.toUsers,
-              },
-              {
-                isSelected: screenMetadata.fromUser,
-                key: 'fromUser',
-                label: 'From',
-                options: formattedMessages.fromUsers,
-              },
-              {
-                isSelected: screenMetadata.toSection,
-                key: 'toSection',
-                label: 'Section',
-                options: formattedMessages.toSections,
-              },
-            ]}
-            onSelect={updateScreenMetadataSequence}
-          ></TableFilters>
-
-          <table className="usa-table ustc-table subsection">
-            <thead>
-              <tr>
-                <th
-                  aria-hidden="true"
-                  className="consolidated-case-column"
-                ></th>
-                <th aria-label="Docket Number" colSpan={2}>
-                  <SortableColumn
-                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-section-outbox-docket-number-header-button"
-                    defaultSortOrder={constants.DESCENDING}
-                    descText={constants.CHRONOLOGICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="docketNumber"
-                    title="Docket No."
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.CHRONOLOGICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-section-outbox-created-at-header-button"
-                    defaultSortOrder={constants.DESCENDING}
-                    descText={constants.CHRONOLOGICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="createdAt"
-                    title="Sent"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-section-outbox-subject-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="subject"
-                    title="Message"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-section-case-title-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="caseTitle"
-                    title="Case Title"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-section-case-status-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="caseStatus"
-                    title="Case Status"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-section-to-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="to"
-                    title="To"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-section-from-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="from"
-                    title="From"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-                <th>
-                  <SortableColumn
-                    ascText={constants.ALPHABETICALLY_ASCENDING}
-                    currentlySortedField={tableSort.sortField}
-                    currentlySortedOrder={tableSort.sortOrder}
-                    data-testid="message-section-to-section-header-button"
-                    defaultSortOrder={constants.ASCENDING}
-                    descText={constants.ALPHABETICALLY_DESCENDING}
-                    hasRows={formattedMessages.hasMessages}
-                    sortField="toSection"
-                    title="Section"
-                    onClickSequence={sortTableSequence}
-                  />
-                </th>
-              </tr>
-            </thead>
-            {formattedMessages.messages.map(message => (
-              <MessageOutboxRow key={message.messageId} message={message} />
-            ))}
-          </table>
-          {!formattedMessages.hasMessages && <div>There are no messages.</div>}
-        </div>
-      </>
+      <MessageList
+        messageColumns={columns}
+        messageFilters={filters}
+        selectable={false}
+      />
     );
   },
 );
 
 MessagesSectionOutbox.displayName = 'MessagesSectionOutbox';
-
-const MessageOutboxRow = React.memo(function MessageOutboxRow({ message }) {
-  return (
-    <tbody>
-      <tr>
-        <td className="consolidated-case-column">
-          <ConsolidatedCaseIcon
-            consolidatedIconTooltipText={message.consolidatedIconTooltipText}
-            inConsolidatedGroup={message.inConsolidatedGroup}
-            showLeadCaseIcon={message.isLeadCase}
-          />
-        </td>
-        <td
-          className="message-queue-row"
-          colSpan={2}
-          data-testid="section-message-outbox-docket-number-cell"
-        >
-          {message.docketNumberWithSuffix}
-        </td>
-        <td
-          className="message-queue-row"
-          data-testid="section-message-outbox-created-at-cell"
-        >
-          <span className="no-wrap">{message.createdAtFormatted}</span>
-        </td>
-        <td className="message-queue-row message-subject">
-          <div className="message-document-title">
-            <Button link className="padding-0" href={message.messageDetailLink}>
-              {message.subject}
-            </Button>
-          </div>
-
-          <div
-            className="message-document-detail"
-            data-testid="section-message-outbox-subject-cell"
-          >
-            {message.message}
-          </div>
-        </td>
-        <td className="message-queue-row max-width-25">{message.caseTitle}</td>
-        <td className="message-queue-row">{message.caseStatus}</td>
-        <td className="message-queue-row to">{message.to}</td>
-        <td className="message-queue-row from">{message.from}</td>
-        <td className="message-queue-row">{message.toSection}</td>
-      </tr>
-    </tbody>
-  );
-});

--- a/web-client/src/views/Public/PublicDocketRecord.tsx
+++ b/web-client/src/views/Public/PublicDocketRecord.tsx
@@ -20,7 +20,7 @@ export const PublicDocketRecord = connect(
         <PublicDocketRecordHeader />
 
         <NonPhone>
-          <div style={{ overflowX: 'scroll', width: '100%' }}>
+          <div className="width-full overflow-x-auto">
             <table
               aria-label="docket record"
               className="usa-table ustc-table usa-table--stacked"


### PR DESCRIPTION
The design debt [ticket](https://github.com/orgs/flexion/projects/11/views/1?pane=issue&itemId=76509485&issue=flexion%7Cef-cms%7C10412) is more or less for getting the sort icons in the sortable message table to not wrap independently. We also decided to allow the table to scroll horizontally as needed.

In the process, I decided it was worth embarking upon a refactor. That is why the PR is not tiny.

**Before (icon wraps independently):**
<img width="854" alt="Screenshot 2024-10-28 at 9 42 23 AM" src="https://github.com/user-attachments/assets/17facda8-e313-4c15-973c-9c4fa10e1a2d">

**After (icon wraps with text):**
<img width="1034" alt="Screenshot 2024-10-28 at 9 41 14 AM" src="https://github.com/user-attachments/assets/963494cd-a3bf-45c5-b61f-ff96accec00e">

**If reviewers do not like the refactor, I can just add changes to fix the icon wrapping, scroll the table, and wrap columns with text containing no spaces (as the current behavior is to allow them to expand horizontally without bound).**

---

Refactor notes:

_TL;DR: Instead of 6 separate message tables all independently built but using a lot of the same code, there is 1 message table that each of the 6 message tables instantiate with different configurations. The refactor is not perfect, but I think it is 1) better and 2) a good start to further refactoring._

While fixing "the" message table, I saw there were actually six very similar message tables (inbox, outbox, and completed for both individuals and sections). I do not like this: 1) every update to "the" message table needs to touch multiple files, 2) it is easy for the tables to get out of sync ("whoops, someone forgot to add that class in one of the files"), and 3) every table is independently responsible for making sure the header columns and row columns match (e.g., that we don't have off-by-one errors where someone forgot a `colspan`). Moreover, I saw that what fields one could sort by/display were opaque: to answer that question, one needed to go into each component separately.

My thoughts are that you should be able to see what fields are available in a given context, pass in some subset of them into some `SortableTable` component, pass in the data object (messages, docket entries, whatever), and see everything "just work." Especially with [10525](https://github.com/orgs/flexion/projects/11/views/1?pane=issue&itemId=82760879&issue=flexion%7Cef-cms%7C10525) and likely other stories adding sorting to tables, I want to get closer to this `SortableTable` ideal. (And then extend this to `FilteredSortableTable`.)

This PR is a step in that direction. It creates a `MessageTable` component that each of the six message tables uses, along with a helper class detailing what fields are available to sort by. My hope is that we can continue to move in this direction to make things less message-specific and therefore reusable across the app.

For transparency, here are (I believe) the pros and cons:

Pros: 

1. Changes to one table (e.g., styles) are maintained across the different message tables
2. `MessageTable` automatically creates the header rows and data rows from the passed in columns without the developer needing to coordinate them
3. `MessageColumns` makes it easier for a developer to see how to construct a table for messages
4. Code deduplication

Cons:

1. The obverse of 1 above: changes to one table affect all others.
2. There are a couple of clunky places in `MessageTable`--concessions to "these tables are all basically--but not _quite_--the same. I think there are ways to improve this: this is not a perfect refactor, just a good start.
3. There is slightly more rendering logic.
