### PR TITLE
10616 Bug: Navigating Back to Case Detail from Edit Petitioner

### DIFF
--- a/web-client/src/presenter/computeds/editPetitionerInformationHelper.test.ts
+++ b/web-client/src/presenter/computeds/editPetitionerInformationHelper.test.ts
@@ -69,6 +69,52 @@ describe('editPetitionerInformationHelper', () => {
     expect(result.userPendingEmail).toEqual('email@example.com');
   });
 
+  it('handles an undefined state.form property', () => {
+    const result = runCompute(editPetitionerInformationHelper, {
+      state: {
+        caseDetail: {
+          petitioners: [
+            { contactType: CONTACT_TYPES.petitioner },
+            { contactType: CONTACT_TYPES.petitioner },
+          ],
+        },
+        form: undefined,
+        permissions: {
+          EDIT_PETITIONER_EMAIL: true,
+          REMOVE_PETITIONER: true,
+          SEAL_ADDRESS: true,
+        },
+      },
+    });
+
+    expect(result.showEditEmail).toEqual(true);
+    expect(result.showRemovePetitionerButton).toBeFalsy();
+    expect(result.showSealAddress).toEqual(true);
+  });
+
+  it('handles an undefined state.form.contact property', () => {
+    const result = runCompute(editPetitionerInformationHelper, {
+      state: {
+        caseDetail: {
+          petitioners: [
+            { contactType: CONTACT_TYPES.petitioner },
+            { contactType: CONTACT_TYPES.petitioner },
+          ],
+        },
+        form: { contact: undefined },
+        permissions: {
+          EDIT_PETITIONER_EMAIL: true,
+          REMOVE_PETITIONER: true,
+          SEAL_ADDRESS: true,
+        },
+      },
+    });
+
+    expect(result.showEditEmail).toEqual(true);
+    expect(result.showRemovePetitionerButton).toBeFalsy();
+    expect(result.showSealAddress).toEqual(true);
+  });
+
   describe('showRemovePetitionerButton', () => {
     it('is false when the current user does not have permission to edit petitioners', () => {
       const result = runCompute(editPetitionerInformationHelper, {

--- a/web-client/src/presenter/computeds/editPetitionerInformationHelper.ts
+++ b/web-client/src/presenter/computeds/editPetitionerInformationHelper.ts
@@ -1,4 +1,3 @@
-import { cloneDeep } from 'lodash';
 import { state } from '@web-client/presenter/app.cerebral';
 
 /**
@@ -16,7 +15,8 @@ export const editPetitionerInformationHelper = (
 ): any => {
   const { CONTACT_TYPES } = applicationContext.getConstants();
   const permissions = get(state.permissions);
-  const { contact } = cloneDeep(get(state.form));
+  const form = get(state.form) || {};
+  const contact = form.contact || {};
   const userPendingEmail = get(state.screenMetadata.userPendingEmail);
   const showEditEmail = permissions.EDIT_PETITIONER_EMAIL && !userPendingEmail;
   const showSealAddress = permissions.SEAL_ADDRESS;


### PR DESCRIPTION
Update the `editPetitionerInformationHelper` computed so that it handles undefined properties on the state tree without erroring out.