### PR TITLE
bug: do not show interstitial page until case creation is complete

### DIFF
--- a/web-client/src/presenter/sequences/submitPetitionFromPaperSequence.ts
+++ b/web-client/src/presenter/sequences/submitPetitionFromPaperSequence.ts
@@ -39,7 +39,6 @@ export const submitPetitionFromPaperSequence = [
           setValidationAlertErrorsAction,
         ],
         success: [
-          setupCurrentPageAction('Interstitial'),
           stopShowValidationAction,
           showProgressSequenceDecorator([
             setCaseTypeAction,
@@ -49,6 +48,7 @@ export const submitPetitionFromPaperSequence = [
             {
               error: [openFileUploadErrorModal],
               success: [
+                setupCurrentPageAction('Interstitial'),
                 clearConfirmationTextStatisticsAction,
                 setCaseAction,
                 assignPetitionToAuthenticatedUserAction,


### PR DESCRIPTION
If the paper case creation process fails during document upload, the loading spinner will never disappear because we are setting the `Intersitial` page too early. We should not set this until we are preparing for page navigation. This fixes the issue