### PR TITLE
10502: add statusUpdateId primary key

### DIFF
--- a/shared/src/business/entities/cases/Case.ts
+++ b/shared/src/business/entities/cases/Case.ts
@@ -2568,6 +2568,7 @@ const generateCaptionFromContacts = ({
 };
 
 export type CaseStatusChange = {
+  statusUpdateId?: string; // db creates this if not set thus ensuring ability to insert duplicate status (which isn't ideal but possible)
   changedBy: string;
   date: string;
   updatedCaseStatus: string;

--- a/web-api/src/database-types.ts
+++ b/web-api/src/database-types.ts
@@ -227,7 +227,8 @@ export type NewPetitionerOnCaseKysely = Insertable<PetitionerOnCaseTable>;
 export type UpdatePetitionerOnCaseKysely = Updateable<PetitionerOnCaseTable>;
 
 export interface CaseStatusUpdateTable {
-  changedBy: string; // TODO: This should almost certainly be a foreign key to a user (with a user for System), but it isn't set up that way. Probably best to wait until Users are migrated over?
+  statusUpdateId: string;
+  changedBy: string;
   date: Date;
   docketNumber: string;
   updatedCaseStatus: string;

--- a/web-api/src/persistence/postgres/cases/mapper.ts
+++ b/web-api/src/persistence/postgres/cases/mapper.ts
@@ -72,6 +72,7 @@ export const DW_CASE_COLUMNS = [
 ];
 
 export const DW_CASE_STATUS_UPDATES_COLUMNS = [
+  'statusUpdateId',
   'changedBy',
   'date',
   'docketNumber',

--- a/web-api/src/persistence/postgres/cases/upsertCaseStatusUpdates.ts
+++ b/web-api/src/persistence/postgres/cases/upsertCaseStatusUpdates.ts
@@ -1,5 +1,6 @@
 import { CaseStatusChange } from '@shared/business/entities/cases/Case';
 import { calculateDate } from '@shared/business/utilities/DateHandler';
+import { getUniqueId } from '@shared/sharedAppContext';
 import { pgInsertInto } from '@web-api/persistence/postgres/utils/operation/pgInsertInto';
 
 export const upsertCaseStatusUpdates = async ({
@@ -12,11 +13,12 @@ export const upsertCaseStatusUpdates = async ({
   await pgInsertInto({
     table: 'dwCaseStatusUpdate',
     values: statusUpdates.map(s => ({
+      statusUpdateId: s.statusUpdateId ? s.statusUpdateId : getUniqueId(),
       changedBy: s.changedBy,
       date: calculateDate({ dateString: s.date }),
       docketNumber,
       updatedCaseStatus: s.updatedCaseStatus,
     })),
-    onConflictColumns: ['docketNumber', 'date'],
+    onConflictColumns: ['statusUpdateId'],
   });
 };

--- a/web-api/src/persistence/postgres/utils/migrate/migrations/0010-case-status-updates.ts
+++ b/web-api/src/persistence/postgres/utils/migrate/migrations/0010-case-status-updates.ts
@@ -3,11 +3,11 @@ import { Kysely } from 'kysely';
 export async function up(db: Kysely<any>): Promise<void> {
   await db.schema
     .createTable('dwCaseStatusUpdate')
+    .addColumn('statusUpdateId', 'varchar', col => col.primaryKey())
     .addColumn('changedBy', 'varchar')
     .addColumn('date', 'timestamptz')
     .addColumn('docketNumber', 'varchar')
     .addColumn('updatedCaseStatus', 'varchar')
-    .addPrimaryKeyConstraint('pkCaseStatusUpdate', ['docketNumber', 'date'])
     .execute();
 }
 

--- a/web-api/src/persistence/postgres/utils/seed/seed.ts
+++ b/web-api/src/persistence/postgres/utils/seed/seed.ts
@@ -21,6 +21,7 @@ import { statisticPenalties } from '@web-api/persistence/postgres/utils/seed/fix
 import { workItems } from './fixtures/workItems';
 import { upsertCases } from '@web-api/persistence/postgres/cases/upsertCases';
 import { calculateDate } from '@shared/business/utilities/DateHandler';
+import { getUniqueId } from '@shared/sharedAppContext';
 
 export const seed = async () => {
   const insertMessages = getDbWriter({
@@ -107,10 +108,11 @@ export const seed = async () => {
         .values(
           caseStatusUpdates.map(s => ({
             ...s,
+            statusUpdateId: s.statusUpdateId ? s.statusUpdateId : getUniqueId(),
             date: calculateDate({ dateString: s.date }),
           })),
         )
-        .onConflict(oc => oc.columns(['docketNumber', 'date']).doNothing())
+        .onConflict(oc => oc.columns(['statusUpdateId']).doNothing())
         .execute(),
     table: null,
   });


### PR DESCRIPTION
We assumed that [date, docketNumber] would be unique for case status updates. They are not. In this PR, we add a unique ID.