### PR TITLE
10363: AWS Batch Piggyback

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -996,10 +996,14 @@ workflows:
     jobs:
       - deploy:
           <<: *only-prod
-      - migrate:
+      - docker-image-zipper:
           <<: *only-prod
           requires:
             - deploy
+      - migrate:
+          <<: *only-prod
+          requires:
+            - docker-image-zipper
       - wait-for-migration:
           <<: *only-prod
           type: approval


### PR DESCRIPTION
_(CircleCI terminology refresher: "workflow" is the entire deployment, a workflow has "jobs" and the jobs have "steps")_

This PR adds the `docker-image-zipper` job to the `build-and-deploy-with-context` (prod deployment) workflow in the same sequence that it occurs in the `build-and-deploy` (lower environment deployment) workflow.