### PR TITLE
10367 duplicated addtional info in printable docket

### DIFF
--- a/shared/src/business/utilities/documentGenerators/docketRecord.test.ts
+++ b/shared/src/business/utilities/documentGenerators/docketRecord.test.ts
@@ -1,3 +1,19 @@
+/**
+ * Test suite for the `docketRecord` PDF document generator.
+ *
+ * This test verifies that the `docketRecord` function generates a printable Docket Record PDF
+ * with the provided case details, practitioners, petitioners, and docket entries.
+ * It uses `generateAndVerifyPdfDiff` to ensure the generated PDF matches the expected output.
+ *
+ * The test data includes:
+ * - Case caption and title
+ * - Docket number and suffix
+ * - Petitioner and practitioner details
+ * - A sample docket entry with formatted dates and served status
+ *
+ * @see docketRecord
+ * @see generateAndVerifyPdfDiff
+ */
 import { PARTIES_CODES, PARTY_TYPES } from '../../entities/EntityConstants';
 import { applicationContext } from '../../test/createTestApplicationContext';
 import { docketRecord } from './docketRecord';
@@ -74,7 +90,7 @@ describe('docketRecord', () => {
               description: 'Test Description',
               eventCode: 'T',
               filedBy: 'Test Filer',
-              filingsAndProceedings: 'Test Filings And Proceedings',
+              descriptionDisplay: 'Test Filings And Proceedings',
               index: 1,
               isNotServedDocument: false,
               isStatusServed: true,

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.tsx
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.tsx
@@ -71,13 +71,15 @@ const RenderContact = ({ contact, countryTypes, showContactDetails }) => {
 };
 
 const RecordDescription = ({ entry }) => {
-  let additionalDescription = entry.filingsAndProceedings
+  console.log('RecordDescription: entry =', entry);
+
+  const additionalDescription = entry.filingsAndProceedings
     ? ` ${entry.filingsAndProceedings}`
     : '';
 
-  if (entry.additionalInfo2) {
-    additionalDescription += ` ${entry.additionalInfo2}`;
-  }
+  // if (entry.additionalInfo2) {
+  //   additionalDescription += ` ${entry.additionalInfo2}`;
+  // }
 
   return (
     <>

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.tsx
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.tsx
@@ -71,8 +71,6 @@ const RenderContact = ({ contact, countryTypes, showContactDetails }) => {
 };
 
 const RecordDescription = ({ entry }) => {
-  console.log('RecordDescription: entry =', entry);
-
   const additionalDescription = entry.filingsAndProceedings
     ? ` ${entry.filingsAndProceedings}`
     : '';

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.tsx
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.tsx
@@ -77,10 +77,6 @@ const RecordDescription = ({ entry }) => {
     ? ` ${entry.filingsAndProceedings}`
     : '';
 
-  // if (entry.additionalInfo2) {
-  //   additionalDescription += ` ${entry.additionalInfo2}`;
-  // }
-
   return (
     <>
       <span

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.tsx
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.tsx
@@ -79,7 +79,7 @@ const RecordDescription = ({ entry }) => {
           entry.isStricken && 'stricken-docket-record',
         )}
       >
-        <strong>{entry.descriptionDisplay}</strong>
+        {entry.descriptionDisplay}
       </span>
       {entry.isStricken && <span> (STRICKEN)</span>}
     </>

--- a/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.tsx
+++ b/shared/src/business/utilities/pdfGenerator/documentTemplates/DocketRecord.tsx
@@ -71,10 +71,6 @@ const RenderContact = ({ contact, countryTypes, showContactDetails }) => {
 };
 
 const RecordDescription = ({ entry }) => {
-  const additionalDescription = entry.filingsAndProceedings
-    ? ` ${entry.filingsAndProceedings}`
-    : '';
-
   return (
     <>
       <span
@@ -84,7 +80,6 @@ const RecordDescription = ({ entry }) => {
         )}
       >
         <strong>{entry.descriptionDisplay}</strong>
-        {additionalDescription}
       </span>
       {entry.isStricken && <span> (STRICKEN)</span>}
     </>


### PR DESCRIPTION
[10367-duplicated-addtional-info-in-printable-docket](https://github.com/ustaxcourt/ef-cms/tree/10367-duplicated-addtional-info-in-printable-docket) : https://github.com/orgs/flexion/projects/11/views/1?filterQuery=10367&pane=issue&itemId=76509721&issue=flexion%7Cef-cms%7C10367