### PR TITLE
10522: Run cases in Update Trial Session in parallel;

### DIFF
--- a/cypress/local-only/tests/integration/trialSession/trial-session-change-of-location.cy.ts
+++ b/cypress/local-only/tests/integration/trialSession/trial-session-change-of-location.cy.ts
@@ -22,21 +22,26 @@ describe('Trial Session - Notice Change of Location', () => {
     cy.get('[data-testid="set-calendar-button"]').click();
     cy.get('[data-testid="modal-button-confirm"]').click();
 
-    loginAsPetitioner();
-    externalUserCreatesElectronicCase().then(docketNumber => {
-      loginAsCaseServicesSupervisor();
-      goToCase(docketNumber);
-    });
+    const createdDocketNumbers: string[] = [];
+    for (let index = 0; index < 3; index++) {
+      loginAsPetitioner();
+      externalUserCreatesElectronicCase().then(docketNumber => {
+        loginAsCaseServicesSupervisor();
+        goToCase(docketNumber);
+        createdDocketNumbers.push(docketNumber);
+        cy.wrap(createdDocketNumbers).as('CREATED_DOCKET_NUMBERS');
+      });
 
-    cy.get('[data-testid="tab-case-information"]').click();
-    cy.get('[data-testid="add-to-trial-session-btn"]').click();
-    cy.get('[data-testid="all-locations-option"]').click();
-    cy.get<{ trialSessionId: string }>('@TRIAL_SESSION_INFO').then(
-      ({ trialSessionId }) => {
-        cy.get('[data-testid="trial-session-select"]').select(trialSessionId);
-      },
-    );
-    cy.get('[data-testid="modal-button-confirm"]').click();
+      cy.get('[data-testid="tab-case-information"]').click();
+      cy.get('[data-testid="add-to-trial-session-btn"]').click();
+      cy.get('[data-testid="all-locations-option"]').click();
+      cy.get<{ trialSessionId: string }>('@TRIAL_SESSION_INFO').then(
+        ({ trialSessionId }) => {
+          cy.get('[data-testid="trial-session-select"]').select(trialSessionId);
+        },
+      );
+      cy.get('[data-testid="modal-button-confirm"]').click();
+    }
 
     cy.get('[data-testid="trial-session-location-link"]').click();
     cy.get('[data-testid="edit-trial-session"]').click();
@@ -46,14 +51,22 @@ describe('Trial Session - Notice Change of Location', () => {
     cy.get('[data-testid="submit-edit-trial-session"]').click();
     cy.get('[data-testid="modal-button-confirm"]').click();
 
-    cy.get('[data-testid="case-link"]').click();
-    cy.get('[data-testid="docket-record-table"] tr').last().as('NCTL_ROW');
-    cy.get('@NCTL_ROW').find('td').eq(3).should('contain.text', 'NCTL');
-    cy.get('@NCTL_ROW')
-      .find('td')
-      .eq(5)
-      .should('contain.text', 'Notice of Change of Trial Location');
-    cy.get('@NCTL_ROW').find('td').eq(6).should('contain.text', '1');
-    cy.get('[data-testid="document-viewer-link-NCTL"]').click();
+    cy.get<string[]>('@CREATED_DOCKET_NUMBERS').then(
+      (docketNumbers: string[]) => {
+        for (let index = 0; index < docketNumbers.length; index++) {
+          goToCase(docketNumbers[index]);
+          cy.get('[data-testid="docket-record-table"] tr')
+            .last()
+            .as('NCTL_ROW');
+          cy.get('@NCTL_ROW').find('td').eq(3).should('contain.text', 'NCTL');
+          cy.get('@NCTL_ROW')
+            .find('td')
+            .eq(5)
+            .should('contain.text', 'Notice of Change of Trial Location');
+          cy.get('@NCTL_ROW').find('td').eq(6).should('contain.text', '1');
+          cy.get('[data-testid="document-viewer-link-NCTL"]').click();
+        }
+      },
+    );
   });
 });

