### PR TITLE
10668: Removing Automatic Block for a Calendared Case with a Docketed Stipulated Decision

### DIFF
--- a/web-api/src/business/useCaseHelper/automaticBlock/updateCaseAutomaticBlock.test.ts
+++ b/web-api/src/business/useCaseHelper/automaticBlock/updateCaseAutomaticBlock.test.ts
@@ -4,6 +4,7 @@ jest.mock(
 import {
   AUTOMATIC_BLOCKED_REASONS,
   CASE_STATUS_TYPES,
+  SIGNED_DOCUMENT_TYPES,
 } from '@shared/business/entities/EntityConstants';
 import { Case } from '@shared/business/entities/cases/Case';
 import { MOCK_CASE, MOCK_CASE_WITHOUT_PENDING } from '@shared/test/mockCase';
@@ -78,11 +79,51 @@ describe('updateCaseAutomaticBlock', () => {
         authorizedUser: mockDocketClerkUser,
       },
     );
+
+    const updateAutomaticBlockedSpy = jest.spyOn(
+      caseEntity,
+      'updateAutomaticBlocked',
+    );
+
     const updatedCase = await updateCaseAutomaticBlock({
       caseEntity,
     });
 
     expect(updatedCase.automaticBlocked).toBeFalsy();
+    expect(updateAutomaticBlockedSpy).not.toHaveBeenCalled();
+  });
+
+  it('should call updateAutomaticBlocked when the case has a trial date and also has a docketed stipulated decision', async () => {
+    getCaseDeadlinesByDocketNumber.mockResolvedValue([]);
+
+    const caseEntity = new Case(
+      {
+        ...MOCK_CASE_WITHOUT_PENDING,
+        highPriority: false,
+        trialDate: '2021-03-01T21:40:46.415Z',
+        docketEntries: [
+          {
+            docketNumber: MOCK_CASE_WITHOUT_PENDING.docketNumber,
+            eventCode: SIGNED_DOCUMENT_TYPES.signedStipulatedDecision.eventCode,
+            isOnDocketRecord: true,
+          },
+        ],
+      },
+      {
+        authorizedUser: mockDocketClerkUser,
+      },
+    );
+
+    const updateAutomaticBlockedSpy = jest.spyOn(
+      caseEntity,
+      'updateAutomaticBlocked',
+    );
+
+    await updateCaseAutomaticBlock({
+      caseEntity,
+    });
+
+    expect(updateAutomaticBlockedSpy).toHaveBeenCalled();
   });
 
   it('does not set the case to automaticBlocked when the case is marked as high priority', async () => {

--- a/web-api/src/business/useCaseHelper/automaticBlock/updateCaseAutomaticBlock.ts
+++ b/web-api/src/business/useCaseHelper/automaticBlock/updateCaseAutomaticBlock.ts
@@ -1,6 +1,7 @@
 import { Case } from '@shared/business/entities/cases/Case';
 import { getCaseDeadlinesByDocketNumber } from '@web-api/persistence/postgres/caseDeadlines/getCaseDeadlinesByDocketNumber';
 import { isEmpty } from 'lodash';
+import { SIGNED_DOCUMENT_TYPES } from '@shared/business/entities/EntityConstants';
 
 export const updateCaseAutomaticBlock = async ({
   caseEntity,
@@ -9,9 +10,15 @@ export const updateCaseAutomaticBlock = async ({
   caseEntity: Case;
   hasCaseDeadline?: boolean;
 }) => {
-  if (caseEntity.trialDate || caseEntity.highPriority) {
-    return caseEntity;
-  }
+  const docketedStipulatedDecision = caseEntity.docketEntries.find(
+    de =>
+      de.eventCode ===
+        SIGNED_DOCUMENT_TYPES.signedStipulatedDecision.eventCode &&
+      de.isOnDocketRecord,
+  );
+
+  if (caseEntity.trialDate && !docketedStipulatedDecision) return caseEntity;
+  if (caseEntity.highPriority) return caseEntity;
 
   if (hasCaseDeadline === undefined) {
     hasCaseDeadline = !isEmpty(


### PR DESCRIPTION
The change in this PR for [10668](https://github.com/flexion/ef-cms/issues/10668) are specifically in response to the use of the use case helper `updateCaseAutomaticBlock` in `removeCasePendingItemInteractor`.

`updateCaseAutomaticBlock` is called in nine other interactors, which are listed below. I don't see any problems in these interactors that this PR would introduce.

- unprioritizeCaseInteractor
- fileAndServeDocumentOnOneCase
- createCaseDeadlineInteractor
- deleteCaseDeadlineInteractor
- addPaperFilingInteractor
- completeDocketEntryQCInteractor
- updateDocketEntryMetaInteractor
- fileExternalDocumentInteractor
- removeCaseFromTrialInteractor