### PR TITLE
Fix broken import in test

### DIFF
--- a/cypress/local-only/tests/integration/trialSessionMinutes/create-and-print-minute-sheet.cy.ts
+++ b/cypress/local-only/tests/integration/trialSessionMinutes/create-and-print-minute-sheet.cy.ts
@@ -6,10 +6,7 @@ import {
 import { createAndServePaperPetition } from 'cypress/helpers/fileAPetition/create-and-serve-paper-petition';
 import { createTrialSession } from 'cypress/helpers/trialSession/create-trial-session';
 import { updateCaseStatus } from 'cypress/helpers/caseDetail/caseInformation/update-case-status';
-import {
-  getCaseDetailTab,
-  navigateTo as navigateToCaseDetail,
-} from '../../../support/pages/case-detail';
+import { getCaseDetailTab } from '../../../support/pages/case-detail';
 import { selectTypeaheadInput } from 'cypress/helpers/components/typeAhead/select-typeahead-input';
 import { attachFile } from 'cypress/helpers/file/upload-file';
 import { goToCase } from 'cypress/helpers/caseDetail/go-to-case';
@@ -20,7 +17,7 @@ describe('Create a minute sheet, fill out sections of the form, navigate away an
     createAndServePaperPetition({ trialLocation: 'Birmingham, Alabama' }).then(
       ({ docketNumber }) => {
         loginAsIrsPractitioner();
-        navigateToCaseDetail('irspractitioner', docketNumber);
+        cy.visit(`case-detail/${docketNumber}`);
         getCaseDetailTab('case-information').click();
 
         cy.get('[data-testid="button-first-irs-document"]').click();


### PR DESCRIPTION
We removed `navigateToCaseDetail` from [here](https://github.com/ustaxcourt/ef-cms/blob/test/cypress/local-only/support/pages/case-detail.ts) in staging but were still trying to import it in test [here](https://github.com/ustaxcourt/ef-cms/blob/test/cypress/local-only/tests/integration/trialSessionMinutes/create-and-print-minute-sheet.cy.ts).