### PR TITLE
Devex: fix kysely type errors

### DIFF
--- a/web-api/src/persistence/postgres/utils/operation/pgDeleteFrom.ts
+++ b/web-api/src/persistence/postgres/utils/operation/pgDeleteFrom.ts
@@ -1,15 +1,11 @@
 import { getDbWriter } from '@web-api/database';
 import { Database } from '@web-api/database-schema';
 import { DeleteQueryBuilder, DeleteResult } from 'kysely';
-import { ExtractTableAlias } from 'kysely/dist/cjs/parser/table-parser';
+import { DeleteFrom } from 'kysely/dist/cjs/parser/delete-from-parser';
 
 type DeleteWhereCallback<T extends keyof Database> = (
-  qb: DeleteQueryBuilder<
-    Database,
-    ExtractTableAlias<Database, T>,
-    DeleteResult
-  >,
-) => DeleteQueryBuilder<Database, ExtractTableAlias<Database, T>, DeleteResult>;
+  qb: DeleteFrom<Database, T>,
+) => DeleteQueryBuilder<Database, T, DeleteResult>;
 
 export const pgDeleteFrom = async <T extends keyof Database>({
   table,
@@ -21,7 +17,6 @@ export const pgDeleteFrom = async <T extends keyof Database>({
   return await getDbWriter({
     cb: async writer => {
       const query = writer.deleteFrom(table);
-      // @ts-ignore 10502 temp ignore while cases is going to test
       return await where(query).returningAll().execute();
     },
     table: null,

--- a/web-api/src/persistence/postgres/utils/operation/pgUpdateTable.ts
+++ b/web-api/src/persistence/postgres/utils/operation/pgUpdateTable.ts
@@ -1,22 +1,11 @@
 import { getDbWriter } from '@web-api/database';
 import { Database } from '@web-api/database-schema';
 import { UpdateQueryBuilder, UpdateResult } from 'kysely';
-import { ExtractTableAlias } from 'kysely/dist/cjs/parser/table-parser';
 import { UpdateObjectExpression } from 'kysely/dist/cjs/parser/update-set-parser';
 
 type UpdateWhereCallback<T extends keyof Database> = (
-  qb: UpdateQueryBuilder<
-    Database,
-    ExtractTableAlias<Database, T>,
-    ExtractTableAlias<Database, T>,
-    UpdateResult
-  >,
-) => UpdateQueryBuilder<
-  Database,
-  ExtractTableAlias<Database, T>,
-  ExtractTableAlias<Database, T>,
-  UpdateResult
->;
+  qb: UpdateQueryBuilder<Database, T, T, UpdateResult>,
+) => UpdateQueryBuilder<Database, T, T, UpdateResult>;
 
 export const pgUpdateTable = async <T extends keyof Database>({
   table,
@@ -24,19 +13,24 @@ export const pgUpdateTable = async <T extends keyof Database>({
   where,
 }: {
   table: T;
-  values: UpdateObjectExpression<
-    Database,
-    ExtractTableAlias<Database, T>,
-    ExtractTableAlias<Database, T>
-  >;
+  values: UpdateObjectExpression<Database, T, T>;
   where: UpdateWhereCallback<T>;
 }) => {
   return await getDbWriter({
-    cb: async writer => {
-      // @ts-ignore 10502 temp ignore while cases is going to test
-      const query = writer.updateTable(table).set(values);
-      return await where(query).returningAll().execute();
-    },
     table,
+    cb: async writer => {
+      // Kysely is not good at dynamically resolving tables, so we cast it here.
+      const query = writer.updateTable(table) as UpdateQueryBuilder<
+        Database,
+        T,
+        T,
+        UpdateResult
+      >;
+
+      const queryWithValues = query.set(values);
+
+      const result = await where(queryWithValues).returningAll().execute();
+      return result;
+    },
   });
 };


### PR DESCRIPTION
We bumped up the version of kysely. That made some types unhappy. This PR resolves that.

Notes:

1. I've tested that we still get all the nice types when using `pgUpdateTable` and `pgDeleteFrom`, e.g., autocomplete completes with fields from the table that is passed in.
2. The same changes to staging are in 10502-dxox.