### PR TITLE
opex: remove the resume-glue-to-test workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,10 +45,6 @@ parameters:
     default: ''
     type: string
 
-  run_resume_glue_to_test:
-    default: false
-    type: boolean
-
 commands:
   npm-and-cypress-install:
     steps:
@@ -777,33 +773,6 @@ jobs:
           command: |
             ./scripts/migration/toggle-streams.sh --on
 
-  resume-indexing-glued-data:
-    docker:
-      - image: *efcms-docker-image
-        aws_auth:
-          aws_access_key_id: $AWS_ACCESS_KEY_ID
-          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
-    resource_class: medium+
-    steps:
-      - git-shallow-clone/checkout
-      - npm-install
-      - run:
-          name: Setup Env
-          command: |
-            ./scripts/env/env-for-circle.sh
-      - run:
-          name: Set Marker to Indicate Data is Finished Gluing
-          command: |
-            COLOR="$CURRENT_COLOR" JOB_NAME="wait-for-glued-data-to-index" ./scripts/migration/set-migration-complete-marker.sh
-      - run:
-          name: Migrate Postgres Data Schema
-          command: |
-            NODE_ENV=production npm run migration:postgres
-      - run:
-          name: Enable Dynamodb Streams
-          command: |
-            ./scripts/migration/toggle-streams.sh --on
-
   cleanup-glue-job:
     docker:
       - image: *efcms-docker-image
@@ -1197,18 +1166,3 @@ workflows:
     jobs:
       - sync-s3-buckets-with-timeout:
           <<: *only-deployed-lower-environments
-
-  resume-glue-to-test:
-    when: << pipeline.parameters.run_resume_glue_to_test >>
-    jobs:
-      - resume-indexing-glued-data:
-          <<: *only-test
-      - wait-for-glued-data-to-index:
-          <<: *only-test
-          type: approval
-          requires:
-            - resume-indexing-glued-data
-      - cleanup-glue-job:
-          <<: *only-test
-          requires:
-            - wait-for-glued-data-to-index


### PR DESCRIPTION
Remove the `resume-glue-to-test` workflow (this effectively reverts 1e29480166446c44241740c1c85e928f4f3a950a)