### PR TITLE
10628 Fix to Test

### DIFF
--- a/web-client/src/presenter/computeds/Public/publicCaseDetailHelper.test.ts
+++ b/web-client/src/presenter/computeds/Public/publicCaseDetailHelper.test.ts
@@ -1544,6 +1544,22 @@ describe('formatDocketEntryOnDocketRecord', () => {
     expect(showNotServed).toBe(false);
   });
 
+  it("should format a docket entry's descriptionDisplay when correctly when the docket entry is a certificate of service", () => {
+    const result = formatDocketEntryOnDocketRecord(applicationContextPublic, {
+      entry: {
+        ...baseDocketEntry,
+        certificateOfService: true,
+        certificateOfServiceDate: '2025-04-01T00:00:00.000-04:00',
+        documentTitle: 'Answer',
+      },
+      isTerminalUser: true,
+      rawCase: mockCase,
+      visibilityPolicyDate: '2010-05-16T00:00:00.000-04:00',
+    });
+
+    expect(result.descriptionDisplay).toBe('Answer (C/S 04/01/25)');
+  });
+
   it('should return formatted docket entry', () => {
     state.caseDetail.docketEntries = [
       {

--- a/web-client/src/presenter/computeds/Public/publicCaseDetailHelper.ts
+++ b/web-client/src/presenter/computeds/Public/publicCaseDetailHelper.ts
@@ -14,6 +14,7 @@ import {
 } from '../../../../../shared/src/business/utilities/getFormattedCaseDetail';
 import { sortDocketEntryTable } from '@web-client/presenter/computeds/formattedDocketEntries';
 import { state } from '@web-client/presenter/app-public.cerebral';
+import { formatDateString } from '@shared/business/utilities/DateHandler';
 
 export const formatDocketEntryOnDocketRecord = (
   applicationContext,
@@ -66,6 +67,13 @@ export const formatDocketEntryOnDocketRecord = (
   entry.servedAtFormatted = applicationContext
     .getUtilities()
     .formatDateString(entry.servedAt, 'MMDDYY');
+
+  if (entry.certificateOfService) {
+    entry.certificateOfServiceDateFormatted = formatDateString(
+      entry.certificateOfServiceDate,
+      'MMDDYY',
+    );
+  }
 
   entry.filingsAndProceedings = getFilingsAndProceedings(entry);
 


### PR DESCRIPTION
See [10628](https://github.com/flexion/ef-cms/issues/10628).

Root cause: The `publicCaseDetailHelper` Cerebral computed was not setting the `certificateOfServiceDateFormatted` property on docket entries, which is necessary to correctly generate the docket entry's description display.