### PR TITLE
Remove chromium from Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   git-shallow-clone: guitarrapc/git-shallow-clone@2.8.0
 
-efcms-docker-image: &efcms-docker-image $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:4.3.21
+efcms-docker-image: &efcms-docker-image $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/ef-cms-us-east-1:4.3.21.1
 
 parameters:
   run_build_and_deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ RUN apt-get install -y \
   jq \
   graphicsmagick \
   ghostscript \
-  chromium \
   openssh-client \
   postgresql-client \
   sudo


### PR DESCRIPTION
Tests that use Chromium aren't actually using an OS-native version of Chromium. We are separately installing the `@sparticuz` Chromium fork as a node package and using _that_.

We are probably better off not installing an OS-native Chromium in our docker image.

Huge thanks to @Mwindo for catching this.

### Manual Steps

- [x] Deploy docker image `4.3.21.1` to the ustc-staging ECR