### PR TITLE
10502: Some query optimization

### DIFF
--- a/web-api/src/business/useCaseHelper/caseAssociation/createCaseAndAssociations.ts
+++ b/web-api/src/business/useCaseHelper/caseAssociation/createCaseAndAssociations.ts
@@ -24,7 +24,7 @@ const createCaseDocketEntries = ({
   applicationContext: ServerApplicationContext;
   authorizedUser: AuthUser;
   docketEntries: any;
-  docketNumber: any;
+  docketNumber: string;
   petitioners: any;
 }) => {
   const validDocketEntries = DocketEntry.validateRawCollection(docketEntries, {

--- a/web-api/src/business/useCases/createCaseFromPaperInteractor.ts
+++ b/web-api/src/business/useCases/createCaseFromPaperInteractor.ts
@@ -151,6 +151,12 @@ const createCaseMetadata = async (
 
   petitionDocketEntryEntity.setFiledBy(user);
 
+  const { workItem: newWorkItem } = addPetitionDocketEntryWithWorkItemToCase({
+    caseToAdd,
+    docketEntryEntity: petitionDocketEntryEntity,
+    user,
+  });
+
   if (applicationForWaiverOfFilingFeeFileId) {
     const { documentTitle } =
       INITIAL_DOCUMENT_TYPES.applicationForWaiverOfFilingFee;
@@ -277,12 +283,6 @@ const createCaseMetadata = async (
 
     caseToAdd.addDocketEntry(atpDocketEntryEntity);
   }
-
-  const { workItem: newWorkItem } = addPetitionDocketEntryWithWorkItemToCase({
-    caseToAdd,
-    docketEntryEntity: petitionDocketEntryEntity,
-    user,
-  });
 
   await applicationContext.getUseCaseHelpers().createCaseAndAssociations({
     applicationContext,

--- a/web-api/src/business/useCases/createCaseFromPaperInteractor.ts
+++ b/web-api/src/business/useCases/createCaseFromPaperInteractor.ts
@@ -13,7 +13,10 @@ import {
 import { RawUser } from '@shared/business/entities/User';
 import { ServerApplicationContext } from '@web-api/applicationContext';
 import { UnauthorizedError } from '@web-api/errors/errors';
-import { UnknownAuthUser } from '@shared/business/entities/authUser/AuthUser';
+import {
+  AuthUser,
+  UnknownAuthUser,
+} from '@shared/business/entities/authUser/AuthUser';
 import { RawWorkItem, WorkItem } from '@shared/business/entities/WorkItem';
 import { createPetitionersOnCase } from '@web-api/persistence/postgres/cases/parties/createPetitionersOnCase';
 import { createCaseStatistic } from '@web-api/persistence/postgres/cases/statistics/createCaseStatistic';
@@ -21,6 +24,11 @@ import { generateDocketNumber } from '@web-api/persistence/postgres/cases/genera
 import { replaceBracketed } from '@shared/business/utilities/replaceBracketed';
 import { setServiceIndicatorsForPetitionersOnCase } from '@shared/business/utilities/setServiceIndicatorsForPetitionersOnCase';
 import { upsertWorkItems } from '@web-api/persistence/postgres/workitems/upsertWorkItems';
+import { UserRecord } from '@web-api/persistence/dynamo/dynamoTypes';
+import {
+  CREATE_CASE_LOCK,
+  mutexLockWrapper,
+} from '@web-api/persistence/postgres/utils/mutex';
 
 const addPetitionDocketEntryWithWorkItemToCase = ({
   caseToAdd,
@@ -67,7 +75,7 @@ const addPetitionDocketEntryWithWorkItemToCase = ({
   };
 };
 
-export const createCaseFromPaperInteractor = async (
+const createCaseMetadata = async (
   applicationContext: ServerApplicationContext,
   {
     applicationForWaiverOfFilingFeeFileId,
@@ -77,6 +85,7 @@ export const createCaseFromPaperInteractor = async (
     petitionMetadata,
     requestForPlaceOfTrialFileId,
     stinFileId,
+    user,
   }: {
     applicationForWaiverOfFilingFeeFileId?: string;
     attachmentToPetitionFileId?: string;
@@ -85,17 +94,10 @@ export const createCaseFromPaperInteractor = async (
     petitionMetadata: CreatedCaseType;
     requestForPlaceOfTrialFileId?: string;
     stinFileId?: string;
+    user: UserRecord;
   },
-  authorizedUser: UnknownAuthUser,
-): Promise<{ caseDetail: RawCase; workItem: RawWorkItem }> => {
-  if (!isAuthorized(authorizedUser, ROLE_PERMISSIONS.START_PAPER_CASE)) {
-    throw new UnauthorizedError('Unauthorized');
-  }
-
-  const user = await applicationContext
-    .getPersistenceGateway()
-    .getUserById({ applicationContext, userId: authorizedUser.userId });
-
+  authorizedUser: AuthUser,
+) => {
   const petitionEntity = new PaperPetition(petitionMetadata, {
     authorizedUser,
   }).validate();
@@ -148,12 +150,6 @@ export const createCaseFromPaperInteractor = async (
   );
 
   petitionDocketEntryEntity.setFiledBy(user);
-
-  const { workItem: newWorkItem } = addPetitionDocketEntryWithWorkItemToCase({
-    caseToAdd,
-    docketEntryEntity: petitionDocketEntryEntity,
-    user,
-  });
 
   if (applicationForWaiverOfFilingFeeFileId) {
     const { documentTitle } =
@@ -288,6 +284,58 @@ export const createCaseFromPaperInteractor = async (
     caseToCreate: caseToAdd.validate().toRawObject(),
   });
 
+  return { caseToAdd, petitionDocketEntryEntity };
+};
+
+export const createCaseFromPaperInteractor = async (
+  applicationContext: ServerApplicationContext,
+  {
+    applicationForWaiverOfFilingFeeFileId,
+    attachmentToPetitionFileId,
+    corporateDisclosureFileId,
+    petitionFileId,
+    petitionMetadata,
+    requestForPlaceOfTrialFileId,
+    stinFileId,
+  }: {
+    applicationForWaiverOfFilingFeeFileId?: string;
+    attachmentToPetitionFileId?: string;
+    corporateDisclosureFileId?: string;
+    petitionFileId: string;
+    petitionMetadata: CreatedCaseType;
+    requestForPlaceOfTrialFileId?: string;
+    stinFileId?: string;
+  },
+  authorizedUser: UnknownAuthUser,
+): Promise<{ caseDetail: RawCase; workItem: RawWorkItem }> => {
+  if (!isAuthorized(authorizedUser, ROLE_PERMISSIONS.START_PAPER_CASE)) {
+    throw new UnauthorizedError('Unauthorized');
+  }
+
+  const user = await applicationContext
+    .getPersistenceGateway()
+    .getUserById({ applicationContext, userId: authorizedUser.userId });
+
+  const { caseToAdd, petitionDocketEntryEntity } = await mutexLockWrapper({
+    lockId: CREATE_CASE_LOCK,
+    callback: async () => {
+      return await createCaseMetadata(
+        applicationContext,
+        {
+          applicationForWaiverOfFilingFeeFileId,
+          attachmentToPetitionFileId,
+          corporateDisclosureFileId,
+          petitionFileId,
+          petitionMetadata,
+          requestForPlaceOfTrialFileId,
+          stinFileId,
+          user,
+        },
+        authorizedUser,
+      );
+    },
+  });
+
   setServiceIndicatorsForPetitionersOnCase(caseToAdd);
 
   await createPetitionersOnCase({
@@ -299,6 +347,11 @@ export const createCaseFromPaperInteractor = async (
     createCaseStatistic({ docketNumber: caseToAdd.docketNumber, statistic }),
   );
 
+  const { workItem: newWorkItem } = addPetitionDocketEntryWithWorkItemToCase({
+    caseToAdd,
+    docketEntryEntity: petitionDocketEntryEntity,
+    user,
+  });
   await upsertWorkItems({
     workItems: [newWorkItem.validate().toRawObject()],
   });

--- a/web-api/src/business/useCases/createCaseFromPaperInteractor.ts
+++ b/web-api/src/business/useCases/createCaseFromPaperInteractor.ts
@@ -278,13 +278,19 @@ const createCaseMetadata = async (
     caseToAdd.addDocketEntry(atpDocketEntryEntity);
   }
 
+  const { workItem: newWorkItem } = addPetitionDocketEntryWithWorkItemToCase({
+    caseToAdd,
+    docketEntryEntity: petitionDocketEntryEntity,
+    user,
+  });
+
   await applicationContext.getUseCaseHelpers().createCaseAndAssociations({
     applicationContext,
     authorizedUser,
     caseToCreate: caseToAdd.validate().toRawObject(),
   });
 
-  return { caseToAdd, petitionDocketEntryEntity };
+  return { caseToAdd, workItem: newWorkItem };
 };
 
 export const createCaseFromPaperInteractor = async (
@@ -316,7 +322,7 @@ export const createCaseFromPaperInteractor = async (
     .getPersistenceGateway()
     .getUserById({ applicationContext, userId: authorizedUser.userId });
 
-  const { caseToAdd, petitionDocketEntryEntity } = await mutexLockWrapper({
+  const { caseToAdd, workItem } = await mutexLockWrapper({
     lockId: CREATE_CASE_LOCK,
     callback: async () => {
       return await createCaseMetadata(
@@ -347,17 +353,12 @@ export const createCaseFromPaperInteractor = async (
     createCaseStatistic({ docketNumber: caseToAdd.docketNumber, statistic }),
   );
 
-  const { workItem: newWorkItem } = addPetitionDocketEntryWithWorkItemToCase({
-    caseToAdd,
-    docketEntryEntity: petitionDocketEntryEntity,
-    user,
-  });
   await upsertWorkItems({
-    workItems: [newWorkItem.validate().toRawObject()],
+    workItems: [workItem.validate().toRawObject()],
   });
 
   return {
     caseDetail: new Case(caseToAdd, { authorizedUser }).toRawObject(),
-    workItem: newWorkItem.validate().toRawObject(),
+    workItem: workItem.validate().toRawObject(),
   };
 };

--- a/web-api/src/business/useCases/createCaseInteractor.ts
+++ b/web-api/src/business/useCases/createCaseInteractor.ts
@@ -276,13 +276,19 @@ const createCaseMetadata = async (
     });
   }
 
+  const newWorkItem = addPetitionDocketEntryToCase({
+    caseToAdd,
+    docketEntryEntity: petitionDocketEntryEntity,
+    user,
+  });
+
   await applicationContext.getUseCaseHelpers().createCaseAndAssociations({
     applicationContext,
     authorizedUser,
     caseToCreate: caseToAdd.validate().toRawObject(),
   });
 
-  return { caseToAdd, petitionDocketEntryEntity };
+  return { caseToAdd, workItem: newWorkItem };
 };
 
 export const createCaseInteractor = async (
@@ -310,7 +316,7 @@ export const createCaseInteractor = async (
     .getPersistenceGateway()
     .getUserById({ applicationContext, userId: authorizedUser.userId });
 
-  const { caseToAdd, petitionDocketEntryEntity } = await mutexLockWrapper({
+  const { caseToAdd, workItem } = await mutexLockWrapper({
     lockId: CREATE_CASE_LOCK,
     callback: async () => {
       return await createCaseMetadata(
@@ -346,13 +352,8 @@ export const createCaseInteractor = async (
     userId: user.userId,
   });
 
-  const newWorkItem = addPetitionDocketEntryToCase({
-    caseToAdd,
-    docketEntryEntity: petitionDocketEntryEntity,
-    user,
-  });
   await upsertWorkItems({
-    workItems: [newWorkItem.validate().toRawObject()],
+    workItems: [workItem.validate().toRawObject()],
   });
 
   applicationContext.logger.info('filed a new petition', {

--- a/web-api/src/business/useCases/createCaseInteractor.ts
+++ b/web-api/src/business/useCases/createCaseInteractor.ts
@@ -14,7 +14,10 @@ import {
 } from '@shared/authorization/authorizationClientService';
 import { ServerApplicationContext } from '@web-api/applicationContext';
 import { UnauthorizedError } from '@web-api/errors/errors';
-import { UnknownAuthUser } from '@shared/business/entities/authUser/AuthUser';
+import {
+  AuthUser,
+  UnknownAuthUser,
+} from '@shared/business/entities/authUser/AuthUser';
 import { UserCase } from '@shared/business/entities/UserCase';
 import { UserRecord } from '@web-api/persistence/dynamo/dynamoTypes';
 import { WorkItem } from '@shared/business/entities/WorkItem';
@@ -23,6 +26,10 @@ import { createCaseStatistic } from '@web-api/persistence/postgres/cases/statist
 import { generateDocketNumber } from '@web-api/persistence/postgres/cases/generateDocketNumber';
 import { setServiceIndicatorsForPetitionersOnCase } from '@shared/business/utilities/setServiceIndicatorsForPetitionersOnCase';
 import { upsertWorkItems } from '@web-api/persistence/postgres/workitems/upsertWorkItems';
+import {
+  CREATE_CASE_LOCK,
+  mutexLockWrapper,
+} from '@web-api/persistence/postgres/utils/mutex';
 
 export type ElectronicCreatedCaseType = Omit<CreatedCaseType, 'trialCitiies'>;
 
@@ -61,7 +68,7 @@ const addPetitionDocketEntryToCase = ({
   return workItemEntity;
 };
 
-export const createCaseInteractor = async (
+const createCaseMetadata = async (
   applicationContext: ServerApplicationContext,
   {
     attachmentToPetitionFileIds,
@@ -69,26 +76,18 @@ export const createCaseInteractor = async (
     petitionFileId,
     petitionMetadata,
     stinFileId,
+    user,
   }: {
     attachmentToPetitionFileIds?: string[];
     corporateDisclosureFileId?: string;
     petitionFileId: string;
     petitionMetadata: any;
     stinFileId: string;
+    user: UserRecord;
   },
-  authorizedUser: UnknownAuthUser,
+  authorizedUser: AuthUser,
 ) => {
-  if (!isAuthorized(authorizedUser, ROLE_PERMISSIONS.PETITION)) {
-    throw new UnauthorizedError('Unauthorized');
-  }
-
-  const user = await applicationContext
-    .getPersistenceGateway()
-    .getUserById({ applicationContext, userId: authorizedUser.userId });
-
   const petitionEntity = new ElectronicPetition(petitionMetadata).validate();
-
-  const docketNumber = await generateDocketNumber({});
 
   let privatePractitioners: UserRecord[] = [];
   if (user.role === ROLES.privatePractitioner) {
@@ -120,6 +119,8 @@ export const createCaseInteractor = async (
 
     privatePractitioners = [practitionerUser];
   }
+
+  const docketNumber = await generateDocketNumber({});
 
   const caseToAdd = new Case(
     {
@@ -172,12 +173,6 @@ export const createCaseInteractor = async (
   );
 
   petitionDocketEntryEntity.setFiledBy(user);
-
-  const newWorkItem = addPetitionDocketEntryToCase({
-    caseToAdd,
-    docketEntryEntity: petitionDocketEntryEntity,
-    user,
-  });
 
   const requestPlaceOfTrialDocketEntry = new DocketEntry(
     {
@@ -287,6 +282,52 @@ export const createCaseInteractor = async (
     caseToCreate: caseToAdd.validate().toRawObject(),
   });
 
+  return { caseToAdd, petitionDocketEntryEntity };
+};
+
+export const createCaseInteractor = async (
+  applicationContext: ServerApplicationContext,
+  {
+    attachmentToPetitionFileIds,
+    corporateDisclosureFileId,
+    petitionFileId,
+    petitionMetadata,
+    stinFileId,
+  }: {
+    attachmentToPetitionFileIds?: string[];
+    corporateDisclosureFileId?: string;
+    petitionFileId: string;
+    petitionMetadata: any;
+    stinFileId: string;
+  },
+  authorizedUser: UnknownAuthUser,
+) => {
+  if (!isAuthorized(authorizedUser, ROLE_PERMISSIONS.PETITION)) {
+    throw new UnauthorizedError('Unauthorized');
+  }
+
+  const user = await applicationContext
+    .getPersistenceGateway()
+    .getUserById({ applicationContext, userId: authorizedUser.userId });
+
+  const { caseToAdd, petitionDocketEntryEntity } = await mutexLockWrapper({
+    lockId: CREATE_CASE_LOCK,
+    callback: async () => {
+      return await createCaseMetadata(
+        applicationContext,
+        {
+          attachmentToPetitionFileIds,
+          corporateDisclosureFileId,
+          petitionFileId,
+          petitionMetadata,
+          stinFileId,
+          user,
+        },
+        authorizedUser,
+      );
+    },
+  });
+
   await createPetitionersOnCase({
     docketNumber: caseToAdd.docketNumber,
     petitioners: caseToAdd.petitioners.map(p => new Petitioner(p)),
@@ -305,6 +346,11 @@ export const createCaseInteractor = async (
     userId: user.userId,
   });
 
+  const newWorkItem = addPetitionDocketEntryToCase({
+    caseToAdd,
+    docketEntryEntity: petitionDocketEntryEntity,
+    user,
+  });
   await upsertWorkItems({
     workItems: [newWorkItem.validate().toRawObject()],
   });

--- a/web-api/src/business/useCases/createCaseInteractor.ts
+++ b/web-api/src/business/useCases/createCaseInteractor.ts
@@ -174,6 +174,12 @@ const createCaseMetadata = async (
 
   petitionDocketEntryEntity.setFiledBy(user);
 
+  const newWorkItem = addPetitionDocketEntryToCase({
+    caseToAdd,
+    docketEntryEntity: petitionDocketEntryEntity,
+    user,
+  });
+
   const requestPlaceOfTrialDocketEntry = new DocketEntry(
     {
       documentTitle: `Request for Place of Trial at ${caseToAdd.preferredTrialCity}`,
@@ -275,12 +281,6 @@ const createCaseMetadata = async (
       caseToAdd.addDocketEntry(atpDocketEntryEntity);
     });
   }
-
-  const newWorkItem = addPetitionDocketEntryToCase({
-    caseToAdd,
-    docketEntryEntity: petitionDocketEntryEntity,
-    user,
-  });
 
   await applicationContext.getUseCaseHelpers().createCaseAndAssociations({
     applicationContext,

--- a/web-api/src/persistence/postgres/caseCorrespondences/getCaseCorrespondenceByDocketNumber.ts
+++ b/web-api/src/persistence/postgres/caseCorrespondences/getCaseCorrespondenceByDocketNumber.ts
@@ -10,7 +10,6 @@ export const getCaseCorrespondenceByDocketNumber = async ({
   const correspondence = await getDbReader(reader =>
     reader
       .selectFrom('dwCaseCorrespondence as cc')
-      .leftJoin('dwCase as c', 'c.docketNumber', 'cc.docketNumber')
       .where('cc.docketNumber', '=', docketNumber)
       .selectAll()
       .select('cc.docketNumber')

--- a/web-api/src/persistence/postgres/caseDeadlines/getCaseDeadlinesByConsolidatedCaseDeadlineId.ts
+++ b/web-api/src/persistence/postgres/caseDeadlines/getCaseDeadlinesByConsolidatedCaseDeadlineId.ts
@@ -10,7 +10,13 @@ export const getCaseDeadlinesByConsolidatedCaseDeadlineId = async (
     const query = reader
       .selectFrom('dwCaseDeadline as cd')
       .innerJoin('dwCase as c', 'c.docketNumber', 'cd.docketNumber')
-      .selectAll()
+      .selectAll('cd')
+      .select([
+        'c.associatedJudge',
+        'c.associatedJudgeId',
+        'c.leadDocketNumber',
+        // TODO: use c.sortableDocketNumber and remove from caseDeadline
+      ])
       .where('cd.consolidatedCaseDeadlineId', '=', consolidatedCaseDeadlineId);
 
     if (!leadDocketNumber) return query.execute();

--- a/web-api/src/persistence/postgres/caseDeadlines/getCaseDeadlinesByDateRange.ts
+++ b/web-api/src/persistence/postgres/caseDeadlines/getCaseDeadlinesByDateRange.ts
@@ -19,8 +19,13 @@ export const getCaseDeadlinesByDateRange = async ({
       let deadlineQuery = reader
         .selectFrom('dwCaseDeadline as cd')
         .leftJoin('dwCase as c', 'c.docketNumber', 'cd.docketNumber')
-        .selectAll()
-        .select('cd.docketNumber')
+        .selectAll('cd')
+        .select([
+          'c.associatedJudge',
+          'c.associatedJudgeId',
+          'c.leadDocketNumber',
+          // TODO: use c.sortableDocketNumber and remove from caseDeadline
+        ])
         .where('cd.deadlineDate', '>=', startDate)
         .where('cd.deadlineDate', '<=', endDate);
 

--- a/web-api/src/persistence/postgres/caseDeadlines/getCaseDeadlinesByDocketNumber.ts
+++ b/web-api/src/persistence/postgres/caseDeadlines/getCaseDeadlinesByDocketNumber.ts
@@ -11,8 +11,13 @@ export const getCaseDeadlinesByDocketNumber = async ({
       .selectFrom('dwCaseDeadline as cd')
       .leftJoin('dwCase as c', 'c.docketNumber', 'cd.docketNumber')
       .where('cd.docketNumber', '=', docketNumber)
-      .selectAll()
-      .select('cd.docketNumber')
+      .selectAll('cd')
+      .select([
+        'c.associatedJudge',
+        'c.associatedJudgeId',
+        'c.leadDocketNumber',
+        // TODO: use c.sortableDocketNumber and remove from caseDeadline
+      ])
       .execute(),
   );
 

--- a/web-api/src/persistence/postgres/cases/generateDocketNumber.ts
+++ b/web-api/src/persistence/postgres/cases/generateDocketNumber.ts
@@ -4,9 +4,7 @@ import {
   formatNow,
   getMonthDayYearInETObj,
 } from '@shared/business/utilities/DateHandler';
-import { getCaseMetadataByDocketNumber } from '@web-api/persistence/postgres/cases/getCaseMetadataByDocketNumber';
 import { getDbWriter } from '@web-api/database';
-import { getLogger } from '@web-api/utilities/logger/getLogger';
 
 const incrementCounter = async (year: string): Promise<number> => {
   if (!year) {
@@ -39,8 +37,7 @@ export const getNextDocketNumber = async ({ year }: { year: string }) => {
   return `${id}-${twoDigitYear}`;
 };
 
-export const MAX_ATTEMPTS = 5;
-
+// Note that this DOES NOT handle concurrency for free, so it should be used within the context of a mutex lock or something similar.
 export const generateDocketNumber = async ({
   receivedAt,
 }: {
@@ -50,32 +47,5 @@ export const generateDocketNumber = async ({
     ? formatDateString(receivedAt, FORMATS.YEAR)
     : formatNow(FORMATS.YEAR);
 
-  let attempt = 0;
-  let nextDocketNumber;
-
-  const docketNumber = await (async () => {
-    while (attempt < MAX_ATTEMPTS) {
-      nextDocketNumber = await getNextDocketNumber({
-        year,
-      });
-
-      const existingCase = await getCaseMetadataByDocketNumber({
-        docketNumber: nextDocketNumber,
-      });
-      if (!existingCase) {
-        return nextDocketNumber;
-      }
-
-      attempt++;
-    }
-  })();
-
-  if (docketNumber) {
-    return docketNumber;
-  } else {
-    // be sure case with this docket number doesn't already exist -- if it does, stop!
-    const message = `${nextDocketNumber}: docket number already exists!`;
-    getLogger().error(message, nextDocketNumber);
-    throw new Error(message);
-  }
+  return getNextDocketNumber({ year });
 };

--- a/web-api/src/persistence/postgres/cases/getCasesByLeadDocketNumber.ts
+++ b/web-api/src/persistence/postgres/cases/getCasesByLeadDocketNumber.ts
@@ -9,16 +9,16 @@ export const getCasesByLeadDocketNumber = async ({
   applicationContext: ServerApplicationContext;
   leadDocketNumber: string;
 }): Promise<RawCase[]> => {
-  const dbCases = await getDbReader(reader =>
+  const dbCaseData = await getDbReader(reader =>
     reader
       .selectFrom('dwCase')
       .where('leadDocketNumber', '=', leadDocketNumber)
-      .selectAll()
+      .select('docketNumber')
       .execute(),
   );
 
   const cases = await Promise.all(
-    dbCases.map(({ docketNumber }) =>
+    dbCaseData.map(({ docketNumber }) =>
       getCaseByDocketNumber({
         applicationContext,
         docketNumber,

--- a/web-api/src/persistence/postgres/cases/getCasesMetadataWithCounselByLeadDocketNumber.ts
+++ b/web-api/src/persistence/postgres/cases/getCasesMetadataWithCounselByLeadDocketNumber.ts
@@ -9,16 +9,16 @@ export const getCasesMetadataWithCounselByLeadDocketNumber = async ({
   applicationContext: ServerApplicationContext;
   leadDocketNumber: string;
 }): Promise<RawCase[]> => {
-  const dbCases = await getDbReader(reader =>
+  const dbCaseData = await getDbReader(reader =>
     reader
       .selectFrom('dwCase')
       .where('leadDocketNumber', '=', leadDocketNumber)
-      .selectAll()
+      .select('docketNumber')
       .execute(),
   );
 
   const cases = await Promise.all(
-    dbCases.map(({ docketNumber }) =>
+    dbCaseData.map(({ docketNumber }) =>
       getCaseMetadataWithCounsel({
         applicationContext,
         docketNumber,

--- a/web-api/src/persistence/postgres/cases/mocks.jest.ts
+++ b/web-api/src/persistence/postgres/cases/mocks.jest.ts
@@ -156,3 +156,12 @@ jest.mock(
   '@web-api/persistence/postgres/cases/statistics/updateCaseStatistic',
   () => mockFactory('updateCaseStatistic'),
 );
+
+// Mutex
+
+jest.mock('@web-api/persistence/postgres/utils/mutex', () => ({
+  mutexLockWrapper: jest.fn().mockImplementation(async ({ _, callback }) => {
+    console.debug(`mutexLockWrapper was not implemented, using default mock`);
+    return await callback();
+  }),
+}));

--- a/web-api/src/persistence/postgres/messages/getCompletedSectionInboxMessages.ts
+++ b/web-api/src/persistence/postgres/messages/getCompletedSectionInboxMessages.ts
@@ -17,8 +17,15 @@ export const getCompletedSectionInboxMessages = async ({
       .where('m.completedBySection', '=', section)
       .where('m.isCompleted', '=', true)
       .where('m.createdAt', '>=', filterDate)
-      .selectAll()
-      .select(['m.docketNumber', 'm.createdAt'])
+      .selectAll('m')
+      .select([
+        'c.status',
+        'c.trialDate',
+        'c.trialLocation',
+        'c.docketNumberSuffix',
+        'c.leadDocketNumber',
+        'c.caption',
+      ])
       .limit(5000)
       .execute(),
   );

--- a/web-api/src/persistence/postgres/messages/getCompletedUserInboxMessages.ts
+++ b/web-api/src/persistence/postgres/messages/getCompletedUserInboxMessages.ts
@@ -17,8 +17,15 @@ export const getCompletedUserInboxMessages = async ({
       .where('m.completedByUserId', '=', userId)
       .where('m.isCompleted', '=', true)
       .where('m.completedAt', '>=', filterDate)
-      .selectAll()
-      .select(['m.docketNumber', 'm.createdAt'])
+      .selectAll('m')
+      .select([
+        'c.status',
+        'c.trialDate',
+        'c.trialLocation',
+        'c.docketNumberSuffix',
+        'c.leadDocketNumber',
+        'c.caption',
+      ])
       .limit(5000)
       .execute(),
   );

--- a/web-api/src/persistence/postgres/messages/getMessageById.ts
+++ b/web-api/src/persistence/postgres/messages/getMessageById.ts
@@ -12,8 +12,15 @@ export const getMessageById = async ({
       .selectFrom('dwMessage as m')
       .leftJoin('dwCase as c', 'c.docketNumber', 'm.docketNumber')
       .where('messageId', '=', messageId)
-      .selectAll()
-      .select(['m.docketNumber', 'm.createdAt'])
+      .selectAll('m')
+      .select([
+        'c.status',
+        'c.trialDate',
+        'c.trialLocation',
+        'c.docketNumberSuffix',
+        'c.leadDocketNumber',
+        'c.caption',
+      ])
       .executeTakeFirst(),
   );
 

--- a/web-api/src/persistence/postgres/messages/getMessageThreadByParentId.ts
+++ b/web-api/src/persistence/postgres/messages/getMessageThreadByParentId.ts
@@ -12,8 +12,15 @@ export const getMessageThreadByParentId = async ({
       .selectFrom('dwMessage as m')
       .leftJoin('dwCase as c', 'c.docketNumber', 'm.docketNumber')
       .where('m.parentMessageId', '=', parentMessageId)
-      .selectAll()
-      .select(['m.docketNumber', 'm.createdAt'])
+      .selectAll('m')
+      .select([
+        'c.status',
+        'c.trialDate',
+        'c.trialLocation',
+        'c.docketNumberSuffix',
+        'c.leadDocketNumber',
+        'c.caption',
+      ])
       .execute(),
   );
 

--- a/web-api/src/persistence/postgres/messages/getMessagesByDocketNumber.ts
+++ b/web-api/src/persistence/postgres/messages/getMessagesByDocketNumber.ts
@@ -12,8 +12,15 @@ export const getMessagesByDocketNumber = async ({
       .selectFrom('dwMessage as m')
       .leftJoin('dwCase as c', 'c.docketNumber', 'm.docketNumber')
       .where('m.docketNumber', '=', docketNumber)
-      .selectAll()
-      .select(['m.docketNumber', 'm.createdAt'])
+      .selectAll('m')
+      .select([
+        'c.status',
+        'c.trialDate',
+        'c.trialLocation',
+        'c.docketNumberSuffix',
+        'c.leadDocketNumber',
+        'c.caption',
+      ])
       .execute(),
   );
 

--- a/web-api/src/persistence/postgres/messages/getSectionInboxMessages.ts
+++ b/web-api/src/persistence/postgres/messages/getSectionInboxMessages.ts
@@ -15,8 +15,15 @@ export const getSectionInboxMessages = async ({
       .where('m.toSection', '=', section)
       .where('m.isRepliedTo', '=', false)
       .where('m.isCompleted', '=', false)
-      .selectAll()
-      .select(['m.docketNumber', 'm.createdAt'])
+      .selectAll('m')
+      .select([
+        'c.status',
+        'c.trialDate',
+        'c.trialLocation',
+        'c.docketNumberSuffix',
+        'c.leadDocketNumber',
+        'c.caption',
+      ])
       .limit(5000)
       .execute(),
   );

--- a/web-api/src/persistence/postgres/messages/getSectionOutboxMessages.ts
+++ b/web-api/src/persistence/postgres/messages/getSectionOutboxMessages.ts
@@ -17,8 +17,15 @@ export const getSectionOutboxMessages = async ({
       .leftJoin('dwCase as c', 'c.docketNumber', 'm.docketNumber')
       .where('m.fromSection', '=', section)
       .where('m.createdAt', '>=', filterDate)
-      .selectAll()
-      .select(['m.docketNumber', 'm.createdAt'])
+      .selectAll('m')
+      .select([
+        'c.status',
+        'c.trialDate',
+        'c.trialLocation',
+        'c.docketNumberSuffix',
+        'c.leadDocketNumber',
+        'c.caption',
+      ])
       .execute(),
   );
 

--- a/web-api/src/persistence/postgres/messages/getUserInboxMessages.ts
+++ b/web-api/src/persistence/postgres/messages/getUserInboxMessages.ts
@@ -15,8 +15,15 @@ export const getUserInboxMessages = async ({
       .where('m.isCompleted', '=', false)
       .where('m.isRepliedTo', '=', false)
       .where('m.toUserId', '=', userId)
-      .selectAll()
-      .select(['m.docketNumber', 'm.createdAt'])
+      .selectAll('m')
+      .select([
+        'c.status',
+        'c.trialDate',
+        'c.trialLocation',
+        'c.docketNumberSuffix',
+        'c.leadDocketNumber',
+        'c.caption',
+      ])
       .execute(),
   );
 

--- a/web-api/src/persistence/postgres/messages/getUserOutboxMessages.ts
+++ b/web-api/src/persistence/postgres/messages/getUserOutboxMessages.ts
@@ -16,8 +16,15 @@ export const getUserOutboxMessages = async ({
       .leftJoin('dwCase as c', 'c.docketNumber', 'm.docketNumber')
       .where('m.fromUserId', '=', userId)
       .where('m.createdAt', '>=', filterDate)
-      .selectAll()
-      .select(['m.docketNumber', 'm.createdAt'])
+      .selectAll('m')
+      .select([
+        'c.status',
+        'c.trialDate',
+        'c.trialLocation',
+        'c.docketNumberSuffix',
+        'c.leadDocketNumber',
+        'c.caption',
+      ])
       .limit(5000)
       .execute(),
   );

--- a/web-api/src/persistence/postgres/utils/mutex.ts
+++ b/web-api/src/persistence/postgres/utils/mutex.ts
@@ -1,0 +1,75 @@
+import { getDbWriter } from '@web-api/database';
+import { CompiledQuery } from 'kysely';
+
+export const CREATE_CASE_LOCK = 112358;
+
+const MUTEX_NUM_ATTEMPTS = 5;
+const RETRY_DELAY_MS = 100;
+
+/**
+ * Executes an asynchronous callback within a mutex lock to ensure exclusive access
+ * to a critical section of code.
+ *
+ * This function acquires a mutex lock identified by `lockId` before invoking the
+ * provided callback. It is designed to protect sensitive operations, such as assigning
+ * the next available docket number when creating a case, from concurrent execution
+ * across processes. Once the callback completes (whether it resolves successfully
+ * or throws an error), the lock is released.
+ *
+ */
+export const mutexLockWrapper = async <T>({
+  lockId,
+  callback,
+}: {
+  lockId: number;
+  callback: () => Promise<T>;
+}): Promise<T> => {
+  await getLock({ lockId });
+  try {
+    return callback();
+  } finally {
+    // Ensure the lock is released regardless of the callback outcome.
+    await releaseLock({ lockId });
+  }
+};
+
+const getLock = async ({ lockId }: { lockId: number }) => {
+  for (let i = 0; i < MUTEX_NUM_ATTEMPTS; i++) {
+    if ((await tryGetLock({ lockId })) === true) {
+      return; // We got the lock
+    }
+    // We did not get the lock, so try again
+    await new Promise(
+      resolve => setTimeout(resolve, RETRY_DELAY_MS * Math.pow(2, i)), // Exponential backoff
+    );
+  }
+  throw new Error(`Could not obtain a lock for ${lockId}`);
+};
+
+const tryGetLock = async ({ lockId }: { lockId: number }) => {
+  const gotLockResult = await getDbWriter({
+    table: null,
+    cb: async writer => {
+      const result = await writer.executeQuery<{ pgTryAdvisoryLock: boolean }>(
+        CompiledQuery.raw(`select pg_try_advisory_lock(${lockId})`, []),
+      );
+      return result;
+    },
+  });
+  const gotLock = gotLockResult.rows[0].pgTryAdvisoryLock;
+  return gotLock;
+};
+
+const releaseLock = async ({ lockId }: { lockId: number }) => {
+  const releasedLockResult = await getDbWriter({
+    table: null,
+    cb: async writer => {
+      const result = await writer.executeQuery<{ pgAdvisoryUnlock: boolean }>(
+        CompiledQuery.raw(`select pg_advisory_unlock(${lockId})`, []),
+      );
+      return result;
+    },
+  });
+  const releasedLock = releasedLockResult.rows[0].pgAdvisoryUnlock;
+  return releasedLock;
+};

--- a/web-api/src/persistence/postgres/workitems/getDocumentQCInboxForSection.ts
+++ b/web-api/src/persistence/postgres/workitems/getDocumentQCInboxForSection.ts
@@ -25,7 +25,12 @@ export const getDocumentQCInboxForSection = async ({
     return builder
       .selectAll('w')
       .select(['c.caption', 'c.status'])
-      .select(['w.docketNumber', 'w.highPriority', 'c.trialDate'])
+      .select([
+        'w.docketNumber',
+        'w.highPriority',
+        'c.trialDate',
+        'c.leadDocketNumber',
+      ])
       .execute();
   });
 

--- a/web-api/src/persistence/postgres/workitems/getDocumentQCInboxForSection.ts
+++ b/web-api/src/persistence/postgres/workitems/getDocumentQCInboxForSection.ts
@@ -23,7 +23,8 @@ export const getDocumentQCInboxForSection = async ({
     }
 
     return builder
-      .selectAll()
+      .selectAll('w')
+      .select(['c.caption', 'c.status'])
       .select(['w.docketNumber', 'w.highPriority'])
       .execute();
   });

--- a/web-api/src/persistence/postgres/workitems/getDocumentQCInboxForSection.ts
+++ b/web-api/src/persistence/postgres/workitems/getDocumentQCInboxForSection.ts
@@ -24,10 +24,9 @@ export const getDocumentQCInboxForSection = async ({
 
     return builder
       .selectAll('w')
-      .select(['c.caption', 'c.status'])
       .select([
-        'w.docketNumber',
-        'w.highPriority',
+        'c.caption',
+        'c.status',
         'c.trialDate',
         'c.trialLocation',
         'c.leadDocketNumber',

--- a/web-api/src/persistence/postgres/workitems/getDocumentQCInboxForSection.ts
+++ b/web-api/src/persistence/postgres/workitems/getDocumentQCInboxForSection.ts
@@ -25,7 +25,7 @@ export const getDocumentQCInboxForSection = async ({
     return builder
       .selectAll('w')
       .select(['c.caption', 'c.status'])
-      .select(['w.docketNumber', 'w.highPriority'])
+      .select(['w.docketNumber', 'w.highPriority', 'c.trialDate'])
       .execute();
   });
 

--- a/web-api/src/persistence/postgres/workitems/getDocumentQCInboxForSection.ts
+++ b/web-api/src/persistence/postgres/workitems/getDocumentQCInboxForSection.ts
@@ -29,6 +29,7 @@ export const getDocumentQCInboxForSection = async ({
         'w.docketNumber',
         'w.highPriority',
         'c.trialDate',
+        'c.trialLocation',
         'c.leadDocketNumber',
       ])
       .execute();

--- a/web-api/src/persistence/postgres/workitems/getDocumentQCInboxForUser.ts
+++ b/web-api/src/persistence/postgres/workitems/getDocumentQCInboxForUser.ts
@@ -14,7 +14,7 @@ export const getDocumentQCInboxForUser = async ({
       .where('w.completedAt', 'is', null)
       .leftJoin('dwCase as c', 'c.docketNumber', 'w.docketNumber')
       .selectAll('w')
-      .select(['c.caption', 'c.status'])
+      .select(['c.caption', 'c.status', 'c.trialDate'])
       .limit(5000)
       .execute();
   });

--- a/web-api/src/persistence/postgres/workitems/getDocumentQCInboxForUser.ts
+++ b/web-api/src/persistence/postgres/workitems/getDocumentQCInboxForUser.ts
@@ -14,7 +14,7 @@ export const getDocumentQCInboxForUser = async ({
       .where('w.completedAt', 'is', null)
       .leftJoin('dwCase as c', 'c.docketNumber', 'w.docketNumber')
       .selectAll('w')
-      .select(['c.caption', 'c.status', 'c.trialDate'])
+      .select(['c.caption', 'c.status', 'c.trialDate', 'c.leadDocketNumber'])
       .limit(5000)
       .execute();
   });

--- a/web-api/src/persistence/postgres/workitems/getDocumentQCInboxForUser.ts
+++ b/web-api/src/persistence/postgres/workitems/getDocumentQCInboxForUser.ts
@@ -14,7 +14,13 @@ export const getDocumentQCInboxForUser = async ({
       .where('w.completedAt', 'is', null)
       .leftJoin('dwCase as c', 'c.docketNumber', 'w.docketNumber')
       .selectAll('w')
-      .select(['c.caption', 'c.status', 'c.trialDate', 'c.leadDocketNumber'])
+      .select([
+        'c.caption',
+        'c.status',
+        'c.trialDate',
+        'c.trialLocation',
+        'c.leadDocketNumber',
+      ])
       .limit(5000)
       .execute();
   });

--- a/web-api/src/persistence/postgres/workitems/getDocumentQCInboxForUser.ts
+++ b/web-api/src/persistence/postgres/workitems/getDocumentQCInboxForUser.ts
@@ -13,8 +13,8 @@ export const getDocumentQCInboxForUser = async ({
       .where('w.assigneeId', '=', userId)
       .where('w.completedAt', 'is', null)
       .leftJoin('dwCase as c', 'c.docketNumber', 'w.docketNumber')
-      .selectAll()
-      .select('w.docketNumber')
+      .selectAll('w')
+      .select(['c.caption', 'c.status'])
       .limit(5000)
       .execute();
   });

--- a/web-api/src/persistence/postgres/workitems/getDocumentQCServedForSection.ts
+++ b/web-api/src/persistence/postgres/workitems/getDocumentQCServedForSection.ts
@@ -15,8 +15,8 @@ export const getDocumentQCServedForSection = async ({
       .leftJoin('dwCase as c', 'c.docketNumber', 'w.docketNumber')
       .where('w.section', 'in', sections)
       .where('w.completedAt', '>=', afterDate)
-      .selectAll()
-      .select('w.docketNumber')
+      .selectAll('w')
+      .select(['c.caption', 'c.status'])
       .execute();
   });
 

--- a/web-api/src/persistence/postgres/workitems/getDocumentQCServedForSection.ts
+++ b/web-api/src/persistence/postgres/workitems/getDocumentQCServedForSection.ts
@@ -16,7 +16,7 @@ export const getDocumentQCServedForSection = async ({
       .where('w.section', 'in', sections)
       .where('w.completedAt', '>=', afterDate)
       .selectAll('w')
-      .select(['c.caption', 'c.status'])
+      .select(['c.caption', 'c.status', 'c.trialDate'])
       .execute();
   });
 

--- a/web-api/src/persistence/postgres/workitems/getDocumentQCServedForSection.ts
+++ b/web-api/src/persistence/postgres/workitems/getDocumentQCServedForSection.ts
@@ -16,7 +16,13 @@ export const getDocumentQCServedForSection = async ({
       .where('w.section', 'in', sections)
       .where('w.completedAt', '>=', afterDate)
       .selectAll('w')
-      .select(['c.caption', 'c.status', 'c.trialDate', 'c.leadDocketNumber'])
+      .select([
+        'c.caption',
+        'c.status',
+        'c.trialDate',
+        'c.trialLocation',
+        'c.leadDocketNumber',
+      ])
       .execute();
   });
 

--- a/web-api/src/persistence/postgres/workitems/getDocumentQCServedForSection.ts
+++ b/web-api/src/persistence/postgres/workitems/getDocumentQCServedForSection.ts
@@ -16,7 +16,7 @@ export const getDocumentQCServedForSection = async ({
       .where('w.section', 'in', sections)
       .where('w.completedAt', '>=', afterDate)
       .selectAll('w')
-      .select(['c.caption', 'c.status', 'c.trialDate'])
+      .select(['c.caption', 'c.status', 'c.trialDate', 'c.leadDocketNumber'])
       .execute();
   });
 

--- a/web-api/src/persistence/postgres/workitems/getDocumentQCServedForUser.ts
+++ b/web-api/src/persistence/postgres/workitems/getDocumentQCServedForUser.ts
@@ -16,7 +16,7 @@ export const getDocumentQCServedForUser = async ({
       .where('w.assigneeId', '=', userId)
       .where('w.completedAt', '>=', afterDate)
       .selectAll('w')
-      .select(['c.caption', 'c.status'])
+      .select(['c.caption', 'c.status', 'c.trialDate'])
       .execute();
   });
 

--- a/web-api/src/persistence/postgres/workitems/getDocumentQCServedForUser.ts
+++ b/web-api/src/persistence/postgres/workitems/getDocumentQCServedForUser.ts
@@ -16,7 +16,13 @@ export const getDocumentQCServedForUser = async ({
       .where('w.assigneeId', '=', userId)
       .where('w.completedAt', '>=', afterDate)
       .selectAll('w')
-      .select(['c.caption', 'c.status', 'c.trialDate', 'c.leadDocketNumber'])
+      .select([
+        'c.caption',
+        'c.status',
+        'c.trialDate',
+        'c.trialLocation',
+        'c.leadDocketNumber',
+      ])
       .execute();
   });
 

--- a/web-api/src/persistence/postgres/workitems/getDocumentQCServedForUser.ts
+++ b/web-api/src/persistence/postgres/workitems/getDocumentQCServedForUser.ts
@@ -16,7 +16,7 @@ export const getDocumentQCServedForUser = async ({
       .where('w.assigneeId', '=', userId)
       .where('w.completedAt', '>=', afterDate)
       .selectAll('w')
-      .select(['c.caption', 'c.status', 'c.trialDate'])
+      .select(['c.caption', 'c.status', 'c.trialDate', 'c.leadDocketNumber'])
       .execute();
   });
 

--- a/web-api/src/persistence/postgres/workitems/getDocumentQCServedForUser.ts
+++ b/web-api/src/persistence/postgres/workitems/getDocumentQCServedForUser.ts
@@ -15,8 +15,8 @@ export const getDocumentQCServedForUser = async ({
       .leftJoin('dwCase as c', 'c.docketNumber', 'w.docketNumber')
       .where('w.assigneeId', '=', userId)
       .where('w.completedAt', '>=', afterDate)
-      .selectAll()
-      .select('w.docketNumber')
+      .selectAll('w')
+      .select(['c.caption', 'c.status'])
       .execute();
   });
 

--- a/web-api/src/persistence/postgres/workitems/getWorkItemById.ts
+++ b/web-api/src/persistence/postgres/workitems/getWorkItemById.ts
@@ -13,7 +13,7 @@ export const getWorkItemById = async ({
       .leftJoin('dwCase as c', 'c.docketNumber', 'w.docketNumber')
       .where('w.workItemId', '=', workItemId)
       .selectAll('w')
-      .select(['c.caption', 'c.status', 'c.trialDate'])
+      .select(['c.caption', 'c.status', 'c.trialDate', 'c.leadDocketNumber'])
       .executeTakeFirst(),
   );
 

--- a/web-api/src/persistence/postgres/workitems/getWorkItemById.ts
+++ b/web-api/src/persistence/postgres/workitems/getWorkItemById.ts
@@ -13,7 +13,13 @@ export const getWorkItemById = async ({
       .leftJoin('dwCase as c', 'c.docketNumber', 'w.docketNumber')
       .where('w.workItemId', '=', workItemId)
       .selectAll('w')
-      .select(['c.caption', 'c.status', 'c.trialDate', 'c.leadDocketNumber'])
+      .select([
+        'c.caption',
+        'c.status',
+        'c.trialDate',
+        'c.trialLocation',
+        'c.leadDocketNumber',
+      ])
       .executeTakeFirst(),
   );
 

--- a/web-api/src/persistence/postgres/workitems/getWorkItemById.ts
+++ b/web-api/src/persistence/postgres/workitems/getWorkItemById.ts
@@ -12,8 +12,8 @@ export const getWorkItemById = async ({
       .selectFrom('dwWorkItem as w')
       .leftJoin('dwCase as c', 'c.docketNumber', 'w.docketNumber')
       .where('w.workItemId', '=', workItemId)
-      .selectAll()
-      .select('w.docketNumber')
+      .selectAll('w')
+      .select(['c.caption', 'c.status'])
       .executeTakeFirst(),
   );
 

--- a/web-api/src/persistence/postgres/workitems/getWorkItemById.ts
+++ b/web-api/src/persistence/postgres/workitems/getWorkItemById.ts
@@ -13,7 +13,7 @@ export const getWorkItemById = async ({
       .leftJoin('dwCase as c', 'c.docketNumber', 'w.docketNumber')
       .where('w.workItemId', '=', workItemId)
       .selectAll('w')
-      .select(['c.caption', 'c.status'])
+      .select(['c.caption', 'c.status', 'c.trialDate'])
       .executeTakeFirst(),
   );
 

--- a/web-api/src/persistence/postgres/workitems/getWorkItemsByDocketNumber.ts
+++ b/web-api/src/persistence/postgres/workitems/getWorkItemsByDocketNumber.ts
@@ -13,7 +13,7 @@ export const getWorkItemsByDocketNumber = async ({
       .leftJoin('dwCase as c', 'c.docketNumber', 'w.docketNumber')
       .where('w.docketNumber', '=', docketNumber)
       .selectAll('w')
-      .select(['c.caption', 'c.status'])
+      .select(['c.caption', 'c.status', 'c.trialDate'])
       .execute();
   });
 

--- a/web-api/src/persistence/postgres/workitems/getWorkItemsByDocketNumber.ts
+++ b/web-api/src/persistence/postgres/workitems/getWorkItemsByDocketNumber.ts
@@ -13,7 +13,13 @@ export const getWorkItemsByDocketNumber = async ({
       .leftJoin('dwCase as c', 'c.docketNumber', 'w.docketNumber')
       .where('w.docketNumber', '=', docketNumber)
       .selectAll('w')
-      .select(['c.caption', 'c.status', 'c.trialDate', 'c.leadDocketNumber'])
+      .select([
+        'c.caption',
+        'c.status',
+        'c.trialDate',
+        'c.trialLocation',
+        'c.leadDocketNumber',
+      ])
       .execute();
   });
 

--- a/web-api/src/persistence/postgres/workitems/getWorkItemsByDocketNumber.ts
+++ b/web-api/src/persistence/postgres/workitems/getWorkItemsByDocketNumber.ts
@@ -13,7 +13,7 @@ export const getWorkItemsByDocketNumber = async ({
       .leftJoin('dwCase as c', 'c.docketNumber', 'w.docketNumber')
       .where('w.docketNumber', '=', docketNumber)
       .selectAll('w')
-      .select(['c.caption', 'c.status', 'c.trialDate'])
+      .select(['c.caption', 'c.status', 'c.trialDate', 'c.leadDocketNumber'])
       .execute();
   });
 


### PR DESCRIPTION
1. Avoid `selectAll` for `dwCase`, which is typically frowned upon anyway. Because the case table is so big, this seems to have a non-trivial impact on performance. (Example: I could not get `16017-21` to load before locally when pointed to test. Now I can.)
2. Avoid race conditions when generating a new docket number by using a mutex lock. (We can explore other solutions in the meantime, like offloading the sequence generation to the database, although there seem to be complexities with this approach.)