### PR TITLE
bug-fix: use absolute paths for podmon-compose

### DIFF
--- a/run-local.sh
+++ b/run-local.sh
@@ -12,7 +12,7 @@ fi
 
 if [[ -z "$CI" ]]; then
   echo "Stopping postgres in case it's already running"
-  $DOCKER_COMPOSE -f $(pwd)/web-api/src/persistence/postgres/docker-compose.yml down || true
+  $DOCKER_COMPOSE -f $(pwd)/web-api/src/persistence/postgres/docker-compose.yml down --volumes || true
 
   echo "Starting postgres"
   $DOCKER_COMPOSE -f $(pwd)/web-api/src/persistence/postgres/docker-compose.yml up -d || { echo "Failed to start Postgres containers"; exit 1; }

--- a/run-local.sh
+++ b/run-local.sh
@@ -12,10 +12,10 @@ fi
 
 if [[ -z "$CI" ]]; then
   echo "Stopping postgres in case it's already running"
-  $DOCKER_COMPOSE -f web-api/src/persistence/postgres/docker-compose.yml down --volumes || true
+  $DOCKER_COMPOSE -f $(pwd)/web-api/src/persistence/postgres/docker-compose.yml down || true
 
   echo "Starting postgres"
-  $DOCKER_COMPOSE -f web-api/src/persistence/postgres/docker-compose.yml up -d || { echo "Failed to start Postgres containers"; exit 1; }
+  $DOCKER_COMPOSE -f $(pwd)/web-api/src/persistence/postgres/docker-compose.yml up -d || { echo "Failed to start Postgres containers"; exit 1; }
 
   echo "Stopping dynamodb in case it's already running"
   pkill -f DynamoDBLocal


### PR DESCRIPTION
Using absolute path here to prevent bug seen in podman compose where it does not handle relative paths correctly. 