### PR TITLE
10293 to test: use unique React key in PendingReportList.tsx

### DIFF
--- a/shared/src/business/utilities/formatPendingItem.test.ts
+++ b/shared/src/business/utilities/formatPendingItem.test.ts
@@ -65,7 +65,7 @@ describe('formatPendingItem', () => {
     ];
   });
 
-  it('should return a list of formatted pending items', () => {
+  it('should return a list of formatted pending items with correct display properties', () => {
     const result = mockPendingItems.map(item =>
       formatPendingItem(item, {
         applicationContext,
@@ -95,6 +95,22 @@ describe('formatPendingItem', () => {
         formattedName: 'Affidavit of Bob in Support of Petition',
       },
     ]);
+  });
+
+  it('should return a list of formatted pending items with unique renderKey properties for each item', () => {
+    const result = mockPendingItems.map(item =>
+      formatPendingItem(item, {
+        applicationContext,
+      }),
+    );
+
+    const allPendingItemFormattedObjectsHaveRenderKey = result.every(
+      obj => typeof obj.renderKey === 'string',
+    );
+    const uniqueRenderKeys = new Set(result.map(obj => obj.renderKey));
+
+    expect(allPendingItemFormattedObjectsHaveRenderKey).toBe(true);
+    expect(uniqueRenderKeys.size).toBe(result.length);
   });
 
   it('should add consolidated properties to a pending item in a consolidated group', () => {

--- a/shared/src/business/utilities/formatPendingItem.test.ts
+++ b/shared/src/business/utilities/formatPendingItem.test.ts
@@ -97,22 +97,6 @@ describe('formatPendingItem', () => {
     ]);
   });
 
-  it('should return a list of formatted pending items with unique renderKey properties for each item', () => {
-    const result = mockPendingItems.map(item =>
-      formatPendingItem(item, {
-        applicationContext,
-      }),
-    );
-
-    const allPendingItemFormattedObjectsHaveRenderKey = result.every(
-      obj => typeof obj.renderKey === 'string',
-    );
-    const uniqueRenderKeys = new Set(result.map(obj => obj.renderKey));
-
-    expect(allPendingItemFormattedObjectsHaveRenderKey).toBe(true);
-    expect(uniqueRenderKeys.size).toBe(result.length);
-  });
-
   it('should add consolidated properties to a pending item in a consolidated group', () => {
     pendingItem.leadDocketNumber = '100-19';
 

--- a/shared/src/business/utilities/formatPendingItem.ts
+++ b/shared/src/business/utilities/formatPendingItem.ts
@@ -15,7 +15,6 @@ export type PendingItemFormatted = {
   isLeadCase: boolean;
   docketNumberWithSuffix: string;
   receivedAt: string;
-  renderKey: string;
 };
 
 export const formatPendingItem = (

--- a/shared/src/business/utilities/formatPendingItem.ts
+++ b/shared/src/business/utilities/formatPendingItem.ts
@@ -20,7 +20,7 @@ export type PendingItemFormatted = {
 
 export const formatPendingItem = (
   item: PendingItem,
-  { applicationContext }: { applicationContext: IApplicationContext },
+  { applicationContext },
 ): PendingItemFormatted => {
   const pendingItemWithConsolidatedFlags = applicationContext
     .getUtilities()

--- a/shared/src/business/utilities/formatPendingItem.ts
+++ b/shared/src/business/utilities/formatPendingItem.ts
@@ -1,4 +1,5 @@
 import { PendingItem } from '@web-api/business/useCases/pendingItems/fetchPendingItemsInteractor';
+import { v4 as uuidv4 } from 'uuid';
 
 export type PendingItemFormatted = {
   docketEntryId: string;
@@ -14,6 +15,7 @@ export type PendingItemFormatted = {
   shouldIndent: boolean;
   isLeadCase: boolean;
   docketNumberWithSuffix: string;
+  renderKey: string;
 };
 
 export const formatPendingItem = (
@@ -62,6 +64,7 @@ export const formatPendingItem = (
     formattedStatus,
     inConsolidatedGroup: pendingItemWithConsolidatedFlags.inConsolidatedGroup,
     isLeadCase: pendingItemWithConsolidatedFlags.isLeadCase,
+    renderKey: uuidv4(),
     shouldIndent: pendingItemWithConsolidatedFlags.shouldIndent,
   };
 };

--- a/shared/src/business/utilities/formatPendingItem.ts
+++ b/shared/src/business/utilities/formatPendingItem.ts
@@ -1,5 +1,4 @@
 import { PendingItem } from '@web-api/business/useCases/pendingItems/fetchPendingItemsInteractor';
-import { v4 as uuidv4 } from 'uuid';
 
 export type PendingItemFormatted = {
   docketEntryId: string;
@@ -66,7 +65,6 @@ export const formatPendingItem = (
     inConsolidatedGroup: pendingItemWithConsolidatedFlags.inConsolidatedGroup,
     isLeadCase: pendingItemWithConsolidatedFlags.isLeadCase,
     receivedAt: item.receivedAt,
-    renderKey: uuidv4(),
     shouldIndent: pendingItemWithConsolidatedFlags.shouldIndent,
   };
 };

--- a/shared/src/business/utilities/formatPendingItem.ts
+++ b/shared/src/business/utilities/formatPendingItem.ts
@@ -15,8 +15,8 @@ export type PendingItemFormatted = {
   shouldIndent: boolean;
   isLeadCase: boolean;
   docketNumberWithSuffix: string;
-  renderKey: string;
   receivedAt: string;
+  renderKey: string;
 };
 
 export const formatPendingItem = (

--- a/shared/src/business/utilities/formatPendingItem.ts
+++ b/shared/src/business/utilities/formatPendingItem.ts
@@ -16,6 +16,7 @@ export type PendingItemFormatted = {
   isLeadCase: boolean;
   docketNumberWithSuffix: string;
   renderKey: string;
+  receivedAt: string;
 };
 
 export const formatPendingItem = (
@@ -64,6 +65,7 @@ export const formatPendingItem = (
     formattedStatus,
     inConsolidatedGroup: pendingItemWithConsolidatedFlags.inConsolidatedGroup,
     isLeadCase: pendingItemWithConsolidatedFlags.isLeadCase,
+    receivedAt: item.receivedAt,
     renderKey: uuidv4(),
     shouldIndent: pendingItemWithConsolidatedFlags.shouldIndent,
   };

--- a/web-client/integration-tests/petitionsClerkVerifiesOffboardedJudgeJourney.test.ts
+++ b/web-client/integration-tests/petitionsClerkVerifiesOffboardedJudgeJourney.test.ts
@@ -1,9 +1,9 @@
 import { advancedDocumentSearchHelper as advancedDocumentSearchComputed } from '../src/presenter/computeds/AdvancedSearch/advancedDocumentSearchHelper';
 import { caseDeadlineReportHelper as caseDeadlineReportComputed } from '../src/presenter/computeds/caseDeadlineReportHelper';
 import { caseInventoryReportHelper as caseInventoryReportComputed } from '../src/presenter/computeds/caseInventoryReportHelper';
-import { formattedPendingItemsHelper as formattedPendingItemsComputed } from '../src/presenter/computeds/formattedPendingItems';
 import { loginAs, setupTest } from './helpers';
 import { messageModalHelper as messageModalHelperComputed } from '../src/presenter/computeds/messageModalHelper';
+import { pendingReportListHelper as pendingReportListComputed } from '../src/presenter/computeds/pendingReportListHelper';
 import { runCompute } from '@web-client/presenter/test.cerebral';
 import { withAppContextDecorator } from '../src/withAppContext';
 
@@ -58,15 +58,15 @@ describe('Petitions clerk verifies offboarded judge journey', () => {
     });
 
     it(`petitions clerk verifies judge ${judgeName} does not appear in the pending report judge dropdown`, () => {
-      const formattedPendingItems = withAppContextDecorator(
-        formattedPendingItemsComputed,
+      const pendingReportList = withAppContextDecorator(
+        pendingReportListComputed,
       );
 
-      const formattedPendingItemsHelper = runCompute(formattedPendingItems, {
+      const pendingReportListHelper = runCompute(pendingReportList, {
         state: cerebralTest.getState(),
       });
 
-      expect(formattedPendingItemsHelper.judges).not.toContain(judgeName);
+      expect(pendingReportListHelper.judges).not.toContain(judgeName);
     });
 
     it(`petitions clerk verifies judge ${judgeName} does not appear in the add trial session judge drop down`, async () => {

--- a/web-client/src/presenter/actions/PendingItems/setPendingItemsAction.test.ts
+++ b/web-client/src/presenter/actions/PendingItems/setPendingItemsAction.test.ts
@@ -22,7 +22,7 @@ describe('setPendingItemsAction', () => {
         },
       },
     });
-    console.log(state.pendingReports);
+
     expect(state.pendingReports.pendingItems).toEqual([{}]);
   });
 

--- a/web-client/src/presenter/actions/PendingItems/setPendingItemsAction.test.ts
+++ b/web-client/src/presenter/actions/PendingItems/setPendingItemsAction.test.ts
@@ -1,11 +1,20 @@
+import { applicationContextForClient as applicationContext } from '@web-client/test/createClientTestApplicationContext';
+import { presenter } from '@web-client/presenter/presenter-mock';
 import { runAction } from '@web-client/presenter/test.cerebral';
 import { setPendingItemsAction } from './setPendingItemsAction';
 
 describe('setPendingItemsAction', () => {
+  beforeAll(() => {
+    presenter.providers.applicationContext = applicationContext;
+  });
+
   it('sets state.pendingReports.pendingItems to the passed in props.pendingItems', async () => {
+    applicationContext.getUtilities().formatPendingItem.mockReturnValue({});
+
     const { state } = await runAction(setPendingItemsAction, {
+      modules: { presenter },
       props: {
-        pendingItems: ['DocketRecord'],
+        pendingItems: [{}],
       },
       state: {
         pendingReports: {
@@ -13,13 +22,17 @@ describe('setPendingItemsAction', () => {
         },
       },
     });
-    expect(state.pendingReports.pendingItems).toEqual(['DocketRecord']);
+    console.log(state.pendingReports);
+    expect(state.pendingReports.pendingItems).toEqual([{}]);
   });
 
   it('sets state.pendingReports.pendingItems to the passed in props.pendingItems and replaces any items that were previously stored in state.pendingReport.pendingItems', async () => {
+    applicationContext.getUtilities().formatPendingItem.mockReturnValue({});
+
     const { state } = await runAction(setPendingItemsAction, {
+      modules: { presenter },
       props: {
-        pendingItems: ['DocketRecord'],
+        pendingItems: [{}],
       },
       state: {
         pendingReports: {
@@ -28,13 +41,14 @@ describe('setPendingItemsAction', () => {
       },
     });
 
-    expect(state.pendingReports.pendingItems).toEqual(['DocketRecord']);
+    expect(state.pendingReports.pendingItems).toEqual([{}]);
   });
 
   it('sets state.pendingReports.hasPendingItemsResults to true when props.pendingItems contains items', async () => {
     const { state } = await runAction(setPendingItemsAction, {
+      modules: { presenter },
       props: {
-        pendingItems: ['DocketRecord'],
+        pendingItems: [{}],
       },
       state: {
         pendingReports: {
@@ -47,6 +61,7 @@ describe('setPendingItemsAction', () => {
 
   it('sets state.pendingReports.hasPendingItemsResults to false when neither props.pendingItems nor state.pendingReports.pendingItems contain items', async () => {
     const { state } = await runAction(setPendingItemsAction, {
+      modules: { presenter },
       props: {
         pendingItems: [],
       },

--- a/web-client/src/presenter/actions/PendingItems/setPendingItemsAction.test.ts
+++ b/web-client/src/presenter/actions/PendingItems/setPendingItemsAction.test.ts
@@ -16,7 +16,7 @@ describe('setPendingItemsAction', () => {
     expect(state.pendingReports.pendingItems).toEqual(['DocketRecord']);
   });
 
-  it('sets state.pendingReports.hasPendingItemsResults to true when state.pendingReports.pendingItems contains items', async () => {
+  it('sets state.pendingReports.pendingItems to the passed in props.pendingItems and replaces any items that were previously stored in state.pendingReport.pendingItems', async () => {
     const { state } = await runAction(setPendingItemsAction, {
       props: {
         pendingItems: ['DocketRecord'],
@@ -28,7 +28,7 @@ describe('setPendingItemsAction', () => {
       },
     });
 
-    expect(state.pendingReports.hasPendingItemsResults).toBe(true);
+    expect(state.pendingReports.pendingItems).toEqual(['DocketRecord']);
   });
 
   it('sets state.pendingReports.hasPendingItemsResults to true when props.pendingItems contains items', async () => {

--- a/web-client/src/presenter/actions/PendingItems/setPendingItemsAction.ts
+++ b/web-client/src/presenter/actions/PendingItems/setPendingItemsAction.ts
@@ -2,11 +2,25 @@ import { PendingItem } from '@web-api/business/useCases/pendingItems/fetchPendin
 import { state } from '@web-client/presenter/app.cerebral';
 
 export const setPendingItemsAction = ({
+  applicationContext,
+
   props,
   store,
 }: ActionProps<{ pendingItems: PendingItem[] }>) => {
   const { pendingItems } = props;
-  store.set(state.pendingReports.pendingItems, pendingItems);
-  store.set(state.pendingReports.hasPendingItemsResults, !!pendingItems.length);
-  store.set(state.pendingReports.pendingItemsTotal, pendingItems.length);
+  const formattedPendingItems = pendingItems.map(item =>
+    applicationContext
+      .getUtilities()
+      .formatPendingItem(item, { applicationContext }),
+  );
+
+  store.set(state.pendingReports.pendingItems, formattedPendingItems);
+  store.set(
+    state.pendingReports.hasPendingItemsResults,
+    !!formattedPendingItems.length,
+  );
+  store.set(
+    state.pendingReports.pendingItemsTotal,
+    formattedPendingItems.length,
+  );
 };

--- a/web-client/src/presenter/actions/PendingItems/setPendingItemsAction.ts
+++ b/web-client/src/presenter/actions/PendingItems/setPendingItemsAction.ts
@@ -2,14 +2,10 @@ import { PendingItem } from '@web-api/business/useCases/pendingItems/fetchPendin
 import { state } from '@web-client/presenter/app.cerebral';
 
 export const setPendingItemsAction = ({
-  get,
   props,
   store,
-}: ActionProps<{ pendingItems: PendingItem[]; total: number }>) => {
-  const pendingItems = [
-    ...get(state.pendingReports.pendingItems),
-    ...props.pendingItems,
-  ];
+}: ActionProps<{ pendingItems: PendingItem[] }>) => {
+  const { pendingItems } = props;
   store.set(state.pendingReports.pendingItems, pendingItems);
   store.set(state.pendingReports.hasPendingItemsResults, !!pendingItems.length);
   store.set(state.pendingReports.pendingItemsTotal, pendingItems.length);

--- a/web-client/src/presenter/computeds/formattedPendingItems.test.ts
+++ b/web-client/src/presenter/computeds/formattedPendingItems.test.ts
@@ -1,66 +1,18 @@
-import {
-  PendingReports,
-  initialPendingReportsState,
-} from '@web-client/presenter/state/pendingReportState';
 import { applicationContextForClient as applicationContext } from '@web-client/test/createClientTestApplicationContext';
 import { cloneDeep } from 'lodash';
 import { formattedPendingItemsHelper as formattedPendingItemsComputed } from './formattedPendingItems';
+import { initialPendingReportsState } from '@web-client/presenter/state/pendingReportState';
 import { runCompute } from '@web-client/presenter/test.cerebral';
 import { withAppContextDecorator } from '../../withAppContext';
 
 describe('formattedPendingItems', () => {
-  const { CHIEF_JUDGE, DOCKET_NUMBER_SUFFIXES, STATUS_TYPES } =
-    applicationContext.getConstants();
+  const { CHIEF_JUDGE } = applicationContext.getConstants();
 
   const formattedPendingItems = withAppContextDecorator(
     formattedPendingItemsComputed,
   );
 
-  let mockPendingItems;
-
-  let pendingReportsState: PendingReports;
-  beforeEach(() => {
-    mockPendingItems = [
-      {
-        associatedJudge: CHIEF_JUDGE,
-        caseStatus: STATUS_TYPES.new,
-        createdAt: '2019-01-10',
-        docketEntryId: '33ddbf4f-90f8-417c-8967-57851b0b9069',
-        docketNumber: '101-19',
-        docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.WHISTLEBLOWER,
-        documentType: 'Administrative Record',
-        eventCode: 'ADMR',
-        receivedAt: '2019-01-10',
-      },
-      {
-        associatedJudge: CHIEF_JUDGE,
-        caseStatus: STATUS_TYPES.new,
-        createdAt: '2018-01-20',
-        docketEntryId: 'dd956ab1-5cde-4e78-bae0-fff4aee40426',
-        docketNumber: '101-19',
-        docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.WHISTLEBLOWER,
-        documentTitle: 'Affidavit of Sally in Support of Petition',
-        documentType: 'Affidavit in Support',
-        eventCode: 'AFF',
-        receivedAt: '2018-01-20',
-      },
-      {
-        associatedJudge: 'Judge A',
-        caseStatus: STATUS_TYPES.new,
-        createdAt: '2018-01-20',
-        docketEntryId: 'dd956ab1-5cde-4e78-bae0-ac7faee40426',
-        docketNumber: '103-19',
-        docketNumberSuffix: DOCKET_NUMBER_SUFFIXES.WHISTLEBLOWER,
-        documentTitle: 'Affidavit of Bob in Support of Petition',
-        documentType: 'Affidavit in Support',
-        eventCode: 'AFF',
-        receivedAt: '2018-01-20',
-      },
-    ];
-
-    pendingReportsState = cloneDeep(initialPendingReportsState);
-    pendingReportsState.pendingItems = mockPendingItems;
-  });
+  const pendingReportsState = cloneDeep(initialPendingReportsState);
 
   it('should return formatted and sorted list of judges', () => {
     const result = runCompute(formattedPendingItems, {

--- a/web-client/src/presenter/computeds/formattedPendingItems.ts
+++ b/web-client/src/presenter/computeds/formattedPendingItems.ts
@@ -1,5 +1,4 @@
 import { Get } from 'cerebral';
-import { PendingItemFormatted } from '@shared/business/utilities/formatPendingItem';
 import { state } from '@web-client/presenter/app.cerebral';
 import qs from 'qs';
 
@@ -9,15 +8,9 @@ export const formattedPendingItemsHelper = (
 ): {
   printUrl: string;
   judges: string[];
-  items: PendingItemFormatted[];
 } => {
   const { CHIEF_JUDGE } = applicationContext.getConstants();
 
-  const items = get(state.pendingReports.pendingItems).map(item =>
-    applicationContext
-      .getUtilities()
-      .formatPendingItem(item, { applicationContext }),
-  );
   const judgeFilter = get(state.screenMetadata.pendingItemsFilters.judge);
   const judges = get(state.judges)
     .map(i => applicationContext.getUtilities().formatJudgeName(i.name))
@@ -27,7 +20,6 @@ export const formattedPendingItemsHelper = (
   const queryString = qs.stringify({ judgeFilter });
 
   return {
-    items,
     judges,
     printUrl: `/reports/pending-report/printable?${queryString}`,
   };

--- a/web-client/src/presenter/computeds/pendingReportHelper.test.ts
+++ b/web-client/src/presenter/computeds/pendingReportHelper.test.ts
@@ -1,32 +1,16 @@
-import { applicationContextForClient as applicationContext } from '@web-client/test/createClientTestApplicationContext';
 import { cloneDeep } from 'lodash';
-import { formattedPendingItemsHelper as formattedPendingItemsComputed } from './formattedPendingItems';
 import { initialPendingReportsState } from '@web-client/presenter/state/pendingReportState';
+import { pendingReportHelper as pendingReportComputed } from './pendingReportHelper';
 import { runCompute } from '@web-client/presenter/test.cerebral';
 import { withAppContextDecorator } from '../../withAppContext';
 
-describe('formattedPendingItems', () => {
-  const { CHIEF_JUDGE } = applicationContext.getConstants();
-
-  const formattedPendingItems = withAppContextDecorator(
-    formattedPendingItemsComputed,
-  );
+describe('pendingReportHelper', () => {
+  const pendingReportHelper = withAppContextDecorator(pendingReportComputed);
 
   const pendingReportsState = cloneDeep(initialPendingReportsState);
 
-  it('should return formatted and sorted list of judges', () => {
-    const result = runCompute(formattedPendingItems, {
-      state: {
-        judges: [{ name: 'Judge A' }, { name: 'Judge B' }],
-        pendingReports: pendingReportsState,
-      },
-    });
-
-    expect(result.judges).toEqual(['A', 'B', CHIEF_JUDGE]);
-  });
-
   it('appends screenMetadata.pendingItemsFilters.judge on the printUrl if one is present', () => {
-    const result = runCompute(formattedPendingItems, {
+    const result = runCompute(pendingReportHelper, {
       state: {
         judges: [],
         pendingReports: pendingReportsState,
@@ -38,7 +22,7 @@ describe('formattedPendingItems', () => {
   });
 
   it('returns default printUrl if screenMetadata.pendingItemsFilters.judge is not set', () => {
-    const result = runCompute(formattedPendingItems, {
+    const result = runCompute(pendingReportHelper, {
       state: {
         judges: [],
         pendingReports: pendingReportsState,

--- a/web-client/src/presenter/computeds/pendingReportHelper.ts
+++ b/web-client/src/presenter/computeds/pendingReportHelper.ts
@@ -2,25 +2,15 @@ import { Get } from 'cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
 import qs from 'qs';
 
-export const formattedPendingItemsHelper = (
+export const pendingReportHelper = (
   get: Get,
-  applicationContext: IApplicationContext,
 ): {
   printUrl: string;
-  judges: string[];
 } => {
-  const { CHIEF_JUDGE } = applicationContext.getConstants();
-
   const judgeFilter = get(state.screenMetadata.pendingItemsFilters.judge);
-  const judges = get(state.judges)
-    .map(i => applicationContext.getUtilities().formatJudgeName(i.name))
-    .concat(CHIEF_JUDGE)
-    .sort();
-
   const queryString = qs.stringify({ judgeFilter });
 
   return {
-    judges,
     printUrl: `/reports/pending-report/printable?${queryString}`,
   };
 };

--- a/web-client/src/presenter/computeds/pendingReportListHelper.test.ts
+++ b/web-client/src/presenter/computeds/pendingReportListHelper.test.ts
@@ -9,38 +9,6 @@ describe('pendingReportListHelper', () => {
     applicationContext,
   );
 
-  it('should set showLoadMore to true when there are additional results to load', () => {
-    const mockState = {
-      pendingReports: {
-        hasPendingItemsResults: true,
-        pendingItems: [],
-        pendingItemsTotal: 1000,
-        selectedJudge: 'Buch',
-      },
-    };
-
-    const { showLoadMore } = runCompute(pendingReportList, {
-      state: mockState,
-    });
-    expect(showLoadMore).toBe(true);
-  });
-
-  it('should set showLoadMore to false when there are no additional results to load', () => {
-    const mockState = {
-      pendingReports: {
-        hasPendingItemsResults: true,
-        pendingItems: [{}],
-        pendingItemsTotal: 1,
-        selectedJudge: 'Buch',
-      },
-    };
-
-    const { showLoadMore } = runCompute(pendingReportList, {
-      state: mockState,
-    });
-    expect(showLoadMore).toBe(false);
-  });
-
   it('should set showNoPendingItems to false when a judge is selected but no results come back', () => {
     const mockState = {
       pendingReports: {

--- a/web-client/src/presenter/computeds/pendingReportListHelper.test.ts
+++ b/web-client/src/presenter/computeds/pendingReportListHelper.test.ts
@@ -1,4 +1,7 @@
+import { CHIEF_JUDGE } from '@shared/business/entities/EntityConstants';
 import { applicationContext } from '../../applicationContext';
+import { cloneDeep } from 'lodash';
+import { initialPendingReportsState } from '../state/pendingReportState';
 import { pendingReportListHelper } from './pendingReportListHelper';
 import { runCompute } from '@web-client/presenter/test.cerebral';
 import { withAppContextDecorator } from '../../withAppContext';
@@ -9,8 +12,9 @@ describe('pendingReportListHelper', () => {
     applicationContext,
   );
 
-  it('should set showNoPendingItems to false when a judge is selected but no results come back', () => {
+  it('should return showNoPendingItems as false when a judge is selected but no results come back', () => {
     const mockState = {
+      judges: [],
       pendingReports: {
         hasPendingItemsResults: false,
         pendingItems: [{}],
@@ -25,8 +29,9 @@ describe('pendingReportListHelper', () => {
     expect(showNoPendingItems).toBe(true);
   });
 
-  it('should set showNoPendingItems to false when results come back and a judge is selected', () => {
+  it('should return showNoPendingItems as false when results come back and a judge is selected', () => {
     const mockState = {
+      judges: [],
       pendingReports: {
         hasPendingItemsResults: true,
         pendingItems: [{}],
@@ -41,8 +46,9 @@ describe('pendingReportListHelper', () => {
     expect(showNoPendingItems).toBe(false);
   });
 
-  it('should set showSelectJudgeText to true when no judge selected', () => {
+  it('should return showSelectJudgeText as true when no judge selected', () => {
     const mockState = {
+      judges: [],
       pendingReports: {
         hasPendingItemsResults: true,
         pendingItems: [{}],
@@ -57,8 +63,9 @@ describe('pendingReportListHelper', () => {
     expect(showSelectJudgeText).toBe(true);
   });
 
-  it('should set showSelectJudgeText to false when a judge is selected', () => {
+  it('should return showSelectJudgeText as false when a judge is selected', () => {
     const mockState = {
+      judges: [],
       pendingReports: {
         hasPendingItemsResults: true,
         pendingItems: [{}],
@@ -71,5 +78,16 @@ describe('pendingReportListHelper', () => {
       state: mockState,
     });
     expect(showSelectJudgeText).toBe(false);
+  });
+
+  it('should return a formatted and sorted list of judges', () => {
+    const mockState = {
+      judges: [{ name: 'Judge A' }, { name: 'Judge B' }],
+      pendingReports: cloneDeep(initialPendingReportsState),
+    };
+
+    const { judges } = runCompute(pendingReportList, { state: mockState });
+
+    expect(judges).toEqual(['A', 'B', CHIEF_JUDGE]);
   });
 });

--- a/web-client/src/presenter/computeds/pendingReportListHelper.ts
+++ b/web-client/src/presenter/computeds/pendingReportListHelper.ts
@@ -4,7 +4,6 @@ import { state } from '@web-client/presenter/app.cerebral';
 export const pendingReportListHelper = (
   get: Get,
 ): {
-  showLoadMore: boolean;
   showNoPendingItems: boolean;
   showSelectJudgeText: boolean;
 } => {
@@ -14,14 +13,11 @@ export const pendingReportListHelper = (
   );
   const judge = get(state.pendingReports.selectedJudge);
 
-  const showLoadMore =
-    get(state.pendingReports.pendingItems).length < searchResultsCount;
   const showSelectJudgeText = !judge;
   const showNoPendingItems =
     searchResultsCount === 0 && !hasPendingItemsResults && !!judge;
 
   return {
-    showLoadMore,
     showNoPendingItems,
     showSelectJudgeText,
   };

--- a/web-client/src/presenter/computeds/pendingReportListHelper.ts
+++ b/web-client/src/presenter/computeds/pendingReportListHelper.ts
@@ -1,4 +1,6 @@
+import { CHIEF_JUDGE } from '@shared/business/entities/EntityConstants';
 import { Get } from 'cerebral';
+import { formatJudgeName } from '@shared/business/utilities/getFormattedJudgeName';
 import { state } from '@web-client/presenter/app.cerebral';
 
 export const pendingReportListHelper = (
@@ -6,6 +8,7 @@ export const pendingReportListHelper = (
 ): {
   showNoPendingItems: boolean;
   showSelectJudgeText: boolean;
+  judges: string[];
 } => {
   const searchResultsCount = get(state.pendingReports.pendingItemsTotal);
   const hasPendingItemsResults = get(
@@ -17,7 +20,13 @@ export const pendingReportListHelper = (
   const showNoPendingItems =
     searchResultsCount === 0 && !hasPendingItemsResults && !!judge;
 
+  const judges = get(state.judges)
+    .map(i => formatJudgeName(i.name))
+    .concat(CHIEF_JUDGE)
+    .sort();
+
   return {
+    judges,
     showNoPendingItems,
     showSelectJudgeText,
   };

--- a/web-client/src/presenter/state.ts
+++ b/web-client/src/presenter/state.ts
@@ -89,7 +89,6 @@ import { formattedDocument } from './computeds/formattedDocument';
 import { formattedEligibleCasesHelper } from './computeds/formattedEligibleCasesHelper';
 import { formattedMessageDetail } from './computeds/formattedMessageDetail';
 import { formattedMessages } from './computeds/formattedMessages';
-import { formattedPendingItemsHelper } from './computeds/formattedPendingItems';
 import { formattedTrialSessionDetails } from './computeds/formattedTrialSessionDetails';
 import { formattedWorkQueue } from './computeds/formattedWorkQueue';
 import { getAllIrsPractitionersForSelectHelper } from '@web-client/presenter/computeds/TrialSession/getAllIrsPractitionersForSelectHelper';
@@ -120,6 +119,7 @@ import { partiesInformationHelper } from './computeds/partiesInformationHelper';
 import { pdfPreviewModalHelper } from './computeds/PDFPreviewModal/pdfPreviewModalHelper';
 import { pdfSignerHelper } from './computeds/pdfSignerHelper';
 import { pendingMotionsHelper } from '@web-client/presenter/computeds/PendingMotions/pendingMotionsHelper';
+import { pendingReportHelper } from './computeds/pendingReportHelper';
 import { pendingReportListHelper } from './computeds/pendingReportListHelper';
 import { petitionQcHelper } from './computeds/petitionQcHelper';
 import { practitionerDetailHelper } from './computeds/practitionerDetailHelper';
@@ -378,10 +378,6 @@ export const computeds = {
   formattedOpenCases: formattedOpenCases as unknown as ReturnType<
     typeof formattedOpenCases
   >,
-  formattedPendingItemsHelper:
-    formattedPendingItemsHelper as unknown as ReturnType<
-      typeof formattedPendingItemsHelper
-    >,
   formattedTrialSessionDetails:
     formattedTrialSessionDetails as unknown as ReturnType<
       typeof formattedTrialSessionDetails
@@ -449,6 +445,9 @@ export const computeds = {
   >,
   pendingMotionsHelper: pendingMotionsHelper as unknown as ReturnType<
     typeof pendingMotionsHelper
+  >,
+  pendingReportHelper: pendingReportHelper as unknown as ReturnType<
+    typeof pendingReportHelper
   >,
   pendingReportListHelper: pendingReportListHelper as unknown as ReturnType<
     typeof pendingReportListHelper

--- a/web-client/src/presenter/state/pendingReportState.ts
+++ b/web-client/src/presenter/state/pendingReportState.ts
@@ -1,9 +1,9 @@
-import { PendingItem } from '@web-api/business/useCases/pendingItems/fetchPendingItemsInteractor';
+import { PendingItemFormatted } from '@shared/business/utilities/formatPendingItem';
 
 export type PendingReports = {
   pendingItemsTotal: number;
   hasPendingItemsResults: boolean;
-  pendingItems: PendingItem[];
+  pendingItems: PendingItemFormatted[];
   selectedJudge: string;
 };
 

--- a/web-client/src/views/PendingReport/PendingReport.tsx
+++ b/web-client/src/views/PendingReport/PendingReport.tsx
@@ -10,13 +10,13 @@ import React, { useState } from 'react';
 export const PendingReport = connect(
   {
     exportPendingReportSequence: sequences.exportPendingReportSequence,
-    formattedPendingItemsHelper: state.formattedPendingItemsHelper,
     hasPendingItemsResults: state.pendingReports.hasPendingItemsResults,
+    pendingReportHelper: state.pendingReportHelper,
   },
   function PendingReport({
     exportPendingReportSequence,
-    formattedPendingItemsHelper,
     hasPendingItemsResults,
+    pendingReportHelper,
   }) {
     const [isSubmitDebounced, setIsSubmitDebounced] = useState(false);
 
@@ -61,7 +61,7 @@ export const PendingReport = connect(
                     aria-label="print pending report"
                     className="margin-top-2"
                     data-testid="print-pending-report"
-                    href={formattedPendingItemsHelper.printUrl}
+                    href={pendingReportHelper.printUrl}
                     icon="print"
                   >
                     Printable Report

--- a/web-client/src/views/PendingReport/PendingReportList.tsx
+++ b/web-client/src/views/PendingReport/PendingReportList.tsx
@@ -115,7 +115,7 @@ export const PendingReportList = connect(
             {pageRecords.map(item => (
               <tr
                 className="pending-item-row"
-                key={`pending-item-${item.formattedFiledDate}-${item.caseTitle}-${item.docketEntryId}`}
+                key={`pending-item-${item.renderKey}`}
               >
                 <td>
                   <ConsolidatedCaseIcon

--- a/web-client/src/views/PendingReport/PendingReportList.tsx
+++ b/web-client/src/views/PendingReport/PendingReportList.tsx
@@ -12,7 +12,6 @@ import React, { useRef } from 'react';
 
 export const PendingReportList = connect(
   {
-    formattedPendingItemsHelper: state.formattedPendingItemsHelper,
     hasPendingItemsResults: state.pendingReports.hasPendingItemsResults,
     pendingItems: state.pendingReports.pendingItems,
     pendingItemsTotal: state.pendingReports.pendingItemsTotal,
@@ -21,7 +20,6 @@ export const PendingReportList = connect(
       sequences.setPendingReportSelectedJudgeSequence,
   },
   function PendingReportList({
-    formattedPendingItemsHelper,
     hasPendingItemsResults,
     pendingItems,
     pendingItemsTotal,
@@ -61,7 +59,7 @@ export const PendingReportList = connect(
                 }}
               >
                 <option value="">-Judge-</option>
-                {formattedPendingItemsHelper.judges.map(judge => (
+                {pendingReportListHelper.judges.map(judge => (
                   <option key={`pending-judge-${judge}`} value={judge}>
                     {judge}
                   </option>

--- a/web-client/src/views/PendingReport/PendingReportList.tsx
+++ b/web-client/src/views/PendingReport/PendingReportList.tsx
@@ -114,7 +114,7 @@ export const PendingReportList = connect(
             {pageRecords.map(item => (
               <tr
                 className="pending-item-row"
-                key={`pending-item-${item.renderKey}`}
+                key={`pending-item-${item.docketNumber}-${item.docketEntryId}`}
               >
                 <td>
                   <ConsolidatedCaseIcon

--- a/web-client/src/views/PendingReport/PendingReportList.tsx
+++ b/web-client/src/views/PendingReport/PendingReportList.tsx
@@ -14,6 +14,7 @@ export const PendingReportList = connect(
   {
     formattedPendingItemsHelper: state.formattedPendingItemsHelper,
     hasPendingItemsResults: state.pendingReports.hasPendingItemsResults,
+    pendingItems: state.pendingReports.pendingItems,
     pendingItemsTotal: state.pendingReports.pendingItemsTotal,
     pendingReportListHelper: state.pendingReportListHelper,
     setPendingReportSelectedJudgeSequence:
@@ -22,6 +23,7 @@ export const PendingReportList = connect(
   function PendingReportList({
     formattedPendingItemsHelper,
     hasPendingItemsResults,
+    pendingItems,
     pendingItemsTotal,
     pendingReportListHelper,
     setPendingReportSelectedJudgeSequence,
@@ -29,10 +31,7 @@ export const PendingReportList = connect(
     const paginatorTop = useRef(null);
 
     const { activePage, pageRecords, setActivePage, totalPages } =
-      useClientSidePaginator(
-        formattedPendingItemsHelper.items,
-        PENDING_REPORT_PAGE_SIZE,
-      );
+      useClientSidePaginator(pendingItems, PENDING_REPORT_PAGE_SIZE);
 
     return (
       <>


### PR DESCRIPTION
[10293](https://github.com/flexion/ef-cms/issues/10293)

Initially, `PendingReportList.tsx` used the following React key implementation:

```tsx
<tbody
    key={`pending-item-${item.formattedFiledDate}-${item.caseTitle}`}
>
```

This approach failed to uniquely identify each rendered item, so the key was updated to the following:

```tsx
<tr
    className="pending-item-row"
    key={`pending-item-${item.formattedFiledDate}-${item.caseTitle}-${item.docketEntryId}`}
>
```

During testing, this updated key also failed to ensure uniqueness.

This PR uses `pending-item-${item.docketNumber}-${item.docketEntryId}` as the React key for the pending report.