### PR TITLE
9161: BUG; practitioner documents

### DIFF
--- a/scripts/run-once-scripts/postgres-migration/upper-case-practitioner-document-barNumbers.ts
+++ b/scripts/run-once-scripts/postgres-migration/upper-case-practitioner-document-barNumbers.ts
@@ -24,7 +24,7 @@ async function main() {
       writer
         .updateTable('dwPractitionerDocuments')
         .set({ barNumber: sql`UPPER("bar_number")` })
-        .where(sql<SqlBool>`regexp_like("bar_number", '^[a-z]{2}[0-9]{4}$')`)
+        .where(sql<SqlBool>`regexp_like("bar_number", '^[a-z]{2}[0-9]+$')`)
         .execute(),
     table: 'dwPractitionerDocuments',
     action: null,

--- a/scripts/run-once-scripts/postgres-migration/upper-case-practitioner-document-barNumbers.ts
+++ b/scripts/run-once-scripts/postgres-migration/upper-case-practitioner-document-barNumbers.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env -S npx ts-node --transpile-only
+
+import {
+  parseArgsAndEnvVars,
+  type ScriptConfig,
+} from '../../helpers/parseArgsAndEnvVars';
+import { getDbWriter } from '@web-api/database';
+import { sql, SqlBool } from 'kysely';
+
+const scriptConfig: ScriptConfig = {
+  description:
+    'upper-case-practitioner-document-barNumbers - Fix practitioner document data created with lower-cased bar numbers',
+  environment: {
+    env: 'ENV',
+  },
+  requireActiveAwsSession: true,
+};
+
+parseArgsAndEnvVars(scriptConfig);
+
+async function main() {
+  await getDbWriter({
+    cb: writer =>
+      writer
+        .updateTable('dwPractitionerDocuments')
+        .set({ barNumber: sql`UPPER("bar_number")` })
+        .where(sql<SqlBool>`regexp_like("bar_number", '^[a-z]{2}[0-9]{4}$')`)
+        .execute(),
+    table: 'dwPractitionerDocuments',
+    action: null,
+  });
+
+  console.log('Done updating practitioner documents');
+}
+
+void main();

--- a/scripts/upload-practitioner-application-packages.ts
+++ b/scripts/upload-practitioner-application-packages.ts
@@ -198,7 +198,7 @@ const convertAllTifsAndConstructDocumentEntities = async ({
       categoryType: 'Application Package',
       description: 'Imported from Blackstone',
       fileName,
-      barNumber: barNumber.toLowerCase(),
+      barNumber,
       practitionerDocumentFileId,
       uploadDate: createISODateString(),
       location: '',

--- a/web-api/src/persistence/postgres/practitionerDocuments/createOrEditPractitionerDocument.ts
+++ b/web-api/src/persistence/postgres/practitionerDocuments/createOrEditPractitionerDocument.ts
@@ -9,8 +9,6 @@ export const createOrEditPractitionerDocument = async ({
   barNumber: string;
   practitionerDocument: RawPractitionerDocument;
 }) => {
-  barNumber = barNumber.toLowerCase();
-
   await pgInsertInto({
     table: 'dwPractitionerDocuments',
     values: toKyselyNewPractitionerDocument(practitionerDocument, barNumber),

--- a/web-api/src/persistence/postgres/practitionerDocuments/deletePractitionerDocument.ts
+++ b/web-api/src/persistence/postgres/practitionerDocuments/deletePractitionerDocument.ts
@@ -7,8 +7,6 @@ export const deletePractitionerDocument = async ({
   barNumber: string;
   practitionerDocumentFileId: string;
 }) => {
-  barNumber = barNumber.toLowerCase();
-
   await pgDeleteFrom({
     table: 'dwPractitionerDocuments',
     where: cb =>

--- a/web-api/src/persistence/postgres/practitionerDocuments/getPractitionerDocumentByFileId.ts
+++ b/web-api/src/persistence/postgres/practitionerDocuments/getPractitionerDocumentByFileId.ts
@@ -9,8 +9,6 @@ export const getPractitionerDocumentByFileId = async ({
   barNumber: string;
   fileId: string;
 }): Promise<RawPractitionerDocument> => {
-  barNumber = barNumber.toLowerCase();
-
   const practitionerDocument = await getDbReader(reader =>
     reader
       .selectFrom('dwPractitionerDocuments as p')

--- a/web-api/src/persistence/postgres/practitionerDocuments/getPractitionerDocuments.ts
+++ b/web-api/src/persistence/postgres/practitionerDocuments/getPractitionerDocuments.ts
@@ -7,8 +7,6 @@ export const getPractitionerDocuments = async ({
 }: {
   barNumber: string;
 }): Promise<RawPractitionerDocument[]> => {
-  barNumber = barNumber.toLowerCase();
-
   const practitionerDocuments = await getDbReader(reader =>
     reader
       .selectFrom('dwPractitionerDocuments as p')


### PR DESCRIPTION
The `barNumber` column in `dwPractitionerDocuments` was migrated _correctly_ (to upper case letters), but the persistence methods converted `barNumber` to lower case both on reads and writes. Result: newly created data was available to the application, migrated data was not. This PR keeps `barNumber` values upper case and rectifies bad data created since the practitioner document migration was deployed

Manual deploy step (sourced to prod env): `scripts/run-once-scripts/postgres-migration/upper-case-practitioner-document-barNumbers.ts`