### PR TITLE
10491-dxox: Fix processWorkItemEntries

### DIFF
--- a/scripts/run-once-scripts/postgres-migration/delete-work-items.ts
+++ b/scripts/run-once-scripts/postgres-migration/delete-work-items.ts
@@ -40,8 +40,8 @@ async function main() {
     const dynamoItemsToDelete = workItemsToDelete.map(c => ({
       DeleteRequest: {
         Key: {
-          pk: `work-item|${c.workItemId}`,
-          sk: 'case$|{c.docketNumber}',
+          pk: 'case|${c.docketNumber}',
+          sk: `work-item|${c.workItemId}`,
         },
       },
     }));

--- a/web-api/src/business/useCases/processStreamRecords/processWorkItemEntries.test.ts
+++ b/web-api/src/business/useCases/processStreamRecords/processWorkItemEntries.test.ts
@@ -34,6 +34,44 @@ describe('processWorkItemEntries', () => {
     },
   };
 
+  const mockSectionOutboxWorkItemRecord = {
+    dynamodb: {
+      NewImage: {
+        docketNumber: {
+          S: '123-45',
+        },
+        entityName: {
+          S: 'WorkItem',
+        },
+        pk: {
+          S: 'section-outbox|docket|2021-04-14',
+        },
+        sk: {
+          S: '2021-04-14T13:20:24.0732',
+        },
+      },
+    },
+  };
+
+  const mockUserOutboxWorkItemRecord = {
+    dynamodb: {
+      NewImage: {
+        docketNumber: {
+          S: '123-45',
+        },
+        entityName: {
+          S: 'WorkItem',
+        },
+        pk: {
+          S: 'user-outbox|50e3b92c-5dgf-1ad8-a9dc-44e3fb2f7309|2021-w15',
+        },
+        sk: {
+          S: '2021-04-14T13:20:24.0732',
+        },
+      },
+    },
+  };
+
   beforeEach(() => {
     applicationContext
       .getPersistenceGateway()
@@ -85,13 +123,17 @@ describe('processWorkItemEntries', () => {
     ]);
   });
 
-  it('should upsert records to postgres', async () => {
+  it('should upsert non-outbox work item records to postgres', async () => {
     await processWorkItemEntries({
       applicationContext,
-      workItemRecords: [mockWorkItemRecord],
+      workItemRecords: [
+        mockWorkItemRecord,
+        mockSectionOutboxWorkItemRecord,
+        mockUserOutboxWorkItemRecord,
+      ],
     });
 
-    expect(upsertWorkItems).toHaveBeenCalled();
+    expect(upsertWorkItems).toHaveBeenCalledTimes(1);
   });
 
   it('should log an error and throw an exception when bulk index returns failed records', async () => {

--- a/web-api/src/business/useCases/processStreamRecords/processWorkItemEntries.ts
+++ b/web-api/src/business/useCases/processStreamRecords/processWorkItemEntries.ts
@@ -65,12 +65,18 @@ export const processWorkItemEntries = async ({
     throw new Error('failed to index work item records');
   }
 
+  // In Dynamo, we often have multiple copies of a work item with different pks: the "main" record, and outbox records.
+  // In SQL, we want only one copy of the work item, and we want that copy to be the "main" copy, not an outbox item.
+  const nonOutboxWorkItemRecords = workItemRecords.filter(record =>
+    record.dynamodb.NewImage.pk.S.startsWith('case|'),
+  );
+
   getLogger().debug(
-    `Upserting ${workItemRecords.length} work item records into postgres`,
+    `Upserting ${nonOutboxWorkItemRecords.length} work item records into postgres`,
   );
 
   await upsertWorkItems({
-    workItems: workItemRecords.map(record => {
+    workItems: nonOutboxWorkItemRecords.map(record => {
       return unmarshall(record.dynamodb.NewImage) as RawWorkItem;
     }),
   });


### PR DESCRIPTION
Currently, in staging/prod environments, we store "a" WorkItem in different ways:
- The "main" WorkItem record with pk `case|<docketNumber>`. This is conditionally updated as part of `updateCaseAndAssociations`. (For instance, if a case's `associatedJudge` is switched, these WorkItem records are updated.)
- User-outbox "copies" with pk `user-outbox...`.
- Section-outbox "copies" with pk `section-outbox...`.

The "main" records are always up-to-date: anytime we make "copies," we also save the "main" record:
- In `saveWorkItemForDocketClerkFilingExternalDocument`, we save the original directly via a call to `put`
- In `putWorkItemInUsersOutbox` and `putWorkItemInOutbox`, we save the original in all spots via `saveWorkItem`


In Postgres (test environment), we have gotten rid of the copies since we can query for relevant "main" WorkItems more easily. However, thanks to Tenille, we noticed that `processWorkItemEntries` does not distinguish between the "main" WorkItem DynamoDB records and the "outbox copy" WorkItem DynamoDB records. This means that the WorkItem that we write to Postgres could be stale: we might write the (up-to-date) "main" record first and then overwrite it with a stale "copy" afterwards. This PR rectifies the issue by filtering out these "copies."