### PR TITLE
10598 Bug: Case Deadlines Blocked Issues in West

### DIFF
--- a/shared/src/business/entities/cases/Case.ts
+++ b/shared/src/business/entities/cases/Case.ts
@@ -72,12 +72,11 @@ import { Statistic } from '../Statistic';
 import { TrialSession } from '../trialSessions/TrialSession';
 import { UnprocessableEntityError } from '../../../../../web-api/src/errors/errors';
 import { User } from '../User';
-import { clone, compact, includes, isEmpty, startCase } from 'lodash';
+import { clone, compact, includes, startCase } from 'lodash';
 import { compareStrings } from '../../utilities/sortFunctions';
 import { getDocketNumberSuffix } from '../../utilities/getDocketNumberSuffix';
 import { shouldGenerateDocketRecordIndex } from '../../utilities/shouldGenerateDocketRecordIndex';
 import joi from 'joi';
-import { RawCaseDeadline } from '@shared/business/entities/CaseDeadline';
 
 export class Case extends JoiValidationEntity {
   public associatedJudge?: string;
@@ -1400,18 +1399,14 @@ export class Case extends JoiValidationEntity {
    * @param {object} caseDeadlines - the case deadlines
    * @returns {Case} the updated case entity
    */
-  updateAutomaticBlocked({
-    caseDeadlines,
-  }: {
-    caseDeadlines?: RawCaseDeadline[];
-  }) {
+  updateAutomaticBlocked({ hasCaseDeadline }: { hasCaseDeadline: boolean }) {
     const hasPendingItems = this.doesHavePendingItems();
     let automaticBlockedReason;
-    if (hasPendingItems && !isEmpty(caseDeadlines)) {
+    if (hasPendingItems && hasCaseDeadline) {
       automaticBlockedReason = AUTOMATIC_BLOCKED_REASONS.pendingAndDueDate;
     } else if (hasPendingItems) {
       automaticBlockedReason = AUTOMATIC_BLOCKED_REASONS.pending;
-    } else if (!isEmpty(caseDeadlines)) {
+    } else if (hasCaseDeadline) {
       automaticBlockedReason = AUTOMATIC_BLOCKED_REASONS.dueDate;
     }
     if (automaticBlockedReason) {

--- a/shared/src/business/entities/cases/Case.updateAutomaticBlocked.test.ts
+++ b/shared/src/business/entities/cases/Case.updateAutomaticBlocked.test.ts
@@ -20,7 +20,7 @@ describe('updateAutomaticBlocked', () => {
 
     expect(caseToUpdate.automaticBlocked).toBeFalsy();
 
-    caseToUpdate.updateAutomaticBlocked({});
+    caseToUpdate.updateAutomaticBlocked({ hasCaseDeadline: false });
 
     expect(caseToUpdate.automaticBlocked).toEqual(true);
     expect(caseToUpdate.consolidatedCases[0].automaticBlocked).toEqual(true);
@@ -48,7 +48,7 @@ describe('updateAutomaticBlocked', () => {
 
     expect(caseToUpdate.automaticBlocked).toBeTruthy();
 
-    caseToUpdate.updateAutomaticBlocked({});
+    caseToUpdate.updateAutomaticBlocked({ hasCaseDeadline: false });
 
     expect(caseToUpdate.consolidatedCases[0].automaticBlocked).toBeFalsy();
     expect(caseToUpdate.automaticBlocked).toBeFalsy();

--- a/web-api/src/business/useCaseHelper/automaticBlock/updateCaseAutomaticBlock.test.ts
+++ b/web-api/src/business/useCaseHelper/automaticBlock/updateCaseAutomaticBlock.test.ts
@@ -10,20 +10,18 @@ jest.mock(
 import {
   AUTOMATIC_BLOCKED_REASONS,
   CASE_STATUS_TYPES,
-} from '../../../../../shared/src/business/entities/EntityConstants';
-import { Case } from '../../../../../shared/src/business/entities/cases/Case';
-import {
-  MOCK_CASE,
-  MOCK_CASE_WITHOUT_PENDING,
-} from '../../../../../shared/src/test/mockCase';
-import { PENDING_DOCKET_ENTRY } from '../../../../../shared/src/test/mockDocketEntry';
-import { applicationContext } from '../../../../../shared/src/business/test/createTestApplicationContext';
+} from '@shared/business/entities/EntityConstants';
+import { Case } from '@shared/business/entities/cases/Case';
+import { MOCK_CASE, MOCK_CASE_WITHOUT_PENDING } from '@shared/test/mockCase';
+import { PENDING_DOCKET_ENTRY } from '@shared/test/mockDocketEntry';
+import { applicationContext } from '@shared/business/test/createTestApplicationContext';
 import { cloneDeep } from 'lodash';
 import { getCaseDeadlinesByDocketNumber as getCaseDeadlinesByDocketNumberMock } from '@web-api/persistence/postgres/caseDeadlines/getCaseDeadlinesByDocketNumber';
 import { mockDocketClerkUser } from '@shared/test/mockAuthUsers';
 import { updateCaseAutomaticBlock } from './updateCaseAutomaticBlock';
 import { deleteCaseTrialSortMappingRecords as deleteCaseTrialSortMappingRecordsMock } from '@web-api/persistence/dynamo/cases/deleteCaseTrialSortMappingRecords';
 import { createCaseTrialSortMappingRecords as createCaseTrialSortMappingRecordsMock } from '@web-api/persistence/dynamo/cases/createCaseTrialSortMappingRecords';
+import { CaseDeadline } from '@shared/business/entities/CaseDeadline';
 
 describe('updateCaseAutomaticBlock', () => {
   let mockCase;
@@ -64,7 +62,7 @@ describe('updateCaseAutomaticBlock', () => {
 
   it('sets the case to automaticBlocked and calls deleteCaseTrialSortMappingRecords if it has deadlines', async () => {
     getCaseDeadlinesByDocketNumber.mockResolvedValue([
-      { deadline: 'something' } as any
+      { deadline: 'something' } as any,
     ]);
 
     const caseEntity = new Case(MOCK_CASE_WITHOUT_PENDING, {
@@ -85,7 +83,7 @@ describe('updateCaseAutomaticBlock', () => {
 
   it('does not set the case to automaticBlocked or call deleteCaseTrialSortMappingRecords if it already has a trial date', async () => {
     getCaseDeadlinesByDocketNumber.mockResolvedValue([
-      { deadline: 'something' } as any
+      { deadline: 'something' } as any,
     ]);
 
     const caseEntity = new Case(
@@ -194,5 +192,26 @@ describe('updateCaseAutomaticBlock', () => {
     });
 
     expect(createCaseTrialSortMappingRecords).not.toHaveBeenCalled();
+  });
+
+  it('should use deadlines that are passed in when available rather than re-fetching the data from persistence', async () => {
+    const caseEntity = new Case(
+      {
+        ...MOCK_CASE_WITHOUT_PENDING,
+        preferredTrialCity: null,
+        status: CASE_STATUS_TYPES.generalDocketReadyForTrial,
+      },
+      {
+        authorizedUser: mockDocketClerkUser,
+      },
+    );
+
+    await updateCaseAutomaticBlock({
+      applicationContext,
+      caseEntity,
+      deadlines: [{} as CaseDeadline],
+    });
+
+    expect(getCaseDeadlinesByDocketNumber).not.toHaveBeenCalled();
   });
 });

--- a/web-api/src/business/useCaseHelper/automaticBlock/updateCaseAutomaticBlock.test.ts
+++ b/web-api/src/business/useCaseHelper/automaticBlock/updateCaseAutomaticBlock.test.ts
@@ -21,7 +21,6 @@ import { mockDocketClerkUser } from '@shared/test/mockAuthUsers';
 import { updateCaseAutomaticBlock } from './updateCaseAutomaticBlock';
 import { deleteCaseTrialSortMappingRecords as deleteCaseTrialSortMappingRecordsMock } from '@web-api/persistence/dynamo/cases/deleteCaseTrialSortMappingRecords';
 import { createCaseTrialSortMappingRecords as createCaseTrialSortMappingRecordsMock } from '@web-api/persistence/dynamo/cases/createCaseTrialSortMappingRecords';
-import { CaseDeadline } from '@shared/business/entities/CaseDeadline';
 
 describe('updateCaseAutomaticBlock', () => {
   let mockCase;
@@ -194,7 +193,7 @@ describe('updateCaseAutomaticBlock', () => {
     expect(createCaseTrialSortMappingRecords).not.toHaveBeenCalled();
   });
 
-  it('should use deadlines that are passed in when available rather than re-fetching the data from persistence', async () => {
+  it('should not fetch deadlines from persistence when hasCaseDeadline is true', async () => {
     const caseEntity = new Case(
       {
         ...MOCK_CASE_WITHOUT_PENDING,
@@ -209,7 +208,7 @@ describe('updateCaseAutomaticBlock', () => {
     await updateCaseAutomaticBlock({
       applicationContext,
       caseEntity,
-      deadlines: [{} as CaseDeadline],
+      hasCaseDeadline: true,
     });
 
     expect(getCaseDeadlinesByDocketNumber).not.toHaveBeenCalled();

--- a/web-api/src/business/useCaseHelper/automaticBlock/updateCaseAutomaticBlock.ts
+++ b/web-api/src/business/useCaseHelper/automaticBlock/updateCaseAutomaticBlock.ts
@@ -1,37 +1,32 @@
-import { CaseDeadline } from '@shared/business/entities/CaseDeadline';
 import { Case } from '@shared/business/entities/cases/Case';
 import { ServerApplicationContext } from '@web-api/applicationContext';
 import { createCaseTrialSortMappingRecords } from '@web-api/persistence/dynamo/cases/createCaseTrialSortMappingRecords';
 import { deleteCaseTrialSortMappingRecords } from '@web-api/persistence/dynamo/cases/deleteCaseTrialSortMappingRecords';
 import { getCaseDeadlinesByDocketNumber } from '@web-api/persistence/postgres/caseDeadlines/getCaseDeadlinesByDocketNumber';
+import { isEmpty } from 'lodash';
 
-/**
- * updateCaseAutomaticBlock
- *
- * @param {object} providers the providers object
- * @param {object} providers.applicationContext the application context
- * @param {object} providers.caseEntity the case entity to update
- * @returns {object} the updated case entity
- */
 export const updateCaseAutomaticBlock = async ({
   applicationContext,
   caseEntity,
-  deadlines = undefined,
+  hasCaseDeadline,
 }: {
   applicationContext: ServerApplicationContext;
   caseEntity: Case;
-  deadlines?: CaseDeadline[];
+  hasCaseDeadline?: boolean;
 }) => {
   if (caseEntity.trialDate || caseEntity.highPriority) {
     return caseEntity;
   }
-  const caseDeadlines =
-    deadlines ||
-    (await getCaseDeadlinesByDocketNumber({
-      docketNumber: caseEntity.docketNumber,
-    }));
 
-  caseEntity.updateAutomaticBlocked({ caseDeadlines });
+  if (hasCaseDeadline === undefined) {
+    hasCaseDeadline = !isEmpty(
+      await getCaseDeadlinesByDocketNumber({
+        docketNumber: caseEntity.docketNumber,
+      }),
+    );
+  }
+
+  caseEntity.updateAutomaticBlocked({ hasCaseDeadline });
 
   if (caseEntity.automaticBlocked) {
     await deleteCaseTrialSortMappingRecords({

--- a/web-api/src/business/useCaseHelper/automaticBlock/updateCaseAutomaticBlock.ts
+++ b/web-api/src/business/useCaseHelper/automaticBlock/updateCaseAutomaticBlock.ts
@@ -1,3 +1,4 @@
+import { CaseDeadline } from '@shared/business/entities/CaseDeadline';
 import { Case } from '@shared/business/entities/cases/Case';
 import { ServerApplicationContext } from '@web-api/applicationContext';
 import { createCaseTrialSortMappingRecords } from '@web-api/persistence/dynamo/cases/createCaseTrialSortMappingRecords';
@@ -15,16 +16,20 @@ import { getCaseDeadlinesByDocketNumber } from '@web-api/persistence/postgres/ca
 export const updateCaseAutomaticBlock = async ({
   applicationContext,
   caseEntity,
+  deadlines = undefined,
 }: {
   applicationContext: ServerApplicationContext;
   caseEntity: Case;
+  deadlines?: CaseDeadline[];
 }) => {
   if (caseEntity.trialDate || caseEntity.highPriority) {
     return caseEntity;
   }
-  const caseDeadlines = await getCaseDeadlinesByDocketNumber({
-    docketNumber: caseEntity.docketNumber,
-  });
+  const caseDeadlines =
+    deadlines ||
+    (await getCaseDeadlinesByDocketNumber({
+      docketNumber: caseEntity.docketNumber,
+    }));
 
   caseEntity.updateAutomaticBlocked({ caseDeadlines });
 

--- a/web-api/src/business/useCases/caseDeadline/createCaseDeadlineInteractor.test.ts
+++ b/web-api/src/business/useCases/caseDeadline/createCaseDeadlineInteractor.test.ts
@@ -7,18 +7,15 @@ jest.mock(
 import {
   AUTOMATIC_BLOCKED_REASONS,
   CHIEF_JUDGE,
-} from '../../../../../shared/src/business/entities/EntityConstants';
-import {
-  MOCK_CASE,
-  MOCK_CASE_WITHOUT_PENDING,
-} from '../../../../../shared/src/test/mockCase';
-import { MOCK_LOCK } from '../../../../../shared/src/test/mockLock';
+} from '@shared/business/entities/EntityConstants';
+import { MOCK_CASE, MOCK_CASE_WITHOUT_PENDING } from '@shared/test/mockCase';
+import { MOCK_LOCK } from '@shared/test/mockLock';
 import {
   ServiceUnavailableError,
   UnauthorizedError,
 } from '@web-api/errors/errors';
 import { UnknownAuthUser } from '@shared/business/entities/authUser/AuthUser';
-import { applicationContext } from '../../../../../shared/src/business/test/createTestApplicationContext';
+import { applicationContext } from '@shared/business/test/createTestApplicationContext';
 import { createCaseDeadlineInteractor } from './createCaseDeadlineInteractor';
 import { getCaseDeadlinesByDocketNumber as getCaseDeadlinesByDocketNumberMock } from '@web-api/persistence/postgres/caseDeadlines/getCaseDeadlinesByDocketNumber';
 import { mockPetitionsClerkUser } from '@shared/test/mockAuthUsers';

--- a/web-api/src/business/useCases/caseDeadline/createCaseDeadlineInteractor.ts
+++ b/web-api/src/business/useCases/caseDeadline/createCaseDeadlineInteractor.ts
@@ -33,13 +33,14 @@ export const createCaseDeadline = async (
     associatedJudgeId: caseEntity.associatedJudgeId,
   });
 
-  await upsertCaseDeadlines([newCaseDeadline.validate().toRawObject()]);
+  const caseDeadlines = await upsertCaseDeadlines([newCaseDeadline.validate().toRawObject()]);
 
   caseEntity = await applicationContext
     .getUseCaseHelpers()
     .updateCaseAutomaticBlock({
       applicationContext,
       caseEntity,
+      deadlines: caseDeadlines
     });
 
   await applicationContext.getUseCaseHelpers().updateCaseAndAssociations({

--- a/web-api/src/business/useCases/caseDeadline/createCaseDeadlineInteractor.ts
+++ b/web-api/src/business/useCases/caseDeadline/createCaseDeadlineInteractor.ts
@@ -33,14 +33,14 @@ export const createCaseDeadline = async (
     associatedJudgeId: caseEntity.associatedJudgeId,
   });
 
-  const caseDeadlines = await upsertCaseDeadlines([newCaseDeadline.validate().toRawObject()]);
+  await upsertCaseDeadlines([newCaseDeadline.validate().toRawObject()]);
 
   caseEntity = await applicationContext
     .getUseCaseHelpers()
     .updateCaseAutomaticBlock({
       applicationContext,
       caseEntity,
-      deadlines: caseDeadlines
+      hasCaseDeadline: true,
     });
 
   await applicationContext.getUseCaseHelpers().updateCaseAndAssociations({

--- a/web-api/src/business/useCases/caseDeadline/deleteCaseDeadlineInteractor.test.ts
+++ b/web-api/src/business/useCases/caseDeadline/deleteCaseDeadlineInteractor.test.ts
@@ -135,7 +135,10 @@ describe('deleteCaseDeadlineInteractor', () => {
   });
 
   it('calls persistence to delete a case deadline and leaves the case automatically blocked if there are more deadlines', async () => {
-    mockDeadlines = [{ deadline: 'something' }];
+    mockDeadlines = [
+      { cadeDeadlineId: '6805d1ab-18d0-43ec-bafb-654e83405416' },
+      { cadeDeadlineId: 'will remain after deletion' },
+    ];
 
     await deleteCaseDeadlineInteractor(
       applicationContext,

--- a/web-api/src/business/useCases/caseDeadline/deleteCaseDeadlineInteractor.test.ts
+++ b/web-api/src/business/useCases/caseDeadline/deleteCaseDeadlineInteractor.test.ts
@@ -68,6 +68,7 @@ describe('deleteCaseDeadlineInteractor', () => {
   });
 
   it('should acquire and remove the lock on the case', async () => {
+    getCaseDeadlinesByDocketNumber.mockResolvedValueOnce([]);
     await deleteCaseDeadlineInteractor(
       applicationContext,
       {

--- a/web-api/src/business/useCases/caseDeadline/deleteCaseDeadlineInteractor.ts
+++ b/web-api/src/business/useCases/caseDeadline/deleteCaseDeadlineInteractor.ts
@@ -29,8 +29,8 @@ export const deleteCaseDeadline = async (
 
   let updatedCase = new Case(caseToUpdate, { authorizedUser });
 
-  // To avoid race conditions where we delete a deadline from one DB endpoint but then read immediately from another (which doesn't yet have the update),
-  // we keep track of the deadlines here and pass them directly to updateCaseAutomaticBlock.
+  // To avoid race conditions such that we delete a deadline from one DB endpoint but then read immediately from another (which doesn't yet have the update),
+  // we keep track of the deadlines in code and pass the info into updateCaseAutomaticBlocked
   const deadlinesBeforeDelete = await getCaseDeadlinesByDocketNumber({
     docketNumber,
   });
@@ -39,14 +39,10 @@ export const deleteCaseDeadline = async (
     caseDeadlineId,
   });
 
-  const deadlinesAfterDelete = deadlinesBeforeDelete.filter(
-    d => d.caseDeadlineId !== caseDeadlineId,
-  );
-
   updatedCase = await updateCaseAutomaticBlock({
     applicationContext,
     caseEntity: updatedCase,
-    deadlines: deadlinesAfterDelete,
+    hasCaseDeadline: deadlinesBeforeDelete.length > 1,
   });
 
   const result = await applicationContext

--- a/web-api/src/business/useCases/caseDeadline/deleteCaseDeadlineInteractor.ts
+++ b/web-api/src/business/useCases/caseDeadline/deleteCaseDeadlineInteractor.ts
@@ -1,14 +1,15 @@
-import { Case } from '../../../../../shared/src/business/entities/cases/Case';
+import { Case } from '@shared/business/entities/cases/Case';
 import {
   ROLE_PERMISSIONS,
   isAuthorized,
-} from '../../../../../shared/src/authorization/authorizationClientService';
+} from '@shared/authorization/authorizationClientService';
 import { ServerApplicationContext } from '@web-api/applicationContext';
 import { UnauthorizedError } from '@web-api/errors/errors';
 import { UnknownAuthUser } from '@shared/business/entities/authUser/AuthUser';
 import { deleteCaseDeadline as deleteDeadline } from '@web-api/persistence/postgres/caseDeadlines/deleteCaseDeadline';
 import { withLocking } from '@web-api/business/useCaseHelper/acquireLock';
 import { updateCaseAutomaticBlock } from '@web-api/business/useCaseHelper/automaticBlock/updateCaseAutomaticBlock';
+import { getCaseDeadlinesByDocketNumber } from '@web-api/persistence/postgres/caseDeadlines/getCaseDeadlinesByDocketNumber';
 
 export const deleteCaseDeadline = async (
   applicationContext: ServerApplicationContext,
@@ -28,14 +29,25 @@ export const deleteCaseDeadline = async (
 
   let updatedCase = new Case(caseToUpdate, { authorizedUser });
 
+  // To avoid race conditions where we delete a deadline from one DB endpoint but then read immediately from another (which doesn't yet have the update),
+  // we keep track of the deadlines here and pass them directly to updateCaseAutomaticBlock.
+  const deadlinesBeforeDelete = await getCaseDeadlinesByDocketNumber({
+    docketNumber,
+  });
+
   await deleteDeadline({
     caseDeadlineId,
   });
 
+  const deadlinesAfterDelete = deadlinesBeforeDelete.filter(
+    d => d.caseDeadlineId !== caseDeadlineId,
+  );
+
   updatedCase = await updateCaseAutomaticBlock({
-      applicationContext,
-      caseEntity: updatedCase,
-    });
+    applicationContext,
+    caseEntity: updatedCase,
+    deadlines: deadlinesAfterDelete,
+  });
 
   const result = await applicationContext
     .getUseCaseHelpers()


### PR DESCRIPTION
Currently, when creating or deleting a case deadline, we immediately thereafter re-fetch the case deadlines as part of updateCaseAutomaticBlock. If we created/deleted the case deadline in the East and then are immediately reading from the West, the West might not yet have the update, which leads to the case not being properly blocked/unblocked.

This PR rectifies the issue by passing in data that results from create/delete rather than re-fetching.