### PR TITLE
BUG: OpenSearch queries that sort on `sortableDocketNumber` stopped working (to test)

### DIFF
--- a/shared/src/business/useCases/getAllUsersByRoleInteractor.ts
+++ b/shared/src/business/useCases/getAllUsersByRoleInteractor.ts
@@ -2,9 +2,9 @@ import {
   ROLE_PERMISSIONS,
   isAuthorized,
 } from '@shared/authorization/authorizationClientService';
-import { ServerApplicationContext } from '@web-api/applicationContext';
 import { UnauthorizedError } from '@web-api/errors/errors';
 import { UnknownAuthUser } from '@shared/business/entities/authUser/AuthUser';
+import type { ServerApplicationContext } from '@web-api/applicationContext';
 
 export const getAllUsersByRoleInteractor = async (
   applicationContext: ServerApplicationContext,

--- a/shared/src/business/useCases/getAllUsersByRoleInteractor.ts
+++ b/shared/src/business/useCases/getAllUsersByRoleInteractor.ts
@@ -2,11 +2,12 @@ import {
   ROLE_PERMISSIONS,
   isAuthorized,
 } from '@shared/authorization/authorizationClientService';
+import { ServerApplicationContext } from '@web-api/applicationContext';
 import { UnauthorizedError } from '@web-api/errors/errors';
 import { UnknownAuthUser } from '@shared/business/entities/authUser/AuthUser';
 
 export const getAllUsersByRoleInteractor = async (
-  applicationContext: IApplicationContext,
+  applicationContext: ServerApplicationContext,
   { roles }: { roles: string[] },
   authorizedUser: UnknownAuthUser,
 ) => {

--- a/web-api/elasticsearch/efcms-case-mappings.ts
+++ b/web-api/elasticsearch/efcms-case-mappings.ts
@@ -128,7 +128,7 @@ export const efcmsCaseMappings: Record<string, Object> = {
           type: 'keyword',
         },
       },
-      type: 'integer',
+      type: 'long',
     },
     'status.S': {
       type: 'keyword',

--- a/web-api/src/persistence/elasticsearch/searchClient.ts
+++ b/web-api/src/persistence/elasticsearch/searchClient.ts
@@ -3,13 +3,18 @@ import { get } from 'lodash';
 import { getIndexNameFromAlias } from '../../../elasticsearch/elasticsearch-aliases';
 import { unmarshall } from '@aws-sdk/util-dynamodb';
 import { updateIndex } from '@web-api/persistence/elasticsearch/helpers/getIndexName';
-import { ServerApplicationContext } from '@web-api/applicationContext';
+import { type ServerApplicationContext } from '@web-api/applicationContext';
 import {
   Count_Request,
   Search_Request,
 } from '@opensearch-project/opensearch/api';
+import {
+  type Common,
+  type Core_Search,
+} from '@opensearch-project/opensearch/api/_types';
+import { MAX_ELASTICSEARCH_PAGINATION } from '@shared/business/entities/EntityConstants';
 
-const CHUNK_SIZE = 10000;
+const CHUNK_SIZE = MAX_ELASTICSEARCH_PAGINATION;
 export type SearchClientResultsType = {
   aggregations?: {
     [x: string]: {
@@ -98,17 +103,14 @@ export const searchRaw = async ({
   applicationContext,
   searchParameters,
 }: {
-  applicationContext: IApplicationContext;
+  applicationContext: ServerApplicationContext;
   searchParameters: Search_Request;
 }): Promise<any> => {
   updateIndex({ searchParameters });
   try {
-    const response = await applicationContext
-      .getSearchClient()
-      .search(searchParameters);
-    return response;
+    return await applicationContext.getSearchClient().search(searchParameters);
   } catch (searchError) {
-    applicationContext.logger.error(searchError);
+    applicationContext.logger.error('OpenSearch error', searchError);
     throw new Error('Search client encountered an error.');
   }
 };
@@ -117,7 +119,7 @@ export const searchAll = async ({
   applicationContext,
   searchParameters,
 }: {
-  applicationContext: IApplicationContext;
+  applicationContext: ServerApplicationContext;
   searchParameters: Search_Request;
 }): Promise<SearchClientResultsType> => {
   updateIndex({ searchParameters });
@@ -125,37 +127,36 @@ export const searchAll = async ({
   const query = searchParameters.body?.query || {};
   const size = searchParameters.size || CHUNK_SIZE;
 
-  let countQ;
-  try {
-    countQ = await applicationContext.getSearchClient().count({
+  const expected = await count({
+    applicationContext,
+    searchParameters: {
       body: {
         query,
       },
       index,
-    });
-  } catch (searchError) {
-    applicationContext.logger.error(searchError);
-    throw new Error('Search client encountered an error.');
-  }
+    },
+  });
 
-  const _source = searchParameters.body?._source || [];
-  let search_after = [0];
+  const _source: Core_Search.SourceConfigParam =
+    (searchParameters.body?._source as Core_Search.SourceConfigParam) || [];
+  let search_after: Common.SortResults = [0];
   const sort = searchParameters.body?.sort || [{ 'pk.S': 'asc' }]; // sort is required for paginated queries
-
-  const expected = get(countQ, 'body.count', 0);
 
   let i = 0;
   let results = [];
   while (i < expected) {
-    const chunk = await applicationContext.getSearchClient().search({
-      _source,
-      body: {
-        query,
-        search_after,
-        sort,
+    const chunk = await searchRaw({
+      applicationContext,
+      searchParameters: {
+        _source,
+        body: {
+          query,
+          search_after,
+          sort,
+        },
+        index,
+        size,
       },
-      index,
-      size,
     });
     const hits = get(chunk, 'body.hits.hits', []);
 
@@ -163,6 +164,7 @@ export const searchAll = async ({
       results = results.concat(hits);
       search_after = hits[hits.length - 1].sort;
     }
+    // i += hits.length;
     i += size; // this avoids an endless loop if expected is somehow greater than the sum of all hits
   }
 

--- a/web-api/src/persistence/elasticsearch/searchClient.ts
+++ b/web-api/src/persistence/elasticsearch/searchClient.ts
@@ -3,16 +3,16 @@ import { get } from 'lodash';
 import { getIndexNameFromAlias } from '../../../elasticsearch/elasticsearch-aliases';
 import { unmarshall } from '@aws-sdk/util-dynamodb';
 import { updateIndex } from '@web-api/persistence/elasticsearch/helpers/getIndexName';
-import { type ServerApplicationContext } from '@web-api/applicationContext';
-import {
+import { MAX_ELASTICSEARCH_PAGINATION } from '@shared/business/entities/EntityConstants';
+import type {
+  Common,
+  Core_Search,
+} from '@opensearch-project/opensearch/api/_types';
+import type {
   Count_Request,
   Search_Request,
 } from '@opensearch-project/opensearch/api';
-import {
-  type Common,
-  type Core_Search,
-} from '@opensearch-project/opensearch/api/_types';
-import { MAX_ELASTICSEARCH_PAGINATION } from '@shared/business/entities/EntityConstants';
+import type { ServerApplicationContext } from '@web-api/applicationContext';
 
 const CHUNK_SIZE = MAX_ELASTICSEARCH_PAGINATION;
 export type SearchClientResultsType = {

--- a/web-api/src/persistence/elasticsearch/users/getAllUsersByRole.ts
+++ b/web-api/src/persistence/elasticsearch/users/getAllUsersByRole.ts
@@ -1,6 +1,6 @@
 import { RawUser } from '@shared/business/entities/User';
-import { ServerApplicationContext } from '@web-api/applicationContext';
 import { searchAll } from '@web-api/persistence/elasticsearch/searchClient';
+import type { ServerApplicationContext } from '@web-api/applicationContext';
 
 export const getAllUsersByRole = async (
   applicationContext: ServerApplicationContext,

--- a/web-api/src/persistence/elasticsearch/users/getAllUsersByRole.ts
+++ b/web-api/src/persistence/elasticsearch/users/getAllUsersByRole.ts
@@ -1,8 +1,9 @@
 import { RawUser } from '@shared/business/entities/User';
 import { searchAll } from '@web-api/persistence/elasticsearch/searchClient';
+import { ServerApplicationContext } from '@web-api/applicationContext';
 
 export const getAllUsersByRole = async (
-  applicationContext: IApplicationContext,
+  applicationContext: ServerApplicationContext,
   roles: string[],
 ): Promise<RawUser[]> => {
   const { results } = await searchAll({

--- a/web-api/src/persistence/elasticsearch/users/getAllUsersByRole.ts
+++ b/web-api/src/persistence/elasticsearch/users/getAllUsersByRole.ts
@@ -1,6 +1,6 @@
 import { RawUser } from '@shared/business/entities/User';
-import { searchAll } from '@web-api/persistence/elasticsearch/searchClient';
 import { ServerApplicationContext } from '@web-api/applicationContext';
+import { searchAll } from '@web-api/persistence/elasticsearch/searchClient';
 
 export const getAllUsersByRole = async (
   applicationContext: ServerApplicationContext,


### PR DESCRIPTION
We recently added some padding to how we generate the `sortableDocketNumber` field on Case entities. These values now exceed the 32-bit integer threshold, so we need to update the `efcms-case` index's mappings to make `sortableDocketNumber` a `long`, which is a 64-bit integer.