### PR TITLE
8955 cleanup - to test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,10 +353,6 @@ jobs:
             if [ "$MIGRATE_FLAG" == "true" ]; then
               ./web-api/enable-deploying-dynamo-stream-trigger.sh
             fi
-      - run:
-          name: Migrate Practitioner Documents from Dynamo to Postgres
-          command: |
-            DYNAMODB_TABLE_NAME="$DESTINATION_TABLE" ./scripts/run-once-scripts/postgres-migration/migrateAllPractitionerDocumentsIntoPostgres.ts
 
   disable-reindex-cron:
     docker:


### PR DESCRIPTION
Removes the practitioner documents migration script from the circleci config