### PR TITLE
10502 Case Updates

### DIFF
--- a/cypress/local-only/tests/integration/caseDetail/caseInformation/edit-case-detail.cy.ts
+++ b/cypress/local-only/tests/integration/caseDetail/caseInformation/edit-case-detail.cy.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../../support/pages/case-detail';
 import { createAndServePaperPetition } from 'cypress/helpers/fileAPetition/create-and-serve-paper-petition';
 import {
+  CASE_STATUS_TYPES,
   CASE_TYPES_MAP,
   PENALTY_TYPES,
 } from '@shared/business/entities/EntityConstants';
@@ -126,17 +127,39 @@ const getDeficiencyStatistics = (docketNumber: string): RawStatistic[] => {
   ];
 };
 
-describe('Edit case detail', () => {
+describe('View/Edit case detail', () => {
   before(function () {
     createAndServePaperPetition({ yearReceived: '1950' }).then(caseRecord => {
       cy.wrap(caseRecord.docketNumber).as('docketNumber');
     });
   });
 
-  it('should change the title of the case', function () {
+  it('should show correct initial case statuses', function () {
     loginAsDocketClerk();
     cy.visit(`/case-detail/${this.docketNumber}`);
     getCaseDetailTab('case-information').click();
+    cy.get('[data-testid="case-status-history-tab"]').click();
+    // We should have two case statuses, the first New and the second General Docket - Not at Issue
+    cy.get('[data-testid="case-status-history-container"]')
+      .find('tbody tr')
+      .should('have.length', 2)
+      .as('statusRows');
+
+    cy.get('@statusRows')
+      .eq(0)
+      .find('td')
+      .eq(1)
+      .should('have.text', CASE_STATUS_TYPES.new);
+
+    cy.get('@statusRows')
+      .eq(1)
+      .find('td')
+      .eq(1)
+      .should('have.text', CASE_STATUS_TYPES.generalDocket);
+  });
+
+  it('should change the title of the case', function () {
+    cy.get('[data-testid="case-overview-tab"]').click();
     getEditCaseCaptionButton().click();
     getCaptionTextArea().clear().type('there is no cow level');
     getButton('Save').click();
@@ -146,7 +169,6 @@ describe('Edit case detail', () => {
   });
 
   it('should change type of case (to deficiency)', function () {
-    getCaseDetailTab('case-information').click();
     cy.get('[data-testid="edit-case-details-button"]').click();
     cy.get('[data-testid="case-type-select"]').select(
       CASE_TYPES_MAP.deficiency,
@@ -156,7 +178,7 @@ describe('Edit case detail', () => {
   });
 
   it('should add deficiency statistics', function () {
-    getButton('Statistics').click();
+    cy.get('[data-testid="case-statistics-tab"]').click();
     for (const statistic of getDeficiencyStatistics(docketNumber)) {
       cy.contains('a', 'Add New Year/Period').click();
       cy.get(`[data-testid="year-or-period-${statistic.yearOrPeriod}"]`);

--- a/cypress/local-only/tests/integration/trialSession/run-suggested-calendar-generator.cy.ts
+++ b/cypress/local-only/tests/integration/trialSession/run-suggested-calendar-generator.cy.ts
@@ -22,7 +22,7 @@ describe('Run the suggested trial session calendar generator', () => {
   it('should run the suggested trial session calendar generator', () => {
     loginAsPetitionsClerk1();
     cy.visit('/trial-sessions');
-    cy.get('[data-testId="open-create-term-modal-button"]').click();
+    cy.get('[data-testid="open-create-term-modal-button"]').click();
     cy.get('[data-testid="term-name-field"]').type('Test Term Name');
     cy.get(
       '.usa-date-picker__wrapper > [data-testid="termStartDate-date-start-input"]',

--- a/web-api/src/business/useCases/createCaseFromPaperInteractor.ts
+++ b/web-api/src/business/useCases/createCaseFromPaperInteractor.ts
@@ -1,4 +1,4 @@
-import { Case } from '@shared/business/entities/cases/Case';
+import { Case, CaseStatusChange } from '@shared/business/entities/cases/Case';
 import {
   CreatedCaseType,
   INITIAL_DOCUMENT_TYPES,
@@ -28,6 +28,7 @@ import { UserRecord } from '@web-api/persistence/dynamo/dynamoTypes';
 import { CREATE_CASE_LOCK_IDENTIFIER } from '@web-api/business/useCases/createCaseInteractor';
 import { acquireLock } from '@web-api/business/useCaseHelper/acquireLock';
 import { removeLock } from '@web-api/persistence/dynamo/locks/acquireLock';
+import { upsertCaseStatusUpdates } from '@web-api/persistence/postgres/cases/upsertCaseStatusUpdates';
 
 const addPetitionDocketEntryWithWorkItemToCase = ({
   caseToAdd,
@@ -362,6 +363,11 @@ export const createCaseFromPaperInteractor = async (
   caseToAdd.statistics?.forEach(statistic =>
     createCaseStatistic({ docketNumber: caseToAdd.docketNumber, statistic }),
   );
+
+  await upsertCaseStatusUpdates({
+    docketNumber: caseToAdd.docketNumber,
+    statusUpdates: caseToAdd.caseStatusHistory as CaseStatusChange[],
+  });
 
   await upsertWorkItems({
     workItems: [workItem.validate().toRawObject()],

--- a/web-api/src/business/useCases/createCaseInteractor.ts
+++ b/web-api/src/business/useCases/createCaseInteractor.ts
@@ -1,4 +1,4 @@
-import { Case } from '@shared/business/entities/cases/Case';
+import { Case, CaseStatusChange } from '@shared/business/entities/cases/Case';
 import {
   CreatedCaseType,
   INITIAL_DOCUMENT_TYPES,
@@ -28,6 +28,7 @@ import { setServiceIndicatorsForPetitionersOnCase } from '@shared/business/utili
 import { upsertWorkItems } from '@web-api/persistence/postgres/workitems/upsertWorkItems';
 import { acquireLock } from '@web-api/business/useCaseHelper/acquireLock';
 import { removeLock } from '@web-api/persistence/dynamo/locks/acquireLock';
+import { upsertCaseStatusUpdates } from '@web-api/persistence/postgres/cases/upsertCaseStatusUpdates';
 
 export type ElectronicCreatedCaseType = Omit<CreatedCaseType, 'trialCitiies'>;
 export const CREATE_CASE_LOCK_IDENTIFIER = '11235';
@@ -360,6 +361,11 @@ export const createCaseInteractor = async (
   caseToAdd.statistics?.forEach(statistic =>
     createCaseStatistic({ docketNumber: caseToAdd.docketNumber, statistic }),
   );
+
+  await upsertCaseStatusUpdates({
+    docketNumber: caseToAdd.docketNumber,
+    statusUpdates: caseToAdd.caseStatusHistory as CaseStatusChange[],
+  });
 
   const userCaseEntity = new UserCase(caseToAdd);
 

--- a/web-api/src/persistence/postgres/cases/mocks.jest.ts
+++ b/web-api/src/persistence/postgres/cases/mocks.jest.ts
@@ -175,3 +175,13 @@ jest.mock(
   '@web-api/persistence/postgres/cases/statistics/clearCaseStatistics',
   () => mockFactory('clearCaseStatistics'),
 );
+
+// Case status updates
+
+jest.mock('@web-api/persistence/postgres/cases/getCaseStatusHistory', () =>
+  mockFactory('getCaseStatusHistory'),
+);
+
+jest.mock('@web-api/persistence/postgres/cases/upsertCaseStatusUpdates', () =>
+  mockFactory('upsertCaseStatusUpdates'),
+);

--- a/web-api/src/persistence/postgres/cases/updateCase.ts
+++ b/web-api/src/persistence/postgres/cases/updateCase.ts
@@ -3,20 +3,20 @@ import { toKyselyNewCase } from '@web-api/persistence/postgres/cases/mapper';
 import { upsertCaseStatusUpdates } from '@web-api/persistence/postgres/cases/upsertCaseStatusUpdates';
 import { upsertPetitionersOnCase } from '@web-api/persistence/postgres/cases/parties/upsertPetitionersOnCase';
 import { upsertCaseStatistics } from '@web-api/persistence/postgres/cases/statistics/upsertCaseStatistics';
-import { pgUpdateTable } from '@web-api/persistence/postgres/utils/operation/pgUpdateTable';
 import { isEmpty } from 'lodash';
 import { clearCaseStatistics } from '@web-api/persistence/postgres/cases/statistics/clearCaseStatistics';
 import { clearPetitionersOnCase } from '@web-api/persistence/postgres/cases/parties/clearPetitionersOnCase';
+import { pgInsertInto } from '@web-api/persistence/postgres/utils/operation/pgInsertInto';
 
 export const updateCase = async ({
   caseToUpdate,
 }: {
   caseToUpdate: RawCase;
 }): Promise<RawCase> => {
-  const updatedCase = await pgUpdateTable({
+  const updatedCase = await pgInsertInto({
     table: 'dwCase',
     values: toKyselyNewCase(caseToUpdate),
-    where: qb => qb.where('docketNumber', '=', caseToUpdate.docketNumber),
+    onConflictColumns: ['docketNumber'],
   });
 
   // Because we used to have nested objects in our case records, we upserted everything.

--- a/web-client/src/views/CaseDetail/CaseDetailInternal.tsx
+++ b/web-client/src/views/CaseDetail/CaseDetailInternal.tsx
@@ -139,7 +139,12 @@ export const CaseDetailInternal = connect(
               bind="currentViewMetadata.caseDetail.caseInformationTab"
               className="classic-horizontal-header3 tab-border"
             >
-              <Tab id="tab-overview" tabName="overview" title="Overview">
+              <Tab
+                id="tab-overview"
+                data-testid="case-overview-tab"
+                tabName="overview"
+                title="Overview"
+              >
                 <CaseInformationInternal />
               </Tab>
               <Tab
@@ -150,7 +155,7 @@ export const CaseDetailInternal = connect(
               >
                 <PartiesInformation />
               </Tab>
-              <Tab id="tab-statistics" tabName="statistics" title="Statistics">
+              <Tab id="tab-statistics" data-testid="case-statistics-tab" tabName="statistics" title="Statistics">
                 <Statistics />
               </Tab>
               <Tab

--- a/web-client/src/views/TrialSessionDetails/TrialSessionDetails.tsx
+++ b/web-client/src/views/TrialSessionDetails/TrialSessionDetails.tsx
@@ -85,7 +85,7 @@ export const TrialSessionDetails = connect(
               {trialSessionDetailsHelper.showSetCalendarButton && (
                 <Button
                   className="tab-right-button ustc-ui-tabs ustc-ui-tabs--right-button-container"
-                  data-testId="set-calendar-button"
+                  data-testid="set-calendar-button"
                   icon="calendar-check"
                   id="set-calendar-button"
                   onClick={() => openSetCalendarModalSequence()}


### PR DESCRIPTION
- In `updateCase.ts`, we were using `pgUpdateTable`. We should have been using `pgInsertInto`. The former treats `undefined` as "do not modify the existing DB record"; the latter treats `undefined` as "overwrite." Without this change, certain fields were not being saved correctly. We only use `updateCase` in `updateCaseAndAssociations`, so it should always function as an upsert, never an update.
- We were not storing the initial status when creating a case. I fixed this and added a test.