### PR TITLE
OpEx: Postgres Quality-of-Life Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,8 +261,7 @@ jobs:
       - run:
           name: Run Postgres Migration
           command: |
-            OUTPUT_ONLY=true npm run deploy:allColors $ENV
-            POSTGRES_HOST=$(cat ./web-api/terraform/applyables/allColors/output.json | jq -r '.rds_host_name.value')
+            POSTGRES_HOST=$(./scripts/postgres/get-read-write-endpoint.sh)
             POSTGRES_HOST=$POSTGRES_HOST POSTGRES_USER=$POSTGRES_USER NODE_ENV=production npm run migration:postgres
       - run:
           name: Enable Check Migration Status Cron

--- a/check-env-variables.sh
+++ b/check-env-variables.sh
@@ -2,6 +2,8 @@
 
 # shellcheck disable=SC1091
 source "./scripts/helpers/suppress-output.sh"
+# shellcheck disable=SC1091
+source "./scripts/helpers/prior-confirmation.sh"
 
 {
   [[ -n $ZSH_VERSION && $ZSH_EVAL_CONTEXT =~ :file$ ]] ||
@@ -10,6 +12,7 @@ source "./scripts/helpers/suppress-output.sh"
 [[ $sourced -eq 0 ]] && exit="exit" || exit="return"
 
 quiet=$(should_suppress_output "$@")
+yes=$(has_prior_confirmation "$@")
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -19,7 +22,13 @@ NC='\033[0m'
 # verify expected env variables are set
 for EXPECTED_ENV_VAR in "$@"; do
   EXPECTED_ENV_VAR=$(xargs echo -n <<< "$EXPECTED_ENV_VAR")
-  if [[ -n "$EXPECTED_ENV_VAR" ]] && [[ "$EXPECTED_ENV_VAR" != "--quiet" ]] && [[ "$EXPECTED_ENV_VAR" != "-q" ]]; then
+  if {
+    [[ -n "$EXPECTED_ENV_VAR" ]] &&
+    [[ "$EXPECTED_ENV_VAR" != "--quiet" ]] &&
+    [[ "$EXPECTED_ENV_VAR" != "-q" ]] &&
+    [[ "$EXPECTED_ENV_VAR" != "--yes" ]] &&
+    [[ "$EXPECTED_ENV_VAR" != "-y" ]]
+  }; then
     # shellcheck disable=SC2296
     if {
       [[ -n $BASH_VERSION ]] && [[ -z "${!EXPECTED_ENV_VAR}" ]];
@@ -43,7 +52,13 @@ if [[ $quiet -eq 0 ]]; then
   # # print all expected env variables
   for EXPECTED_ENV_VAR in "$@"; do
     EXPECTED_ENV_VAR=$(xargs echo -n <<< "$EXPECTED_ENV_VAR")
-    if [[ -n "$EXPECTED_ENV_VAR" ]] && [[ "$EXPECTED_ENV_VAR" != "--quiet" ]] && [[ "$EXPECTED_ENV_VAR" != "-q" ]]; then
+    if {
+     [[ -n "$EXPECTED_ENV_VAR" ]] &&
+     [[ "$EXPECTED_ENV_VAR" != "--quiet" ]] &&
+     [[ "$EXPECTED_ENV_VAR" != "-q" ]] &&
+     [[ "$EXPECTED_ENV_VAR" != "--yes" ]] &&
+     [[ "$EXPECTED_ENV_VAR" != "-y" ]]
+    }; then
       if [[ ${EXPECTED_ENV_VAR} == *"AWS"* ]] || [[ ${EXPECTED_ENV_VAR} == *"PASS"* ]]; then
         echo "- $EXPECTED_ENV_VAR=*******"
       else
@@ -54,7 +69,7 @@ if [[ $quiet -eq 0 ]]; then
     fi
   done
 
-  if [[ -z "${CI}" ]] && { [[ -n $BASH_VERSION ]] || [[ $sourced -eq 0 ]]; }; then
+  if { [[ -z "${CI}" ]] && [[ $yes -eq 0 ]]; } && { [[ -n $BASH_VERSION ]] || [[ $sourced -eq 0 ]]; }; then
     printf  "%bAre you sure you want to continue? (press y to confirm)%b\n\n" "${YELLOW}" "${NC}"
     read -p "continue? (press y to confirm)" -n 1 -r
 

--- a/check-env-variables.sh
+++ b/check-env-variables.sh
@@ -6,10 +6,10 @@ source "./scripts/helpers/suppress-output.sh"
 source "./scripts/helpers/prior-confirmation.sh"
 
 {
-  [[ -n $ZSH_VERSION && $ZSH_EVAL_CONTEXT =~ :file$ ]] ||
-  [[ -n $BASH_VERSION ]] && (return 0 2>/dev/null);
+  [[ -n "$ZSH_VERSION" && "$ZSH_EVAL_CONTEXT" =~ :file$ ]] ||
+  [[ -n "$BASH_VERSION" ]] && (return 0 2>/dev/null);
 } && sourced=1 || sourced=0
-[[ $sourced -eq 0 ]] && exit="exit" || exit="return"
+[[ "$sourced" -eq 0 ]] && exit="exit" || exit="return"
 
 quiet=$(should_suppress_output "$@")
 yes=$(has_prior_confirmation "$@")
@@ -27,27 +27,27 @@ for EXPECTED_ENV_VAR in "$@"; do
     [[ "$EXPECTED_ENV_VAR" != "--quiet" ]] &&
     [[ "$EXPECTED_ENV_VAR" != "-q" ]] &&
     [[ "$EXPECTED_ENV_VAR" != "--yes" ]] &&
-    [[ "$EXPECTED_ENV_VAR" != "-y" ]]
+    [[ "$EXPECTED_ENV_VAR" != "-y" ]];
   }; then
     # shellcheck disable=SC2296
     if {
-      [[ -n $BASH_VERSION ]] && [[ -z "${!EXPECTED_ENV_VAR}" ]];
+      [[ -n "$BASH_VERSION" ]] && [[ -z "${!EXPECTED_ENV_VAR}" ]];
     } || {
-      [[ -n $ZSH_VERSION ]] && [[ -z "${(P)EXPECTED_ENV_VAR}" ]];
+      [[ -n "$ZSH_VERSION" ]] && [[ -z "${(P)EXPECTED_ENV_VAR}" ]];
     }; then
       MISSING_ENV="true"
-      if [[ $quiet -eq 0 ]]; then
+      if [[ "$quiet" -eq 0 ]]; then
         printf "%bERROR - You must have %b${EXPECTED_ENV_VAR}%b set in your environment to run this script!%b\n" "${RED}" "${YELLOW}" "${RED}" "${NC}"
       fi
     fi
   fi
 done
 
-if [[ -n "${MISSING_ENV}" ]]; then
+if [[ -n "$MISSING_ENV" ]]; then
   $exit 1;
 fi
 
-if [[ $quiet -eq 0 ]]; then
+if [[ "$quiet" -eq 0 ]]; then
   printf "\n%bVerify these env variables seem correct:%b\n" "${GREEN}" "${NC}"
   # # print all expected env variables
   for EXPECTED_ENV_VAR in "$@"; do
@@ -57,24 +57,24 @@ if [[ $quiet -eq 0 ]]; then
      [[ "$EXPECTED_ENV_VAR" != "--quiet" ]] &&
      [[ "$EXPECTED_ENV_VAR" != "-q" ]] &&
      [[ "$EXPECTED_ENV_VAR" != "--yes" ]] &&
-     [[ "$EXPECTED_ENV_VAR" != "-y" ]]
+     [[ "$EXPECTED_ENV_VAR" != "-y" ]];
     }; then
