### PR TITLE
10461 Story: Addressing UX Feedback Round 2

### DIFF
--- a/web-client/src/ustc-ui/Icon/CaseIcons.tsx
+++ b/web-client/src/ustc-ui/Icon/CaseIcons.tsx
@@ -5,8 +5,11 @@ import classNames from 'classnames';
 
 export function CaseIcons({ formattedCase }: { formattedCase: any }) {
   return (
-    <div className="multi-filing-type-icon">
-      <div
+    <div
+      className="multi-filing-type-icon"
+      style={{ display: 'flex', flexWrap: 'nowrap', gap: '1rem' }} // USWDS overwrites these styles at certain breakpoints even with !important
+    >
+      <span
         className={
           formattedCase.isSealed ? 'visibility-visible' : 'visibility-hidden'
         }
@@ -19,7 +22,7 @@ export function CaseIcons({ formattedCase }: { formattedCase: any }) {
           icon="lock"
           title="Sealed"
         />
-      </div>
+      </span>
       <span
         className={classNames({
           'margin-left-2':

--- a/web-client/src/views/Public/TrialSessions/PublicTrialSessionDetails.tsx
+++ b/web-client/src/views/Public/TrialSessions/PublicTrialSessionDetails.tsx
@@ -124,10 +124,11 @@ function NonMobileOpenCases({
 }) {
   return (
     <React.Fragment>
-      <div className="text-right margin-bottom-2">
+      <div className="text-right">
         <span className="text-semibold">Count: </span>
         {openCases.length}
       </div>
+      <div className="padding-1"></div>
       <div className="overflow-x-auto overflow-y-hidden">
         <table
           className="usa-table ustc-table trial-sessions subsection"

--- a/web-client/src/views/Public/TrialSessions/PublicTrialSessionDetails.tsx
+++ b/web-client/src/views/Public/TrialSessions/PublicTrialSessionDetails.tsx
@@ -13,7 +13,6 @@ import { TrialSessionDetailsHeader } from '@web-client/views/TrialSessionDetails
 import { connect } from '@web-client/presenter/shared.cerebral';
 import { state } from '@web-client/presenter/app-public.cerebral';
 import React from 'react';
-import classNames from 'classnames';
 
 export const PublicTrialSessionDetails = connect(
   {
@@ -158,15 +157,7 @@ function NonMobileOpenCases({
                   <CaseIcons formattedCase={publicCase} />
                 </td>
                 <td>
-                  <span
-                    className={classNames({
-                      'margin-left-2':
-                        publicCase.inConsolidatedGroup &&
-                        !publicCase.isLeadCase,
-                    })}
-                  >
-                    <CaseLink formattedCase={publicCase} />
-                  </span>
+                  <CaseLink formattedCase={publicCase} />
                 </td>
                 <td>{publicCase.caseTitle}</td>
                 <td>
@@ -196,8 +187,7 @@ function MobileOpenCases({
 }) {
   return (
     <React.Fragment>
-      <div className="grid-row margin-bottom-2 width-full flex-align-center"></div>
-      <div className="text-right margin-bottom-2">
+      <div className="text-right">
         <span className="text-semibold">Count: </span>
         {openCases.length}
       </div>
@@ -215,15 +205,17 @@ function MobileOpenCases({
               <tr className="padding-0" key={publicCase.docketNumberWithSuffix}>
                 <td>
                   <div style={{ alignItems: 'center', display: 'flex' }}>
-                    <span className="margin-right-3">
-                      <ConsolidatedCaseIcon
-                        consolidatedIconTooltipText={
-                          publicCase.consolidatedIconTooltipText
-                        }
-                        inConsolidatedGroup={publicCase.inConsolidatedGroup}
-                        showLeadCaseIcon={publicCase.isLeadCase}
-                      />
-                    </span>
+                    {publicCase.inConsolidatedGroup && (
+                      <span className="margin-right-105">
+                        <ConsolidatedCaseIcon
+                          consolidatedIconTooltipText={
+                            publicCase.consolidatedIconTooltipText
+                          }
+                          inConsolidatedGroup={publicCase.inConsolidatedGroup}
+                          showLeadCaseIcon={publicCase.isLeadCase}
+                        />
+                      </span>
+                    )}
                     <CaseLink formattedCase={publicCase} />
                     {publicCase.isSealed && (
                       <span className="text-right margin-left-auto">
@@ -243,23 +235,29 @@ function MobileOpenCases({
                     className="padding-bottom-3"
                     key={publicCase.docketNumberWithSuffix}
                   >
-                    <div className="display-flex flex-column gap-3">
+                    <div className="display-flex gap-3">
                       <div>
                         <span className="label">Case Title</span>
                         {publicCase.caseTitle}
                       </div>
-                      {publicCase.privatePractitioners?.map(practitioner => (
-                        <div key={practitioner?.name}>
-                          <span className="label">Petitioner Counsel</span>
-                          <div>{practitioner?.name}</div>
-                        </div>
-                      ))}
-                      {publicCase.irsPractitioners?.map(respondent => (
-                        <div key={respondent?.name}>
-                          <span className="label">Respondent Counsel</span>
-                          <div>{respondent?.name}</div>
-                        </div>
-                      ))}
+                      {publicCase.privatePractitioners &&
+                        publicCase.privatePractitioners.length > 0 && (
+                          <div>
+                            <span className="label">Petitioner Counsel</span>
+                            {publicCase.privatePractitioners?.map(counsel => (
+                              <div key={counsel.name}>{counsel.name}</div>
+                            ))}
+                          </div>
+                        )}
+                      {publicCase.irsPractitioners &&
+                        publicCase.irsPractitioners.length > 0 && (
+                          <div>
+                            <span className="label">Respondent Counsel</span>
+                            {publicCase.irsPractitioners?.map(counsel => (
+                              <div key={counsel.name}>{counsel.name}</div>
+                            ))}
+                          </div>
+                        )}
                     </div>
                   </div>
                 </td>

--- a/web-client/src/views/TrialSessionDetails/AllCases.tsx
+++ b/web-client/src/views/TrialSessionDetails/AllCases.tsx
@@ -14,7 +14,7 @@ export const AllCases = connect(
     return (
       <React.Fragment>
         <div className="overflow-x-auto overflow-y-hidden">
-          <div className="push-right margin-bottom-2">
+          <div className="text-right margin-bottom-2">
             <span className="text-semibold">Count: </span>
             {allCases.length}
           </div>

--- a/web-client/src/views/TrialSessionDetails/AllCases.tsx
+++ b/web-client/src/views/TrialSessionDetails/AllCases.tsx
@@ -13,11 +13,11 @@ export const AllCases = connect(
   function AllCases({ allCases }) {
     return (
       <React.Fragment>
+        <div className="text-right margin-bottom-2">
+          <span className="text-semibold">Count: </span>
+          {allCases.length}
+        </div>
         <div className="overflow-x-auto overflow-y-hidden">
-          <div className="text-right margin-bottom-2">
-            <span className="text-semibold">Count: </span>
-            {allCases.length}
-          </div>
           <table
             aria-describedby="all-cases-tab"
             className="usa-table ustc-table trial-sessions subsection"

--- a/web-client/src/views/TrialSessionDetails/AllCases.tsx
+++ b/web-client/src/views/TrialSessionDetails/AllCases.tsx
@@ -13,10 +13,11 @@ export const AllCases = connect(
   function AllCases({ allCases }) {
     return (
       <React.Fragment>
-        <div className="text-right margin-bottom-2">
+        <div className="text-right">
           <span className="text-semibold">Count: </span>
           {allCases.length}
         </div>
+        <div className="padding-1"></div>
         <div className="overflow-x-auto overflow-y-hidden">
           <table
             aria-describedby="all-cases-tab"

--- a/web-client/src/views/TrialSessionDetails/InactiveCases.tsx
+++ b/web-client/src/views/TrialSessionDetails/InactiveCases.tsx
@@ -13,7 +13,7 @@ export const InactiveCases = connect(
     return (
       <React.Fragment>
         <div className="overflow-x-auto overflow-y-hidden">
-          <div className="push-right margin-bottom-2">
+          <div className="text-right margin-bottom-2">
             <span className="text-semibold">Count: </span>
             {inactiveCases.length}
           </div>

--- a/web-client/src/views/TrialSessionDetails/InactiveCases.tsx
+++ b/web-client/src/views/TrialSessionDetails/InactiveCases.tsx
@@ -12,11 +12,11 @@ export const InactiveCases = connect(
   function InactiveCases({ inactiveCases }) {
     return (
       <React.Fragment>
+        <div className="text-right margin-bottom-2">
+          <span className="text-semibold">Count: </span>
+          {inactiveCases.length}
+        </div>
         <div className="overflow-x-auto overflow-y-hidden">
-          <div className="text-right margin-bottom-2">
-            <span className="text-semibold">Count: </span>
-            {inactiveCases.length}
-          </div>
           <table
             aria-describedby="inactive-cases-tab"
             className="usa-table ustc-table trial-sessions subsection"

--- a/web-client/src/views/TrialSessionDetails/InactiveCases.tsx
+++ b/web-client/src/views/TrialSessionDetails/InactiveCases.tsx
@@ -12,10 +12,11 @@ export const InactiveCases = connect(
   function InactiveCases({ inactiveCases }) {
     return (
       <React.Fragment>
-        <div className="text-right margin-bottom-2">
+        <div className="text-right">
           <span className="text-semibold">Count: </span>
           {inactiveCases.length}
         </div>
+        <div className="padding-1"></div>
         <div className="overflow-x-auto overflow-y-hidden">
           <table
             aria-describedby="inactive-cases-tab"

--- a/web-client/src/views/TrialSessionDetails/OpenCases.tsx
+++ b/web-client/src/views/TrialSessionDetails/OpenCases.tsx
@@ -15,7 +15,7 @@ export const OpenCases = connect(
     return (
       <React.Fragment>
         <div className="overflow-x-auto overflow-y-hidden">
-          <div className="push-right margin-bottom-2">
+          <div className="text-right margin-bottom-2">
             <span className="text-semibold">Count: </span>
             {openCases.length}
           </div>

--- a/web-client/src/views/TrialSessionDetails/OpenCases.tsx
+++ b/web-client/src/views/TrialSessionDetails/OpenCases.tsx
@@ -14,10 +14,11 @@ export const OpenCases = connect(
   function OpenCases({ openCases }) {
     return (
       <React.Fragment>
-        <div className="text-right margin-bottom-2">
+        <div className="text-right">
           <span className="text-semibold">Count: </span>
           {openCases.length}
         </div>
+        <div className="padding-1"></div>
         <div className="overflow-x-auto overflow-y-hidden">
           <table
             aria-describedby="open-cases-tab"

--- a/web-client/src/views/TrialSessionDetails/OpenCases.tsx
+++ b/web-client/src/views/TrialSessionDetails/OpenCases.tsx
@@ -14,11 +14,11 @@ export const OpenCases = connect(
   function OpenCases({ openCases }) {
     return (
       <React.Fragment>
+        <div className="text-right margin-bottom-2">
+          <span className="text-semibold">Count: </span>
+          {openCases.length}
+        </div>
         <div className="overflow-x-auto overflow-y-hidden">
-          <div className="text-right margin-bottom-2">
-            <span className="text-semibold">Count: </span>
-            {openCases.length}
-          </div>
           <table
             aria-describedby="open-cases-tab"
             className="usa-table ustc-table trial-sessions subsection"

--- a/web-client/src/views/TrialSessions/TrialSessionsTable.tsx
+++ b/web-client/src/views/TrialSessions/TrialSessionsTable.tsx
@@ -40,13 +40,13 @@ export const TrialSessionsTable = connect(
             <div className="grid-col-2"></div>
           </div>
         </div>
+        <div className="text-right">
+          <span className="text-semibold">Count: </span>
+          {trialSessionsHelper.trialSessionsCount}
+        </div>
+        <div className="padding-1"></div>
         <div className="overflow-x-auto">
           <div className="minw-tablet-lg">
-            <div className="text-right">
-              <span className="text-semibold">Count: </span>
-              {trialSessionsHelper.trialSessionsCount}
-            </div>
-            <div className="padding-1"></div>
             <table
               aria-describedby="trial-sessions-filter-label locationFilter proceedingFilter sessionFilter judgeFilter"
               aria-label={`${trialSessionsPage.filters.currentTab} trial sessions`}


### PR DESCRIPTION
- Make sure icons don't wrap on smaller screens, and reduce some spacing
- Fix mobile table: header for petitioner and respondent counsels was in the `map` instead of outside of it
- Move the Count indicators across the trial sessions pages outside of the scroll div so that they are right aligned with the screen (and therefore visible to the user even when the edge of the table is not)