### PR TITLE
10684 Large Cases Bug (An Update to Test)

### DIFF
--- a/shared/src/business/entities/WorkItem.test.ts
+++ b/shared/src/business/entities/WorkItem.test.ts
@@ -98,7 +98,7 @@ describe('WorkItem', () => {
     const assignment = {
       assigneeId: '111cd447-6278-461b-b62b-d9e357eea62c',
       assigneeName: 'Joe',
-      section: 'Some Section',
+      section: DOCKET_SECTION as typeof DOCKET_SECTION,
       sentBy: 'Sender Name',
       sentBySection: 'Sender Section',
       sentByUserId: '222cd447-6278-461b-b62b-d9e357eea62c',

--- a/shared/src/business/entities/WorkItem.test.ts
+++ b/shared/src/business/entities/WorkItem.test.ts
@@ -2,6 +2,8 @@ import {
   CASE_STATUS_TYPES,
   DOCKET_NUMBER_SUFFIXES,
   DOCKET_SECTION,
+  INITIAL_DOCUMENT_TYPES,
+  PETITIONS_SECTION,
 } from './EntityConstants';
 import { WorkItem } from './WorkItem';
 
@@ -138,6 +140,37 @@ describe('WorkItem', () => {
       expect(
         WorkItem.isHighPriority({ status: CASE_STATUS_TYPES.assignedCase }),
       ).toEqual(false);
+    });
+  });
+
+  describe('getWorkItemSectionFromUserSection', () => {
+    it('should return docket section when section is docket', () => {
+      const result = WorkItem.getWorkItemSectionFromUserSection({
+        section: DOCKET_SECTION,
+        documentTitle: 'N/A',
+      });
+      expect(result).toEqual(DOCKET_SECTION);
+    });
+    it('should return petitions section when section is petitions', () => {
+      const result = WorkItem.getWorkItemSectionFromUserSection({
+        section: PETITIONS_SECTION,
+        documentTitle: 'N/A',
+      });
+      expect(result).toEqual(PETITIONS_SECTION);
+    });
+    it('should return petitions section when section is not petitions or docket and document is a petition', () => {
+      const result = WorkItem.getWorkItemSectionFromUserSection({
+        section: 'some other user section',
+        documentTitle: INITIAL_DOCUMENT_TYPES.petition.documentTitle,
+      });
+      expect(result).toEqual(PETITIONS_SECTION);
+    });
+    it('should return docket section when section is not petitions or docket and document is not a petition', () => {
+      const result = WorkItem.getWorkItemSectionFromUserSection({
+        section: 'some other user section',
+        documentTitle: 'This is a good document',
+      });
+      expect(result).toEqual(DOCKET_SECTION);
     });
   });
 });

