### PR TITLE
10612: fix infinite spinner on edit petitioner after removing email, v2

### DIFF
--- a/web-api/src/business/useCases/removePetitionerEmailInteractor.test.ts
+++ b/web-api/src/business/useCases/removePetitionerEmailInteractor.test.ts
@@ -6,7 +6,10 @@ import { MOCK_CASE } from '@shared/test/mockCase';
 import { upsertPetitionersOnCase as upsertPetitonerOnCaseMock } from '@web-api/persistence/postgres/cases/parties/upsertPetitionersOnCase';
 import { updatePetitionerOnCase as updatePetitionerOnCaseMock } from '@web-api/persistence/postgres/cases/parties/updatePetitionerOnCase';
 import { getCaseByDocketNumber as getCaseByDocketNumberMock } from '@web-api/persistence/postgres/cases/getCaseByDocketNumber';
-import { mockAdmissionsClerkUser } from '@shared/test/mockAuthUsers';
+import {
+  mockAdmissionsClerkUser,
+  mockDocketClerkUser,
+} from '@shared/test/mockAuthUsers';
 import { removePetitionerEmailInteractor } from '@web-api/business/useCases/removePetitionerEmailInteractor';
 import { deleteUserFromCase as deleteUserFromCaseMock } from '@web-api/persistence/dynamo/cases/deleteUserFromCase';
 import { SERVICE_INDICATOR_TYPES } from '@shared/business/entities/EntityConstants';
