### PR TITLE
BugFix: Fix hanging Node.js scripts by adding explicit exit signals

### DIFF
--- a/web-api/src/persistence/postgres/utils/migrate/migrate.ts
+++ b/web-api/src/persistence/postgres/utils/migrate/migrate.ts
@@ -36,4 +36,12 @@ async function migrateToLatest() {
   });
 }
 
-migrateToLatest().catch;
+migrateToLatest()
+  .then(() => {
+    console.log('Postgres migration completed Successfully!');
+    process.exit(0);
+  })
+  .catch(err => {
+    console.log('Migration failed.');
+    console.log(err);
+  });

--- a/web-api/src/persistence/postgres/utils/seed/seed.ts
+++ b/web-api/src/persistence/postgres/utils/seed/seed.ts
@@ -11,4 +11,12 @@ export const seed = async () => {
   );
 };
 
-seed().catch;
+seed()
+  .then(() => {
+    console.log('Database data seeded successfully!');
+    process.exit(0);
+  })
+  .catch(err => {
+    console.log('Could not seed postgres data.');
+    console.log(err);
+  });


### PR DESCRIPTION
Currently, on some local machines, running `npm run start:api` along with `npm run postgres:seed` and other scripts fails to successfully hand off to subsequent scripts. This causes a state where Node.js scripts hang indefinitely without clear indications of the issue.

To address this, we have added explicit exits using `process.exit(0)` in the promise resolution block of the affected scripts. This provides a clear 'done' signal, ensuring that scripts terminate correctly. While this issue is currently observed on one machine, it is best practice to communicate explicit signals from scripts to accommodate variations in local environments.