### PR TITLE
devex: update test case with hardcoded date

### DIFF
--- a/web-api/src/business/useCases/trialSessions/closeTrialSessionInteractor.test.ts
+++ b/web-api/src/business/useCases/trialSessions/closeTrialSessionInteractor.test.ts
@@ -121,18 +121,24 @@ describe('closeTrialSessionInteractor', () => {
       ...MOCK_TRIAL_REGULAR,
       caseOrder: undefined,
       sessionScope: TRIAL_SESSION_SCOPE_TYPES.standaloneRemote,
-      startDate: '2025-03-01T00:00:00.000Z',
+      startDate: FUTURE_DATE,
     };
 
-    await expect(
-      closeTrialSessionInteractor(
-        applicationContext,
-        {
-          trialSessionId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
-        },
-        mockDocketClerkUser,
-      ),
-    ).rejects.not.toThrow('Trial session cannot be closed with open cases');
+    const closeTrialSessionPromise = closeTrialSessionInteractor(
+      applicationContext,
+      {
+        trialSessionId: 'c54ba5a9-b37b-479d-9201-067ec6e335bb',
+      },
+      mockDocketClerkUser,
+    );
+
+    await expect(closeTrialSessionPromise).rejects.not.toThrow(
+      'Trial session cannot be closed with open cases',
+    );
+
+    await expect(closeTrialSessionPromise).rejects.toThrow(
+      'Trial session cannot be closed until after its start date',
+    );
   });
 
   it('should not close the trial session and throws an error instead', async () => {


### PR DESCRIPTION
This test case was failing because over the weekend March 1, 2025 became a date in the pass, not the future.

This test has been updated to use a date that will remain in the future for the duration of DAWSON's lifecycle. It also now explicitly expects the particular exception that the function under test should throw under these conditions--the previous arrangement of the test case only implied this outcome.