### PR TITLE
10580: Fix structured clone error

### DIFF
--- a/web-client/src/applicationContext.ts
+++ b/web-client/src/applicationContext.ts
@@ -374,6 +374,11 @@ const clientSupportsES2022 = (() => {
       return false;
     }
 
+    // Check structuredClone exists
+    if (typeof structuredClone !== 'function') {
+      return false;
+    }
+
     // Check Array.prototype.at
     if (!Array.prototype.at) {
       return false;


### PR DESCRIPTION
This PR adds a condition in `clientSupportsES2022` (which determines whether or not we load modern or legacy pdfjs) to see if `structuredClone` is supported in the client's browser.