### PR TITLE
USWDS: Fix alignment of ModalDialog buttons

### DIFF
--- a/web-client/src/views/ModalDialog.tsx
+++ b/web-client/src/views/ModalDialog.tsx
@@ -152,7 +152,7 @@ export const ModalDialog = ({
             {message && <p className={messageClass}>{message}</p>}
             {children}
             {showButtons && (
-              <div className="margin-top-5 button-container">
+              <div className="margin-top-5">
                 <Button
                   aria-label={`${confirmLabel} submit button`}
                   className="modal-button-confirm"


### PR DESCRIPTION
This PR removes a class from the div element containing buttons in the ModalDialog component so that the buttons are centered.