### PR TITLE
10619 Bug: Filtering by Judge on Case Deadlines Report

### DIFF
--- a/shared/src/business/useCases/getCaseDeadlinesInteractor.test.ts
+++ b/shared/src/business/useCases/getCaseDeadlinesInteractor.test.ts
@@ -2,6 +2,7 @@ import '@web-api/persistence/postgres/cases/mocks.jest';
 import '@web-api/persistence/postgres/caseDeadlines/mocks.jest';
 import {
   CASE_TYPES_MAP,
+  CHIEF_JUDGE,
   CONTACT_TYPES,
   COUNTRY_TYPES,
   DOCKET_NUMBER_SUFFIXES,
@@ -164,11 +165,12 @@ describe('getCaseDeadlinesInteractor', () => {
   });
 
   it('passes date and filtering params to getCaseDeadlinesByDateRange persistence call', async () => {
+    const judgeId = '123456';
     await getCaseDeadlinesInteractor(
       {
         endDate: END_DATE,
         from: 0,
-        judge: 'Buch',
+        judgeId,
         startDate: START_DATE,
       },
       mockPetitionsClerkUser,
@@ -177,7 +179,27 @@ describe('getCaseDeadlinesInteractor', () => {
     expect(getCaseDeadlinesByDateRange.mock.calls[0][0]).toMatchObject({
       endDate: END_DATE,
       from: 0,
-      judge: 'Buch',
+      judgeId,
+      startDate: START_DATE,
+    });
+  });
+
+  it('passes null for judgeId to getCaseDeadlinesByDateRange persistence call when chief judge is requested', async () => {
+    await getCaseDeadlinesInteractor(
+      applicationContext,
+      {
+        endDate: END_DATE,
+        from: 0,
+        judgeId: CHIEF_JUDGE,
+        startDate: START_DATE,
+      },
+      mockPetitionsClerkUser,
+    );
+
+    expect(getCaseDeadlinesByDateRange.mock.calls[0][0]).toMatchObject({
+      endDate: END_DATE,
+      from: 0,
+      judgeId: null,
       startDate: START_DATE,
     });
   });

--- a/shared/src/business/useCases/getCaseDeadlinesInteractor.test.ts
+++ b/shared/src/business/useCases/getCaseDeadlinesInteractor.test.ts
@@ -186,7 +186,6 @@ describe('getCaseDeadlinesInteractor', () => {
 
   it('passes null for judgeId to getCaseDeadlinesByDateRange persistence call when chief judge is requested', async () => {
     await getCaseDeadlinesInteractor(
-      applicationContext,
       {
         endDate: END_DATE,
         from: 0,

--- a/shared/src/business/useCases/getCaseDeadlinesInteractor.ts
+++ b/shared/src/business/useCases/getCaseDeadlinesInteractor.ts
@@ -1,6 +1,9 @@
 import { UnknownAuthUser } from '@shared/business/entities/authUser/AuthUser';
 import { CaseDeadline } from '@shared/business//entities/CaseDeadline';
-import { CASE_DEADLINES_REPORT_PAGE_SIZE } from '@shared/business//entities/EntityConstants';
+import {
+  CASE_DEADLINES_REPORT_PAGE_SIZE,
+  CHIEF_JUDGE,
+} from '@shared/business//entities/EntityConstants';
 import {
   ROLE_PERMISSIONS,
   isAuthorized,
@@ -26,12 +29,12 @@ export const getCaseDeadlinesInteractor = async (
   {
     endDate,
     from,
-    judge,
+    judgeId,
     startDate,
   }: {
     endDate: string;
     from: number;
-    judge: string;
+    judgeId: string;
     startDate;
   },
   authorizedUser: UnknownAuthUser,
@@ -43,7 +46,7 @@ export const getCaseDeadlinesInteractor = async (
   const { foundDeadlines, totalCount } = await getCaseDeadlinesByDateRange({
     endDate,
     from,
-    judge,
+    judgeId: getJudgeIdForPersistence(judgeId),
     pageSize: CASE_DEADLINES_REPORT_PAGE_SIZE,
     startDate,
   });
@@ -73,4 +76,10 @@ export const getCaseDeadlinesInteractor = async (
   }
 
   return { deadlines: deadlinesWithFullInfo, totalCount: Number(totalCount) };
+};
+
+const getJudgeIdForPersistence = (
+  judgeId: string | undefined,
+): string | undefined | null => {
+  return judgeId === CHIEF_JUDGE ? null : judgeId;
 };

--- a/shared/src/proxies/caseDeadline/getCaseDeadlinesProxy.ts
+++ b/shared/src/proxies/caseDeadline/getCaseDeadlinesProxy.ts
@@ -11,7 +11,7 @@ import { get } from '../requests';
  */
 export const getCaseDeadlinesInteractor = (
   applicationContext,
-  { endDate, from, judge, startDate },
+  { endDate, from, judgeId, startDate },
 ) => {
   return get({
     applicationContext,
@@ -19,7 +19,7 @@ export const getCaseDeadlinesInteractor = (
     params: {
       endDate,
       from,
-      judge,
+      judgeId,
       startDate,
     },
   });

--- a/web-api/src/persistence/postgres/caseDeadlines/getCaseDeadlinesByDateRange.ts
+++ b/web-api/src/persistence/postgres/caseDeadlines/getCaseDeadlinesByDateRange.ts
@@ -71,7 +71,11 @@ export const getCaseDeadlinesByDateRange = async ({
 };
 
 const applyJudgeFilter = (query, judgeId) => {
-  return !!judgeId || judgeId === null
-    ? query.where('associatedJudgeId', '=', judgeId)
-    : query;
+  if (judgeId === null) {
+    return query.where('associatedJudgeId', 'is', null);
+  } else if (judgeId !== undefined) {
+    return query.where('associatedJudgeId', '=', judgeId);
+  }
+
+  return query;
 };

--- a/web-api/src/persistence/postgres/caseDeadlines/getCaseDeadlinesByDateRange.ts
+++ b/web-api/src/persistence/postgres/caseDeadlines/getCaseDeadlinesByDateRange.ts
@@ -46,10 +46,10 @@ export const getCaseDeadlinesByDateRange = async ({
       const results = await deadlineQuery.execute();
 
       let countQuery = reader
-        .selectFrom('dwCaseDeadline')
+        .selectFrom('dwCaseDeadline as cd')
         .select(reader.fn.count('docketNumber').as('totalCount'))
-        .where('deadlineDate', '>=', startDate)
-        .where('deadlineDate', '<=', endDate);
+        .where('cd.deadlineDate', '>=', startDate)
+        .where('cd.deadlineDate', '<=', endDate);
 
       countQuery = applyJudgeFilter(countQuery, judgeId);
 
@@ -72,9 +72,9 @@ export const getCaseDeadlinesByDateRange = async ({
 
 const applyJudgeFilter = (query, judgeId) => {
   if (judgeId === null) {
-    return query.where('associatedJudgeId', 'is', null);
+    return query.where('cd.associatedJudgeId', 'is', null);
   } else if (judgeId !== undefined) {
-    return query.where('associatedJudgeId', '=', judgeId);
+    return query.where('cd.associatedJudgeId', '=', judgeId);
   }
 
   return query;

--- a/web-api/src/persistence/postgres/caseDeadlines/getCaseDeadlinesByDateRange.ts
+++ b/web-api/src/persistence/postgres/caseDeadlines/getCaseDeadlinesByDateRange.ts
@@ -5,9 +5,15 @@ import { getDbReader } from '@web-api/database';
 export const getCaseDeadlinesByDateRange = async ({
   endDate,
   from = 0,
-  judge,
+  judgeId,
   pageSize,
   startDate,
+}: {
+  endDate;
+  from: number;
+  judgeId?: string | null;
+  pageSize: number;
+  startDate;
 }) => {
   const size =
     pageSize && pageSize <= CASE_DEADLINES_REPORT_PAGE_SIZE
@@ -29,9 +35,7 @@ export const getCaseDeadlinesByDateRange = async ({
         .where('cd.deadlineDate', '>=', startDate)
         .where('cd.deadlineDate', '<=', endDate);
 
-      if (judge) {
-        deadlineQuery = deadlineQuery.where('cd.associatedJudge', '=', judge);
-      }
+      deadlineQuery = applyJudgeFilter(deadlineQuery, judgeId);
 
       deadlineQuery = deadlineQuery
         .offset(from)
@@ -47,9 +51,7 @@ export const getCaseDeadlinesByDateRange = async ({
         .where('deadlineDate', '>=', startDate)
         .where('deadlineDate', '<=', endDate);
 
-      if (judge) {
-        countQuery = countQuery.where('associatedJudge', '=', judge);
-      }
+      countQuery = applyJudgeFilter(countQuery, judgeId);
 
       const total = await countQuery.executeTakeFirst();
 
@@ -66,4 +68,10 @@ export const getCaseDeadlinesByDateRange = async ({
     ),
     totalCount,
   };
+};
+
+const applyJudgeFilter = (query, judgeId) => {
+  return !!judgeId || judgeId === null
+    ? query.where('associatedJudgeId', '=', judgeId)
+    : query;
 };

--- a/web-client/integration-tests/journey/petitionsClerkViewsDeadlineReport.ts
+++ b/web-client/integration-tests/journey/petitionsClerkViewsDeadlineReport.ts
@@ -55,39 +55,37 @@ export const petitionsClerkViewsDeadlineReport = (
     expect(deadlines.length).toEqual(6);
 
     // verify sorting by date and docket number
-    expect(deadlines).toMatchObject([
-      {
+    expect(deadlines).toEqual([
+      expect.objectContaining({
         associatedJudge: 'Buch',
-        associatedJudgeId: '123456',
         deadlineDate: `${options.year}-01-${options.day}T05:00:00.000Z`,
         docketNumber: cerebralTest.createdDocketNumbers[0],
-      },
-      {
+      }),
+      expect.objectContaining({
         associatedJudge: CHIEF_JUDGE,
         deadlineDate: `${options.year}-01-${options.day}T05:00:00.000Z`,
         docketNumber: cerebralTest.createdDocketNumbers[1],
-      },
-      {
+      }),
+      expect.objectContaining({
         associatedJudge: CHIEF_JUDGE,
         deadlineDate: `${options.year}-01-${options.day}T05:00:00.000Z`,
         docketNumber: cerebralTest.createdDocketNumbers[2],
-      },
-      {
+      }),
+      expect.objectContaining({
         associatedJudge: 'Buch',
-        associatedJudgeId: '123456',
         deadlineDate: `${options.year}-02-${options.day}T05:00:00.000Z`,
         docketNumber: cerebralTest.createdDocketNumbers[0],
-      },
-      {
+      }),
+      expect.objectContaining({
         associatedJudge: CHIEF_JUDGE,
         deadlineDate: `${options.year}-02-${options.day}T05:00:00.000Z`,
         docketNumber: cerebralTest.createdDocketNumbers[1],
-      },
-      {
+      }),
+      expect.objectContaining({
         associatedJudge: CHIEF_JUDGE,
         deadlineDate: `${options.year}-02-${options.day}T05:00:00.000Z`,
         docketNumber: cerebralTest.createdDocketNumbers[2],
-      },
+      }),
     ]);
 
     runCompute(caseDeadlineReportHelper, {

--- a/web-client/integration-tests/journey/petitionsClerkViewsDeadlineReport.ts
+++ b/web-client/integration-tests/journey/petitionsClerkViewsDeadlineReport.ts
@@ -112,13 +112,11 @@ export const petitionsClerkViewsDeadlineReport = (
     expect(deadlines).toMatchObject([
       {
         associatedJudge: 'Buch',
-        associatedJudgeId: '123456',
         deadlineDate: `${options.year}-01-${options.day}T05:00:00.000Z`,
         docketNumber: cerebralTest.createdDocketNumbers[0],
       },
       {
         associatedJudge: 'Buch',
-        associatedJudgeId: '123456',
         deadlineDate: `${options.year}-02-${options.day}T05:00:00.000Z`,
         docketNumber: cerebralTest.createdDocketNumbers[0],
       },

--- a/web-client/integration-tests/journey/petitionsClerkViewsDeadlineReport.ts
+++ b/web-client/integration-tests/journey/petitionsClerkViewsDeadlineReport.ts
@@ -58,6 +58,7 @@ export const petitionsClerkViewsDeadlineReport = (
     expect(deadlines).toMatchObject([
       {
         associatedJudge: 'Buch',
+        associatedJudgeId: '123456',
         deadlineDate: `${options.year}-01-${options.day}T05:00:00.000Z`,
         docketNumber: cerebralTest.createdDocketNumbers[0],
       },
@@ -73,6 +74,7 @@ export const petitionsClerkViewsDeadlineReport = (
       },
       {
         associatedJudge: 'Buch',
+        associatedJudgeId: '123456',
         deadlineDate: `${options.year}-02-${options.day}T05:00:00.000Z`,
         docketNumber: cerebralTest.createdDocketNumbers[0],
       },
@@ -93,7 +95,7 @@ export const petitionsClerkViewsDeadlineReport = (
     });
 
     await cerebralTest.runSequence('filterCaseDeadlinesByJudgeSequence', {
-      judge: 'Buch',
+      selectedJudgeId: '123456',
     });
 
     deadlines = cerebralTest.getState(
@@ -110,11 +112,13 @@ export const petitionsClerkViewsDeadlineReport = (
     expect(deadlines).toMatchObject([
       {
         associatedJudge: 'Buch',
+        associatedJudgeId: '123456',
         deadlineDate: `${options.year}-01-${options.day}T05:00:00.000Z`,
         docketNumber: cerebralTest.createdDocketNumbers[0],
       },
       {
         associatedJudge: 'Buch',
+        associatedJudgeId: '123456',
         deadlineDate: `${options.year}-02-${options.day}T05:00:00.000Z`,
         docketNumber: cerebralTest.createdDocketNumbers[0],
       },

--- a/web-client/integration-tests/journey/petitionsClerkViewsDeadlineReport.ts
+++ b/web-client/integration-tests/journey/petitionsClerkViewsDeadlineReport.ts
@@ -25,6 +25,9 @@ export const petitionsClerkViewsDeadlineReport = (
 
     const computedStartDate = `01/${options.day}/${options.year}`;
     const computedEndDate = `02/${options.day}/${options.year}`;
+    const buchUserId = cerebralTest
+      .getState('judges')
+      .find(judge => judge.name === 'Buch').userId;
 
     await cerebralTest.runSequence('selectDateRangeFromCalendarSequence', {
       endDate: prepareDateFromString(computedEndDate, FORMATS.MMDDYYYY),
@@ -55,37 +58,39 @@ export const petitionsClerkViewsDeadlineReport = (
     expect(deadlines.length).toEqual(6);
 
     // verify sorting by date and docket number
-    expect(deadlines).toEqual([
-      expect.objectContaining({
+    expect(deadlines).toMatchObject([
+      {
         associatedJudge: 'Buch',
+        associatedJudgeId: buchUserId,
         deadlineDate: `${options.year}-01-${options.day}T05:00:00.000Z`,
         docketNumber: cerebralTest.createdDocketNumbers[0],
-      }),
-      expect.objectContaining({
+      },
+      {
         associatedJudge: CHIEF_JUDGE,
         deadlineDate: `${options.year}-01-${options.day}T05:00:00.000Z`,
         docketNumber: cerebralTest.createdDocketNumbers[1],
-      }),
-      expect.objectContaining({
+      },
+      {
         associatedJudge: CHIEF_JUDGE,
         deadlineDate: `${options.year}-01-${options.day}T05:00:00.000Z`,
         docketNumber: cerebralTest.createdDocketNumbers[2],
-      }),
-      expect.objectContaining({
+      },
+      {
         associatedJudge: 'Buch',
+        associatedJudgeId: buchUserId,
         deadlineDate: `${options.year}-02-${options.day}T05:00:00.000Z`,
         docketNumber: cerebralTest.createdDocketNumbers[0],
-      }),
-      expect.objectContaining({
+      },
+      {
         associatedJudge: CHIEF_JUDGE,
         deadlineDate: `${options.year}-02-${options.day}T05:00:00.000Z`,
         docketNumber: cerebralTest.createdDocketNumbers[1],
-      }),
-      expect.objectContaining({
+      },
+      {
         associatedJudge: CHIEF_JUDGE,
         deadlineDate: `${options.year}-02-${options.day}T05:00:00.000Z`,
         docketNumber: cerebralTest.createdDocketNumbers[2],
-      }),
+      },
     ]);
 
     runCompute(caseDeadlineReportHelper, {
@@ -93,7 +98,7 @@ export const petitionsClerkViewsDeadlineReport = (
     });
 
     await cerebralTest.runSequence('filterCaseDeadlinesByJudgeSequence', {
-      selectedJudgeId: '123456',
+      selectedJudgeId: buchUserId,
     });
 
     deadlines = cerebralTest.getState(
@@ -107,17 +112,19 @@ export const petitionsClerkViewsDeadlineReport = (
     });
 
     // verify filtering by judge
-    expect(deadlines).toEqual([
-      expect.objectContaining({
+    expect(deadlines).toMatchObject([
+      {
         associatedJudge: 'Buch',
+        associatedJudgeId: buchUserId,
         deadlineDate: `${options.year}-01-${options.day}T05:00:00.000Z`,
         docketNumber: cerebralTest.createdDocketNumbers[0],
-      }),
-      expect.objectContaining({
+      },
+      {
         associatedJudge: 'Buch',
+        associatedJudgeId: buchUserId,
         deadlineDate: `${options.year}-02-${options.day}T05:00:00.000Z`,
         docketNumber: cerebralTest.createdDocketNumbers[0],
-      }),
+      },
     ]);
   });
 };

--- a/web-client/integration-tests/journey/petitionsClerkViewsDeadlineReport.ts
+++ b/web-client/integration-tests/journey/petitionsClerkViewsDeadlineReport.ts
@@ -109,17 +109,17 @@ export const petitionsClerkViewsDeadlineReport = (
     });
 
     // verify filtering by judge
-    expect(deadlines).toMatchObject([
-      {
+    expect(deadlines).toEqual([
+      expect.objectContaining({
         associatedJudge: 'Buch',
         deadlineDate: `${options.year}-01-${options.day}T05:00:00.000Z`,
         docketNumber: cerebralTest.createdDocketNumbers[0],
-      },
-      {
+      }),
+      expect.objectContaining({
         associatedJudge: 'Buch',
         deadlineDate: `${options.year}-02-${options.day}T05:00:00.000Z`,
         docketNumber: cerebralTest.createdDocketNumbers[0],
-      },
+      }),
     ]);
   });
 };

--- a/web-client/integration-tests/petitionsClerkVerifiesOffboardedJudgeJourney.test.ts
+++ b/web-client/integration-tests/petitionsClerkVerifiesOffboardedJudgeJourney.test.ts
@@ -42,7 +42,7 @@ describe('Petitions clerk verifies offboarded judge journey', () => {
         state: cerebralTest.getState(),
       });
 
-      expect(caseDeadlineReportHelper.judges).not.toContain(judgeName);
+      expect(caseDeadlineReportHelper.judgeOptions).not.toContain(judgeName);
     });
 
     it(`petitions clerk verifies judge ${judgeName} does not appear in the case inventory report judge dropdown`, () => {

--- a/web-client/src/presenter/actions/CaseDeadline/getCaseDeadlinesAction.test.ts
+++ b/web-client/src/presenter/actions/CaseDeadline/getCaseDeadlinesAction.test.ts
@@ -18,13 +18,14 @@ describe('getCaseDeadlinesAction', () => {
   });
 
   it('gets all case deadlines', async () => {
+    const judgeId = '123456';
     const result = await runAction(getCaseDeadlinesAction, {
       modules: {
         presenter,
       },
       state: {
         caseDeadlineReport: {
-          judgeFilter: 'Buch',
+          judgeIdFilter: judgeId,
         },
         screenMetadata: {
           filterEndDate: END_DATE,
@@ -38,7 +39,7 @@ describe('getCaseDeadlinesAction', () => {
         .calls[0][1],
     ).toMatchObject({
       endDate: END_DATE,
-      judge: 'Buch',
+      judgeId,
       startDate: START_DATE,
     });
     expect(result.output).toEqual({

--- a/web-client/src/presenter/actions/CaseDeadline/getCaseDeadlinesAction.ts
+++ b/web-client/src/presenter/actions/CaseDeadline/getCaseDeadlinesAction.ts
@@ -15,7 +15,7 @@ export const getCaseDeadlinesAction = async ({
 }: ActionProps) => {
   const startDate = get(state.screenMetadata.filterStartDate);
   const endDate = get(state.screenMetadata.filterEndDate);
-  const judgeFilter = get(state.caseDeadlineReport.judgeFilter);
+  const judgeIdFilter = get(state.caseDeadlineReport.judgeIdFilter);
   const from = props.selectedPage
     ? props.selectedPage * CASE_DEADLINES_REPORT_PAGE_SIZE
     : 0;
@@ -25,7 +25,7 @@ export const getCaseDeadlinesAction = async ({
     .getCaseDeadlinesInteractor(applicationContext, {
       endDate,
       from,
-      judge: judgeFilter,
+      judgeId: judgeIdFilter,
       startDate,
     });
 

--- a/web-client/src/presenter/actions/CaseDeadline/setCaseDeadlineReportJudgeFilterAction.test.ts
+++ b/web-client/src/presenter/actions/CaseDeadline/setCaseDeadlineReportJudgeFilterAction.test.ts
@@ -4,16 +4,17 @@ import { setCaseDeadlineReportJudgeFilterAction } from './setCaseDeadlineReportJ
 
 describe('setCaseDeadlineReportJudgeFilterAction', () => {
   it('sets state.caseDeadlineReport.judgeFilter to the props.judge passed in', async () => {
+    const judgeId = '123456';
     const result = await runAction(setCaseDeadlineReportJudgeFilterAction, {
       modules: { presenter },
       props: {
-        judge: 'Buch',
+        selectedJudgeId: judgeId,
       },
       state: {
         caseDeadlineReport: {},
       },
     });
 
-    expect(result.state.caseDeadlineReport.judgeFilter).toEqual('Buch');
+    expect(result.state.caseDeadlineReport.judgeIdFilter).toEqual(judgeId);
   });
 });

--- a/web-client/src/presenter/actions/CaseDeadline/setCaseDeadlineReportJudgeFilterAction.ts
+++ b/web-client/src/presenter/actions/CaseDeadline/setCaseDeadlineReportJudgeFilterAction.ts
@@ -11,5 +11,5 @@ export const setCaseDeadlineReportJudgeFilterAction = ({
   props,
   store,
 }: ActionProps) => {
-  store.set(state.caseDeadlineReport.judgeFilter, props.judge);
+  store.set(state.caseDeadlineReport.judgeIdFilter, props.selectedJudgeId);
 };

--- a/web-client/src/presenter/computeds/caseDeadlineReportHelper.test.ts
+++ b/web-client/src/presenter/computeds/caseDeadlineReportHelper.test.ts
@@ -2,6 +2,7 @@ import { applicationContextForClient as applicationContext } from '@web-client/t
 import { caseDeadlineReportHelper as caseDeadlineReportHelperComputed } from './caseDeadlineReportHelper';
 import { runCompute } from '@web-client/presenter/test.cerebral';
 import { withAppContextDecorator } from '../../withAppContext';
+import { CHIEF_JUDGE } from '@shared/business/entities/EntityConstants';
 
 describe('caseDeadlineReportHelper', () => {
   const caseDeadlineReportHelper = withAppContextDecorator(
@@ -55,18 +56,27 @@ describe('caseDeadlineReportHelper', () => {
     expect(result.formattedFilterDateHeader).toEqual('August 21, 2019');
   });
 
-  it('should return sorted and formatted judges with Chief Judge concatenated', () => {
+  it('should return formatted judges options sorted by name with Chief Judge included', () => {
     const result = runCompute(caseDeadlineReportHelper, {
       state: {
         caseDeadlineReport: { caseDeadlinesForCurrentPage: caseDeadlines },
-        judges: [{ name: 'Carluzzo' }, { name: 'Buch' }, { name: 'Dredd' }],
+        judges: [
+          { userId: '123456', name: 'Carluzzo' },
+          { userId: '234567', name: 'Buch' },
+          { userId: '345678', name: 'Dredd' },
+        ],
         screenMetadata: {
           filterEndDate: '2019-08-21T12:59:59.000Z',
           filterStartDate: '2019-08-21T04:00:00.000Z',
         },
       },
     });
-    expect(result.judges).toEqual(['Buch', 'Carluzzo', 'Chief Judge', 'Dredd']);
+    expect(result.judgeOptions).toEqual([
+      { id: '234567', name: 'Buch' },
+      { id: '123456', name: 'Carluzzo' },
+      { id: CHIEF_JUDGE, name: CHIEF_JUDGE },
+      { id: '345678', name: 'Dredd' },
+    ]);
   });
 
   it('should format the associated judge name to remove title so only the last name is returned', () => {
@@ -167,7 +177,7 @@ describe('caseDeadlineReportHelper', () => {
         state: {
           caseDeadlineReport: {
             caseDeadlines: [],
-            judgeFilter: 'Carluzzo',
+            judgeIdFilter: '987654',
           },
           screenMetadata: {
             filterEndDate: '2019-08-23T04:00:00.000Z',

--- a/web-client/src/presenter/computeds/caseDeadlineReportHelper.ts
+++ b/web-client/src/presenter/computeds/caseDeadlineReportHelper.ts
@@ -22,7 +22,7 @@ export const caseDeadlineReportHelper = (
     inLeadCase: boolean;
   })[];
   formattedFilterDateHeader;
-  judges: string[];
+  judgeOptions: Array<{ id: string; name: string }>;
   pageCount: number;
   showJudgeSelect: boolean;
   showNoDeadlines: boolean;
@@ -31,14 +31,17 @@ export const caseDeadlineReportHelper = (
 
   const caseDeadlinesForCurrentPage =
     get(state.caseDeadlineReport.caseDeadlinesForCurrentPage) || [];
-  const judgeFilter = get(state.caseDeadlineReport.judgeFilter);
   const showJudgeSelect =
-    caseDeadlinesForCurrentPage.length > 0 || !!judgeFilter;
+    caseDeadlinesForCurrentPage.length > 0 ||
+    !!get(state.caseDeadlineReport.judgeIdFilter);
   const showNoDeadlines = caseDeadlinesForCurrentPage.length === 0;
-  const judges = (get(state.judges) || [])
-    .map(i => applicationContext.getUtilities().formatJudgeName(i.name))
-    .concat(CHIEF_JUDGE)
-    .sort();
+  const judgeOptions = (get(state.judges) || [])
+    .map(judge => ({
+      id: judge.userId,
+      name: applicationContext.getUtilities().formatJudgeName(judge.name),
+    }))
+    .concat({ id: CHIEF_JUDGE, name: CHIEF_JUDGE })
+    .sort((a, b) => a.name.localeCompare(b.name));
 
   let filterStartDate = get(state.screenMetadata.filterStartDate);
   let filterEndDate = get(state.screenMetadata.filterEndDate);
@@ -99,7 +102,7 @@ export const caseDeadlineReportHelper = (
   return {
     formattedCaseDeadlines,
     formattedFilterDateHeader,
-    judges,
+    judgeOptions,
     pageCount,
     showJudgeSelect,
     showNoDeadlines,

--- a/web-client/src/presenter/state.ts
+++ b/web-client/src/presenter/state.ts
@@ -645,7 +645,7 @@ export const baseState = {
       leadDocketNumber: string;
     })[];
     caseDeadlinesTotalCount: 0;
-    judgeFilter: string;
+    judgeIdFilter: string;
   },
   caseDeadlines: [] as RawCaseDeadline[],
   caseDetail: {} as RawCase,

--- a/web-client/src/views/CaseDeadlines/CaseDeadlines.tsx
+++ b/web-client/src/views/CaseDeadlines/CaseDeadlines.tsx
@@ -107,18 +107,18 @@ export const CaseDeadlines = connect(
                     className="select-left width-card-lg inline-select"
                     name="judges"
                     placeholder="- Judge -"
-                    value={caseDeadlineReport.judgeFilter}
+                    value={caseDeadlineReport.judgeIdFilter}
                     onChange={e => {
                       filterCaseDeadlinesByJudgeSequence({
-                        judge: e,
+                        selectedJudgeId: e,
                       });
                       setActivePage(0);
                     }}
                   >
                     <option value="">-Judge-</option>
-                    {caseDeadlineReportHelper.judges.map(judge => (
-                      <option key={judge} value={judge}>
-                        {judge}
+                    {caseDeadlineReportHelper.judgeOptions.map(judgeOption => (
+                      <option key={judgeOption.id} value={judgeOption.id}>
+                        {judgeOption.name}
                       </option>
                     ))}
                   </BindedSelect>
@@ -131,7 +131,6 @@ export const CaseDeadlines = connect(
                     totalPages={caseDeadlineReportHelper.pageCount}
                     onPageChange={pageChange => {
                       setActivePage(pageChange);
-                      console.log('pageChange', pageChange);
                       updateCaseDeadlineReportPageSequence({
                         selectedPage: pageChange,
                       });


### PR DESCRIPTION
See [10619](https://github.com/flexion/ef-cms/issues/10619). The root cause of this issue was the fact that some judges had varying, inconsistent, values in the case deadlines table in persistence: because the case deadline report had been filtering by judge name, this led to inconsistencies in the report.

This PR uses `associatedJudgeId` instead of `associatedJudge` to filter the case deadline report.