-      if [[ ${EXPECTED_ENV_VAR} == *"AWS"* ]] || [[ ${EXPECTED_ENV_VAR} == *"PASS"* ]]; then
+      if [[ "$EXPECTED_ENV_VAR" == *"AWS"* ]] || [[ "$EXPECTED_ENV_VAR" == *"PASS"* ]]; then
         echo "- $EXPECTED_ENV_VAR=*******"
       else
         # shellcheck disable=SC2296
-        [[ -n $BASH_VERSION ]] && value="${!EXPECTED_ENV_VAR}" || value="${(P)EXPECTED_ENV_VAR}"
+        [[ -n "$BASH_VERSION" ]] && value="${!EXPECTED_ENV_VAR}" || value="${(P)EXPECTED_ENV_VAR}"
         echo "- $EXPECTED_ENV_VAR=${value}"
       fi
     fi
   done
 
-  if { [[ -z "${CI}" ]] && [[ $yes -eq 0 ]]; } && { [[ -n $BASH_VERSION ]] || [[ $sourced -eq 0 ]]; }; then
+  if { [[ -z "${CI}" ]] && [[ "$yes" -eq 0 ]]; } && { [[ -n "$BASH_VERSION" ]] || [[ "$sourced" -eq 0 ]]; }; then
     printf  "%bAre you sure you want to continue? (press y to confirm)%b\n\n" "${YELLOW}" "${NC}"
     read -p "continue? (press y to confirm)" -n 1 -r
 
     echo    # (optional) move to a new line