--- a/shared/src/business/utilities/documentGenerators/combineAllPdfDocuments.test.ts
+++ b/shared/src/business/utilities/documentGenerators/combineAllPdfDocuments.test.ts
@@ -1,0 +1,87 @@
+import { PDFDocument } from 'pdf-lib';
+import { applicationContext } from '@shared/business/test/createTestApplicationContext';
+import { combineAllPdfDocuments } from '@shared/business/utilities/documentGenerators/combineAllPdfDocuments';
+
+describe('combineAllPdfDocuments', () => {
+  it('should merge all the PDF Documents into one', async () => {
+    const NUMBER_OF_CASES = 4;
+    const TEST_PDFS = Array.from({ length: NUMBER_OF_CASES }, (_, index) => {
+      return {
+        getPageIndices: () =>
+          Array.from(
+            { length: index + 1 },
+            (_temp, subIndex) => `${index + 1}_${subIndex + 1}`,
+          ),
+        index,
+      } as unknown as PDFDocument;
+    });
+
+    const CreateMock = {
+      addPage: jest.fn(),
+      copyPages: jest.fn().mockImplementation((_pdfDoc, pdfPages) => pdfPages),
+    };
+
+    const PDFDocumentMock = {
+      create: jest.fn().mockReturnValue(CreateMock),
+    };
+
+    applicationContext.getPdfLib = () => {
+      return {
+        PDFDocument: PDFDocumentMock,
+      };
+    };
+
+    const results = await combineAllPdfDocuments(applicationContext, TEST_PDFS);
+
+    expect(results).toBe(CreateMock);
+
+    const copyPagesCalls = CreateMock.copyPages.mock.calls;
+    expect(copyPagesCalls.length).toBe(NUMBER_OF_CASES);
+
+    const [[, case1Pages], [, case2Pages], [, case3Pages], [, case4Pages]] =
+      copyPagesCalls;
+    expect(case1Pages).toEqual(['1_1']);
+    expect(case2Pages).toEqual(['2_1', '2_2']);
+    expect(case3Pages).toEqual(['3_1', '3_2', '3_3']);
+    expect(case4Pages).toEqual(['4_1', '4_2', '4_3', '4_4']);
+
+    const addPageCalls = CreateMock.addPage.mock.calls;
+    expect(addPageCalls.length).toBe(10);
+    expect(addPageCalls).toEqual([
+      ['1_1'],
+      ['2_1'],
+      ['2_2'],
+      ['3_1'],
+      ['3_2'],
+      ['3_3'],
+      ['4_1'],
+      ['4_2'],
+      ['4_3'],
+      ['4_4'],
+    ]);
+  });
+
+  it('should return empty PDF document if length of PDF document is 0', async () => {
+    const CreateMock = {
+      addPage: jest.fn(),
+      copyPages: jest.fn().mockImplementation((_pdfDoc, pdfPages) => pdfPages),
+    };
+
+    const PDFDocumentMock = {
+      create: jest.fn().mockReturnValue(CreateMock),
+    };
+
+    applicationContext.getPdfLib = () => {
+      return {
+        PDFDocument: PDFDocumentMock,
+      };
+    };
+
+    const results = await combineAllPdfDocuments(applicationContext, []);
+
+    expect(results).toBe(CreateMock);
+
+    const copyPagesCalls = CreateMock.copyPages.mock.calls;
+    expect(copyPagesCalls.length).toBe(0);
+  });
+});

--- a/shared/src/business/utilities/documentGenerators/combineAllPdfDocuments.ts
+++ b/shared/src/business/utilities/documentGenerators/combineAllPdfDocuments.ts
@@ -1,0 +1,21 @@
+import { PDFDocument as PDFDocumentType } from 'pdf-lib';
+import { ServerApplicationContext } from '@web-api/applicationContext';
+
+export const combineAllPdfDocuments = async (
+  applicationContext: ServerApplicationContext,
+  allPDFDocuments: PDFDocumentType[],
+): Promise<PDFDocumentType> => {
+  const { PDFDocument } = await applicationContext.getPdfLib();
+  const mergedPdf = await PDFDocument.create();
+  if (allPDFDocuments.length === 0) return mergedPdf;
+
+  for (const pdfDoc of allPDFDocuments) {
+    const copiedPages = await mergedPdf.copyPages(
+      pdfDoc,
+      pdfDoc.getPageIndices(),
+    );
+    copiedPages.forEach(page => mergedPdf.addPage(page));
+  }
+
+  return mergedPdf;
+};

