### PR TITLE
Devex: Add Migrate Postgres Data Schema action to config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -765,6 +765,10 @@ jobs:
           command: |
             COLOR="$CURRENT_COLOR" JOB_NAME="wait-for-glued-data-to-index" ./scripts/migration/set-migration-complete-marker.sh
       - run:
+          name: Migrate Postgres Data Schema
+          command: |
+            npm run migration:postgres
+      - run:
           name: Enable Dynamodb Streams
           command: |
             ./scripts/migration/toggle-streams.sh --on


### PR DESCRIPTION
We "hook into" the reindexing step of our workflows to get data into postgres. During a glue job, the schema our app code in test expects might differ from the schema that comes from production, so we run a schema migration before re-indexing.