### PR TITLE
Fix format of response object in our logs

### DIFF
--- a/web-api/src/logger.test.ts
+++ b/web-api/src/logger.test.ts
@@ -61,7 +61,7 @@ describe('logger', () => {
     const instance = req.locals.logger;
 
     instance.info = jest.fn();
-    instance.addContext = jest.fn();
+    jest.spyOn(instance, 'addContext');
 
     res.end();
 

--- a/web-api/src/logger.test.ts
+++ b/web-api/src/logger.test.ts
@@ -61,11 +61,12 @@ describe('logger', () => {
     const instance = req.locals.logger;
 
     instance.info = jest.fn();
+    instance.addContext = jest.fn();
 
     res.end();
 
-    expect(instance.info).toHaveBeenCalledWith(
-      expect.any(String),
+    expect(instance.info).toHaveBeenCalledWith(expect.any(String));
+    expect(instance.addContext).toHaveBeenCalledWith(
       expect.objectContaining({
         response: expect.objectContaining({
           statusCode: 200,

--- a/web-api/src/logger.ts
+++ b/web-api/src/logger.ts
@@ -43,13 +43,15 @@ export const expressLogger = (req, res, next) => {
     end.apply(this, arguments);
     const responseTimeMs = new Date() - req.locals.startTime;
 
-    logger.info(`Request ended: ${req.method} ${req.url}`, {
+    logger.addContext({
       response: {
         responseSize: parseInt(res.get('content-length') ?? '0'),
         responseTimeMs,
         statusCode: res.statusCode,
       },
     });
+
+    logger.info(`Request ended: ${req.method} ${req.url}`);
     logger.clearContext();
   };
 


### PR DESCRIPTION
As of https://github.com/ustaxcourt/ef-cms/pull/5305, we are putting response data like `responseTime` in the default `metadata.context` object rather than the top-level log object. This PR fixes that by calling `addContext` with the response data before logging.

**Before (in our logs):**
<img width="322" alt="Screenshot 2024-12-16 at 2 23 42 PM" src="https://github.com/user-attachments/assets/d79c5e84-4f9c-426b-9cff-13953f8fad90" />

**Expected after (which is what we had before 5305), which we need to see in test:**
<img width="251" alt="Screenshot 2024-12-16 at 2 20 56 PM" src="https://github.com/user-attachments/assets/d19f75fa-61ff-4639-81dc-24340bee559d" />
