### PR TITLE
devex: move index-docket-entries-once into its own workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,10 @@ parameters:
     default: false
     type: boolean
 
+  run_index_once:
+    default: false
+    type: boolean
+
   lower_env:
     default: test
     type: string
@@ -357,25 +361,6 @@ jobs:
               ./web-api/enable-deploying-dynamo-stream-trigger.sh
             fi
 
-  index-docket-entries-once-test:
-    docker:
-      - image: *efcms-docker-image
-        aws_auth:
-          aws_access_key_id: $AWS_ACCESS_KEY_ID
-          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
-    resource_class: medium+
-    steps:
-      - git-shallow-clone/checkout
-      - npm-install
-      - run:
-          name: Setup Env
-          command: |
-            ./scripts/env/env-for-circle.sh
-      - run:
-          name: Index Docket Entries
-          command: |
-            NODE_ENV=production ./scripts/run-once-scripts/postgres-migration/index-docket-entries/index-docket-entries.ts 6
-
   disable-reindex-cron:
     docker:
       - image: *efcms-docker-image
@@ -626,6 +611,25 @@ jobs:
             if [ $MIGRATE_FLAG == true ]; then
               npm run migration:cleanup -- $ENV
             fi
+
+  index-docket-entries-once-test:
+    docker:
+      - image: *efcms-docker-image
+        aws_auth:
+          aws_access_key_id: $AWS_ACCESS_KEY_ID
+          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
+    resource_class: xlarge
+    steps:
+      - git-shallow-clone/checkout
+      - npm-install
+      - run:
+          name: Setup Env
+          command: |
+            ./scripts/env/env-for-circle.sh
+      - run:
+          name: Index Docket Entries
+          command: |
+            NODE_ENV=production ./scripts/run-once-scripts/postgres-migration/index-docket-entries/index-docket-entries.ts 6
 
   ######################## GLUE JOB: Jobs that run in a lower environment ########################
 
@@ -1078,10 +1082,6 @@ workflows:
           type: approval
           requires:
             - migrate
-      - index-docket-entries-once-test:
-          <<: *only-deployed-lower-environments
-          requires:
-            - wait-for-migration
       - prepare-for-reindex:
           <<: *only-deployed-lower-environments
           requires:
@@ -1276,6 +1276,12 @@ workflows:
           type: approval
           requires:
             - initiate-s3-sync
+
+  index-once:
+    when: << pipeline.parameters.run_index_once >>
+    jobs:
+      - index-docket-entries-once-test:
+          <<: *only-deployed-lower-environments
 
   sync-s3-to-lower-env:
     when: << pipeline.parameters.run_sync_s3_to_lower_env >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,10 @@ parameters:
     default: false
     type: boolean
 
+  index_threads:
+    default: ''
+    type: string
+
   lower_env:
     default: test
     type: string
@@ -612,13 +616,15 @@ jobs:
               npm run migration:cleanup -- $ENV
             fi
 
-  index-docket-entries-once-test:
+  index-docket-entries-once:
     docker:
       - image: *efcms-docker-image
         aws_auth:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
     resource_class: xlarge
+    environment:
+      THREADS: << pipeline.parameters.index_threads >>
     steps:
       - git-shallow-clone/checkout
       - npm-install
@@ -629,7 +635,7 @@ jobs:
       - run:
           name: Index Docket Entries
           command: |
-            NODE_ENV=production ./scripts/run-once-scripts/postgres-migration/index-docket-entries/index-docket-entries.ts 6
+            NODE_ENV=production ./scripts/run-once-scripts/postgres-migration/index-docket-entries/index-docket-entries.ts "$THREADS"
 
   ######################## GLUE JOB: Jobs that run in a lower environment ########################
 
@@ -1280,7 +1286,7 @@ workflows:
   index-once:
     when: << pipeline.parameters.run_index_once >>
     jobs:
-      - index-docket-entries-once-test:
+      - index-docket-entries-once:
           <<: *only-deployed-lower-environments
 
   sync-s3-to-lower-env:

--- a/scripts/run-once-scripts/postgres-migration/index-docket-entries/index-docket-entries.ts
+++ b/scripts/run-once-scripts/postgres-migration/index-docket-entries/index-docket-entries.ts
@@ -35,10 +35,6 @@ This script partitions docket entries into N (= num_processes argument) equal gr
 to index each group.
 */
 async function main() {
-  // eslint-disable-next-line custom-rules-plugin/no-new-dates
-  if (new Date().toISOString().slice(0, 10) !== '2025-07-08') {
-    process.exit(0); //Run only today, this is a failsafe in case we don't remove this before the next person deploys
-  }
   const count = await getDocketEntriesCount();
 
   const numProcesses = Number(num_processes);


### PR DESCRIPTION
This moves the docket entries index test into its own workflow and out of the `build-and-deploy` workflow.