### PR TITLE
DevEx: fix for deploying the stale-cases-email lambda in prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,6 +190,16 @@ jobs:
           name: 'Deploy - Inactive Cases Email Lambda and Monthly Cron Trigger'
           command: |
             if [ -n "$INACTIVITY_REPORT_RECIPIENTS" ]; then
+              ES_DOMAIN="$SOURCE_ELASTICSEARCH"
+              if [ "$MIGRATE_FLAG" == "true" ]; then
+                ES_DOMAIN=$(./scripts/elasticsearch/get-destination-elasticsearch.sh "$ENV")
+              fi
+              ES_ENDPOINT=$(aws es describe-elasticsearch-domain \
+                --domain-name "$ES_DOMAIN" \
+                --region "us-east-1" \
+                --query 'DomainStatus.Endpoint' \
+                --output text)
+              export ELASTICSEARCH_ENDPOINT="$ES_ENDPOINT"
               npm run deploy:stale-cases-email-cron -- $ENV
             fi
       - run:


### PR DESCRIPTION
Couple of different fixes for the CI bit that deploys the stale-cases-email lambda.

First, the `ELASTICSEARCH_ENDPOINT` environment variable is not set in circle, so we have to set it before calling `npm run deploy:stale-cases-email-cron`.

Second, it should be set to the destination endpoint if we're migrating.