### PR TITLE
opex: resume glue jobs, take 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -777,7 +777,7 @@ jobs:
       - run:
           name: Migrate Postgres Data Schema
           command: |
-            npm run migration:postgres
+            NODE_ENV=production npm run migration:postgres
       - run:
           name: Enable Dynamodb Streams
           command: |
@@ -804,7 +804,7 @@ jobs:
       - run:
           name: Migrate Postgres Data Schema
           command: |
-            npm run migration:postgres
+            NODE_ENV=production npm run migration:postgres
       - run:
           name: Enable Dynamodb Streams
           command: |


### PR DESCRIPTION
 Explicitly set NODE_ENV to 'production' before running a postgres migration in circleci