-    if [[ ! ($REPLY =~ ^[Yy]$) ]]; then
+    if [[ ! ("$REPLY" =~ ^[Yy]$) ]]; then
       echo "Aborted..."
       $exit 1;
     else

--- a/docs/postgres/connect-to-deployed-db.md
+++ b/docs/postgres/connect-to-deployed-db.md
@@ -1,8 +1,24 @@
-# Connecting to a Deployed Postgres Database from TablePlus
+# Connecting to a Deployed Postgres Database
 
 Note: run all commands from the root of the `ef-cms` directory.
 
-## Creating a new connection in TablePlus
+## CLI: `psql`
+
+1. Use the [environment switcher](../additional-resources/environment-switcher.md) to point to the deployed environment:
+   ```bash
+   . scripts/env/set-env.zsh ustc-dev
+   ```
+1. Run `connect.sh` to automatically generate a temporary access token and use it to connect:
+   - To connect to the read-only endpoint:
+      ```bash
+      scripts/postgres/connect.sh
+      ```
+   - To connect to the writeable endpoint:
+      ```bash
+      scripts/postgres/connect.sh --rw
+      ```
+
+## GUI: TablePlus
 
 1. Use the [environment switcher](../additional-resources/environment-switcher.md) to point to the deployed environment:
    ```bash
@@ -19,11 +35,14 @@ Note: run all commands from the root of the `ef-cms` directory.
       ```
 1. Add a new connection in TablePlus:
    1. Populate the host, port, username, password, and database fields using the values from the `generate-token.sh` output from step 2
-   1. Select "SSL mode preferred"
+   1. Select "SSL mode preferred" (even if it is preselected)
    1. Select "CA Cert..." and choose the `global-bundle.pem` file in the root of the repo
-1. The token generated above is temporary. After it expires, you will need to run `generate-token.sh` again to retrieve a new token, or follow the optional steps below to configure TablePlus to retrieve tokens automatically.
+1. The token generated above is temporary. After it expires, you will need to run `generate-token.sh` again to retrieve a new token. Try passing in the `--succinct` flag this time:
+   ```bash
+   scripts/postgres/generate-token.sh --succinct # --rw
+   ```
 