@@ -26,7 +29,7 @@ describe('removePetitionerEmailInteractor', () => {
   });
 
   it('should remove the email from the petitioner and set serviceIndicator to Paper', async () => {
-    await removePetitionerEmailInteractor(
+    const result = await removePetitionerEmailInteractor(
       {
         docketNumber: MOCK_CASE.docketNumber,
         email: MOCK_CASE.petitioners[0].email!,
@@ -65,5 +68,34 @@ describe('removePetitionerEmailInteractor', () => {
     expect(deleteUserFromCase.mock.calls[0][0].userId).toEqual(
       updatedPetitioner.contactId,
     );
+
+    expect(result).toBeDefined();
+    expect(result).toEqual(updatePetitionerOnCase.mock.calls[0][0].petitioner);
+  });
+
+  it('should throw an unauthorized error when user does not have permission', async () => {
+    await expect(
+      removePetitionerEmailInteractor(
+        {
+          docketNumber: MOCK_CASE.docketNumber,
+          email: MOCK_CASE.petitioners[0].email!,
+        },
+        mockDocketClerkUser,
+      ),
+    ).rejects.toThrow('Unauthorized');
+  });
+
+  it('should throw an error when petitioner with given email is not found', async () => {
+    const nonExistentEmail = 'nonexistent@example.com';
+
+    await expect(
+      removePetitionerEmailInteractor(
+        {
+          docketNumber: MOCK_CASE.docketNumber,
+          email: nonExistentEmail,
+        },
+        mockAdmissionsClerkUser,
+      ),
+    ).rejects.toThrow(`Petitioner with email ${nonExistentEmail} not found`);
   });
 });

--- a/web-api/src/business/useCases/removePetitionerEmailInteractor.ts
+++ b/web-api/src/business/useCases/removePetitionerEmailInteractor.ts
@@ -16,7 +16,7 @@ import { deleteUserFromCase } from '@web-api/persistence/dynamo/cases/deleteUser
 export const removePetitionerEmailInteractor = async (
   { docketNumber, email }: { docketNumber: string; email: string },
   authorizedUser: UnknownAuthUser,
-): Promise<void> => {
+): Promise<Petitioner> => {
   if (!isAuthorized(authorizedUser, ROLE_PERMISSIONS.REMOVE_PETITIONER_EMAIL)) {
     throw new UnauthorizedError('Unauthorized');
   }
@@ -62,4 +62,6 @@ export const removePetitionerEmailInteractor = async (
     docketNumber,
     userId: petitionerToRemove.contactId,
   });
+
+  return petitionerToUpdate;
 };

--- a/web-client/src/presenter/actions/CaseAssociation/removePetitionerEmailAction.test.ts
+++ b/web-client/src/presenter/actions/CaseAssociation/removePetitionerEmailAction.test.ts
@@ -53,6 +53,11 @@ describe('removePetitionerEmailAction', () => {
       state: {
         caseDetail: {
           docketNumber: '101-20',
+          petitioners: [
+            {
+              email: 'test@example.com',
+            },
+          ],
         },
         modal: {
           petitionerEmailToRemove: 'test@example.com',

--- a/web-client/src/presenter/actions/CaseAssociation/removePetitionerEmailAction.ts
+++ b/web-client/src/presenter/actions/CaseAssociation/removePetitionerEmailAction.ts
@@ -4,18 +4,27 @@ export const removePetitionerEmailAction = async ({
   applicationContext,
   get,
   path,
+  store,
 }: ActionProps) => {
   const caseDetail = get(state.caseDetail);
-  const email = get(state.modal.petitionerEmailToRemove);
-  const { docketNumber } = caseDetail;
+  const petitionerEmailToRemove = get(state.modal.petitionerEmailToRemove);
+  const { docketNumber, petitioners } = caseDetail;
 
   try {
-    await applicationContext
+    const updatedPetitioner = await applicationContext
       .getUseCases()
       .removePetitionerEmailInteractor(applicationContext, {
         docketNumber,
-        email,
+        email: petitionerEmailToRemove,
       });
+
+    const petitionerIndex = petitioners.findIndex(
+      petitioner => petitioner.email === petitionerEmailToRemove,
+    );
+
+    petitioners[petitionerIndex] = {
+      ...updatedPetitioner,
+    };
   } catch (error) {
     return path.error({
       alertError: {
@@ -24,6 +33,7 @@ export const removePetitionerEmailAction = async ({
     });
   }
 
+  store.set(state.caseDetail.petitioners, petitioners);
   return path.success({
     alertSuccess: {
       message: 'Changes saved.',

--- a/web-client/src/presenter/sequences/removePetitionerEmailSequence.ts
+++ b/web-client/src/presenter/sequences/removePetitionerEmailSequence.ts
@@ -2,30 +2,14 @@ import { removePetitionerEmailAction } from '@web-client/presenter/actions/CaseA
 import { clearModalAction } from '../actions/clearModalAction';
 import { setAlertSuccessAction } from '../actions/setAlertSuccessAction';
 import { showProgressSequenceDecorator } from '../utilities/showProgressSequenceDecorator';
-import { navigateToCaseDetailCaseInformationActionFactory } from '@web-client/presenter/actions/navigateToCaseDetailCaseInformationActionFactory';
-import { setSaveAlertsForNavigationAction } from '@web-client/presenter/actions/setSaveAlertsForNavigationAction';
 import { clearModalStateAction } from '@web-client/presenter/actions/clearModalStateAction';
 import { setAlertErrorAction } from '@web-client/presenter/actions/setAlertErrorAction';
-import { state } from '@web-client/presenter/app.cerebral';
 
 export const removePetitionerEmailSequence = showProgressSequenceDecorator([
   clearModalAction,
   removePetitionerEmailAction,
   {
     error: [setAlertErrorAction, clearModalAction, clearModalStateAction],
-    success: [
-      setSaveAlertsForNavigationAction,
-      setAlertSuccessAction,
-      clearModalAction,
-      clearModalStateAction,
-      // This is a workaround to force the router (in navigateToCaseDetailCaseInformationActionFactory)
-      // to re-run the router handler in the event that the user is removing the email
-      // immediately after having edited the petitioner details via the edit form.
-      ({ get, router }) => {
-        const { docketNumber } = get(state.caseDetail);
-        router.route(`/case-detail/${docketNumber}`);
-      },
-      navigateToCaseDetailCaseInformationActionFactory('parties'),
-    ],
+    success: [setAlertSuccessAction, clearModalAction, clearModalStateAction],
   },
 ]) as unknown as () => void;


### PR DESCRIPTION
flexion#10612

The previous attempt at this fix was a naive attempt at relying on the front end reloading "case details" to ensure the petitioner information in state was up-to-date. This worked consistently locally and when hitting us-east, but was an inconsistent fix when hitting us-west. Current thought is that this was due to replication lag being sometimes longer than it took for the front end to reload case details state.

This fix changes the approach such that the API returns the updated state of the petitioner for the front end to use to set that petitioner's state, rather than relying on read-after-write.