### PR TITLE
10612 to test again

### DIFF
--- a/web-client/src/presenter/sequences/removePetitionerEmailSequence.ts
+++ b/web-client/src/presenter/sequences/removePetitionerEmailSequence.ts
@@ -6,18 +6,26 @@ import { navigateToCaseDetailCaseInformationActionFactory } from '@web-client/pr
 import { setSaveAlertsForNavigationAction } from '@web-client/presenter/actions/setSaveAlertsForNavigationAction';
 import { clearModalStateAction } from '@web-client/presenter/actions/clearModalStateAction';
 import { setAlertErrorAction } from '@web-client/presenter/actions/setAlertErrorAction';
+import { state } from '@web-client/presenter/app.cerebral';
 
 export const removePetitionerEmailSequence = showProgressSequenceDecorator([
   clearModalAction,
   removePetitionerEmailAction,
   {
-    error: [setAlertErrorAction],
+    error: [setAlertErrorAction, clearModalAction, clearModalStateAction],
     success: [
       setSaveAlertsForNavigationAction,
       setAlertSuccessAction,
+      clearModalAction,
+      clearModalStateAction,
+      // This is a workaround to force the router (in navigateToCaseDetailCaseInformationActionFactory)
+      // to re-run the router handler in the event that the user is removing the email
+      // immediately after having edited the petitioner details via the edit form.
+      ({ get, router }) => {
+        const { docketNumber } = get(state.caseDetail);
+        router.route(`/case-detail/${docketNumber}`);
+      },
       navigateToCaseDetailCaseInformationActionFactory('parties'),
     ],
-    clearModalAction,
-    clearModalStateAction,
   },
 ]) as unknown as () => void;


### PR DESCRIPTION
flexion#10612

This PR fixes an issue causing an infinite spinner (referencing property of undefined) when the user attempted to remove the petitioner email immediately after having "Saved" changes in the petitioner edit form.

We relied on the router's route handler function to re-load data on the page after removing the petitioner email. Since the edit form submit sequence and our remove email sequence relied on calling "router.route()" on the same URL, the routers route handlers wouldn't run as it didn't detect a change in the route.