### PR TITLE
10504 dxox: Fix finalBriefDueDate issue in case worksheet

### DIFF
--- a/web-api/src/database-types.ts
+++ b/web-api/src/database-types.ts
@@ -85,7 +85,7 @@ export type UpdateCaseDeadlineKysely = Updateable<CaseDeadlineTable>;
 
 export interface CaseWorksheetTable {
   docketNumber: string;
-  finalBriefDueDate?: Date;
+  finalBriefDueDate?: Date | null;
   primaryIssue?: string;
   statusOfMatter?: string;
   judgeUserId?: string;

--- a/web-api/src/persistence/postgres/caseWorksheets/upsertCaseWorksheets.ts
+++ b/web-api/src/persistence/postgres/caseWorksheets/upsertCaseWorksheets.ts
@@ -11,7 +11,9 @@ export const upsertCaseWorksheets = async (
   const caseWorksheetsToUpsert = caseWorksheets.map(cw => {
     return {
       docketNumber: cw.docketNumber,
-      finalBriefDueDate: calculateDate({ dateString: cw.finalBriefDueDate }),
+      finalBriefDueDate: cw.finalBriefDueDate
+        ? calculateDate({ dateString: cw.finalBriefDueDate })
+        : null,
       judgeUserId: cw.judgeUserId,
       primaryIssue: cw.primaryIssue,
       statusOfMatter: cw.statusOfMatter,


### PR DESCRIPTION
In dynamo, an upsert with an undefined field will "erase" the field. In Postgres, it will not: we have to specifically null the field. This PR fixes an instance in which we were not nulling out the field, which meant that Postgres had incorrect data being stored if the user removed (= set to undefined) the `finalBriefDueDate`.