### PR TITLE
Parallelize smoke tests in circle deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,12 +348,13 @@ jobs:
             ./scripts/reindex/disable-reindex-cron.sh
 
   smoketests:
+    parallelism: 6
     docker:
       - image: *efcms-docker-image
         aws_auth:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
-    resource_class: medium+
+    resource_class: large
     steps:
       - git-shallow-clone/checkout
       - npm-and-cypress-install
@@ -366,7 +367,7 @@ jobs:
             ./scripts/env/env-for-circle.sh
       - run:
           name: 'Cypress Smoke Tests'
-          command: npm run cypress:smoketests
+          command: find cypress/deployed-and-local/integration -type f -name "*.cy.ts" | circleci tests run --split-by=timings --command 'paste -sd, - | xargs -I {} ./scripts/run-cypress.sh -s -t {}'
       - store_artifacts:
           path: /root/project/cypress/deployed-and-local/videos/
 
@@ -936,12 +937,10 @@ workflows:
           <<: *only-deployed-lower-environments
       - docker-image-zipper:
           <<: *only-deployed-lower-environments
-          requires:
-            - deploy
       - migrate:
           <<: *only-deployed-lower-environments
           requires:
-            - docker-image-zipper
+            - deploy
       - wait-for-migration:
           <<: *only-deployed-lower-environments
           type: approval

--- a/run-local.sh
+++ b/run-local.sh
@@ -6,10 +6,10 @@
 
 if [[ -z "$CI" ]]; then
   echo "Stopping postgres in case it's already running"
-  docker-compose -f web-api/src/persistence/postgres/docker-compose.yml down || true
+  docker compose --compatibility -f web-api/src/persistence/postgres/docker-compose.yml down || true
 
   echo "Starting postgres"
-  docker-compose -f web-api/src/persistence/postgres/docker-compose.yml up -d || { echo "Failed to start Postgres containers"; exit 1; }
+  docker compose --compatibility -f web-api/src/persistence/postgres/docker-compose.yml up -d || { echo "Failed to start Postgres containers"; exit 1; }
 
   echo "Stopping dynamodb in case it's already running"
   pkill -f DynamoDBLocal

--- a/run-local.sh
+++ b/run-local.sh
@@ -6,10 +6,10 @@
 
 if [[ -z "$CI" ]]; then
   echo "Stopping postgres in case it's already running"
-  docker compose --compatibility -f web-api/src/persistence/postgres/docker-compose.yml down || true
+  docker-compose -f web-api/src/persistence/postgres/docker-compose.yml down || true
 
   echo "Starting postgres"
-  docker compose --compatibility -f web-api/src/persistence/postgres/docker-compose.yml up -d || { echo "Failed to start Postgres containers"; exit 1; }
+  docker-compose -f web-api/src/persistence/postgres/docker-compose.yml up -d || { echo "Failed to start Postgres containers"; exit 1; }
 
   echo "Stopping dynamodb in case it's already running"
   pkill -f DynamoDBLocal

--- a/scripts/run-cypress.sh
+++ b/scripts/run-cypress.sh
@@ -127,8 +127,6 @@ else
   export CYPRESS_MIGRATE=$CYPRESS_MIGRATE
 fi	
 
-echo "${RUN_SPECIFIC_TEST}"
-
 if [ -n "${OPEN}" ]; then
   ./node_modules/.bin/cypress open --browser "${BROWSER}" -C "${CONFIG_FILE}"
 else

--- a/scripts/run-cypress.sh
+++ b/scripts/run-cypress.sh
@@ -127,12 +127,15 @@ else
   export CYPRESS_MIGRATE=$CYPRESS_MIGRATE
 fi	
 
+echo "${RUN_SPECIFIC_TEST}"
+
 if [ -n "${OPEN}" ]; then
   ./node_modules/.bin/cypress open --browser "${BROWSER}" -C "${CONFIG_FILE}"
 else
   if [ -n "${RUN_SPECIFIC_TEST}" ]; then
+    RUN_SPECIFIC_TEST="${RUN_SPECIFIC_TEST// /,}"
     ./node_modules/.bin/cypress run --browser "${BROWSER}" -C "${CONFIG_FILE}" --spec "${RUN_SPECIFIC_TEST}"
-  else 
+  else
     ./node_modules/.bin/cypress run --browser "${BROWSER}" -C "${CONFIG_FILE}"
-  fi    
+  fi
 fi


### PR DESCRIPTION
Does as the title says: splits smoke tests across six parallel executors when running smoke tests in cypress. It also bumps up the resource allocation for the smoke tests job to handle the additional load of parallel cypress runs.

This cuts our smoke tests duration from ~35 minutes to ~10 minutes

Here's a successful deploy to test: https://app.circleci.com/pipelines/github/ustaxcourt/ef-cms/9210/workflows/cbb7c74d-304c-4a74-bc96-9226944d1819