### PR TITLE
Remove flaky multi-tab tests

### DIFF
--- a/cypress/local-only/tests/integration/logoutBehavior/idle-logout.cy.ts
+++ b/cypress/local-only/tests/integration/logoutBehavior/idle-logout.cy.ts
@@ -54,39 +54,4 @@ describe('Idle Logout Behavior', () => {
     cy.get('[data-testid="are-you-still-there-modal"]').should('not.exist');
     cy.puppeteer('closeTab', newTabUrl);
   });
-
-  it('should sign out of all tabs after idle', () => {
-    // Note that throughout this test, we interact with the first tab via cypress
-    // and all other tabs through the puppeteer plugin. Mixing this up will cause errors.
-    const sessionTimeout = 15000;
-    const areYouStillThereTime = 2000;
-    loginAsColvin();
-    const urls = [
-      '/messages/my/inbox',
-      '/document-qc/section/inbox',
-      '/trial-sessions',
-    ];
-    urls.forEach(url => {
-      cy.puppeteer(
-        'openNewTab',
-        Cypress.config('baseUrl') + url,
-        areYouStillThereTime,
-        sessionTimeout,
-      );
-    });
-    cy.window().then((window: Window) => {
-      overrideIdleTimeouts({
-        areYouStillThereTime,
-        sessionTimeout,
-        windowObj: window as unknown as IdleLogoutTesting,
-      });
-    });
-
-    // We sync all the tabs to timeout at the same time by clicking, which broadcasts a "last active" time across tabs.
-    // They should all sign out at the same time.
-    cy.get('body').click();
-
-    cy.get('[data-testid="idle-logout-login-button"]').should('exist');
-    cy.puppeteer('verifyAllTabsAreOnIdleLogout');
-  });
 });


### PR DESCRIPTION
This tests has been flaky on PRs with three engineers trying to fix it. We still have tests around idle-logout, just not multi-tab idle logout.