### PR TITLE
Devex: Adjust preparation of expected dates in test cases

### DIFF
--- a/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeD.test.ts
+++ b/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeD.test.ts
@@ -2,6 +2,7 @@ import { CourtIssuedDocumentFactory } from './CourtIssuedDocumentFactory';
 import {
   calculateISODate,
   createISODateString,
+  formatDateString,
   FORMATS,
   getBusinessDateInFuture,
 } from '../../utilities/DateHandler';
@@ -13,11 +14,10 @@ const oneMonthFromNow = getBusinessDateInFuture({
   startDate: createISODateString(),
 });
 
-const dateInDashedFormat = getBusinessDateInFuture({
-  numberOfDays: 30,
-  outputFormat: FORMATS.MMDDYYYY_DASHED,
-  startDate: createISODateString(),
-});
+const oneMonthFromNowInSlashedFormat = formatDateString(
+  oneMonthFromNow,
+  'MMDDYY',
+);
 
 describe('CourtIssuedDocumentTypeD', () => {
   describe('constructor', () => {
@@ -164,7 +164,7 @@ describe('CourtIssuedDocumentTypeD', () => {
       });
 
       expect(extDoc.getDocumentTitle()).toEqual(
-        `Order for Amended Petition and Filing Fee on ${dateInDashedFormat} Some free text`,
+        `Order for Amended Petition and Filing Fee on ${oneMonthFromNowInSlashedFormat} Some free text`,
       );
     });
 
@@ -179,7 +179,7 @@ describe('CourtIssuedDocumentTypeD', () => {
       });
 
       expect(extDoc.getDocumentTitle()).toEqual(
-        `Order for Amended Petition and Filing Fee on ${dateInDashedFormat}`,
+        `Order for Amended Petition and Filing Fee on ${oneMonthFromNowInSlashedFormat}`,
       );
     });
   });

--- a/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeD.test.ts
+++ b/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeD.test.ts
@@ -14,9 +14,9 @@ const oneMonthFromNow = getBusinessDateInFuture({
   startDate: createISODateString(),
 });
 
-const oneMonthFromNowInSlashedFormat = formatDateString(
+const oneMonthFromNowInExpectedFormat = formatDateString(
   oneMonthFromNow,
-  'MMDDYY',
+  FORMATS.MMDDYYYY_DASHED,
 );
 
 describe('CourtIssuedDocumentTypeD', () => {
@@ -164,7 +164,7 @@ describe('CourtIssuedDocumentTypeD', () => {
       });
 
       expect(extDoc.getDocumentTitle()).toEqual(
-        `Order for Amended Petition and Filing Fee on ${oneMonthFromNowInSlashedFormat} Some free text`,
+        `Order for Amended Petition and Filing Fee on ${oneMonthFromNowInExpectedFormat} Some free text`,
       );
     });
 
@@ -179,7 +179,7 @@ describe('CourtIssuedDocumentTypeD', () => {
       });
 
       expect(extDoc.getDocumentTitle()).toEqual(
-        `Order for Amended Petition and Filing Fee on ${oneMonthFromNowInSlashedFormat}`,
+        `Order for Amended Petition and Filing Fee on ${oneMonthFromNowInExpectedFormat}`,
       );
     });
   });