--- a/web-api/src/business/useCases/trialSessions/updateTrialSessionInteractor.locking.test.ts
+++ b/web-api/src/business/useCases/trialSessions/updateTrialSessionInteractor.locking.test.ts
@@ -23,6 +23,12 @@ describe('determineEntitiesToLock', () => {
     mockParams = {
       trialSession: { trialSessionId },
     };
+
+    applicationContext.getUtilities().combineAllPdfDocuments.mockResolvedValue({
+      getPageCount: () => {},
+      save: () => {},
+    });
+
     applicationContext
       .getPersistenceGateway()
       .getTrialSessionById.mockReturnValue({ caseOrder: mockCases });

--- a/web-api/src/business/useCases/trialSessions/updateTrialSessionInteractor.noticeGeneration.test.ts
+++ b/web-api/src/business/useCases/trialSessions/updateTrialSessionInteractor.noticeGeneration.test.ts
@@ -17,6 +17,11 @@ describe('updateTrialSessionInteractor should Generate Notices of', () => {
         fileId: 'f1501fb1-c2c8-4489-b28e-00212d45c93e',
         url: 'www.example.com',
       });
+
+    applicationContext.getUtilities().combineAllPdfDocuments.mockResolvedValue({
+      getPageCount: () => {},
+      save: () => {},
+    });
   });
 
   describe('In-Person Proceeding', () => {

--- a/web-api/src/business/useCases/trialSessions/updateTrialSessionInteractor.test.ts
+++ b/web-api/src/business/useCases/trialSessions/updateTrialSessionInteractor.test.ts
@@ -14,13 +14,22 @@ import { mockDocketClerkUser } from '@shared/test/mockAuthUsers';
 import { updateTrialSessionInteractor } from './updateTrialSessionInteractor';
 
 describe('updateTrialSessionInteractor', () => {
+  let TEST_MOCK_TRIAL_INPERSON: typeof MOCK_TRIAL_INPERSON;
+
   beforeEach(() => {
+    TEST_MOCK_TRIAL_INPERSON = cloneDeep(MOCK_TRIAL_INPERSON);
+
     applicationContext
       .getUseCaseHelpers()
       .saveFileAndGenerateUrl.mockReturnValue({
         fileId: 'fef6cbf1-8589-46f9-a52e-285a21cac9b3',
         url: 'www.example.com',
       });
+
+    applicationContext.getUtilities().combineAllPdfDocuments.mockReturnValue({
+      getPageCount: () => 3,
+      save: () => {},
+    });
 
     applicationContext
       .getPersistenceGateway()
@@ -104,13 +113,13 @@ describe('updateTrialSessionInteractor', () => {
   it('should make a call to persistence to update the trial session', async () => {
     applicationContext
       .getPersistenceGateway()
-      .getTrialSessionById.mockResolvedValue(MOCK_TRIAL_INPERSON);
+      .getTrialSessionById.mockResolvedValue(TEST_MOCK_TRIAL_INPERSON);
 
     await updateTrialSessionInteractor(
       applicationContext,
       {
         clientConnectionId: '123',
-        trialSession: MOCK_TRIAL_INPERSON,
+        trialSession: TEST_MOCK_TRIAL_INPERSON,
       },
       mockDocketClerkUser,
     );
@@ -124,7 +133,7 @@ describe('updateTrialSessionInteractor', () => {
     applicationContext
       .getPersistenceGateway()
       .getTrialSessionById.mockResolvedValue({
-        ...MOCK_TRIAL_INPERSON,
+        ...TEST_MOCK_TRIAL_INPERSON,
         judge: undefined,
       });
 
@@ -133,7 +142,7 @@ describe('updateTrialSessionInteractor', () => {
       {
         clientConnectionId: '123',
         trialSession: {
-          ...MOCK_TRIAL_INPERSON,
+          ...TEST_MOCK_TRIAL_INPERSON,
           judge: undefined,
         },
       },
@@ -147,7 +156,7 @@ describe('updateTrialSessionInteractor', () => {
 
   it('should create a trial session working copy when the updated trial session has a judge assigned and a judge was not set on the old trial session', async () => {
     const mockTrialSessionWithJudge = {
-      ...MOCK_TRIAL_INPERSON,
+      ...TEST_MOCK_TRIAL_INPERSON,
       judge: undefined,
     };
     applicationContext
@@ -159,7 +168,7 @@ describe('updateTrialSessionInteractor', () => {
       {
         clientConnectionId: '123',
         trialSession: {
-          ...MOCK_TRIAL_INPERSON,
+          ...TEST_MOCK_TRIAL_INPERSON,
           judge: judgeUser,
         },
       },
@@ -170,7 +179,7 @@ describe('updateTrialSessionInteractor', () => {
       applicationContext.getPersistenceGateway().createTrialSessionWorkingCopy
         .mock.calls[0][0].trialSessionWorkingCopy,
     ).toMatchObject({
-      trialSessionId: MOCK_TRIAL_INPERSON.trialSessionId,
+      trialSessionId: TEST_MOCK_TRIAL_INPERSON.trialSessionId,
       userId: judgeUser.userId,
     });
   });
@@ -179,7 +188,7 @@ describe('updateTrialSessionInteractor', () => {
     applicationContext
       .getPersistenceGateway()
       .getTrialSessionById.mockResolvedValue({
-        ...MOCK_TRIAL_INPERSON,
+        ...TEST_MOCK_TRIAL_INPERSON,
         judge: {
           name: 'Judge South',
           userId: '7c062db4-ea1e-4a51-a615-9ef8d6499ed7',
@@ -191,7 +200,7 @@ describe('updateTrialSessionInteractor', () => {
       {
         clientConnectionId: '123',
         trialSession: {
-          ...MOCK_TRIAL_INPERSON,
+          ...TEST_MOCK_TRIAL_INPERSON,
           judge: {
             name: 'Judge North',
             userId: 'c7d90c05-f6cd-442c-a168-202db587f16f', // different judge id
@@ -205,7 +214,7 @@ describe('updateTrialSessionInteractor', () => {
       applicationContext.getPersistenceGateway().createTrialSessionWorkingCopy
         .mock.calls[0][0].trialSessionWorkingCopy,
     ).toMatchObject({
-      trialSessionId: MOCK_TRIAL_INPERSON.trialSessionId,
+      trialSessionId: TEST_MOCK_TRIAL_INPERSON.trialSessionId,
       userId: 'c7d90c05-f6cd-442c-a168-202db587f16f',
     });
   });
@@ -214,7 +223,7 @@ describe('updateTrialSessionInteractor', () => {
     applicationContext
       .getPersistenceGateway()
       .getTrialSessionById.mockResolvedValue({
-        ...MOCK_TRIAL_INPERSON,
+        ...TEST_MOCK_TRIAL_INPERSON,
         trialClerk: undefined,
       });
 
@@ -223,7 +232,7 @@ describe('updateTrialSessionInteractor', () => {
       {
         clientConnectionId: '123',
         trialSession: {
-          ...MOCK_TRIAL_INPERSON,
+          ...TEST_MOCK_TRIAL_INPERSON,
           trialClerk: trialClerkUser,
         },
       },
@@ -234,7 +243,7 @@ describe('updateTrialSessionInteractor', () => {
       applicationContext.getPersistenceGateway().createTrialSessionWorkingCopy
         .mock.calls[0][0].trialSessionWorkingCopy,
     ).toMatchObject({
-      trialSessionId: MOCK_TRIAL_INPERSON.trialSessionId,
+      trialSessionId: TEST_MOCK_TRIAL_INPERSON.trialSessionId,
       userId: trialClerkUser.userId,
     });
   });
@@ -243,7 +252,7 @@ describe('updateTrialSessionInteractor', () => {
     applicationContext
       .getPersistenceGateway()
       .getTrialSessionById.mockReturnValue({
-        ...MOCK_TRIAL_INPERSON,
+        ...TEST_MOCK_TRIAL_INPERSON,
         trialClerk: {
           name: 'Clerk Tom Haberford',
           userId: 'a2d6531c-93fb-432b-a71d-5ea11f953963',
@@ -255,7 +264,7 @@ describe('updateTrialSessionInteractor', () => {
       {
         clientConnectionId: '123',
         trialSession: {
-          ...MOCK_TRIAL_INPERSON,
+          ...TEST_MOCK_TRIAL_INPERSON,
           trialClerk: {
             name: 'Clerk Magni',
             userId: 'c7d90c05-f6cd-442c-a168-202db587f16f', // different trial clerk id
@@ -269,7 +278,7 @@ describe('updateTrialSessionInteractor', () => {
       applicationContext.getPersistenceGateway().createTrialSessionWorkingCopy
         .mock.calls[0][0].trialSessionWorkingCopy,
     ).toMatchObject({
-      trialSessionId: MOCK_TRIAL_INPERSON.trialSessionId,
+      trialSessionId: TEST_MOCK_TRIAL_INPERSON.trialSessionId,
       userId: 'c7d90c05-f6cd-442c-a168-202db587f16f',
     });
   });
@@ -277,31 +286,38 @@ describe('updateTrialSessionInteractor', () => {
   it('should update the hearing associated with the updated trial session when a hearing trialSessionId matches the case.trialSessionId', async () => {
     applicationContext
       .getPersistenceGateway()
-      .getCaseByDocketNumber.mockReturnValue({
-        ...MOCK_CASE,
-        hearings: [MOCK_TRIAL_INPERSON],
+      .getCaseByDocketNumber.mockImplementation(({ docketNumber }) => {
+        return {
+          ...MOCK_CASE,
+          docketNumber,
+          hearings: [TEST_MOCK_TRIAL_INPERSON],
+        };
       });
 
     applicationContext
       .getPersistenceGateway()
-      .getTrialSessionById.mockReturnValue(MOCK_TRIAL_INPERSON);
+      .getTrialSessionById.mockReturnValue(TEST_MOCK_TRIAL_INPERSON);
 
     await updateTrialSessionInteractor(
       applicationContext,
       {
         clientConnectionId: '123',
-        trialSession: MOCK_TRIAL_INPERSON,
+        trialSession: TEST_MOCK_TRIAL_INPERSON,
       },
       mockDocketClerkUser,
     );
 
-    expect(
-      applicationContext.getPersistenceGateway().updateCaseHearing.mock
-        .calls[0][0],
-    ).toMatchObject({
+    const updateCaseHearingCalls =
+      applicationContext.getPersistenceGateway().updateCaseHearing.mock.calls;
+
+    expect(updateCaseHearingCalls.length).toEqual(2);
+    expect(updateCaseHearingCalls[0][0]).toMatchObject({
       applicationContext,
       docketNumber: MOCK_CASE.docketNumber,
-      hearingToUpdate: MOCK_TRIAL_INPERSON,
+    });
+    expect(updateCaseHearingCalls[1][0]).toMatchObject({
+      applicationContext,
+      docketNumber: '123-45',
     });
   });
 
@@ -310,19 +326,19 @@ describe('updateTrialSessionInteractor', () => {
       .getPersistenceGateway()
       .getCaseByDocketNumber.mockReturnValue({
         ...MOCK_CASE,
-        trialDate: MOCK_TRIAL_INPERSON.startDate,
-        trialSessionId: MOCK_TRIAL_INPERSON.trialSessionId,
+        trialDate: TEST_MOCK_TRIAL_INPERSON.startDate,
+        trialSessionId: TEST_MOCK_TRIAL_INPERSON.trialSessionId,
       });
 
     applicationContext
       .getPersistenceGateway()
-      .getTrialSessionById.mockReturnValue(MOCK_TRIAL_INPERSON);
+      .getTrialSessionById.mockReturnValue(TEST_MOCK_TRIAL_INPERSON);
 
     await updateTrialSessionInteractor(
       applicationContext,
       {
         clientConnectionId: '123',
-        trialSession: MOCK_TRIAL_INPERSON,
+        trialSession: TEST_MOCK_TRIAL_INPERSON,
       },
       mockDocketClerkUser,
     );
@@ -331,7 +347,7 @@ describe('updateTrialSessionInteractor', () => {
       applicationContext.getPersistenceGateway().updateCase.mock.calls[0][0]
         .caseToUpdate,
     ).toMatchObject({
-      trialDate: MOCK_TRIAL_INPERSON.startDate,
+      trialDate: TEST_MOCK_TRIAL_INPERSON.startDate,
     });
   });
 
@@ -373,14 +389,14 @@ describe('updateTrialSessionInteractor', () => {
 
     applicationContext
       .getPersistenceGateway()
-      .getTrialSessionById.mockReturnValue(MOCK_TRIAL_INPERSON);
+      .getTrialSessionById.mockReturnValue(TEST_MOCK_TRIAL_INPERSON);
 
     await updateTrialSessionInteractor(
       applicationContext,
       {
         clientConnectionId: '123',
         trialSession: {
-          ...MOCK_TRIAL_INPERSON,
+          ...TEST_MOCK_TRIAL_INPERSON,
           ...updatedFields,
         },
       },
@@ -391,7 +407,7 @@ describe('updateTrialSessionInteractor', () => {
       applicationContext.getPersistenceGateway().updateTrialSession.mock
         .calls[0][0].trialSessionToUpdate,
     ).toMatchObject({
-      ...MOCK_TRIAL_INPERSON,
+      ...TEST_MOCK_TRIAL_INPERSON,
       ...updatedFields,
     });
   });
@@ -403,14 +419,14 @@ describe('updateTrialSessionInteractor', () => {
 
     applicationContext
       .getPersistenceGateway()
-      .getTrialSessionById.mockReturnValue(MOCK_TRIAL_INPERSON);
+      .getTrialSessionById.mockReturnValue(TEST_MOCK_TRIAL_INPERSON);
 
     await updateTrialSessionInteractor(
       applicationContext,
       {
         clientConnectionId: '123',
         trialSession: {
-          ...MOCK_TRIAL_INPERSON,
+          ...TEST_MOCK_TRIAL_INPERSON,
           ...updatedFields,
         },
       },
@@ -421,7 +437,7 @@ describe('updateTrialSessionInteractor', () => {
       applicationContext.getPersistenceGateway().updateTrialSession.mock
         .calls[0][0].trialSessionToUpdate,
     ).toMatchObject({
-      ...MOCK_TRIAL_INPERSON,
+      ...TEST_MOCK_TRIAL_INPERSON,
       ...updatedFields,
     });
   });
@@ -430,7 +446,7 @@ describe('updateTrialSessionInteractor', () => {
     applicationContext
       .getPersistenceGateway()
       .getTrialSessionById.mockReturnValue({
-        ...MOCK_TRIAL_INPERSON,
+        ...TEST_MOCK_TRIAL_INPERSON,
         isCalendared: false,
       });
 
@@ -439,7 +455,7 @@ describe('updateTrialSessionInteractor', () => {
       {
         clientConnectionId: '123',
         trialSession: {
-          ...MOCK_TRIAL_INPERSON,
+          ...TEST_MOCK_TRIAL_INPERSON,
           isCalendared: true,
         },
       },
@@ -462,13 +478,13 @@ describe('updateTrialSessionInteractor', () => {
 
     applicationContext
       .getPersistenceGateway()
-      .getTrialSessionById.mockReturnValue(MOCK_TRIAL_INPERSON);
+      .getTrialSessionById.mockReturnValue(TEST_MOCK_TRIAL_INPERSON);
 
     await updateTrialSessionInteractor(
       applicationContext,
       {
         clientConnectionId: '123',
-        trialSession: MOCK_TRIAL_INPERSON,
+        trialSession: TEST_MOCK_TRIAL_INPERSON,
       },
       mockDocketClerkUser,
     );
@@ -482,7 +498,7 @@ describe('updateTrialSessionInteractor', () => {
     applicationContext
       .getPersistenceGateway()
       .getTrialSessionById.mockReturnValue({
-        ...MOCK_TRIAL_INPERSON,
+        ...TEST_MOCK_TRIAL_INPERSON,
         caseOrder: [],
       });
 
@@ -490,7 +506,7 @@ describe('updateTrialSessionInteractor', () => {
       applicationContext,
       {
         clientConnectionId: '123',
-        trialSession: MOCK_TRIAL_INPERSON,
+        trialSession: TEST_MOCK_TRIAL_INPERSON,
       },
       mockDocketClerkUser,
     );
@@ -505,14 +521,14 @@ describe('updateTrialSessionInteractor', () => {
 
     applicationContext
       .getPersistenceGateway()
-      .getTrialSessionById.mockReturnValue(MOCK_TRIAL_INPERSON);
+      .getTrialSessionById.mockReturnValue(TEST_MOCK_TRIAL_INPERSON);
 
     await updateTrialSessionInteractor(
       applicationContext,
       {
         clientConnectionId: '123',
         trialSession: {
-          ...MOCK_TRIAL_INPERSON,
+          ...TEST_MOCK_TRIAL_INPERSON,
           caseOrder: [
             {
               docketNumber: mockCaseRemovedFromTrialDocketNumber,
@@ -540,7 +556,7 @@ describe('updateTrialSessionInteractor', () => {
       {
         clientConnectionId: '123',
         trialSession: {
-          ...MOCK_TRIAL_INPERSON,
+          ...TEST_MOCK_TRIAL_INPERSON,
           swingSession: true,
           swingSessionId: mockSwingSessionId,
         },
@@ -562,8 +578,8 @@ describe('updateTrialSessionInteractor', () => {
     let originalTrialSession: RawTrialSession;
 
     beforeEach(() => {
-      desiredTrialSession = cloneDeep(MOCK_TRIAL_INPERSON);
-      originalTrialSession = cloneDeep(MOCK_TRIAL_INPERSON);
+      desiredTrialSession = cloneDeep(TEST_MOCK_TRIAL_INPERSON);
+      originalTrialSession = cloneDeep(TEST_MOCK_TRIAL_INPERSON);
       originalTrialSession.isCalendared = true;
       applicationContext.getPdfLib = jest.fn().mockResolvedValue({
         PDFDocument: {
@@ -614,9 +630,15 @@ describe('updateTrialSessionInteractor', () => {
       expect(
         applicationContext.getUseCaseHelpers().setNoticeOfChangeOfTrialJudge,
       ).toHaveBeenCalled();
-      expect(
+
+      const updateTrialSessionCalls =
         applicationContext.getPersistenceGateway().updateTrialSession.mock
-          .calls[0][0].trialSessionToUpdate.paperServicePdfs[0].title,
+          .calls;
+
+      expect(updateTrialSessionCalls.length).toEqual(1);
+      expect(
+        updateTrialSessionCalls[0][0].trialSessionToUpdate.paperServicePdfs[0]
+          .title,
       ).toEqual('Notice of Change of Trial Judge');
     });
 

--- a/web-api/src/business/useCases/trialSessions/updateTrialSessionInteractor.ts
+++ b/web-api/src/business/useCases/trialSessions/updateTrialSessionInteractor.ts
@@ -5,6 +5,7 @@ import {
 } from '@shared/business/entities/authUser/AuthUser';
 import { Case } from '@shared/business/entities/cases/Case';
 import { NotFoundError } from '../../../errors/errors';
+import { PDFDocument as PDFDocumentType } from 'pdf-lib';
 import {
   ROLE_PERMISSIONS,
   isAuthorized,
@@ -120,9 +121,6 @@ export const updateTrialSession = async (
   let pdfUrl: string | undefined;
   let fileId: string | undefined;
   if (currentTrialSession.caseOrder?.length) {
-    const { PDFDocument } = await applicationContext.getPdfLib();
-    const paperServicePdfsCombined = await PDFDocument.create();
-
     const shouldSetNoticeOfChangeToInPersonProceeding =
       currentTrialSession.proceedingType ===
         TRIAL_SESSION_PROCEEDING_TYPES.remote &&
@@ -154,11 +152,10 @@ export const updateTrialSession = async (
         updatedTrialSessionEntity,
       );
 
-    await updateCasesAndSetNoticeOfChange({
+    const paperServicePdfsCombined = await updateCasesAndSetNoticeOfChange({
       applicationContext,
       authorizedUser,
       currentTrialSession,
-      paperServicePdfsCombined,
       shouldIssueNoticeOfChangeOfTrialJudge,
       shouldSetNoticeOfChangeToInPersonProceeding,
       shouldSetNoticeOfChangeToRemoteProceeding,
@@ -223,7 +220,6 @@ const updateCasesAndSetNoticeOfChange = async ({
   applicationContext,
   authorizedUser,
   currentTrialSession,
-  paperServicePdfsCombined,
   shouldIssueNoticeOfChangeOfTrialJudge,
   shouldSetNoticeOfChangeToInPersonProceeding,
   shouldSetNoticeOfChangeToRemoteProceeding,
@@ -232,14 +228,13 @@ const updateCasesAndSetNoticeOfChange = async ({
 }: {
   applicationContext: ServerApplicationContext;
   currentTrialSession: RawTrialSession;
-  paperServicePdfsCombined: any;
   updatedTrialSessionEntity: TrialSession;
   authorizedUser: AuthUser;
   shouldSetNoticeOfChangeToRemoteProceeding: boolean;
   shouldSetNoticeOfTrialSessionLocationChange: boolean;
   shouldSetNoticeOfChangeToInPersonProceeding: boolean;
   shouldIssueNoticeOfChangeOfTrialJudge: boolean;
-}): Promise<void> => {
+}): Promise<PDFDocumentType> => {
   const calendaredCaseEntities = await Promise.all(
     currentTrialSession
       .caseOrder!.filter(c => !c.removedFromTrial)
@@ -261,7 +256,10 @@ const updateCasesAndSetNoticeOfChange = async ({
         aCase.trialSessionId === updatedTrialSessionEntity.trialSessionId,
     );
 
-  for (const caseEntity of casesThatShouldReceiveNotices) {
+  const TASKS = casesThatShouldReceiveNotices.map(async (caseEntity: Case) => {
+    const { PDFDocument } = await applicationContext.getPdfLib();
+    const newPdfDoc = await PDFDocument.create();
+
     if (shouldSetNoticeOfChangeToRemoteProceeding) {
       await applicationContext
         .getUseCaseHelpers()
@@ -269,7 +267,7 @@ const updateCasesAndSetNoticeOfChange = async ({
           applicationContext,
           {
             caseEntity,
-            newPdfDoc: paperServicePdfsCombined,
+            newPdfDoc,
             newTrialSessionEntity: updatedTrialSessionEntity,
           },
           authorizedUser,
@@ -283,7 +281,7 @@ const updateCasesAndSetNoticeOfChange = async ({
           applicationContext,
           {
             caseEntity,
-            newPdfDoc: paperServicePdfsCombined,
+            newPdfDoc,
             newTrialSessionEntity: updatedTrialSessionEntity,
           },
           authorizedUser,
@@ -298,7 +296,7 @@ const updateCasesAndSetNoticeOfChange = async ({
           {
             caseEntity,
             currentTrialSession,
-            newPdfDoc: paperServicePdfsCombined,
+            newPdfDoc,
             newTrialSessionEntity: updatedTrialSessionEntity,
           },
           authorizedUser,
@@ -312,7 +310,7 @@ const updateCasesAndSetNoticeOfChange = async ({
           applicationContext,
           {
             caseEntity,
-            newPdfDoc: paperServicePdfsCombined,
+            newPdfDoc,
             newTrialSessionEntity: updatedTrialSessionEntity,
             previousTrialSession: currentTrialSession,
           },
@@ -327,7 +325,14 @@ const updateCasesAndSetNoticeOfChange = async ({
       authorizedUser,
       caseToUpdate: caseEntity,
     });
-  }
+
+    return newPdfDoc;
+  });
+
+  const casePdfDocuments = await Promise.all(TASKS);
+  const paperServicePdfsCombined = await applicationContext
+    .getUtilities()
+    .combineAllPdfDocuments(applicationContext, casePdfDocuments);
 
   const updatedHearingPromises = calendaredCaseEntities.map(async aCase => {
     const matchingHearing = aCase.hearings.find(
@@ -342,7 +347,9 @@ const updateCasesAndSetNoticeOfChange = async ({
       });
     }
   });
+
   await Promise.all(updatedHearingPromises);
+  return paperServicePdfsCombined;
 };
 
 const createWorkingCopyForNewUserOnSession = async ({

--- a/web-api/src/business/useCases/trialSessions/updateTrialSessionInteractor.ts
+++ b/web-api/src/business/useCases/trialSessions/updateTrialSessionInteractor.ts
@@ -253,12 +253,14 @@ const updateCasesAndSetNoticeOfChange = async ({
         return new Case(aCase, { authorizedUser });
       }),
   );
+
   const casesThatShouldReceiveNotices = calendaredCaseEntities
     .filter(aCase => !aCase.isClosed())
     .filter(
       aCase =>
         aCase.trialSessionId === updatedTrialSessionEntity.trialSessionId,
     );
+
   for (const caseEntity of casesThatShouldReceiveNotices) {
     if (shouldSetNoticeOfChangeToRemoteProceeding) {
       await applicationContext

--- a/web-api/src/getUtilities.ts
+++ b/web-api/src/getUtilities.ts
@@ -13,6 +13,7 @@ import {
   prepareDateFromString,
 } from '../../shared/src/business/utilities/DateHandler';
 import { caseStatusWithTrialInformation } from '@shared/business/utilities/caseStatusWithTrialInformation';
+import { combineAllPdfDocuments } from '@shared/business/utilities/documentGenerators/combineAllPdfDocuments';
 import { combineTwoPdfs } from '../../shared/src/business/utilities/documentGenerators/combineTwoPdfs';
 import {
   compareCasesByDocketNumber,
@@ -58,6 +59,7 @@ const utilities = {
   calculateDifferenceInDays,
   calculateISODate,
   caseStatusWithTrialInformation,
+  combineAllPdfDocuments,
   combineTwoPdfs,
   compareCasesByDocketNumber,
   compareISODateStrings,


### PR DESCRIPTION
Got feedback that generating NCTL would take a long time for trial sessions with around 100 cases. Looked into the code and it seems like we for loop through each case (sync) and generate the PDF and add as a docket entry to the case. 

This was necessary because we need to generate one PDF containing all the NTCL for paper service. 

So I decided to refactor and run all cases in parallel with their own pdf-lib PDFDocument and merge them all at the end to speed up the process.