### PR TITLE
10504: Fix bug in updating case deadlines

### DIFF
--- a/web-client/src/presenter/actions/CaseDeadline/updateCaseDeadlineAction.test.ts
+++ b/web-client/src/presenter/actions/CaseDeadline/updateCaseDeadlineAction.test.ts
@@ -28,6 +28,7 @@ describe('updateCaseDeadlineAction', () => {
     await runAction(updateCaseDeadlineAction, {
       modules: { presenter },
       state: {
+        caseDeadlines: [{ caseDeadlineId: '123' }],
         caseDetail: {
           associatedJudge: 'TEST_ASSOCIATED_JUDGE',
           associatedJudgeId: 'TEST_ASSOCIATED_JUDGE_ID',

--- a/web-client/src/presenter/actions/CaseDeadline/updateCaseDeadlineAction.ts
+++ b/web-client/src/presenter/actions/CaseDeadline/updateCaseDeadlineAction.ts
@@ -4,6 +4,7 @@ export const updateCaseDeadlineAction = async ({
   applicationContext,
   get,
   path,
+  store,
 }: ActionProps) => {
   const { associatedJudge, associatedJudgeId, docketNumber, leadDocketNumber } =
     get(state.caseDetail);
@@ -21,6 +22,16 @@ export const updateCaseDeadlineAction = async ({
     .updateCaseDeadlineInteractor(applicationContext, {
       caseDeadline,
     });
+
+  const existingCaseDeadlines = get(state.caseDeadlines);
+
+  const updatedCaseDeadlines = existingCaseDeadlines.map(deadline =>
+    deadline.caseDeadlineId === updateCaseDeadlineResult.caseDeadlineId
+      ? updateCaseDeadlineResult
+      : deadline,
+  );
+
+  store.set(state.caseDeadlines, updatedCaseDeadlines);
 
   return path.success({
     alertSuccess: {

--- a/web-client/src/presenter/sequences/updateCaseDeadlineSequence.ts
+++ b/web-client/src/presenter/sequences/updateCaseDeadlineSequence.ts
@@ -3,7 +3,6 @@ import { clearFormAction } from '../actions/clearFormAction';
 import { clearModalAction } from '../actions/clearModalAction';
 import { clearModalStateAction } from '../actions/clearModalStateAction';
 import { clearScreenMetadataAction } from '../actions/clearScreenMetadataAction';
-import { getCaseDeadlinesForCaseAction } from '../actions/CaseDeadline/getCaseDeadlinesForCaseAction';
 import { setValidationErrorsAction } from '../actions/setValidationErrorsAction';
 import { showProgressSequenceDecorator } from '../utilities/showProgressSequenceDecorator';
 import { startShowValidationAction } from '../actions/startShowValidationAction';
@@ -26,7 +25,6 @@ export const updateCaseDeadlineSequence = [
       clearScreenMetadataAction,
       clearModalAction,
       clearModalStateAction,
-      getCaseDeadlinesForCaseAction,
     ]),
   },
 ];


### PR DESCRIPTION
When updating case deadlines, we are writing to the DB, then immediately trying to read the update from the DB. If the user is reading from the read replica (west coast), the update might not get to the main db (east coast) in time. To fix this, we update the `caseDeadlines` state directly in `updateCaseDeadlineAction` based on the API response to the "writing to the DB" request.