--- a/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeE.test.ts
+++ b/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeE.test.ts
@@ -125,7 +125,7 @@ describe('CourtIssuedDocumentTypeE', () => {
 
   describe('title generation', () => {
     it('should generate valid title', () => {
-      const expectedDate = formatDateString(
+      const oneMonthFromNowInExpectedFormat = formatDateString(
         oneMonthFromNow,
         FORMATS.MMDDYYYY_DASHED,
       );
@@ -139,7 +139,7 @@ describe('CourtIssuedDocumentTypeE', () => {
         scenario: 'Type E',
       });
       expect(extDoc.getDocumentTitle()).toEqual(
-        `Order time is extended to ${expectedDate} for petr(s) to pay the filing fee`,
+        `Order time is extended to ${oneMonthFromNowInExpectedFormat} for petr(s) to pay the filing fee`,
       );
     });
   });

--- a/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeE.test.ts
+++ b/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeE.test.ts
@@ -2,6 +2,7 @@ import { CourtIssuedDocumentFactory } from './CourtIssuedDocumentFactory';
 import {
   calculateISODate,
   createISODateString,
+  formatDateString,
   FORMATS,
   getBusinessDateInFuture,
 } from '../../utilities/DateHandler';
@@ -124,12 +125,10 @@ describe('CourtIssuedDocumentTypeE', () => {
 
   describe('title generation', () => {
     it('should generate valid title', () => {
-      const expectedDate = getBusinessDateInFuture({
-        numberOfDays: 30,
-        outputFormat: FORMATS.MMDDYYYY_DASHED,
-        startDate: createISODateString(),
-      });
-
+      const expectedDate = formatDateString(
+        oneMonthFromNow,
+        FORMATS.MMDDYYYY_DASHED,
+      );
       const extDoc = CourtIssuedDocumentFactory({
         attachments: false,
         date: oneMonthFromNow,

--- a/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeG.test.ts
+++ b/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeG.test.ts
@@ -4,6 +4,7 @@ import {
   getBusinessDateInFuture,
   FORMATS,
   createISODateString,
+  formatDateString,
 } from '@shared/business/utilities/DateHandler';
 
 const oneMonthFromNow = getBusinessDateInFuture({
@@ -12,11 +13,11 @@ const oneMonthFromNow = getBusinessDateInFuture({
   startDate: createISODateString(),
 });
 
-const dateInDashedFormat = getBusinessDateInFuture({
-  numberOfDays: 30,
-  outputFormat: FORMATS.MMDDYYYY_DASHED,
-  startDate: createISODateString(),
-});
+const oneMonthFromNowInSlashedFormat = formatDateString(
+  oneMonthFromNow,
+  'MMDDYY',
+);
+
 describe('CourtIssuedDocumentTypeG', () => {
   describe('constructor', () => {
     it('should set attachments to false when no value is provided', () => {
@@ -113,7 +114,7 @@ describe('CourtIssuedDocumentTypeG', () => {
         trialLocation: 'Seattle, Washington',
       });
       expect(extDoc.getDocumentTitle()).toEqual(
-        `Notice of Trial on ${dateInDashedFormat} at Seattle, Washington`,
+        `Notice of Trial on ${oneMonthFromNowInSlashedFormat} at Seattle, Washington`,
       );
     });
 
@@ -127,7 +128,7 @@ describe('CourtIssuedDocumentTypeG', () => {
         trialLocation: TRIAL_SESSION_SCOPE_TYPES.standaloneRemote,
       });
       expect(extDoc.getDocumentTitle()).toEqual(
-        `Notice of Trial on ${dateInDashedFormat} in standalone remote session`,
+        `Notice of Trial on ${oneMonthFromNowInSlashedFormat} in standalone remote session`,
       );
     });
   });

--- a/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeG.test.ts
+++ b/shared/src/business/entities/courtIssuedDocument/CourtIssuedDocumentTypeG.test.ts
@@ -13,9 +13,9 @@ const oneMonthFromNow = getBusinessDateInFuture({
   startDate: createISODateString(),
 });
 
-const oneMonthFromNowInSlashedFormat = formatDateString(
+const oneMonthFromNowInExpectedFormat = formatDateString(
   oneMonthFromNow,
-  'MMDDYY',
+  FORMATS.MMDDYYYY_DASHED,
 );
 
 describe('CourtIssuedDocumentTypeG', () => {
@@ -114,7 +114,7 @@ describe('CourtIssuedDocumentTypeG', () => {
         trialLocation: 'Seattle, Washington',
       });
       expect(extDoc.getDocumentTitle()).toEqual(
-        `Notice of Trial on ${oneMonthFromNowInSlashedFormat} at Seattle, Washington`,
+        `Notice of Trial on ${oneMonthFromNowInExpectedFormat} at Seattle, Washington`,
       );
     });
 
@@ -128,7 +128,7 @@ describe('CourtIssuedDocumentTypeG', () => {
         trialLocation: TRIAL_SESSION_SCOPE_TYPES.standaloneRemote,
       });
       expect(extDoc.getDocumentTitle()).toEqual(
-        `Notice of Trial on ${oneMonthFromNowInSlashedFormat} in standalone remote session`,
+        `Notice of Trial on ${oneMonthFromNowInExpectedFormat} in standalone remote session`,
       );
     });
   });

--- a/web-client/src/presenter/computeds/caseStatusHistoryHelper.test.ts
+++ b/web-client/src/presenter/computeds/caseStatusHistoryHelper.test.ts
@@ -6,6 +6,7 @@ import {
   getBusinessDateInFuture,
   FORMATS,
   createISODateString,
+  formatDateString,
 } from '@shared/business/utilities/DateHandler';
 
 const caseStatusHistoryHelper = withAppContextDecorator(
@@ -20,11 +21,10 @@ const oneMonthFromNow = getBusinessDateInFuture({
   startDate: createISODateString(),
 });
 
-const dateInSlashedFormat = getBusinessDateInFuture({
-  numberOfDays: 30,
-  outputFormat: FORMATS.MMDDYY,
-  startDate: createISODateString(),
-});
+const oneMonthFromNowInSlashedFormat = formatDateString(
+  oneMonthFromNow,
+  'MMDDYY',
+);
 
 describe('caseTypeDescriptionHelper', () => {
   it('should return a array of formatted case status history objects with a formattedDateChanged', () => {
@@ -46,7 +46,7 @@ describe('caseTypeDescriptionHelper', () => {
       {
         changedBy: 'Test Docketclerk',
         date: oneMonthFromNow,
-        formattedDateChanged: dateInSlashedFormat,
+        formattedDateChanged: oneMonthFromNowInSlashedFormat,
         updatedCaseStatus: CASE_STATUS_TYPES.new,
       },
     ]);

--- a/web-client/src/presenter/computeds/caseStatusHistoryHelper.ts
+++ b/web-client/src/presenter/computeds/caseStatusHistoryHelper.ts
@@ -1,25 +1,13 @@
 import { state } from '@web-client/presenter/app.cerebral';
-
-/**
- * a computed used for formatting the case status history table entries.
- *
- * @param {*} get cerebral get function
- * @param {object} applicationContext the application context
- * @returns {object} array of case types with descriptions
- */
-import { ClientApplicationContext } from '@web-client/applicationContext';
 import { Get } from 'cerebral';
-export const caseStatusHistoryHelper = (
-  get: Get,
-  applicationContext: ClientApplicationContext,
-): any => {
+import { formatDateString } from '@shared/business/utilities/DateHandler';
+
+export const caseStatusHistoryHelper = (get: Get): any => {
   const caseStatusHistory = get(state.caseDetail.caseStatusHistory);
   return {
     formattedCaseStatusHistory: caseStatusHistory?.map(history => ({
       ...history,
-      formattedDateChanged: applicationContext
-        .getUtilities()
-        .formatDateString(history.date, 'MMDDYY'),
+      formattedDateChanged: formatDateString(history.date, 'MMDDYY'),
     })),
     isTableDisplayed: caseStatusHistory && caseStatusHistory.length > 0,
   };


### PR DESCRIPTION
This PR updates four test cases to use a date in the `USTC_TZ` timezone instead of an ISO date for expectations for code under test that uses `formatDateString`, which always outputs a `USTC_TZ` derived date string.