### PR TITLE
10536: Fix messages jumping when clicking message complete checkbox;

### DIFF
--- a/cypress/local-only/tests/integration/messages/messages.cy.ts
+++ b/cypress/local-only/tests/integration/messages/messages.cy.ts
@@ -149,7 +149,7 @@ describe('Messages', () => {
           ).click();
           verifySubjectTitleOrder({
             boxType: 'inbox',
-            isAscending: false,
+            isAscending: true,
             prefix: 'Subject Line',
             queueType: 'individual',
           });
@@ -226,7 +226,7 @@ describe('Messages', () => {
           ).click();
           verifySubjectTitleOrder({
             boxType: 'completed',
-            isAscending: true,
+            isAscending: false,
             prefix: 'Complete',
             queueType: 'individual',
           });
@@ -373,7 +373,7 @@ describe('Messages', () => {
           ).click();
           verifySubjectTitleOrder({
             boxType: 'inbox',
-            isAscending: false,
+            isAscending: true,
             prefix: 'Subject Line',
           });
           cy.get(
@@ -455,7 +455,7 @@ describe('Messages', () => {
           ).click();
           verifySubjectTitleOrder({
             boxType: 'completed',
-            isAscending: true,
+            isAscending: false,
             prefix: 'Complete',
           });
         });
@@ -539,7 +539,7 @@ describe('Messages', () => {
           ).click();
           verifySubjectTitleOrder({
             boxType: 'outbox',
-            isAscending: true,
+            isAscending: false,
             prefix: 'Subject Line',
           });
         });

--- a/web-client/src/presenter/utilities/processFormattedMessages.test.ts
+++ b/web-client/src/presenter/utilities/processFormattedMessages.test.ts
@@ -232,7 +232,7 @@ describe('processFormattedMessages', () => {
       expect(result).toMatchObject(messages);
     });
 
-    it('should not mutate the original array and consistently sort the array', () => {
+    it('should sort correctly when sort runs twice with descending order', () => {
       const formattedCaseMessages = [
         { createdAt: '2025-02-14T18:13:48.341Z', docketNumber: '101-25' },
         { createdAt: '2020-08-18T18:07:36.333Z', docketNumber: '104-19' },
@@ -243,14 +243,14 @@ describe('processFormattedMessages', () => {
 
       const firstSort = sortFormattedMessages(formattedCaseMessages, {
         sortField: 'createdAt',
-        sortOrder: 'asc',
+        sortOrder: 'desc',
       });
 
       expect(formattedCaseMessages).toEqual(originalFormattedCaseMessages);
 
       const secondSort = sortFormattedMessages(formattedCaseMessages, {
         sortField: 'createdAt',
-        sortOrder: 'asc',
+        sortOrder: 'desc',
       });
 
       expect(secondSort).toEqual(firstSort);

--- a/web-client/src/presenter/utilities/processFormattedMessages.test.ts
+++ b/web-client/src/presenter/utilities/processFormattedMessages.test.ts
@@ -231,6 +231,30 @@ describe('processFormattedMessages', () => {
 
       expect(result).toMatchObject(messages);
     });
+
+    it('should not mutate the original array and consistently sort the array', () => {
+      const formattedCaseMessages = [
+        { createdAt: '2025-02-14T18:13:48.341Z', docketNumber: '101-25' },
+        { createdAt: '2020-08-18T18:07:36.333Z', docketNumber: '104-19' },
+        { createdAt: '2025-02-14T18:14:32.069Z', docketNumber: '101-25' },
+      ];
+
+      const originalFormattedCaseMessages = [...formattedCaseMessages];
+
+      const firstSort = sortFormattedMessages(formattedCaseMessages, {
+        sortField: 'createdAt',
+        sortOrder: 'asc',
+      });
+
+      expect(formattedCaseMessages).toEqual(originalFormattedCaseMessages);
+
+      const secondSort = sortFormattedMessages(formattedCaseMessages, {
+        sortField: 'createdAt',
+        sortOrder: 'asc',
+      });
+
+      expect(secondSort).toEqual(firstSort);
+    });
   });
 
   describe('sortCompletedMessages', () => {

--- a/web-client/src/presenter/utilities/processFormattedMessages.ts
+++ b/web-client/src/presenter/utilities/processFormattedMessages.ts
@@ -58,26 +58,8 @@ export const sortFormattedMessages = (
   );
 
   if (tableSort && tableSort.sortOrder === DESCENDING) {
-    return sortedFormattedMessages.reverse();
+    return [...sortedFormattedMessages].reverse();
   }
-  return sortedFormattedMessages;
-};
-
-export const sortCompletedMessages = (
-  sortedMessages,
-  tableSort: null | TableSort = null,
-) => {
-  const completedMessages = sortedMessages.filter(
-    message => message.isCompleted,
-  );
-
-  if (!tableSort) {
-    return completedMessages.sort((a, b) =>
-      b.completedAt.localeCompare(a.completedAt),
-    );
-  }
-
-  return completedMessages;
 };
 
 // useful for users that have a large amount of messages (ADC Users) since

--- a/web-client/src/presenter/utilities/processFormattedMessages.ts
+++ b/web-client/src/presenter/utilities/processFormattedMessages.ts
@@ -25,7 +25,7 @@ export const sortFormattedMessages = (
   formattedCaseMessages,
   tableSort: null | TableSort = null,
 ) => {
-  const sortedFormattedMessages = formattedCaseMessages.sort(
+  const sortedFormattedMessages = [...formattedCaseMessages].sort(
     (messageA, messageB) => {
       let sortNumber = 0;
 

--- a/web-client/src/presenter/utilities/processFormattedMessages.ts
+++ b/web-client/src/presenter/utilities/processFormattedMessages.ts
@@ -60,6 +60,24 @@ export const sortFormattedMessages = (
   if (tableSort && tableSort.sortOrder === DESCENDING) {
     return [...sortedFormattedMessages].reverse();
   }
+  return sortedFormattedMessages;
+};
+
+export const sortCompletedMessages = (
+  sortedMessages,
+  tableSort: null | TableSort = null,
+) => {
+  const completedMessages = sortedMessages.filter(
+    message => message.isCompleted,
+  );
+
+  if (!tableSort) {
+    return completedMessages.sort((a, b) =>
+      b.completedAt.localeCompare(a.completedAt),
+    );
+  }
+
+  return completedMessages;
 };
 
 // useful for users that have a large amount of messages (ADC Users) since


### PR DESCRIPTION
When sorting in descending order, the function first sorts the array and then reverses it using array.reverse(). When a checkbox is clicked, it triggers a state update and re-renders, which unexpectedly reverses the array again. Since array.reverse() mutates the original array, the order was already changed before the re-render. Cloning the array before reversing fixes this bug.
