### PR TITLE
OpEx: Stale Cases Report

### DIFF
--- a/scripts/reports/stale-cases.ts
+++ b/scripts/reports/stale-cases.ts
@@ -1,7 +1,10 @@
 // usage:
 // npx ts-node --transpile-only scripts/reports/stale-cases.ts
 
-import { CASE_STATUS_TYPES } from '@shared/business/entities/EntityConstants';
+import {
+  CASE_STATUS_TYPES,
+  CaseStatus,
+} from '@shared/business/entities/EntityConstants';
 import {
   ServerApplicationContext,
   createApplicationContext,
@@ -11,6 +14,7 @@ import {
   calculateDifferenceInDays,
   createISODateString,
 } from '@shared/business/utilities/DateHandler';
+import { compareStrings } from '@shared/business/utilities/sortFunctions';
 import {
   search,
   searchAll,
@@ -28,7 +32,16 @@ const excludedCaseStatuses = [
   CASE_STATUS_TYPES.onAppeal,
 ];
 
-const staleCases = {};
+type StaleCase = {
+  caption: string;
+  deAge: number;
+  deRcvdAt: string;
+  docketNumber: string;
+  judge: string;
+  status: CaseStatus;
+};
+
+const staleCases: StaleCase[] = [];
 
 const getAllCasesNotInExcludedStatus = async ({
   applicationContext,
@@ -116,18 +129,19 @@ const isCaseStale = async ({
   const deRcvdAt = mostRecentDocketEntry?.receivedAt;
   const deAge = deRcvdAt ? calculateDifferenceInDays(todayISO, deRcvdAt) : 0;
   if (deAge >= YEAR_IN_DAYS) {
-    const judge = aCase.associatedJudge
-      ?.replace('Chief Special Trial ', '')
-      .replace('Special Trial ', '')
-      .replace('Judge ', '');
-    staleCases[aCase.docketNumber] = {
-      caption: aCase.caseCaption,
+    const judge =
+      aCase.associatedJudge
+        ?.replace('Chief Special Trial ', '')
+        .replace('Special Trial ', '')
+        .replace('Judge ', '') ?? '';
+    staleCases.push({
+      caption: aCase.caseCaption.replace(/\r\n|\r|\n/g, ' '),
       deAge,
       deRcvdAt: deRcvdAt!.split('T')[0],
       docketNumber: aCase.docketNumber,
       judge,
       status: aCase.status,
-    };
+    });
     console.log(
       `Docket number ${aCase.docketNumber} is stale! Most recent document is` +
         ` ${deAge} days old, last filed on ${deRcvdAt!.split('T')[0]}`,
@@ -151,17 +165,18 @@ const isCaseStale = async ({
       await isCaseStale({ aCase, applicationContext }),
   );
   await queue.addAll(funcs);
-
-  console.log(`Found ${Object.keys(staleCases).length} stale cases.`);
+  console.log(`Found ${staleCases.length} stale cases.`);
 
   console.log(`Writing CSV to ${OUTPUT_FILENAME}...`);
+  const sortedStaleCases = staleCases
+    .sort((a, b) => b.deAge - a.deAge)
+    .sort((a, b) => compareStrings(a.judge, b.judge));
   let output =
-    '"Docket Number","Caption","Status","Judge","Last Filed","Age in Days"';
-  for (const docketNumber in staleCases) {
+    '"Judge","Docket Number","Caption","Status","Last Filed","Age in Days"';
+  for (const sc of sortedStaleCases) {
     output +=
-      `\n"${docketNumber}","${staleCases[docketNumber].caption}",` +
-      `"${staleCases[docketNumber].status}","${staleCases[docketNumber].judge}",` +
-      `"${staleCases[docketNumber].deRcvdAt}","${staleCases[docketNumber].deAge}"`;
+      `\n"${sc.judge}","${sc.docketNumber}","${sc.caption}","${sc.status}",` +
+      `"${sc.deRcvdAt}","${sc.deAge}"`;
   }
   appendFileSync(OUTPUT_FILENAME, output);
 })();

--- a/scripts/reports/stale-cases.ts
+++ b/scripts/reports/stale-cases.ts
@@ -20,14 +20,15 @@ import PQueue from 'p-queue';
 const todayISO = createISODateString();
 const OUTPUT_DIR = `${process.env.HOME}/Documents`;
 const OUTPUT_FILENAME = `${OUTPUT_DIR}/stale-cases_${todayISO.split('T')[0]}.csv`;
-const CHUNK_SIZE = 50;
-const staleCases = {};
-
+const CONCURRENCY = 50;
+const YEAR_IN_DAYS = 365;
 const excludedCaseStatuses = [
   CASE_STATUS_TYPES.closed,
   CASE_STATUS_TYPES.closedDismissed,
   CASE_STATUS_TYPES.onAppeal,
 ];
+
+const staleCases = {};
 
 const getAllCasesNotInExcludedStatus = async ({
   applicationContext,
@@ -114,7 +115,7 @@ const isCaseStale = async ({
   });
   const deRcvdAt = mostRecentDocketEntry?.receivedAt;
   const deAge = deRcvdAt ? calculateDifferenceInDays(todayISO, deRcvdAt) : 0;
-  if (deAge > 364) {
+  if (deAge >= YEAR_IN_DAYS) {
     const judge = aCase.associatedJudge
       ?.replace('Chief Special Trial ', '')
       .replace('Special Trial ', '')
@@ -144,7 +145,7 @@ const isCaseStale = async ({
   console.log(
     `Found ${casesNotClosedOrOnAppeal.length} cases not closed or on appeal.`,
   );
-  const queue = new PQueue({ concurrency: CHUNK_SIZE });
+  const queue = new PQueue({ concurrency: CONCURRENCY });
   const funcs = casesNotClosedOrOnAppeal.map(
     (aCase: RawCase) => async () =>
       await isCaseStale({ aCase, applicationContext }),
@@ -155,8 +156,7 @@ const isCaseStale = async ({
 
   console.log(`Writing CSV to ${OUTPUT_FILENAME}...`);
   let output =
-    '"Docket Number","Case Caption","Case Status","Judge",' +
-    '"Last Document Filed On","Last Document Filed Age in Days"';
+    '"Docket Number","Caption","Status","Judge","Last Filed","Age in Days"';
   for (const docketNumber in staleCases) {
     output +=
       `\n"${docketNumber}","${staleCases[docketNumber].caption}",` +

--- a/scripts/reports/stale-cases.ts
+++ b/scripts/reports/stale-cases.ts
@@ -146,7 +146,8 @@ const isCaseStale = async ({
   );
   const queue = new PQueue({ concurrency: CHUNK_SIZE });
   const funcs = casesNotClosedOrOnAppeal.map(
-    (aCase: RawCase) => () => isCaseStale({ aCase, applicationContext }),
+    (aCase: RawCase) => async () =>
+      await isCaseStale({ aCase, applicationContext }),
   );
   await queue.addAll(funcs);
 

--- a/scripts/reports/stale-cases.ts
+++ b/scripts/reports/stale-cases.ts
@@ -9,7 +9,7 @@ import {
   ServerApplicationContext,
   createApplicationContext,
 } from '@web-api/applicationContext';
-import { appendFileSync } from 'fs';
+import { appendFileSync, existsSync, unlinkSync } from 'fs';
 import {
   calculateDifferenceInDays,
   createISODateString,
@@ -177,6 +177,9 @@ const isCaseStale = async ({
     output +=
       `\n"${sc.judge}","${sc.docketNumber}","${sc.caption}","${sc.status}",` +
       `"${sc.deRcvdAt}","${sc.deAge}"`;
+  }
+  if (existsSync(OUTPUT_FILENAME)) {
+    unlinkSync(OUTPUT_FILENAME);
   }
   appendFileSync(OUTPUT_FILENAME, output);
 })();

--- a/scripts/reports/stale-cases.ts
+++ b/scripts/reports/stale-cases.ts
@@ -1,0 +1,166 @@
+// usage:
+// npx ts-node --transpile-only scripts/reports/stale-cases.ts
+
+import { CASE_STATUS_TYPES } from '@shared/business/entities/EntityConstants';
+import {
+  ServerApplicationContext,
+  createApplicationContext,
+} from '@web-api/applicationContext';
+import { appendFileSync } from 'fs';
+import {
+  calculateDifferenceInDays,
+  createISODateString,
+} from '@shared/business/utilities/DateHandler';
+import {
+  search,
+  searchAll,
+} from '@web-api/persistence/elasticsearch/searchClient';
+import PQueue from 'p-queue';
+
+const todayISO = createISODateString();
+const OUTPUT_DIR = `${process.env.HOME}/Documents`;
+const OUTPUT_FILENAME = `${OUTPUT_DIR}/stale-cases_${todayISO.split('T')[0]}.csv`;
+const CHUNK_SIZE = 50;
+const staleCases = {};
+
+const excludedCaseStatuses = [
+  CASE_STATUS_TYPES.closed,
+  CASE_STATUS_TYPES.closedDismissed,
+  CASE_STATUS_TYPES.onAppeal,
+];
+
+const getAllCasesNotInExcludedStatus = async ({
+  applicationContext,
+}: {
+  applicationContext: ServerApplicationContext;
+}): Promise<RawCase[]> => {
+  const { results } = await searchAll({
+    applicationContext,
+    searchParameters: {
+      body: {
+        query: {
+          bool: {
+            must: [
+              {
+                term: {
+                  'entityName.S': 'Case',
+                },
+              },
+            ],
+            must_not: [
+              {
+                terms: {
+                  'status.S': excludedCaseStatuses,
+                },
+              },
+            ],
+          },
+        },
+        sort: [{ 'sortableDocketNumber.N': 'asc' }],
+      },
+      index: 'efcms-case',
+    },
+  });
+  return results;
+};
+
+const getMostRecentDocketEntry = async ({
+  applicationContext,
+  docketNumber,
+}: {
+  applicationContext: ServerApplicationContext;
+  docketNumber: string;
+}): Promise<RawDocketEntry | undefined> => {
+  const { results } = await search({
+    applicationContext,
+    searchParameters: {
+      body: {
+        from: 0,
+        query: {
+          bool: {
+            must: [
+              {
+                term: {
+                  'entityName.S': 'DocketEntry',
+                },
+              },
+              {
+                term: {
+                  'docketNumber.S': docketNumber,
+                },
+              },
+            ],
+          },
+        },
+        size: 1,
+        sort: [{ 'receivedAt.S': 'desc' }],
+      },
+      index: 'efcms-docket-entry',
+    },
+  });
+  return results[0];
+};
+
+const isCaseStale = async ({
+  aCase,
+  applicationContext,
+}: {
+  aCase: RawCase;
+  applicationContext: ServerApplicationContext;
+}): Promise<void> => {
+  const mostRecentDocketEntry = await getMostRecentDocketEntry({
+    applicationContext,
+    docketNumber: aCase.docketNumber,
+  });
+  const deRcvdAt = mostRecentDocketEntry?.receivedAt;
+  const deAge = deRcvdAt ? calculateDifferenceInDays(todayISO, deRcvdAt) : 0;
+  if (deAge > 364) {
+    const judge = aCase.associatedJudge
+      ?.replace('Chief Special Trial ', '')
+      .replace('Special Trial ', '')
+      .replace('Judge ', '');
+    staleCases[aCase.docketNumber] = {
+      caption: aCase.caseCaption,
+      deAge,
+      deRcvdAt: deRcvdAt!.split('T')[0],
+      docketNumber: aCase.docketNumber,
+      judge,
+      status: aCase.status,
+    };
+    console.log(
+      `Docket number ${aCase.docketNumber} is stale! Most recent document is` +
+        ` ${deAge} days old, last filed on ${deRcvdAt!.split('T')[0]}`,
+    );
+  }
+};
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+(async () => {
+  const applicationContext = createApplicationContext({});
+
+  const casesNotClosedOrOnAppeal = await getAllCasesNotInExcludedStatus({
+    applicationContext,
+  });
+  console.log(
+    `Found ${casesNotClosedOrOnAppeal.length} cases not closed or on appeal.`,
+  );
+  const queue = new PQueue({ concurrency: CHUNK_SIZE });
+  const funcs = casesNotClosedOrOnAppeal.map(
+    (aCase: RawCase) => () => isCaseStale({ aCase, applicationContext }),
+  );
+  await queue.addAll(funcs);
+
+  console.log(`Found ${Object.keys(staleCases).length} stale cases.`);
+
+  console.log(`Writing CSV to ${OUTPUT_FILENAME}...`);
+  let output =
+    '"Docket Number","Case Caption","Case Status","Judge",' +
+    '"Last Document Filed On","Last Document Filed Age in Days"';
+  for (const docketNumber in staleCases) {
+    output +=
+      `\n"${docketNumber}","${staleCases[docketNumber].caption}",` +
+      `"${staleCases[docketNumber].status}","${staleCases[docketNumber].judge}",` +
+      `"${staleCases[docketNumber].deRcvdAt}","${staleCases[docketNumber].deAge}"`;
+  }
+  appendFileSync(OUTPUT_FILENAME, output);
+})();


### PR DESCRIPTION
Outputs a CSV of cases that are not closed or on appeal but haven't had a document filed in over a year.

Unfortunately, I was unable to achieve this without querying for the "most recently filed document" in each case individually.

I tried to do a `terms` query on `docketNumber.S`, providing the not-closed-not-on-appeal docket numbers (roughly 21,000) as the input. According to the OpenSearch documentation, terms queries have a limit of 65,536 terms, so I'm not quite sure why this didn't work.

Undeterred, I was pleased with the performance gains when executing the "get most recently filed document" queries in a priority queue:

Execution time with a `for of` loop: 13 minutes 12 seconds
Execution time with `pqueue`: 34 seconds

Just imagine how much easier these kinds of reports will be when all our data is in postgres!