### PR TITLE
Add some error catching to avoid potential re-indexing failure in the glue job

### DIFF
--- a/web-api/src/business/useCases/processStreamRecords/processCaseEntries.ts
+++ b/web-api/src/business/useCases/processStreamRecords/processCaseEntries.ts
@@ -5,6 +5,7 @@ import { upsertCaseStatusUpdates } from '@web-api/persistence/postgres/cases/ups
 import { Statistic } from '@shared/business/entities/Statistic';
 import { unmarshall } from '@aws-sdk/util-dynamodb';
 import { settlePromises } from '@web-api/utilities/settlePromises';
+import { getLogger } from '@web-api/utilities/logger/getLogger';
 
 export const processCaseEntries = async ({
   caseEntityRecords,
@@ -13,43 +14,49 @@ export const processCaseEntries = async ({
 }) => {
   if (!caseEntityRecords.length) return;
 
-  const casesToUpsert: Record<string, any> = {};
+  try {
+    const casesToUpsert: Record<string, any> = {};
 
-  for (const caseRecord of caseEntityRecords) {
-    const caseNewImage = unmarshall(caseRecord.dynamodb.NewImage);
+    for (const caseRecord of caseEntityRecords) {
+      const caseNewImage = unmarshall(caseRecord.dynamodb.NewImage);
 
-    // Only upsert the most recent update of any duplicate case record since otherwise Postgres will throw an error.
-    casesToUpsert[caseNewImage.docketNumber] = caseNewImage;
-  }
+      // Only upsert the most recent update of any duplicate case record since otherwise Postgres will throw an error.
+      casesToUpsert[caseNewImage.docketNumber] = caseNewImage;
+    }
 
-  await upsertCases(Object.values(casesToUpsert));
-  const postgresUpserts: Promise<void>[] = [];
-  for (const caseRecord of Object.values(casesToUpsert)) {
-    caseRecord.petitioners?.forEach(p => {
-      p.hasConsentedToElectronicService = p?.hasConsentedToEService;
-      p.hasElectronicAccess = p?.hasEAccess;
-    });
-    postgresUpserts.push(
-      upsertPetitionersOnCase({
-        docketNumber: caseRecord.docketNumber,
-        petitionerCase: caseRecord,
-      }),
-    );
-    postgresUpserts.push(
-      upsertCaseStatusUpdates({
-        docketNumber: caseRecord.docketNumber,
-        statusUpdates: caseRecord.caseStatusHistory || [],
-      }),
-    );
-    if (caseRecord.statistics) {
+    await upsertCases(Object.values(casesToUpsert));
+    const postgresUpserts: Promise<void>[] = [];
+    for (const caseRecord of Object.values(casesToUpsert)) {
+      caseRecord.petitioners?.forEach(p => {
+        p.hasConsentedToElectronicService = p?.hasConsentedToEService;
+        p.hasElectronicAccess = p?.hasEAccess;
+      });
       postgresUpserts.push(
-        upsertCaseStatistics({
+        upsertPetitionersOnCase({
           docketNumber: caseRecord.docketNumber,
-          statistics: caseRecord.statistics.map(s => new Statistic(s)),
+          petitionerCase: caseRecord,
         }),
       );
+      postgresUpserts.push(
+        upsertCaseStatusUpdates({
+          docketNumber: caseRecord.docketNumber,
+          statusUpdates: caseRecord.caseStatusHistory || [],
+        }),
+      );
+      if (caseRecord.statistics) {
+        postgresUpserts.push(
+          upsertCaseStatistics({
+            docketNumber: caseRecord.docketNumber,
+            statistics: caseRecord.statistics.map(s => new Statistic(s)),
+          }),
+        );
+      }
     }
-  }
 
-  await settlePromises(postgresUpserts);
+    await settlePromises(postgresUpserts);
+  } catch (e) {
+    getLogger().error(
+      `Postgres re-indexing failure: Failed to process case record: ${e}`,
+    );
+  }
 };

--- a/web-api/src/business/useCases/processStreamRecords/processDocketEntries.test.ts
+++ b/web-api/src/business/useCases/processStreamRecords/processDocketEntries.test.ts
@@ -140,21 +140,4 @@ describe('processDocketEntries', () => {
       },
     ]);
   });
-
-  it('should log an error and throw an exception when bulk index returns failed records', async () => {
-    applicationContext
-      .getPersistenceGateway()
-      .bulkIndexRecords.mockReturnValueOnce({
-        failedRecords: [{ id: 'failed record' }],
-      });
-
-    await expect(
-      processDocketEntries({
-        applicationContext,
-        docketEntryRecords: [mockUnsearchableDocketEntryRecord],
-      }),
-    ).rejects.toThrow('failed to index docket entry');
-
-    expect(applicationContext.logger.error).toHaveBeenCalled();
-  });
 });

