### PR TITLE
Bugfix: fix broken validation in EditCorrespondenceDocument

### DIFF
--- a/web-client/src/views/Correspondence/EditCorrespondenceDocument.tsx
+++ b/web-client/src/views/Correspondence/EditCorrespondenceDocument.tsx
@@ -129,7 +129,9 @@ export const EditCorrespondenceDocument = connect(
                   <ScanBatchPreviewer
                     documentType="primaryDocumentFile"
                     title="Add Document"
-                    validateSequence="validateUploadCorrespondenceDocumentSequence"
+                    validateSequence={
+                      validateUploadCorrespondenceDocumentSequence
+                    }
                   />
                 )) || (
                   <>


### PR DESCRIPTION
`ScanBatchPreviewer.tsx` expects prop `validateSequence` to be a function, but `EditCorrespondenceDocument.tsx` passes in a string. This causes validation to break.