### PR TITLE
10693 prevent overwriting subject line

### DIFF
--- a/cypress/local-only/tests/integration/caseDetail/docketRecord/courtIssuedFiling/docket-clerk-uploads-and-edits-court-issued-docket-entry.cy.ts
+++ b/cypress/local-only/tests/integration/caseDetail/docketRecord/courtIssuedFiling/docket-clerk-uploads-and-edits-court-issued-docket-entry.cy.ts
@@ -118,7 +118,7 @@ describe('Docket clerk uploads and edits court-issued docket entries', () => {
         });
       cy.get('[data-testid="modal-confirm"]').click();
       cy.get('#tab-case-messages').click();
-      cy.contains('a', title).click();
+      cy.contains('a', messageTitle).click();
 
       // Act: edit the docket entry from the messages view
       cy.get('[data-testid="edit-signed-document-button"]').click();
@@ -168,7 +168,7 @@ describe('Docket clerk uploads and edits court-issued docket entries', () => {
         });
       cy.get('[data-testid="modal-confirm"]').click();
       cy.get('#tab-case-messages').click();
-      cy.contains('a', title).click();
+      cy.contains('a', messageTitle).click();
 
       // Act: edit the docket entry from the messages view
       cy.get('[data-testid="edit-unsigned-document-button"]').click();

--- a/web-client/src/presenter/actions/updateMessageModalAttachmentsAction.test.ts
+++ b/web-client/src/presenter/actions/updateMessageModalAttachmentsAction.test.ts
@@ -228,6 +228,32 @@ describe('updateMessageModalAttachmentsAction', () => {
     expect(result.state.modal.form.subject).toEqual('Petition');
   });
 
+  it('does not update the subject field on first attachment if the subject field is already set', async () => {
+    const existingSubject = 'My Custom Subject';
+    const result = await runAction(updateMessageModalAttachmentsAction, {
+      modules: { presenter },
+      props: {
+        action: 'add',
+        documentId: '123',
+      },
+      state: {
+        caseDetail,
+        modal: {
+          form: {
+            attachments: [],
+            draftAttachments: [],
+            subject: existingSubject,
+          },
+        },
+      },
+    });
+
+    expect(result.state.modal.form.subject).toEqual(existingSubject);
+    expect(result.state.modal.form.draftAttachments).toEqual([
+      { documentId: '123', documentTitle: 'Petition' },
+    ]);
+  });
+
   it('truncates the document title to 250 characters when updating the subject field', async () => {
     const result = await runAction(updateMessageModalAttachmentsAction, {
       modules: { presenter },

--- a/web-client/src/presenter/actions/updateMessageModalAttachmentsAction.ts
+++ b/web-client/src/presenter/actions/updateMessageModalAttachmentsAction.ts
@@ -6,7 +6,6 @@ export const updateMessageModalAttachmentsAction = ({
   props,
   store,
 }: ActionProps) => {
-  console.log('updateMessageModalAttachmentsAction called', props);
   const { attachments, draftAttachments, subject } = get(state.modal.form);
   const caseDetail = get(state.caseDetail);
   const documentId = props.documentId || get(state.docketEntryId);
@@ -22,18 +21,11 @@ export const updateMessageModalAttachmentsAction = ({
     const documentTitle = applicationContext
       .getUtilities()
       .getDescriptionDisplay(document);
-    
-    console.log(`Subject state: ${subject}`);
-    // TODO: Alter this logic for 10693
-    if (attachments.length + draftAttachments.length === 0) {
-      // TODO 10693: Bug here. If the subject is removed, it will not be updated.
-      // This is the first attachment, so we should update the subject
-      // We are updating the subject line
-      console.log(`Updating subject to: ${documentTitle.slice(0, 250)}`);
+
+    const isSubjectEmpty = !subject || subject.trim() === '';
+    if (isSubjectEmpty && attachments.length + draftAttachments.length === 0) {
       store.set(state.modal.form.subject, documentTitle.slice(0, 250));
-      
     }
-    console.log(`Document title: ${documentTitle}`);
     if (props.action === 'add') {
       draftAttachments.push({
         documentId,

--- a/web-client/src/presenter/actions/updateMessageModalAttachmentsAction.ts
+++ b/web-client/src/presenter/actions/updateMessageModalAttachmentsAction.ts
@@ -6,7 +6,8 @@ export const updateMessageModalAttachmentsAction = ({
   props,
   store,
 }: ActionProps) => {
-  const { attachments, draftAttachments } = get(state.modal.form);
+  console.log('updateMessageModalAttachmentsAction called', props);
+  const { attachments, draftAttachments, subject } = get(state.modal.form);
   const caseDetail = get(state.caseDetail);
   const documentId = props.documentId || get(state.docketEntryId);
 
@@ -21,11 +22,18 @@ export const updateMessageModalAttachmentsAction = ({
     const documentTitle = applicationContext
       .getUtilities()
       .getDescriptionDisplay(document);
-
+    
+    console.log(`Subject state: ${subject}`);
+    // TODO: Alter this logic for 10693
     if (attachments.length + draftAttachments.length === 0) {
+      // TODO 10693: Bug here. If the subject is removed, it will not be updated.
       // This is the first attachment, so we should update the subject
+      // We are updating the subject line
+      console.log(`Updating subject to: ${documentTitle.slice(0, 250)}`);
       store.set(state.modal.form.subject, documentTitle.slice(0, 250));
+      
     }
+    console.log(`Document title: ${documentTitle}`);
     if (props.action === 'add') {
       draftAttachments.push({
         documentId,


### PR DESCRIPTION
Prevents overwritting Subject line when manually populated. See [10693 Ticket](https://github.com/orgs/flexion/projects/11/views/1?filterQuery=10693&pane=issue&itemId=118002344&issue=flexion%7Cef-cms%7C10693)