### PR TITLE
10491 Work Items: Add indices and restructure queries

### DIFF
--- a/web-api/src/persistence/postgres/utils/migrate/migrations/0006-init-work-item-indexes.ts
+++ b/web-api/src/persistence/postgres/utils/migrate/migrations/0006-init-work-item-indexes.ts
@@ -1,0 +1,82 @@
+import { Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  // Index for docketNumber
+  await db.schema
+    .createIndex('idx_workItem_docketNumber')
+    .on('dwWorkItem')
+    .column('docketNumber')
+    .execute();
+
+  // Index for section
+  await db.schema
+    .createIndex('idx_workItem_section')
+    .on('dwWorkItem')
+    .column('section')
+    .execute();
+
+  // Index for completedAt
+  await db.schema
+    .createIndex('idx_workItem_completedAt')
+    .on('dwWorkItem')
+    .column('completedAt')
+    .execute();
+
+  // Index for createdAt
+  await db.schema
+    .createIndex('idx_workItem_createdAt')
+    .on('dwWorkItem')
+    .column('createdAt')
+    .execute();
+
+  // Index for highPriority
+  await db.schema
+    .createIndex('idx_workItem_highPriority')
+    .on('dwWorkItem')
+    .column('highPriority')
+    .execute();
+
+  // Index for assigneeId
+  await db.schema
+    .createIndex('idx_workItem_assigneeId')
+    .on('dwWorkItem')
+    .column('assigneeId')
+    .execute();
+
+  // Index for associatedJudge
+  await db.schema
+    .createIndex('idx_workItem_associatedJudge')
+    .on('dwWorkItem')
+    .column('associatedJudge')
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  // Drop indexes in reverse order to ensure clean rollback
+  await db.schema
+    .dropIndex('idx_workItem_associatedJudge')
+    .on('dwWorkItem')
+    .execute();
+  await db.schema
+    .dropIndex('idx_workItem_assigneeId')
+    .on('dwWorkItem')
+    .execute();
+  await db.schema
+    .dropIndex('idx_workItem_highPriority')
+    .on('dwWorkItem')
+    .execute();
+
+  await db.schema
+    .dropIndex('idx_workItem_createdAt')
+    .on('dwWorkItem')
+    .execute();
+  await db.schema
+    .dropIndex('idx_workItem_completedAt')
+    .on('dwWorkItem')
+    .execute();
+  await db.schema.dropIndex('idx_workItem_section').on('dwWorkItem').execute();
+  await db.schema
+    .dropIndex('idx_workItem_docketNumber')
+    .on('dwWorkItem')
+    .execute();
+}

--- a/web-api/src/persistence/postgres/workitems/getDocumentQCInboxForSection.ts
+++ b/web-api/src/persistence/postgres/workitems/getDocumentQCInboxForSection.ts
@@ -12,8 +12,11 @@ export const getDocumentQCInboxForSection = async ({
   const workItems = await getDbReader(reader => {
     let builder = reader
       .selectFrom('dwWorkItem as w')
+      .where('w.section', '=', section)
+      .where('w.completedAt', 'is', null)
       .leftJoin('dwCase as c', 'c.docketNumber', 'w.docketNumber')
-      .where('w.section', '=', section);
+      .orderBy('w.highPriority', 'desc')
+      .limit(5000);
 
     if (judgeUserName) {
       builder = builder.where('w.associatedJudge', '=', judgeUserName);

--- a/web-api/src/persistence/postgres/workitems/getDocumentQCInboxForUser.ts
+++ b/web-api/src/persistence/postgres/workitems/getDocumentQCInboxForUser.ts
@@ -10,10 +10,11 @@ export const getDocumentQCInboxForUser = async ({
   const workItems = await getDbReader(reader => {
     return reader
       .selectFrom('dwWorkItem as w')
-      .leftJoin('dwCase as c', 'c.docketNumber', 'w.docketNumber')
       .where('w.assigneeId', '=', userId)
+      .leftJoin('dwCase as c', 'c.docketNumber', 'w.docketNumber')
       .selectAll()
       .select('w.docketNumber')
+      .limit(5000)
       .execute();
   });
 


### PR DESCRIPTION
We have 1 million work items as of last night in test, and our queries over work items were taking a long time. We added indices and restructured queries to speed things up.