### PR TITLE
Devex: tear down postgres volumes on (re)starting api locally

### DIFF
--- a/run-local.sh
+++ b/run-local.sh
@@ -12,7 +12,7 @@ fi
 
 if [[ -z "$CI" ]]; then
   echo "Stopping postgres in case it's already running"
-  $DOCKER_COMPOSE -f web-api/src/persistence/postgres/docker-compose.yml down || true
+  $DOCKER_COMPOSE -f web-api/src/persistence/postgres/docker-compose.yml down --volumes || true
 
   echo "Starting postgres"
   $DOCKER_COMPOSE -f web-api/src/persistence/postgres/docker-compose.yml up -d || { echo "Failed to start Postgres containers"; exit 1; }


### PR DESCRIPTION
This is in postgres work, but given that it takes time to get postgres tickets through, I figured I would just make a separate PR to get it in sooner.