### PR TITLE
10491 (Postgres Work Items): Fix Document QC Served

### DIFF
--- a/web-api/src/persistence/postgres/workitems/getDocumentQCServedForUser.ts
+++ b/web-api/src/persistence/postgres/workitems/getDocumentQCServedForUser.ts
@@ -14,7 +14,7 @@ export const getDocumentQCServedForUser = async ({
       .selectFrom('dwWorkItem as w')
       .leftJoin('dwCase as c', 'c.docketNumber', 'w.docketNumber')
       .where('w.assigneeId', '=', userId)
-      .where('w.createdAt', '>', afterDate)
+      .where('w.completedAt', '>=', afterDate)
       .selectAll()
       .select('w.docketNumber')
       .execute();


### PR DESCRIPTION
We were filtering out served work items by created date. We should be filtering by completed date. This PR rectifies the issue.