--- a/shared/src/business/entities/WorkItem.ts
+++ b/shared/src/business/entities/WorkItem.ts
@@ -22,7 +22,7 @@ export class WorkItem extends JoiValidationEntity {
   public docketNumber: string;
   public inProgress?: boolean;
   public isRead?: boolean;
-  public section: string;
+  public section: typeof PETITIONS_SECTION | typeof DOCKET_SECTION;
   public sentBy: string;
   public sentBySection?: string;
   public sentByUserId?: string;

--- a/shared/src/business/entities/WorkItem.ts
+++ b/shared/src/business/entities/WorkItem.ts
@@ -92,7 +92,7 @@ export class WorkItem extends JoiValidationEntity {
   }: {
     assigneeId?: string;
     assigneeName?: string;
-    section: string;
+    section: typeof PETITIONS_SECTION | typeof DOCKET_SECTION;
     sentBy: string;
     sentBySection?: string;
     sentByUserId?: string;

--- a/shared/src/business/entities/WorkItem.ts
+++ b/shared/src/business/entities/WorkItem.ts
@@ -2,7 +2,12 @@ import { JoiValidationEntity } from '@shared/business/entities/JoiValidationEnti
 import { createISODateString } from '../utilities/DateHandler';
 import { getUniqueId } from '@shared/sharedAppContext';
 import { JoiValidationConstants } from '@shared/business/entities/JoiValidationConstants';
-import { CASE_STATUS_TYPES } from '@shared/business/entities/EntityConstants';
+import {
+  CASE_STATUS_TYPES,
+  DOCKET_SECTION,
+  INITIAL_DOCUMENT_TYPES,
+  PETITIONS_SECTION,
+} from '@shared/business/entities/EntityConstants';
 import joi from 'joi';
 
 export class WorkItem extends JoiValidationEntity {
@@ -139,20 +144,23 @@ export class WorkItem extends JoiValidationEntity {
   }: {
     section?: string;
     documentTitle: string;
-  }) {
+  }): typeof PETITIONS_SECTION | typeof DOCKET_SECTION | undefined {
     if (!section) {
       return undefined;
     }
-    // We have sections for caseServicesSupervisor and clerkofcourt, but as far as we can tell, they aren't used.
-    // Instead, we need to translate these into either the petitions section or the docket section depending
-    // on the document type.
-    if (!['caseServicesSupervisor', 'clerkofcourt'].includes(section)) {
-      return section;
+    // A work item is assigned to either the petitions section or the docket section.
+    // If the section we are passing in is either of those, just return it.
+    if ([DOCKET_SECTION, PETITIONS_SECTION].includes(section)) {
+      return section as typeof PETITIONS_SECTION | typeof DOCKET_SECTION;
     }
-    if (documentTitle?.toLocaleLowerCase() == 'petition') {
-      return 'petitions';
+    // Otherwise, we will assign a petition to the petitions section and anything else to the docket section.
+    if (
+      documentTitle?.toLocaleLowerCase() ==
+      INITIAL_DOCUMENT_TYPES.petition.documentTitle.toLocaleLowerCase()
+    ) {
+      return PETITIONS_SECTION;
     }
-    return 'docket';
+    return DOCKET_SECTION;
   }
 }
 

--- a/shared/src/business/entities/WorkItem.ts
+++ b/shared/src/business/entities/WorkItem.ts
@@ -132,6 +132,28 @@ export class WorkItem extends JoiValidationEntity {
   getValidationRules() {
     return WorkItem.VALIDATION_RULES;
   }
+
+  static getWorkItemSectionFromUserSection({
+    section,
+    documentTitle,
+  }: {
+    section?: string;
+    documentTitle: string;
+  }) {
+    if (!section) {
+      return undefined;
+    }
+    // We have sections for caseServicesSupervisor and clerkofcourt, but as far as we can tell, they aren't used.
+    // Instead, we need to translate these into either the petitions section or the docket section depending
+    // on the document type.
+    if (!['caseServicesSupervisor', 'clerkofcourt'].includes(section)) {
+      return section;
+    }
+    if (documentTitle?.toLocaleLowerCase() == 'petition') {
+      return 'petitions';
+    }
+    return 'docket';
+  }
 }
 
 export type RawWorkItem = ExcludeMethods<WorkItem>;

--- a/shared/src/business/entities/WorkItem.ts
+++ b/shared/src/business/entities/WorkItem.ts
@@ -144,13 +144,10 @@ export class WorkItem extends JoiValidationEntity {
   }: {
     section?: string;
     documentTitle: string;
-  }): typeof PETITIONS_SECTION | typeof DOCKET_SECTION | undefined {
-    if (!section) {
-      return undefined;
-    }
+  }): typeof PETITIONS_SECTION | typeof DOCKET_SECTION {
     // A work item is assigned to either the petitions section or the docket section.
     // If the section we are passing in is either of those, just return it.
-    if ([DOCKET_SECTION, PETITIONS_SECTION].includes(section)) {
+    if (section && [DOCKET_SECTION, PETITIONS_SECTION].includes(section)) {
       return section as typeof PETITIONS_SECTION | typeof DOCKET_SECTION;
     }
     // Otherwise, we will assign a petition to the petitions section and anything else to the docket section.

--- a/shared/src/business/utilities/getWorkQueueFilters.test.ts
+++ b/shared/src/business/utilities/getWorkQueueFilters.test.ts
@@ -377,7 +377,7 @@ describe('getWorkQueueFilters', () => {
           docketEntry: {
             isFileAttached: false,
           } as RawDocketEntry,
-          section: CASE_SERVICES_SUPERVISOR_SECTION,
+          section: DOCKET_SECTION,
           workItemId: '1',
         },
         {
@@ -388,7 +388,7 @@ describe('getWorkQueueFilters', () => {
           inProgress: true,
           docketEntryId: 'anId',
           docketEntry: {} as RawDocketEntry,
-          section: CASE_SERVICES_SUPERVISOR_SECTION,
+          section: DOCKET_SECTION,
           workItemId: '2',
         },
         {
@@ -400,7 +400,7 @@ describe('getWorkQueueFilters', () => {
             isFileAttached: true,
           } as RawDocketEntry,
           inProgress: false,
-          section: CASE_SERVICES_SUPERVISOR_SECTION,
+          section: DOCKET_SECTION,
           workItemId: '3',
         },
         {
@@ -414,7 +414,7 @@ describe('getWorkQueueFilters', () => {
             isFileAttached: true,
           } as RawDocketEntry,
           inProgress: false,
-          section: CASE_SERVICES_SUPERVISOR_SECTION,
+          section: DOCKET_SECTION,
           workItemId: '4',
         },
       ];
@@ -439,7 +439,12 @@ describe('getWorkQueueFilters', () => {
       ]);
     });
 
-    [PETITIONS_SECTION, DOCKET_SECTION].forEach(sectionToTest => {
+    (
+      [PETITIONS_SECTION, DOCKET_SECTION] as (
+        | typeof PETITIONS_SECTION
+        | typeof DOCKET_SECTION
+      )[]
+    ).forEach(sectionToTest => {
       it(`returns an object containing a filter map for ${sectionToTest} section work queues and boxes`, () => {
         const sectionWorkItems: RawWorkItemWithCaseAndDocketEntryInfo[] = [
           {

--- a/shared/src/test/mockAuthUsers.ts
+++ b/shared/src/test/mockAuthUsers.ts
@@ -91,3 +91,10 @@ export const mockCaseServicesSupervisorUser: AuthUser = {
   role: ROLES.caseServicesSupervisor,
   userId: '97451b05-ae9c-46d5-9074-1ac6ef12cfc6',
 };
+
+export const mockClerkOfTheCourtUser: AuthUser = {
+  email: 'mcokClerkOfTheCourt@example.com',
+  name: 'Balthasar Leclerk',
+  role: ROLES.clerkOfCourt,
+  userId: '48da1916-4b0b-44e5-bef7-68cac4d5b358',
+};

--- a/shared/src/test/mockAuthUsers.ts
+++ b/shared/src/test/mockAuthUsers.ts
@@ -93,7 +93,7 @@ export const mockCaseServicesSupervisorUser: AuthUser = {
 };
 
 export const mockClerkOfTheCourtUser: AuthUser = {
-  email: 'mcokClerkOfTheCourt@example.com',
+  email: 'mockClerkOfTheCourt@example.com',
   name: 'Balthasar Leclerk',
   role: ROLES.clerkOfCourt,
   userId: '48da1916-4b0b-44e5-bef7-68cac4d5b358',

--- a/web-api/src/business/useCaseHelper/docketEntry/fileAndServeDocumentOnOneCase.ts
+++ b/web-api/src/business/useCaseHelper/docketEntry/fileAndServeDocumentOnOneCase.ts
@@ -58,6 +58,7 @@ export const fileAndServeDocumentOnOneCase = async ({
   await completeWorkItem({
     user,
     workItemToUpdate: workItem,
+    docketEntryEntity,
   });
 
   docketEntryEntity.validate();
@@ -87,11 +88,18 @@ export const fileAndServeDocumentOnOneCase = async ({
   });
 };
 
-const completeWorkItem = async ({ user, workItemToUpdate }) => {
+const completeWorkItem = async ({
+  user,
+  workItemToUpdate,
+  docketEntryEntity,
+}) => {
   workItemToUpdate.assignToUser({
     assigneeId: user.userId,
     assigneeName: user.name,
-    section: user.section,
+    section: WorkItem.getWorkItemSectionFromUserSection({
+      section: user.section,
+      documentTitle: docketEntryEntity.documentTitle,
+    }),
     sentBy: user.name,
     sentBySection: user.section,
     sentByUserId: user.userId,

--- a/web-api/src/business/useCases/createCaseFromPaperInteractor.ts
+++ b/web-api/src/business/useCases/createCaseFromPaperInteractor.ts
@@ -42,7 +42,10 @@ const addPetitionDocketEntryWithWorkItemToCase = ({
     docketEntryId: docketEntryEntity.docketEntryId,
     docketNumber: caseToAdd.docketNumber,
     inProgress: true,
-    section: user.section,
+    section: WorkItem.getWorkItemSectionFromUserSection({
+      section: user.section,
+      documentTitle: docketEntryEntity.documentTitle,
+    }),
     sentBy: user.name,
     sentBySection: user.section,
     sentByUserId: user.userId,

--- a/web-api/src/business/useCases/docketEntry/addPaperFilingInteractor.ts
+++ b/web-api/src/business/useCases/docketEntry/addPaperFilingInteractor.ts
@@ -123,7 +123,10 @@ export const addPaperFiling = async (
       docketEntryId: docketEntryEntity.docketEntryId,
       inProgress: isSavingForLater,
       isRead: user.role !== ROLES.privatePractitioner,
-      section: user.section,
+      section: WorkItem.getWorkItemSectionFromUserSection({
+        section: user.section,
+        documentTitle: docketEntryEntity.documentTitle,
+      }),
       sentBy: user.name,
       sentBySection: user.section,
       sentByUserId: user.userId,

--- a/web-api/src/business/useCases/docketEntry/completeDocketEntryQCInteractor.ts
+++ b/web-api/src/business/useCases/docketEntry/completeDocketEntryQCInteractor.ts
@@ -216,7 +216,7 @@ const completeDocketEntryQC = async (
     section: WorkItem.getWorkItemSectionFromUserSection({
       section: sectionToAssignTo,
       documentTitle: updatedDocketEntry.documentTitle,
-    })!,
+    }),
     sentBy: user.name,
     sentBySection: user.section,
     sentByUserId: user.userId,

--- a/web-api/src/business/useCases/docketEntry/completeDocketEntryQCInteractor.ts
+++ b/web-api/src/business/useCases/docketEntry/completeDocketEntryQCInteractor.ts
@@ -36,6 +36,7 @@ import { getWorkItemByDocketNumberAndDocketEntryId } from '@web-api/persistence/
 import { getUserById } from '@web-api/persistence/postgres/users/getUserById';
 import { updateCaseAndAssociations } from '@web-api/business/useCaseHelper/caseAssociation/updateCaseAndAssociations';
 import { withLocking } from '@web-api/persistence/postgres/utils/mutex';
+import { WorkItem } from '@shared/business/entities/WorkItem';
 
 const completeDocketEntryQC = async (
   applicationContext: ServerApplicationContext,
@@ -212,7 +213,10 @@ const completeDocketEntryQC = async (
   workItem.assignToUser({
     assigneeId: user.userId,
     assigneeName: user.name,
-    section: sectionToAssignTo,
+    section: WorkItem.getWorkItemSectionFromUserSection({
+      section: sectionToAssignTo,
+      documentTitle: updatedDocketEntry.documentTitle,
+    })!,
     sentBy: user.name,
     sentBySection: user.section,
     sentByUserId: user.userId,

--- a/web-api/src/business/useCases/docketEntry/editPaperFilingInteractor.ts
+++ b/web-api/src/business/useCases/docketEntry/editPaperFilingInteractor.ts
@@ -29,6 +29,7 @@ import {
   asyncHandleLockError,
   withLocking,
 } from '@web-api/persistence/postgres/utils/mutex';
+import { WorkItem } from '@shared/business/entities/WorkItem';
 
 interface IEditPaperFilingRequest {
   documentMetadata: any;
@@ -469,7 +470,10 @@ const updateAndSaveWorkItem = async ({
   workItem.assignToUser({
     assigneeId: user.userId,
     assigneeName: user.name,
-    section: user.section!,
+    section: WorkItem.getWorkItemSectionFromUserSection({
+      section: user.section,
+      documentTitle: docketEntry.documentTitle,
+    })!,
     sentBy: user.name,
     sentBySection: user.section,
     sentByUserId: user.userId,

--- a/web-api/src/business/useCases/docketEntry/editPaperFilingInteractor.ts
+++ b/web-api/src/business/useCases/docketEntry/editPaperFilingInteractor.ts
@@ -473,7 +473,7 @@ const updateAndSaveWorkItem = async ({
     section: WorkItem.getWorkItemSectionFromUserSection({
       section: user.section,
       documentTitle: docketEntry.documentTitle,
-    })!,
+    }),
     sentBy: user.name,
     sentBySection: user.section,
     sentByUserId: user.userId,

--- a/web-api/src/business/useCases/docketEntry/fileCourtIssuedDocketEntryInteractor.ts
+++ b/web-api/src/business/useCases/docketEntry/fileCourtIssuedDocketEntryInteractor.ts
@@ -148,7 +148,10 @@ export const fileCourtIssuedDocketEntry = async (
       workItem.assignToUser({
         assigneeId: user.userId,
         assigneeName: user.name,
-        section: user.section,
+        section: WorkItem.getWorkItemSectionFromUserSection({
+          section: user.section,
+          documentTitle: docketEntryEntity.documentTitle,
+        }),
         sentBy: user.name,
         sentBySection: user.section,
         sentByUserId: user.userId,

--- a/web-api/src/business/useCases/docketEntry/fileCourtIssuedDocketEntryInteractor.ts
+++ b/web-api/src/business/useCases/docketEntry/fileCourtIssuedDocketEntryInteractor.ts
@@ -151,7 +151,7 @@ export const fileCourtIssuedDocketEntry = async (
         section: WorkItem.getWorkItemSectionFromUserSection({
           section: user.section,
           documentTitle: docketEntryEntity.documentTitle,
-        })!,
+        }),
         sentBy: user.name,
         sentBySection: user.section,
         sentByUserId: user.userId,

--- a/web-api/src/business/useCases/docketEntry/fileCourtIssuedDocketEntryInteractor.ts
+++ b/web-api/src/business/useCases/docketEntry/fileCourtIssuedDocketEntryInteractor.ts
@@ -151,7 +151,7 @@ export const fileCourtIssuedDocketEntry = async (
         section: WorkItem.getWorkItemSectionFromUserSection({
           section: user.section,
           documentTitle: docketEntryEntity.documentTitle,
-        }),
+        })!,
         sentBy: user.name,
         sentBySection: user.section,
         sentByUserId: user.userId,

--- a/web-api/src/business/useCases/workItems/assignWorkItemsInteractor.test.ts
+++ b/web-api/src/business/useCases/workItems/assignWorkItemsInteractor.test.ts
@@ -1,21 +1,36 @@
 import '@web-api/persistence/postgres/workitems/mocks.jest';
 import '@web-api/persistence/postgres/users/mocks.jest';
-import { DOCKET_SECTION } from '@shared/business/entities/EntityConstants';
+import '@web-api/persistence/postgres/docketEntries/mocks.jest';
+import {
+  CASE_SERVICES_SUPERVISOR_SECTION,
+  CLERK_OF_COURT_SECTION,
+  DOCKET_SECTION,
+  PETITIONS_SECTION,
+} from '@shared/business/entities/EntityConstants';
 import { RawWorkItem, WorkItem } from '@shared/business/entities/WorkItem';
 import { applicationContext } from '@shared/business/test/createTestApplicationContext';
 import { assignWorkItemsInteractor } from './assignWorkItemsInteractor';
 import { caseServicesSupervisorUser } from '@shared/test/mockUsers';
 import { getWorkItemById as getWorkItemByIdMock } from '@web-api/persistence/postgres/workitems/getWorkItemById';
-import { mockDocketClerkUser } from '@shared/test/mockAuthUsers';
+import {
+  mockCaseServicesSupervisorUser,
+  mockClerkOfTheCourtUser,
+  mockDocketClerkUser,
+  mockPetitionsClerkUser,
+} from '@shared/test/mockAuthUsers';
 import { upsertWorkItems as upsertWorkItemsMock } from '@web-api/persistence/postgres/workitems/upsertWorkItems';
 import { getUserById as getUserByIdMock } from '@web-api/persistence/postgres/users/getUserById';
 import { DbUser } from '@web-api/persistence/postgres/users/mapper';
+import { getDocketEntriesByDocketNumberAndDocketEntryId as getDocketEntriesByDocketNumberAndDocketEntryIdMock } from '@web-api/persistence/postgres/docketEntries/getDocketEntriesByDocketNumberAndDocketEntryId';
 
 const getUserById = jest.mocked(getUserByIdMock);
 
 describe('assignWorkItemsInteractor', () => {
   const upsertWorkItems = upsertWorkItemsMock as jest.Mock;
   const getWorkItemById = getWorkItemByIdMock as jest.Mock;
+  const getDocketEntriesByDocketNumberAndDocketEntryId = jest.mocked(
+    getDocketEntriesByDocketNumberAndDocketEntryIdMock,
+  );
 
   const options = { assigneeId: 'ss', assigneeName: 'ss', workItemId: '' };
   let mockWorkItem: RawWorkItem;
@@ -39,6 +54,9 @@ describe('assignWorkItemsInteractor', () => {
     } as DbUser);
 
     getWorkItemById.mockResolvedValue(new WorkItem(mockWorkItem));
+    getDocketEntriesByDocketNumberAndDocketEntryId.mockResolvedValue([
+      { documentTitle: 'Something' },
+    ] as RawDocketEntry[]);
   });
 
   it('should throw an unauthorized error when the user does not have permission to assign work items', async () => {
@@ -83,7 +101,11 @@ describe('assignWorkItemsInteractor', () => {
     ).rejects.toThrow();
   });
 
-  it('should assign work item to current user when given work item', async () => {
+  it('should assign work item to current docket clerk user when given work item', async () => {
+    getUserById.mockResolvedValue({
+      ...mockDocketClerkUser,
+      section: DOCKET_SECTION,
+    } as DbUser);
     await assignWorkItemsInteractor(
       applicationContext,
       {
@@ -104,23 +126,139 @@ describe('assignWorkItemsInteractor', () => {
     ]);
   });
 
-  it('assigns a work item to the current user', async () => {
+  it('should assign work item to current petitions clerk user when given work item', async () => {
+    getUserById.mockResolvedValue({
+      ...mockPetitionsClerkUser,
+      section: PETITIONS_SECTION,
+    } as DbUser);
     await assignWorkItemsInteractor(
       applicationContext,
       {
-        assigneeId: mockDocketClerkUser.userId,
-        assigneeName: 'Ted Docket',
-        workItemId: mockWorkItem.workItemId,
+        assigneeId: mockPetitionsClerkUser.userId,
+        assigneeName: mockPetitionsClerkUser.name,
+        workItem: mockWorkItem,
+        workItemId: undefined,
       },
-      mockDocketClerkUser,
+      mockPetitionsClerkUser,
     );
+    await expect(upsertWorkItems.mock.calls[0][0].workItems).toMatchObject([
+      {
+        section: PETITIONS_SECTION,
+        sentBy: mockPetitionsClerkUser.name,
+        sentBySection: PETITIONS_SECTION,
+        sentByUserId: mockPetitionsClerkUser.userId,
+      },
+    ]);
+  });
 
-    expect(upsertWorkItems.mock.calls[0][0].workItems).toMatchObject([
+  it('should assign work item for a petition docket entry to the petitions section when filed by case services supervisor', async () => {
+    getUserById.mockResolvedValue({
+      ...mockCaseServicesSupervisorUser,
+      section: CASE_SERVICES_SUPERVISOR_SECTION,
+    } as DbUser);
+    getDocketEntriesByDocketNumberAndDocketEntryId.mockResolvedValue([
+      { documentTitle: 'Petition' },
+    ] as RawDocketEntry[]);
+    await assignWorkItemsInteractor(
+      applicationContext,
+      {
+        assigneeId: mockCaseServicesSupervisorUser.userId,
+        assigneeName: mockCaseServicesSupervisorUser.name,
+        workItem: mockWorkItem,
+        workItemId: undefined,
+      },
+      mockCaseServicesSupervisorUser,
+    );
+    await expect(upsertWorkItems.mock.calls[0][0].workItems).toMatchObject([
+      {
+        section: PETITIONS_SECTION,
+        sentBy: mockCaseServicesSupervisorUser.name,
+        sentBySection: CASE_SERVICES_SUPERVISOR_SECTION,
+        sentByUserId: mockCaseServicesSupervisorUser.userId,
+      },
+    ]);
+  });
+
+  it('should assign work item for a petition docket entry to the petitions section when filed by clerk of the court', async () => {
+    getUserById.mockResolvedValue({
+      ...mockClerkOfTheCourtUser,
+      section: CLERK_OF_COURT_SECTION,
+    } as DbUser);
+    getDocketEntriesByDocketNumberAndDocketEntryId.mockResolvedValue([
+      { documentTitle: 'Petition' },
+    ] as RawDocketEntry[]);
+    await assignWorkItemsInteractor(
+      applicationContext,
+      {
+        assigneeId: mockClerkOfTheCourtUser.userId,
+        assigneeName: mockClerkOfTheCourtUser.name,
+        workItem: mockWorkItem,
+        workItemId: undefined,
+      },
+      mockClerkOfTheCourtUser,
+    );
+    await expect(upsertWorkItems.mock.calls[0][0].workItems).toMatchObject([
+      {
+        section: PETITIONS_SECTION,
+        sentBy: mockClerkOfTheCourtUser.name,
+        sentBySection: CLERK_OF_COURT_SECTION,
+        sentByUserId: mockClerkOfTheCourtUser.userId,
+      },
+    ]);
+  });
+
+  it('should assign work item for a non-petition docket entry to the petitions section when filed by case services supervisor', async () => {
+    getUserById.mockResolvedValue({
+      ...mockCaseServicesSupervisorUser,
+      section: CASE_SERVICES_SUPERVISOR_SECTION,
+    } as DbUser);
+    getDocketEntriesByDocketNumberAndDocketEntryId.mockResolvedValue([
+      { documentTitle: 'Something' },
+    ] as RawDocketEntry[]);
+    await assignWorkItemsInteractor(
+      applicationContext,
+      {
+        assigneeId: mockCaseServicesSupervisorUser.userId,
+        assigneeName: mockCaseServicesSupervisorUser.name,
+        workItem: mockWorkItem,
+        workItemId: undefined,
+      },
+      mockCaseServicesSupervisorUser,
+    );
+    await expect(upsertWorkItems.mock.calls[0][0].workItems).toMatchObject([
       {
         section: DOCKET_SECTION,
-        sentBy: mockDocketClerkUser.name,
-        sentBySection: DOCKET_SECTION,
-        sentByUserId: mockDocketClerkUser.userId,
+        sentBy: mockCaseServicesSupervisorUser.name,
+        sentBySection: CASE_SERVICES_SUPERVISOR_SECTION,
+        sentByUserId: mockCaseServicesSupervisorUser.userId,
+      },
+    ]);
+  });
+
+  it('should assign work item for a non-petition docket entry to the petitions section when filed by clerk of the court', async () => {
+    getUserById.mockResolvedValue({
+      ...mockClerkOfTheCourtUser,
+      section: CLERK_OF_COURT_SECTION,
+    } as DbUser);
+    getDocketEntriesByDocketNumberAndDocketEntryId.mockResolvedValue([
+      { documentTitle: 'Something' },
+    ] as RawDocketEntry[]);
+    await assignWorkItemsInteractor(
+      applicationContext,
+      {
+        assigneeId: mockClerkOfTheCourtUser.userId,
+        assigneeName: mockClerkOfTheCourtUser.name,
+        workItem: mockWorkItem,
+        workItemId: undefined,
+      },
+      mockClerkOfTheCourtUser,
+    );
+    await expect(upsertWorkItems.mock.calls[0][0].workItems).toMatchObject([
+      {
+        section: DOCKET_SECTION,
+        sentBy: mockClerkOfTheCourtUser.name,
+        sentBySection: CLERK_OF_COURT_SECTION,
+        sentByUserId: mockClerkOfTheCourtUser.userId,
       },
     ]);
   });

--- a/web-api/src/business/useCases/workItems/assignWorkItemsInteractor.ts
+++ b/web-api/src/business/useCases/workItems/assignWorkItemsInteractor.ts
@@ -10,6 +10,7 @@ import { User } from '@shared/business/entities/User';
 import { getWorkItemById } from '@web-api/persistence/postgres/workitems/getWorkItemById';
 import { upsertWorkItems } from '@web-api/persistence/postgres/workitems/upsertWorkItems';
 import { getUserById } from '@web-api/persistence/postgres/users/getUserById';
+import { getDocketEntriesByDocketNumberAndDocketEntryId } from '@web-api/persistence/postgres/docketEntries/getDocketEntriesByDocketNumberAndDocketEntryId';
 
 /**
  * getWorkItem
@@ -54,9 +55,7 @@ export const assignWorkItemsInteractor = async (
   });
 
   if (!userBeingAssigned) {
-    throw new NotFoundError(
-      `User not found with user id ${assigneeId}`,
-    );
+    throw new NotFoundError(`User not found with user id ${assigneeId}`);
   }
 
   let workItemEntity;
@@ -69,6 +68,23 @@ export const assignWorkItemsInteractor = async (
     }
   } else {
     workItemEntity = new WorkItem(workItem);
+  }
+
+  const docketEntry = (
+    await getDocketEntriesByDocketNumberAndDocketEntryId({
+      docketNumbersAndIds: [
+        {
+          docketNumber: workItemEntity.docketNumber,
+          docketEntryId: workItemEntity.docketEntryId,
+        },
+      ],
+    })
+  ).at(0);
+
+  if (!docketEntry) {
+    throw new NotFoundError(
+      `Docket entry associated with work item ${workItemId} was not found.`,
+    );
   }
 
   const userIsCaseServices = User.isCaseServicesUser({ section: user.section });
@@ -90,7 +106,10 @@ export const assignWorkItemsInteractor = async (
     assigneeName,
     section: sectionToAssignTo,
     sentBy: user.name,
-    sentBySection: user.section,
+    sentBySection: WorkItem.getWorkItemSectionFromUserSection({
+      section: user.section,
+      documentTitle: docketEntry.documentTitle,
+    }),
     sentByUserId: user.userId,
   });
 

--- a/web-api/src/business/useCases/workItems/assignWorkItemsInteractor.ts
+++ b/web-api/src/business/useCases/workItems/assignWorkItemsInteractor.ts
@@ -9,8 +9,8 @@ import { UnknownAuthUser } from '@shared/business/entities/authUser/AuthUser';
 import { User } from '@shared/business/entities/User';
 import { getWorkItemById } from '@web-api/persistence/postgres/workitems/getWorkItemById';
 import { upsertWorkItems } from '@web-api/persistence/postgres/workitems/upsertWorkItems';
-import { getUserById } from '@web-api/persistence/postgres/users/getUserById';
 import { getDocketEntriesByDocketNumberAndDocketEntryId } from '@web-api/persistence/postgres/docketEntries/getDocketEntriesByDocketNumberAndDocketEntryId';
+import { getUserById } from '@web-api/persistence/postgres/users/getUserById';
 
 /**
  * getWorkItem
@@ -83,7 +83,7 @@ export const assignWorkItemsInteractor = async (
 
   if (!docketEntry) {
     throw new NotFoundError(
-      `Docket entry associated with work item ${workItemId} was not found.`,
+      `Docket entry associated with work ${workItemId} was not found.`,
     );
   }
 
@@ -104,12 +104,12 @@ export const assignWorkItemsInteractor = async (
   workItemEntity.assignToUser({
     assigneeId,
     assigneeName,
-    section: sectionToAssignTo,
-    sentBy: user.name,
-    sentBySection: WorkItem.getWorkItemSectionFromUserSection({
-      section: user.section,
+    section: WorkItem.getWorkItemSectionFromUserSection({
+      section: sectionToAssignTo,
       documentTitle: docketEntry.documentTitle,
     }),
+    sentBy: user.name,
+    sentBySection: user.section,
     sentByUserId: user.userId,
   });
 

--- a/web-api/src/business/useCases/workItems/assignWorkItemsInteractor.ts
+++ b/web-api/src/business/useCases/workItems/assignWorkItemsInteractor.ts
@@ -58,7 +58,7 @@ export const assignWorkItemsInteractor = async (
     throw new NotFoundError(`User not found with user id ${assigneeId}`);
   }
 
-  let workItemEntity;
+  let workItemEntity: WorkItem | undefined;
   if (!workItem && workItemId) {
     workItemEntity = await getWorkItemById({
       workItemId,
@@ -107,7 +107,7 @@ export const assignWorkItemsInteractor = async (
     section: WorkItem.getWorkItemSectionFromUserSection({
       section: sectionToAssignTo,
       documentTitle: docketEntry.documentTitle,
-    }),
+    })!,
     sentBy: user.name,
     sentBySection: user.section,
     sentByUserId: user.userId,

--- a/web-api/src/business/useCases/workItems/assignWorkItemsInteractor.ts
+++ b/web-api/src/business/useCases/workItems/assignWorkItemsInteractor.ts
@@ -107,7 +107,7 @@ export const assignWorkItemsInteractor = async (
     section: WorkItem.getWorkItemSectionFromUserSection({
       section: sectionToAssignTo,
       documentTitle: docketEntry.documentTitle,
-    })!,
+    }),
     sentBy: user.name,
     sentBySection: user.section,
     sentByUserId: user.userId,

--- a/web-api/src/persistence/postgres/workitems/mapper.ts
+++ b/web-api/src/persistence/postgres/workitems/mapper.ts
@@ -9,25 +9,6 @@ import {
   WorkItemWithCaseInfoKysely,
 } from '@web-api/persistence/postgres/workitems/schema';
 
-function getWorkItemSection({
-  section,
-  documentTitle,
-}: {
-  section: string;
-  documentTitle?: string;
-}) {
-  // We have sections for caseServicesSupervisor and clerkofcourt, but as far as we can tell, they aren't used.
-  // Instead, we need to translate these into either the petitions section or the docket section depending
-  // on the document type.
-  if (!['caseServicesSupervisor', 'clerkofcourt'].includes(section)) {
-    return section;
-  }
-  if (documentTitle?.toLocaleLowerCase() == 'petition') {
-    return 'petitions';
-  }
-  return 'docket';
-}
-
 export function toKyselyNewWorkItem(workItem: RawWorkItem): NewWorkItemKysely {
   return {
     assigneeId: workItem.assigneeId,
@@ -43,9 +24,7 @@ export function toKyselyNewWorkItem(workItem: RawWorkItem): NewWorkItemKysely {
     docketNumber: workItem.docketNumber,
     inProgress: workItem.inProgress,
     isRead: workItem.isRead,
-    section: getWorkItemSection({
-      section: workItem.section,
-    }),
+    section: workItem.section,
     sentBy: workItem.sentBy,
     sentBySection: workItem.sentBySection,
     sentByUserId: workItem.sentByUserId,


### PR DESCRIPTION
Thank you to @zachrog and @codyseibert for catching this!

**What is the bug?**

In some spots we upsert a work item with `section` set to `user.section` (or some derivative thereof). For sections `caseServicesSupervisor` and `clerkofcourt` (or, more accurately, any section that is not `petitions` or `docket`), we should translate the section to `petitions` for a petition and `docket` for anything else. Before 10684, we used the `documentTitle` of the associated docket entry to determine if the document was a petition. 10684 removed that logic, which means that the work items for documents made by, or the work items assigned to, `caseServicesSupervisor` and `clerkofcourt` users now all get assigned to the `petition` section. Whoops. Luckily 10684 has not been merged to test.

**What is the fix?**

Before, we re-calculated the section _every time we saved a work item_. That's silly. The current fix says, "Hey, when you need to set/change the section in an interactor, make sure you get the appropriate one."

TODO:

- [x] **Write a test.** I opted for a few unit tests and better typing. There are several pathways in which we could set the wrong section, and e2e tests either seemed overkill or arbitrary.
- [x] **Can we determine the section directly from the document without having to think about the user at all?** (Answer: I don't believe so.)
- [x] **Check that this actually fixes the thing and does not cause more issues**