### PR TITLE
Devex: clear judgeUser state on logout

### DIFF
--- a/web-client/src/presenter/actions/clearUserAction.ts
+++ b/web-client/src/presenter/actions/clearUserAction.ts
@@ -8,6 +8,7 @@ export const clearUserAction = async ({
   store,
 }: ActionProps) => {
   store.set(state.user, cloneDeep(emptyUserState));
+  store.unset(state.judgeUser);
   store.unset(state.token);
   store.unset(state.permissions);
 


### PR DESCRIPTION
Currently, `judgeUser` is not cleared upon logging out. This can cause issues if a user (e.g., a test user) logs in as a judge, logs out, then logs in as a non-judge.