### PR TITLE
9063: don't manually reindex record after upserting

### DIFF
--- a/web-api/src/business/useCases/docketEntry/scrapeDocumentContentsWorker.test.ts
+++ b/web-api/src/business/useCases/docketEntry/scrapeDocumentContentsWorker.test.ts
@@ -1,15 +1,11 @@
 jest.mock('@web-api/persistence/postgres/cases/getCaseByDocketNumber');
 jest.mock('@web-api/persistence/postgres/docketEntries/upsertDocketEntries');
-jest.mock(
-  '../../../../elasticsearch/docketEntries/indexOpenSearchDocketEntries',
-);
 import { Case } from '@shared/business/entities/cases/Case';
 import { MOCK_CASE } from '@shared/test/mockCase';
 import { UnauthorizedError } from '@web-api/errors/errors';
 import { applicationContext } from '@shared/business/test/createTestApplicationContext';
 import { docketClerkUser } from '@shared/test/mockUsers';
 import { getCaseByDocketNumber as getCaseByDocketNumberMock } from '@web-api/persistence/postgres/cases/getCaseByDocketNumber';
-import { indexOpenSearchDocketEntries as indexOpenSearchDocketEntriesMock } from '../../../../elasticsearch/docketEntries/indexOpenSearchDocketEntries';
 import {
   mockDocketClerkUser,
   mockPetitionerUser,
@@ -48,9 +44,6 @@ const mockPdfContents = 'totally real pdf contents';
 const getCaseByDocketNumber = getCaseByDocketNumberMock as jest.Mock;
 const upsertDocketEntries = upsertDocketEntriesMock as jest.Mock;
 upsertDocketEntries.mockImplementation(jest.fn());
-const indexOpenSearchDocketEntries =
-  indexOpenSearchDocketEntriesMock as jest.Mock;
-indexOpenSearchDocketEntries.mockImplementation(jest.fn());
 
 describe('scrapeDocumentContentsWorker', () => {
   beforeEach(() => {
@@ -257,24 +250,12 @@ describe('scrapeDocumentContentsWorker', () => {
     ]);
   });
 
-  it('indexes the document contents in opensearch', async () => {
+  it('logs pertinent information', async () => {
     await scrapeDocumentContentsWorker(
       applicationContext,
       mockScrapeDocumentContentsMessage,
       mockAuthUser,
     );
-    expect(indexOpenSearchDocketEntries).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: expect.objectContaining({
-          payload: [
-            {
-              docketEntryId: mockDocketEntryId,
-              docketNumber: mockDocketNumber,
-            },
-          ],
-        }),
-      }),
-    );
-    expect(applicationContext.logger.info).toHaveBeenCalledTimes(7);
+    expect(applicationContext.logger.info).toHaveBeenCalledTimes(6);
   });
 });

--- a/web-api/src/business/useCases/docketEntry/scrapeDocumentContentsWorker.ts
+++ b/web-api/src/business/useCases/docketEntry/scrapeDocumentContentsWorker.ts
@@ -1,18 +1,12 @@
 import { type AuthUser } from '@shared/business/entities/authUser/AuthUser';
 import { type ServerApplicationContext } from '@web-api/applicationContext';
 import { getCaseByDocketNumber } from '@web-api/persistence/postgres/cases/getCaseByDocketNumber';
-import { indexOpenSearchDocketEntries } from '../../../../elasticsearch/docketEntries/indexOpenSearchDocketEntries';
 import {
   isAuthorized,
   ROLE_PERMISSIONS,
 } from '@shared/authorization/authorizationClientService';
 import { upsertDocketEntries } from '@web-api/persistence/postgres/docketEntries/upsertDocketEntries';
 import { Case } from '@shared/business/entities/cases/Case';
-import { DateTime } from 'luxon';
-import {
-  OPENSEARCH_SYNC_ACTIONS,
-  type OpenSearchSyncMessageType,
-} from '@web-api/lambdas/openSearch/openSearchSyncHandler';
 import { UnauthorizedError } from '@web-api/errors/errors';
 
 export const scrapeDocumentContentsWorker = async (
@@ -47,7 +41,7 @@ export const scrapeDocumentContentsWorker = async (
   }
   applicationContext.logger.info(
     `scrapeDocumentContentsWorker: Found docket entry ${docketEntryId}`,
-    { docketEntry: docketEntryEntity.toRawObject() },
+    { existingDocumentContentsId: docketEntryEntity.documentContentsId },
   );
 
   const docketEntryPdfData = await applicationContext
@@ -92,20 +86,6 @@ export const scrapeDocumentContentsWorker = async (
   await upsertDocketEntries([validatedDocketEntry]);
   applicationContext.logger.info(
     `scrapeDocumentContentsWorker: Updated docket entry ${docketEntryId}`,
-    { docketEntry: validatedDocketEntry },
-  );
-
-  const indexOpenSearchDocketEntryMessage = {
-    payload: [{ docketEntryId, docketNumber }],
-    type: 'dwDocketEntry' as OpenSearchSyncMessageType,
-    timestamp: DateTime.now().toMillis().toString(),
-    action: OPENSEARCH_SYNC_ACTIONS.UPSERT,
-  };
-  await indexOpenSearchDocketEntries({
-    message: indexOpenSearchDocketEntryMessage,
-  });
-  applicationContext.logger.info(
-    `scrapeDocumentContentsWorker: Indexed docket entry ${docketEntryId} in OpenSearch`,
-    { docketEntryId },
+    { documentContentsId: validatedDocketEntry.documentContentsId },
   );
 };


### PR DESCRIPTION
no longer logging entire case or docket entry entities in the scrapeDocumentContentsWorker

removed code to explicitly index a docket entry after upserting it because indexing happens automatically when the record is upserted