### PR TITLE
10652 status report order enhancement, grey text if disabled

### DIFF
--- a/web-client/src/views/StatusReportOrder.tsx
+++ b/web-client/src/views/StatusReportOrder.tsx
@@ -261,6 +261,7 @@ export const StatusReportOrder = connect(
                         className="usa-checkbox__label"
                         htmlFor="stricken-from-trial-sessions"
                         id="stricken-from-trial-sessions-label"
+                        style={!statusReportOrderHelper.isCalendared ? { color: '#757575' } : {}}
                         title={statusReportOrderHelper.isCalendared ? '' : 'Case is not calendared'}
                       >
                         Case is stricken from the trial session


### PR DESCRIPTION
https://github.com/orgs/flexion/projects/11/views/1?filterQuery=assignee%3Aalexdziarn&pane=issue&itemId=109321136&issue=flexion%7Cef-cms%7C10652

need to add grey text if the input is disabled. Have to use inline styling because '.usa-checkboxinput:disabled + .usa-checkboxlabel' overides the classes