### PR TITLE
10684 Large Case Followup (dropping a table)

### DIFF
--- a/web-api/src/persistence/postgres/utils/migrate/migrations/2025-07-26T23_34_53Z-drop-docketEntry-from-dwWorkItem.ts
+++ b/web-api/src/persistence/postgres/utils/migrate/migrations/2025-07-26T23_34_53Z-drop-docketEntry-from-dwWorkItem.ts
@@ -1,0 +1,13 @@
+import { Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema.alterTable('dwWorkItem').dropColumn('docketEntry').execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('dwWorkItem')
+    .addColumn('docketEntry', 'jsonb', col => col.notNull().defaultTo({}))
+    .execute();
+  // TODO: add script to paginate over relevant docket entries and jsonify them into dwWorkItem docketEntry
+}

--- a/web-api/src/persistence/postgres/utils/migrate/migrations/2025-07-26T23_34_53Z-drop-docketEntry-from-dwWorkItem.ts
+++ b/web-api/src/persistence/postgres/utils/migrate/migrations/2025-07-26T23_34_53Z-drop-docketEntry-from-dwWorkItem.ts
@@ -1,4 +1,5 @@
-import { Kysely } from 'kysely';
+import { Database } from '@web-api/database-schema';
+import { CompiledQuery, Kysely } from 'kysely';
 
 export async function up(db: Kysely<any>): Promise<void> {
   await db.schema.alterTable('dwWorkItem').dropColumn('docketEntry').execute();
@@ -7,7 +8,21 @@ export async function up(db: Kysely<any>): Promise<void> {
 export async function down(db: Kysely<any>): Promise<void> {
   await db.schema
     .alterTable('dwWorkItem')
-    .addColumn('docketEntry', 'jsonb', col => col.notNull().defaultTo({}))
+    .addColumn('docketEntry', 'jsonb', col =>
+      col.notNull().defaultTo(JSON.stringify({})),
+    )
     .execute();
-  // TODO: add script to paginate over relevant docket entries and jsonify them into dwWorkItem docketEntry
+  await attachDocketEntryDataToWorkItems(db);
+}
+
+async function attachDocketEntryDataToWorkItems(db: Kysely<Database>) {
+  // Easier to do this in raw SQL rather than fiddling with kysely, and we don't really need the types anyway
+  return db.executeQuery(
+    CompiledQuery.raw(`
+      UPDATE dw_work_item AS w
+      SET    docket_entry = row_to_json(d)
+      FROM   dw_docket_entry AS d
+      WHERE  w.docket_entry_id = d.docket_entry_id
+        AND  w.docket_number    = d.docket_number;`),
+  );
 }


### PR DESCRIPTION
In https://github.com/ustaxcourt/ef-cms/pull/6241, we stopped using the `docketEntry` column of work items and instead used the `dwDocketEntry` table. Here, we finish the job and drop the `docketEntry` column entirely. (This has to be done as a follow-up so that we do not drop the `docketEntry` column while the active color is still using it.)