### PR TITLE
10643 Bug: Fix Order Response edit link issue

### DIFF
--- a/web-client/src/presenter/actions/MotionOrderResponse/setEditMotionOrderResponseFormAction.test.ts
+++ b/web-client/src/presenter/actions/MotionOrderResponse/setEditMotionOrderResponseFormAction.test.ts
@@ -26,7 +26,7 @@ describe('setEditMotionOrderResponseFormAction', () => {
     expect(result.state.form).toEqual(mockDraftOrderState);
     expect(result.state.docketEntryId).toEqual('123');
     expect(result.output.path).toEqual(
-      '/messages/123-45/message-detail/abc/xyz/motion-response-order-edit',
+      '/messages/123-45/message-detail/abc/xyz/motion-order-response-edit',
     );
   });
 

--- a/web-client/src/presenter/actions/MotionOrderResponse/setEditMotionOrderResponseFormAction.ts
+++ b/web-client/src/presenter/actions/MotionOrderResponse/setEditMotionOrderResponseFormAction.ts
@@ -8,7 +8,7 @@ export const setEditMotionOrderResponseFormAction = ({
   const documentToEdit = get(state.documentToEdit);
   const { caseDetail, docketEntryIdToEdit } = props;
   const pathUrl = props.parentMessageId
-    ? `/messages/${caseDetail.docketNumber}/message-detail/${props.parentMessageId}/${docketEntryIdToEdit}/motion-response-order-edit`
+    ? `/messages/${caseDetail.docketNumber}/message-detail/${props.parentMessageId}/${docketEntryIdToEdit}/motion-order-response-edit`
     : `/case-detail/${caseDetail.docketNumber}/documents/${docketEntryIdToEdit}/motion-order-response-edit`;
 
   store.set(state.form, documentToEdit.draftOrderState);

--- a/web-client/src/presenter/actions/StatusReportOrder/isEditOrderResponseAction.ts
+++ b/web-client/src/presenter/actions/StatusReportOrder/isEditOrderResponseAction.ts
@@ -1,6 +1,8 @@
 export const isEditOrderResponseAction = ({ path, props }: ActionProps) => {
   if (props.isEditing) {
-    return path.edit({ docketEntryIdToEdit: props.docketEntryId });
+    return path.edit({
+      docketEntryIdToEdit: props.docketEntryId ?? props.docketEntryIdToEdit, // Yuck. Sometimes we look for docketEntryId, sometimes for docketEntryIdToEdit.
+    });
   }
   return path.create();
 };


### PR DESCRIPTION
There are two issues:

1. The route [here](https://github.com/ustaxcourt/ef-cms/blob/09b446b30fb47599ff6d67d5b2ab02fdd7efbde8/web-client/src/presenter/actions/MotionOrderResponse/setEditMotionOrderResponseFormAction.test.ts#L29) does not match the actual route [here](https://github.com/ustaxcourt/ef-cms/blob/09b446b30fb47599ff6d67d5b2ab02fdd7efbde8/web-client/src/router.ts#L1391)
2. We sometimes pass in `docketEntryId` and other times `docketEntryIdToEdit` in our routes. The relevant action is only looking for one of them.

---

Note: I think the way this PR fixes the second issue is "ok," but not good. However, I think a good solution is more involved:

1. Standardize `docketEntryId` and `docketEntryIdToEdit`, ensuring there are no unintended side effects. With global state used everywhere, this is non-trivial.
2. Remove the duplicative flows for editing documents. We have parallel flows (even including parallel .tsx files) for editing a document depending on if it is being edited from the case details screen or the messages screen. The routes might be different (although I think even these could be done with query parameters rather than paths), but editing a document should do essentially the same thing under the hood. (For every custom document type and every place it might appear, we need a new path, new actions, a new edit screen, separate tests, etc.? That's silly.) This, I think, is the real issue, and it has caused problems before with the Status Report Order.