--- a/web-api/src/business/useCases/processStreamRecords/processDocketEntries.ts
+++ b/web-api/src/business/useCases/processStreamRecords/processDocketEntries.ts
@@ -4,6 +4,7 @@ import { upsertDocketEntries } from '@web-api/persistence/postgres/docketEntries
 import type { IDynamoDBRecord } from '@web-api/business/useCases/processStreamRecords/processStreamUtilities';
 import type { ServerApplicationContext } from '@web-api/applicationContext';
 import { settlePromises } from '@web-api/utilities/settlePromises';
+import { getLogger } from '@web-api/utilities/logger/getLogger';
 
 /**
  * fetches the latest version of the case from dynamodb and re-indexes this docket-entries combined with the latest case info.
@@ -23,85 +24,91 @@ export const processDocketEntries = async ({
     `going to index ${records.length} docketEntryRecords`,
   );
 
-  const newDocketEntryRecords: IDynamoDBRecord[] = await settlePromises(
-    records.map(async record => {
-      const fullDocketEntry = unmarshall(record.dynamodb.NewImage);
+  try {
+    const newDocketEntryRecords: IDynamoDBRecord[] = await settlePromises(
+      records.map(async record => {
+        const fullDocketEntry = unmarshall(record.dynamodb.NewImage);
 
-      if (
-        DocketEntry.isSearchable(fullDocketEntry.eventCode) &&
-        fullDocketEntry.documentContentsId
-      ) {
-        // TODO: for performance, we should not re-index doc contents if we do not have to (use a contents hash?)
-        try {
-          const buffer = await applicationContext
-            .getPersistenceGateway()
-            .getDocument({
-              applicationContext,
-              key: fullDocketEntry.documentContentsId,
-              useTempBucket: false,
-            });
-          const docketEntry = new TextDecoder('utf-8').decode(buffer);
+        if (
+          DocketEntry.isSearchable(fullDocketEntry.eventCode) &&
+          fullDocketEntry.documentContentsId
+        ) {
+          // TODO: for performance, we should not re-index doc contents if we do not have to (use a contents hash?)
+          try {
+            const buffer = await applicationContext
+              .getPersistenceGateway()
+              .getDocument({
+                applicationContext,
+                key: fullDocketEntry.documentContentsId,
+                useTempBucket: false,
+              });
+            const docketEntry = new TextDecoder('utf-8').decode(buffer);
 
-          const { documentContents } = JSON.parse(docketEntry);
+            const { documentContents } = JSON.parse(docketEntry);
 
-          fullDocketEntry.documentContents = documentContents;
-        } catch (err) {
-          applicationContext.logger.error(
-            `the s3 document of ${fullDocketEntry.documentContentsId} was not found in s3`,
-            { err },
-          );
+            fullDocketEntry.documentContents = documentContents;
+          } catch (err) {
+            applicationContext.logger.error(
+              `the s3 document of ${fullDocketEntry.documentContentsId} was not found in s3`,
+              { err },
+            );
+          }
         }
-      }
 
-      const caseDocketEntryMappingRecordId = `${fullDocketEntry.pk}_${fullDocketEntry.pk}|mapping`;
+        const caseDocketEntryMappingRecordId = `${fullDocketEntry.pk}_${fullDocketEntry.pk}|mapping`;
 
-      return {
-        dynamodb: {
-          Keys: {
-            pk: {
-              S: fullDocketEntry.pk,
+        return {
+          dynamodb: {
+            Keys: {
+              pk: {
+                S: fullDocketEntry.pk,
+              },
+              sk: {
+                S: fullDocketEntry.sk,
+              },
             },
-            sk: {
-              S: fullDocketEntry.sk,
+            NewImage: {
+              ...marshall(fullDocketEntry),
+              case_relations: {
+                name: 'document',
+                parent: caseDocketEntryMappingRecordId,
+              },
             },
           },
-          NewImage: {
-            ...marshall(fullDocketEntry),
-            case_relations: {
-              name: 'document',
-              parent: caseDocketEntryMappingRecordId,
-            },
-          },
-        },
-        eventName: 'MODIFY',
-      };
-    }),
-  );
-
-  const { failedRecords } = await applicationContext
-    .getPersistenceGateway()
-    .bulkIndexRecords({
-      applicationContext,
-      records: newDocketEntryRecords,
-    });
-
-  if (failedRecords.length > 0) {
-    applicationContext.logger.error(
-      'the docket entry records that failed to index',
-      { failedRecords },
+          eventName: 'MODIFY',
+        };
+      }),
     );
-    throw new Error('failed to index docket entry records');
+
+    const { failedRecords } = await applicationContext
+      .getPersistenceGateway()
+      .bulkIndexRecords({
+        applicationContext,
+        records: newDocketEntryRecords,
+      });
+
+    if (failedRecords.length > 0) {
+      applicationContext.logger.error(
+        'the docket entry records that failed to index',
+        { failedRecords },
+      );
+      throw new Error('failed to index docket entry records');
+    }
+
+    const pgDocketEntries: Record<string, RawDocketEntry> = {};
+
+    for (const record of records) {
+      const unmarshalledRecord = unmarshall(record.dynamodb.NewImage);
+      const key =
+        unmarshalledRecord.docketNumber + unmarshalledRecord.docketEntryId;
+      // Only upsert the most recent update of any duplicate docket entry record since otherwise Postgres will throw an error.
+      pgDocketEntries[key] = unmarshalledRecord as RawDocketEntry;
+    }
+
+    await upsertDocketEntries(Object.values(pgDocketEntries));
+  } catch (e) {
+    getLogger().error(
+      `Postgres re-indexing failure: Failed to process docket entry record: ${e}`,
+    );
   }
-
-  const pgDocketEntries: Record<string, RawDocketEntry> = {};
-
-  for (const record of records) {
-    const unmarshalledRecord = unmarshall(record.dynamodb.NewImage);
-    const key =
-      unmarshalledRecord.docketNumber + unmarshalledRecord.docketEntryId;
-    // Only upsert the most recent update of any duplicate docket entry record since otherwise Postgres will throw an error.
-    pgDocketEntries[key] = unmarshalledRecord as RawDocketEntry;
-  }
-
-  await upsertDocketEntries(Object.values(pgDocketEntries));
 };

--- a/web-api/src/business/useCases/processStreamRecords/processPractitionerMappingEntries.test.ts
+++ b/web-api/src/business/useCases/processStreamRecords/processPractitionerMappingEntries.test.ts
@@ -88,25 +88,6 @@ describe('processPractitionerMappingEntries', () => {
     ).toHaveBeenCalled();
   });
 
-  it('should log an error and throw an exception when bulk index returns failed records', async () => {
-    getCaseMetadataWithCounsel.mockResolvedValue(mockCaseRecord as any);
-
-    applicationContext
-      .getPersistenceGateway()
-      .bulkIndexRecords.mockReturnValueOnce({
-        failedRecords: [{ id: 'failed record' }],
-      });
-
-    await expect(
-      processPractitionerMappingEntries({
-        applicationContext,
-        practitionerMappingRecords: mockPractitionerMappingEntries,
-      }),
-    ).rejects.toThrow('failed to index practitioner mapping records');
-
-    expect(applicationContext.logger.error).toHaveBeenCalled();
-  });
-
   it('should fallback to dynamo when case is not found in postgres during re-indexing', async () => {
     getCaseMetadataWithCounsel.mockRejectedValue({});
     getCaseDataFromDynamo.mockResolvedValue({});

--- a/web-api/src/business/useCases/processStreamRecords/processPractitionerMappingEntries.ts
+++ b/web-api/src/business/useCases/processStreamRecords/processPractitionerMappingEntries.ts
@@ -20,92 +20,98 @@ export const processPractitionerMappingEntries = async ({
 }) => {
   if (!practitionerMappingRecords.length) return;
 
-  const indexCaseEntryForPractitionerMapping =
-    async practitionerMappingRecord => {
-      const practitionerMappingData =
-        practitionerMappingRecord.dynamodb.NewImage ||
-        practitionerMappingRecord.dynamodb.OldImage;
-      const caseRecords: IDynamoDBRecord[] = [];
+  try {
+    const indexCaseEntryForPractitionerMapping =
+      async practitionerMappingRecord => {
+        const practitionerMappingData =
+          practitionerMappingRecord.dynamodb.NewImage ||
+          practitionerMappingRecord.dynamodb.OldImage;
+        const caseRecords: IDynamoDBRecord[] = [];
 
-      const docketNumber = practitionerMappingData.pk.S.substring(
-        'case|'.length,
-      );
-
-      // After case records have been moved into postgres, we need to get the case data associated with the practitioner from postgres.
-      // However, when we try to fetch case data here during the initial blue-green migration re-indexing step (to get case records
-      // into postgres in the first place), the case data might not yet have been moved over to postgres. Therefore, we fallback to the case data from Dynamo.
-      // TODO after 10502: Only rely on postgres by in-lining getCaseDataFromPostgres here.
-      let caseRecord: any;
-      try {
-        caseRecord = await getCaseDataFromPostgres({
-          applicationContext,
-          docketNumber,
-        });
-      } catch (e) {
-        getLogger().warn(
-          `Failed to find case ${practitionerMappingData.pk.S} in postgres in processPractitionerMappingEntries: ${e}.
-          If this occurred in a test or as part of re-indexing during a blue-green migration, it is safe to ignore.`,
+        const docketNumber = practitionerMappingData.pk.S.substring(
+          'case|'.length,
         );
-        caseRecord = await getCaseDataFromDynamo({
-          applicationContext,
-          docketNumber,
+
+        // After case records have been moved into postgres, we need to get the case data associated with the practitioner from postgres.
+        // However, when we try to fetch case data here during the initial blue-green migration re-indexing step (to get case records
+        // into postgres in the first place), the case data might not yet have been moved over to postgres. Therefore, we fallback to the case data from Dynamo.
+        // TODO after 10502: Only rely on postgres by in-lining getCaseDataFromPostgres here.
+        let caseRecord: any;
+        try {
+          caseRecord = await getCaseDataFromPostgres({
+            applicationContext,
+            docketNumber,
+          });
+        } catch (e) {
+          getLogger().warn(
+            `Failed to find case ${practitionerMappingData.pk.S} in postgres in processPractitionerMappingEntries: ${e}.
+          If this occurred in a test or as part of re-indexing during a blue-green migration, it is safe to ignore.`,
+          );
+          caseRecord = await getCaseDataFromDynamo({
+            applicationContext,
+            docketNumber,
+          });
+        }
+
+        caseRecords.push({
+          dynamodb: {
+            Keys: {
+              pk: {
+                S: practitionerMappingData.pk.S,
+              },
+              sk: {
+                S: practitionerMappingData.pk.S,
+              },
+            },
+            NewImage: {
+              ...caseRecord,
+              case_relations: { name: 'case' },
+              entityName: { S: 'CaseDocketEntryMapping' },
+            }, // Create a mapping record on the docket-entry index for parent-child relationships
+          },
+          eventName: 'MODIFY',
         });
-      }
 
-      caseRecords.push({
-        dynamodb: {
-          Keys: {
-            pk: {
-              S: practitionerMappingData.pk.S,
+        caseRecords.push({
+          dynamodb: {
+            Keys: {
+              pk: {
+                S: practitionerMappingData.pk.S,
+              },
+              sk: {
+                S: practitionerMappingData.sk.S,
+              },
             },
-            sk: {
-              S: practitionerMappingData.pk.S,
-            },
+            NewImage: caseRecord as { [key: string]: AttributeValueWithName },
           },
-          NewImage: {
-            ...caseRecord,
-            case_relations: { name: 'case' },
-            entityName: { S: 'CaseDocketEntryMapping' },
-          }, // Create a mapping record on the docket-entry index for parent-child relationships
-        },
-        eventName: 'MODIFY',
-      });
+          eventName: 'MODIFY',
+        });
 
-      caseRecords.push({
-        dynamodb: {
-          Keys: {
-            pk: {
-              S: practitionerMappingData.pk.S,
-            },
-            sk: {
-              S: practitionerMappingData.sk.S,
-            },
-          },
-          NewImage: caseRecord as { [key: string]: AttributeValueWithName },
-        },
-        eventName: 'MODIFY',
-      });
+        return caseRecords;
+      };
 
-      return caseRecords;
-    };
-
-  const indexRecords = await settlePromises(
-    practitionerMappingRecords.map(indexCaseEntryForPractitionerMapping),
-  );
-
-  const { failedRecords } = await applicationContext
-    .getPersistenceGateway()
-    .bulkIndexRecords({
-      applicationContext,
-      records: flattenDeep(indexRecords),
-    });
-
-  if (failedRecords.length > 0) {
-    applicationContext.logger.error(
-      'the practitioner mapping record that failed to index',
-      { failedRecords },
+    const indexRecords = await settlePromises(
+      practitionerMappingRecords.map(indexCaseEntryForPractitionerMapping),
     );
-    throw new Error('failed to index practitioner mapping records');
+
+    const { failedRecords } = await applicationContext
+      .getPersistenceGateway()
+      .bulkIndexRecords({
+        applicationContext,
+        records: flattenDeep(indexRecords),
+      });
+
+    if (failedRecords.length > 0) {
+      applicationContext.logger.error(
+        'the practitioner mapping record that failed to index',
+        { failedRecords },
+      );
+      throw new Error('failed to index practitioner mapping records');
+    }
+  } catch (e) {
+    getLogger().error(
+      `Postgres re-indexing failure: Failed to process practitioner mapping record: ${e}`,
+    );
   }
 };
 


### PR DESCRIPTION
We have had failures in an entire glue job because, e.g., one data point is off while re-indexing. Rather than fail the entire glue job, we want to log the error.

This PR adds a try/catch with a consistent error message to look for in:

- processDocketEntries
- processCaseEntries
- processPractitionerMappingEntries