### PR TITLE
10502 Cases: Fix terraform variables

### DIFF
--- a/web-api/terraform/modules/opensearch-sync/opensearch-sync.tf
+++ b/web-api/terraform/modules/opensearch-sync/opensearch-sync.tf
@@ -2,8 +2,8 @@ data "aws_caller_identity" "current" {}
 
 module "opensearch_sync_lambda" {
   source         = "../lambda"
-  handler_file   = "./web-api/src/lambdas/opensearch/sync-handler.ts"
-  handler_method = "syncHandler"
+  handler_file   = "./web-api/src/lambdas/openSearch/openSearchSyncHandler.ts"
+  handler_method = "openSearchSyncHandler"
   lambda_name    = "opensearch_sync_lambda_${var.environment}_${var.color}"
   role           = var.lambda_role_arn
   environment    = var.lambda_environment


### PR DESCRIPTION
We renamed our openSearch sync lambda, and we were behind on the AWS Terraform provider version.