-## (Optional) Configuring an existing connection to automatically retrieve tokens
+### (Optional) Configuring an existing connection to automatically retrieve tokens
 
 1. Determine the exact full path to the `get-token-for-tableplus.zsh` script:
    ```bash

--- a/scripts/helpers/prior-confirmation.sh
+++ b/scripts/helpers/prior-confirmation.sh
@@ -2,9 +2,7 @@
 
 function has_prior_confirmation() {
   for param in "$@"; do
-    if [[ "$param" == "--yes" ]] || [[ "$param" == "-y" ]]; then
-      YES=1
-    fi
+    { [[ "$param" == "--yes" ]] || [[ "$param" == "-y" ]]; } && YES=1
   done
   [[ "$YES" -eq 1 ]] && echo 1 || echo 0
 }

--- a/scripts/helpers/prior-confirmation.sh
+++ b/scripts/helpers/prior-confirmation.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+function has_prior_confirmation() {
+  for param in "$@"; do
+    if [[ "$param" == "--yes" ]] || [[ "$param" == "-y" ]]; then
+      YES=1
+    fi
+  done
+  [[ "$YES" -eq 1 ]] && echo 1 || echo 0
+}

--- a/scripts/helpers/suppress-output.sh
+++ b/scripts/helpers/suppress-output.sh
@@ -2,9 +2,7 @@
 
 function should_suppress_output() {
   for param in "$@"; do
-    if [[ "$param" == "--quiet" ]] || [[ "$param" == "-q" ]]; then
-      QUIET=1
-    fi
+    { [[ "$param" == "--quiet" ]] || [[ "$param" == "-q" ]]; } && QUIET=1
   done
   [[ "$QUIET" -eq 1 ]] && echo 1 || echo 0
 }

--- a/scripts/postgres/connect.sh
+++ b/scripts/postgres/connect.sh
@@ -17,7 +17,7 @@ GENERATE_TOKEN_PARAMS=("--quiet")
 
 for param in "$@"; do
   [[ "$param" == "--rw" ]] && GENERATE_TOKEN_PARAMS+=("--rw")
-  [[ "$param" == "--yes" ]] && CHECK_ENV_PARAMS+=("--yes")
+  { [[ "$param" == "--yes" ]] || [[ "$param" == "-y" ]]; } && CHECK_ENV_PARAMS+=("--yes")
 done
 
 ./check-env-variables.sh "${CHECK_ENV_PARAMS[@]}"

--- a/scripts/postgres/connect.sh
+++ b/scripts/postgres/connect.sh
@@ -4,20 +4,26 @@
 
 # Parameters
 #   --rw    Connects to the cluster's writeable endpoint
+#   --yes   Presumes prior confirmation when checking environment variables
 
 # Usage examples
 #   ENV=dev ./scripts/postgres/connect.sh
-#   ENV=dev ./scripts/postgres/connect.sh --rw
+#   ENV=dev ./scripts/postgres/connect.sh --rw --yes
 
 ( ! command -v psql > /dev/null ) && echo "psql must be installed on your machine." && exit 1
 
+CHECK_ENV_PARAMS=("ENV" "AWS_ACCESS_KEY_ID" "AWS_SECRET_ACCESS_KEY")
+GENERATE_TOKEN_PARAMS=("--quiet")
+
 for param in "$@"; do
-  if [[ "$param" == "--rw" ]]; then
-    RW="--rw"
-  fi
+  [[ "$param" == "--rw" ]] && GENERATE_TOKEN_PARAMS+=("--rw")
+  [[ "$param" == "--yes" ]] && CHECK_ENV_PARAMS+=("--yes")
 done
 
-source "./scripts/postgres/generate-token.sh" "$RW" --quiet
+./check-env-variables.sh "${CHECK_ENV_PARAMS[@]}"
+
+# shellcheck disable=SC1091
+source "./scripts/postgres/generate-token.sh" "${GENERATE_TOKEN_PARAMS[@]}"
 
 {
   [[ -z "$DB_HOST" ]] ||

--- a/scripts/postgres/connect.sh
+++ b/scripts/postgres/connect.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -e
+
+# Generates a temporary auth token for the given environment's RDS cluster and initiates a connection with psql
+
+# Parameters
+#   --rw    Connects to the cluster's writeable endpoint
+
+# Usage examples
+#   ENV=dev ./scripts/postgres/connect.sh
+#   ENV=dev ./scripts/postgres/connect.sh --rw
+
+( ! command -v psql > /dev/null ) && echo "psql must be installed on your machine." && exit 1
+
+for param in "$@"; do
+  if [[ "$param" == "--rw" ]]; then
+    RW="--rw"
+  fi
+done
+
+source "./scripts/postgres/generate-token.sh" "$RW" --quiet
+
+{
+  [[ -z "$DB_HOST" ]] ||
+  [[ -z "$DB_USER" ]] ||
+  [[ -z "$DB_TOKEN" ]] ||
+  [[ -z "$DB_NAME" ]];
+} && echo "Unable to generate IAM token" && exit 1
+
+PGPASSWORD="$DB_TOKEN" psql -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME"

--- a/scripts/postgres/connect.sh
+++ b/scripts/postgres/connect.sh
@@ -7,8 +7,8 @@
 #   --yes   Presumes prior confirmation when checking environment variables
 
 # Usage examples
-#   ENV=dev ./scripts/postgres/connect.sh
-#   ENV=dev ./scripts/postgres/connect.sh --rw --yes
+#   ./scripts/postgres/connect.sh
+#   DB_USER="${ENV}_dawson" ./scripts/postgres/connect.sh --rw --yes
 
 ( ! command -v psql > /dev/null ) && echo "psql must be installed on your machine." && exit 1
 

--- a/scripts/postgres/generate-token.sh
+++ b/scripts/postgres/generate-token.sh
@@ -19,10 +19,10 @@ source "./scripts/helpers/suppress-output.sh"
 source "./scripts/helpers/prior-confirmation.sh"
 
 {
-  [[ -n $ZSH_VERSION && $ZSH_EVAL_CONTEXT =~ :file$ ]] ||
-  [[ -n $BASH_VERSION ]] && (return 0 2>/dev/null);
+  [[ -n "$ZSH_VERSION" && "$ZSH_EVAL_CONTEXT" =~ :file$ ]] ||
+  [[ -n "$BASH_VERSION" ]] && (return 0 2>/dev/null);
 } && sourced=1 || sourced=0
-[[ $sourced -eq 0 ]] && exit="exit" || exit="return"
+[[ "$sourced" -eq 0 ]] && exit="exit" || exit="return"
 
 succinct=0
 for param in "$@"; do
@@ -34,16 +34,15 @@ for param in "$@"; do
   fi
 done
 
+CHECK_PARAMS=("ENV" "AWS_ACCESS_KEY_ID" "AWS_SECRET_ACCESS_KEY")
+
 sshhh=$(should_suppress_output "$@")
-{ [[ "$sshhh" -eq 1 ]] || [[ "$succinct" -eq 1 ]]; } && QUIET="--quiet"
+{ [[ "$sshhh" -eq 1 ]] || [[ "$succinct" -eq 1 ]]; } && CHECK_PARAMS+=("--quiet")
 
 confirmed=$(has_prior_confirmation "$@")
-[[ "$sshhh" -eq 0 ]] && [[ "$succinct" -eq 0 ]] && [[ "$confirmed" -eq 1 ]] && YES="--yes"
+[[ "$sshhh" -eq 0 ]] && [[ "$succinct" -eq 0 ]] && [[ "$confirmed" -eq 1 ]] && CHECK_PARAMS+=("--yes")
 
-./check-env-variables.sh "${QUIET}${YES}" \
-  "ENV" \
-  "AWS_SECRET_ACCESS_KEY" \
-  "AWS_ACCESS_KEY_ID"
+./check-env-variables.sh "${CHECK_PARAMS[@]}"
 
 [[ "$RW" -eq 1 ]] && ENDPOINT="Endpoint" || ENDPOINT="ReaderEndpoint"
 

--- a/scripts/postgres/generate-token.sh
+++ b/scripts/postgres/generate-token.sh
@@ -9,9 +9,9 @@
 #   --succinct    Outputs only the generated token (not compatible with --quiet)
 
 # Usage examples
-#   ENV=dev ./scripts/postgres/generate-token.sh
-#   ENV=dev ./scripts/postgres/generate-token.sh --rw --succinct
-#   ENV=dev DB_USER=test_dawson ./scripts/postgres/generate-token.sh --rw
+#   ./scripts/postgres/generate-token.sh
+#   ./scripts/postgres/generate-token.sh --rw --succinct
+#   DB_USER="${ENV}_dawson" ./scripts/postgres/generate-token.sh --rw
 
 # shellcheck disable=SC1091
 source "./scripts/helpers/suppress-output.sh"

--- a/scripts/postgres/generate-token.sh
+++ b/scripts/postgres/generate-token.sh
@@ -2,11 +2,21 @@
 
 # Generates a temporary auth token for the given environment's RDS cluster
 
-# Usage
-#   ENV=dev ./scripts/postgres/generate-token.sh --rw
+# Parameters
+#   --rw          Generates a token for the writeable endpoint
+#   --yes         Presumes prior confirmation when checking environment variables
+#   --quiet       Exports values to environment variables and produces no output
+#   --succinct    Outputs only the generated token (not compatible with --quiet)
+
+# Usage examples
+#   ENV=dev ./scripts/postgres/generate-token.sh
+#   ENV=dev ./scripts/postgres/generate-token.sh --rw --succinct
+#   ENV=dev DB_USER=test_dawson ./scripts/postgres/generate-token.sh --rw
 
 # shellcheck disable=SC1091
 source "./scripts/helpers/suppress-output.sh"
+# shellcheck disable=SC1091
+source "./scripts/helpers/prior-confirmation.sh"
 
 {
   [[ -n $ZSH_VERSION && $ZSH_EVAL_CONTEXT =~ :file$ ]] ||
@@ -14,26 +24,34 @@ source "./scripts/helpers/suppress-output.sh"
 } && sourced=1 || sourced=0
 [[ $sourced -eq 0 ]] && exit="exit" || exit="return"
 
-sshhh=$(should_suppress_output "$@")
-[[ "$sshhh" -eq 1 ]] && QUIET="--quiet"
-
-./check-env-variables.sh "$QUIET" \
-  "ENV" \
-  "AWS_SECRET_ACCESS_KEY" \
-  "AWS_ACCESS_KEY_ID"
-
+succinct=0
 for param in "$@"; do
   if [[ "$param" == "--rw" ]]; then
     RW=1
   fi
+  if [[ "$param" == "--succinct" ]]; then
+    succinct=1
+  fi
 done
+
+sshhh=$(should_suppress_output "$@")
+{ [[ "$sshhh" -eq 1 ]] || [[ "$succinct" -eq 1 ]]; } && QUIET="--quiet"
+
+confirmed=$(has_prior_confirmation "$@")
+[[ "$sshhh" -eq 0 ]] && [[ "$succinct" -eq 0 ]] && [[ "$confirmed" -eq 1 ]] && YES="--yes"
+
+./check-env-variables.sh "${QUIET}${YES}" \
+  "ENV" \
+  "AWS_SECRET_ACCESS_KEY" \
+  "AWS_ACCESS_KEY_ID"
+
 [[ "$RW" -eq 1 ]] && ENDPOINT="Endpoint" || ENDPOINT="ReaderEndpoint"
 
 DESCRIPTION=$(aws rds describe-db-clusters --db-cluster-identifier "${ENV}-dawson-cluster" | jq -r ".DBClusters[0]")
 REGION="us-east-1"
 DB_HOST=$(jq -r ".${ENDPOINT}" <<< "$DESCRIPTION")
 DB_PORT=$(jq -r ".Port" <<< "$DESCRIPTION")
-DB_USER="${ENV}_developers"
+[[ -z "$DB_USER" ]] && DB_USER="${ENV}_developers"
 DB_NAME="${ENV}_dawson"
 
 TOKEN=$(aws rds generate-db-auth-token \
@@ -48,18 +66,22 @@ if [[ -z "$TOKEN" ]]; then
 fi
 
 if [[ "$sshhh" -eq 0 ]]; then
-  echo -e "\n"
-  echo -e "############ Temporary postgres credentials ############\n"
-  echo "Host/Socket:"
-  echo -e "${DB_HOST}\n"
-  echo "Port:"
-  echo -e "${DB_PORT}\n"
-  echo "User:"
-  echo -e "${DB_USER}\n"
-  echo "Password:"
-  echo -e "${TOKEN}\n"
-  echo "Database:"
-  echo -e "${DB_NAME}\n"
+  if [[ "$succinct" -eq 1 ]]; then
+    echo "$TOKEN"
+  else
+    echo -e "\n"
+    echo -e "############ Temporary postgres credentials ############\n"
+    echo "Host/Socket:"
+    echo -e "${DB_HOST}\n"
+    echo "Port:"
+    echo -e "${DB_PORT}\n"
+    echo "User:"
+    echo -e "${DB_USER}\n"
+    echo "Password:"
+    echo -e "${TOKEN}\n"
+    echo "Database:"
+    echo -e "${DB_NAME}\n"
+  fi
 else
   export DB_HOST="$DB_HOST"
   export DB_PORT="$DB_PORT"

--- a/scripts/postgres/generate-token.sh
+++ b/scripts/postgres/generate-token.sh
@@ -26,12 +26,8 @@ source "./scripts/helpers/prior-confirmation.sh"
 
 succinct=0
 for param in "$@"; do
-  if [[ "$param" == "--rw" ]]; then
-    RW=1
-  fi
-  if [[ "$param" == "--succinct" ]]; then
-    succinct=1
-  fi
+  [[ "$param" == "--rw" ]] && RW=1
+  [[ "$param" == "--succinct" ]] && succinct=1
 done
 
 CHECK_PARAMS=("ENV" "AWS_ACCESS_KEY_ID" "AWS_SECRET_ACCESS_KEY")
@@ -68,8 +64,7 @@ if [[ "$sshhh" -eq 0 ]]; then
   if [[ "$succinct" -eq 1 ]]; then
     echo "$TOKEN"
   else
-    echo -e "\n"
-    echo -e "############ Temporary postgres credentials ############\n"
+    echo -e "\n\n############ Temporary postgres credentials ############\n"
     echo "Host/Socket:"
     echo -e "${DB_HOST}\n"
     echo "Port:"

--- a/scripts/postgres/get-read-only-endpoint.sh
+++ b/scripts/postgres/get-read-only-endpoint.sh
@@ -13,12 +13,11 @@
 # shellcheck disable=SC1091
 source "./scripts/helpers/prior-confirmation.sh"
 
-confirmed=$(has_prior_confirmation "$@")
-{ [[ "$confirmed" -eq 1 ]] || [[ -n "$CI" ]]; } && QUIET="--quiet"
+CHECK_PARAMS=("ENV" "AWS_ACCESS_KEY_ID" "AWS_SECRET_ACCESS_KEY")
 
-./check-env-variables.sh "$QUIET" \
-  "ENV" \
-  "AWS_SECRET_ACCESS_KEY" \
-  "AWS_ACCESS_KEY_ID"
+confirmed=$(has_prior_confirmation "$@")
+{ [[ "$confirmed" -eq 1 ]] || [[ -n "$CI" ]]; } && CHECK_PARAMS+=("--quiet")
+
+./check-env-variables.sh "${CHECK_PARAMS[@]}"
 
 aws rds describe-db-clusters --db-cluster-identifier "${ENV}-dawson-cluster" | jq -r ".DBClusters[0].ReaderEndpoint"

--- a/scripts/postgres/get-read-only-endpoint.sh
+++ b/scripts/postgres/get-read-only-endpoint.sh
@@ -2,12 +2,21 @@
 
 # Returns the read-only endpoint for a given environment's RDS cluster
 
+# Parameters
+#   --yes    Presumes prior confirmation when checking environment variables
+
 # Usage
-#   ENV=dev ./scripts/postgres/get-read-only-endpoint.sh
+#   ENV=dev ./scripts/postgres/get-read-only-endpoint.sh --yes
 
 ( ! command -v jq > /dev/null ) && echo "jq must be installed on your machine." && exit 1
 
-./check-env-variables.sh \
+# shellcheck disable=SC1091
+source "./scripts/helpers/prior-confirmation.sh"
+
+confirmed=$(has_prior_confirmation "$@")
+{ [[ "$confirmed" -eq 1 ]] || [[ -n "$CI" ]]; } && QUIET="--quiet"
+
+./check-env-variables.sh "$QUIET" \
   "ENV" \
   "AWS_SECRET_ACCESS_KEY" \
   "AWS_ACCESS_KEY_ID"

--- a/scripts/postgres/get-read-write-endpoint.sh
+++ b/scripts/postgres/get-read-write-endpoint.sh
@@ -13,12 +13,11 @@
 # shellcheck disable=SC1091
 source "./scripts/helpers/prior-confirmation.sh"
 
-confirmed=$(has_prior_confirmation "$@")
-{ [[ "$confirmed" -eq 1 ]] || [[ -n "$CI" ]]; } && QUIET="--quiet"
+CHECK_PARAMS=("ENV" "AWS_ACCESS_KEY_ID" "AWS_SECRET_ACCESS_KEY")
 
-./check-env-variables.sh "$QUIET" \
-  "ENV" \
-  "AWS_SECRET_ACCESS_KEY" \
-  "AWS_ACCESS_KEY_ID"
+confirmed=$(has_prior_confirmation "$@")
+{ [[ "$confirmed" -eq 1 ]] || [[ -n "$CI" ]]; } && CHECK_PARAMS+=("--quiet")
+
+./check-env-variables.sh "${CHECK_PARAMS[@]}"
 
 aws rds describe-db-clusters --db-cluster-identifier "${ENV}-dawson-cluster" | jq -r ".DBClusters[0].Endpoint"

--- a/scripts/postgres/get-read-write-endpoint.sh
+++ b/scripts/postgres/get-read-write-endpoint.sh
@@ -2,12 +2,21 @@
 
 # Returns the read-write endpoint for a given environment's RDS cluster
 
+# Parameters
+#   --yes    Presumes prior confirmation when checking environment variables
+
 # Usage
-#   ENV=dev ./scripts/postgres/get-read-write-endpoint.sh
+#   ENV=dev ./scripts/postgres/get-read-write-endpoint.sh --yes
 
 ( ! command -v jq > /dev/null ) && echo "jq must be installed on your machine." && exit 1
 
-./check-env-variables.sh \
+# shellcheck disable=SC1091
+source "./scripts/helpers/prior-confirmation.sh"
+
+confirmed=$(has_prior_confirmation "$@")
+{ [[ "$confirmed" -eq 1 ]] || [[ -n "$CI" ]]; } && QUIET="--quiet"
+
+./check-env-variables.sh "$QUIET" \
   "ENV" \
   "AWS_SECRET_ACCESS_KEY" \
   "AWS_ACCESS_KEY_ID"


### PR DESCRIPTION
## Quality-of-Life Improvements to Postgres Command-Line Utilities

### Generate Token Script

1. Added a `--yes` parameter to presume prior confirmation of environment variables
2. Added a `--succinct` parameter to output only the generated token
3. Now supports generating tokens for other database users by overriding the `$DB_USER` environment variable

### Get Endpoint URL Scripts

1. Added a `--yes` parameter to presume prior confirmation of environment variables
2. When run with the `$CI` environment variable set, will output only the endpoint URL

### New "Connect" Script

Running `connect.sh` will generate a database token and connect with it using `psql`:

__Connecting to the read-only endpoint:__
```bash
./scripts/postgres/connect.sh
```

__Connecting to the writeable endpoint:__
```bash
./scripts/postgres/connect.sh --rw
```

__Overriding the default user and connecting to the writeable endpoint:__
```bash
DB_USER="${ENV}_dawson" ./scripts/postgres/connect.sh --rw
```