### PR TITLE
opex-dkim-naming-for-prod: set the dkim name format

### DIFF
--- a/web-api/terraform/modules/everything-else-deprecated/ses.tf
+++ b/web-api/terraform/modules/everything-else-deprecated/ses.tf
@@ -40,7 +40,7 @@ resource "aws_ses_domain_dkim" "main" {
 resource "aws_route53_record" "dkim" {
   count   = 3
   zone_id = data.aws_route53_zone.zone.id
-  name    = "${aws_ses_domain_dkim.main.dkim_tokens[count.index]}._domainkey"
+  name    = format("%s._domainkey.%s", aws_ses_domain_dkim.main.dkim_tokens[count.index], aws_ses_domain_identity.main.domain)
   type    = "CNAME"
   ttl     = "600"
   records = ["${aws_ses_domain_dkim.main.dkim_tokens[count.index]}.dkim.amazonses.com"]


### PR DESCRIPTION
…to match what's already in prod to avoid destroying prod's existing cname records