### PR TITLE
Review  -  Removed Amazon pay language

### DIFF
--- a/web-client/src/views/StartCaseUpdated/FilePetitionStep7.tsx
+++ b/web-client/src/views/StartCaseUpdated/FilePetitionStep7.tsx
@@ -26,7 +26,7 @@ export const FilePetitionStep7 = connect(
         </div>
         <h3 className="margin-top-205">Pay $60 filing fee</h3>
         <div className="petitioner-flow-text">
-          {`Pay by credit/debit card, Amazon Pay, PayPal or ACH (bank account)
+          {`Pay by credit/debit card, PayPal or ACH (bank account)
           online. You’ll need ${isPetitioner ? 'your' : 'the'} docket number.`}
         </div>
         <div className="petitioner-flow-text margin-top-1">


### PR DESCRIPTION
https://github.com/flexion/ef-cms/issues/10677


On page 7 of our petitioner flow we indicate that pay.gov will accept Amazon pay. They do not. We should remove that language so we don't mislead anyone.

AC: Remove Amazon Pay from the list of accepted ways to pay.