### PR TITLE
Fix regex in emailReplacer

### DIFF
--- a/scripts/emailReplacer.ts
+++ b/scripts/emailReplacer.ts
@@ -3,7 +3,8 @@ import * as fs from 'fs';
 import * as readline from 'readline';
 
 const DOMAIN_REPLACER = 'ef-cms.ustaxcourt.gov';
-const emailRegex = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
+// Use a negative look-behind to avoid \nSOMEEMAIL --> \SOMEEMAIL
+const emailRegex = /(?<!\\)[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
 
 export function sanitizeEmail(email: string) {
   const hash = crypto.createHash('md5').update(email).digest('hex');


### PR DESCRIPTION
Add a negative look-behind so that `\nSOMEEMAIL` does not become `\SOMEEMAILHASHED`.

Before:

<img width="550" alt="Screenshot 2025-06-03 at 3 44 32 PM" src="https://github.com/user-attachments/assets/145e8c3a-43ca-4191-8a5a-e77a2378ae6b" />


After:

<img width="535" alt="Screenshot 2025-06-03 at 3 44 02 PM" src="https://github.com/user-attachments/assets/c162c61d-1290-42d4-b705-de9ee78c4a87" />
