### PR TITLE
[Addendum to 10408] Rm judge edit perms from trial session info page to test

### DIFF
--- a/web-client/src/presenter/computeds/formattedTrialSessionDetails.test.ts
+++ b/web-client/src/presenter/computeds/formattedTrialSessionDetails.test.ts
@@ -378,7 +378,7 @@ describe('formattedTrialSessionDetails', () => {
       });
     });
 
-    it('should be false when trial session start date is in the future, it is NOT closed, the user is a judge role', () => {
+    it('should  NOT allow judge to edit trial session info page', () => {
       mockTrialSession = {
         ...TRIAL_SESSION,
         sessionStatus: SESSION_STATUS_GROUPS.open,

--- a/web-client/src/presenter/computeds/formattedTrialSessionDetails.test.ts
+++ b/web-client/src/presenter/computeds/formattedTrialSessionDetails.test.ts
@@ -14,6 +14,7 @@ import { applicationContextForClient as applicationContext } from '@web-client/t
 import {
   colvinsChambersUser,
   docketClerkUser,
+  judgeUser,
   trialClerkUser,
 } from '../../../../shared/src/test/mockUsers';
 import { formattedTrialSessionDetails as formattedTrialSessionDetailsComputed } from './formattedTrialSessionDetails';
@@ -369,6 +370,25 @@ describe('formattedTrialSessionDetails', () => {
         state: {
           trialSession: {},
           user: colvinsChambersUser,
+        },
+      });
+
+      expect(result).toMatchObject({
+        canEdit: false,
+      });
+    });
+
+    it('should be false when trial session start date is in the future, it is NOT closed, the user is a judge role', () => {
+      mockTrialSession = {
+        ...TRIAL_SESSION,
+        sessionStatus: SESSION_STATUS_GROUPS.open,
+        startDate: FUTURE_DATE,
+      };
+
+      const result: any = runCompute(formattedTrialSessionDetails, {
+        state: {
+          trialSession: {},
+          user: judgeUser,
         },
       });
 

--- a/web-client/src/presenter/computeds/formattedTrialSessionDetails.ts
+++ b/web-client/src/presenter/computeds/formattedTrialSessionDetails.ts
@@ -93,6 +93,7 @@ export const formattedTrialSessionDetails = (
 
     const user = get(state.user);
     const isChambersUser = user.role === USER_ROLES.chambers;
+    const isJudgeUser = user.role === USER_ROLES.judge;
     const trialDateInFuture = trialDateFormatted > nowDateFormatted;
     const docketClerkCanEditCheck = sessionType => {
       const editableSessionTypes = ['Special', 'Motion/Hearing'];
@@ -103,7 +104,8 @@ export const formattedTrialSessionDetails = (
     canEdit =
       trialDateInFuture &&
       formattedTrialSession.sessionStatus !== SESSION_STATUS_GROUPS.closed &&
-      !isChambersUser;
+      !isChambersUser &&
+      !isJudgeUser;
 
     if (user.role === USER_ROLES.docketClerk && canEdit) {
       canEdit = docketClerkCanEditCheck(formattedTrialSession.sessionType);


### PR DESCRIPTION
This removes the ability of the a Judge to edit Trial Session Info page. This is a request from the court and may not necessarily make it into the release of 10408 so adding here. This should be release closely (preferably in the same release as) [10408](https://github.com/orgs/flexion/projects/11/views/1?pane=issue&itemId=76509708&issue=flexion%7Cef-cms%7C10408)