### PR TITLE
OpEx: turn our yellow `info` clusters green

### DIFF
--- a/aws/lambdas/LogsToElasticSearch_info/index-template.json
+++ b/aws/lambdas/LogsToElasticSearch_info/index-template.json
@@ -1,5 +1,9 @@
 {
   "index_patterns": ["cwl-*"],
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  },
   "mappings": {
     "properties": {
       "authorizer": {


### PR DESCRIPTION
Set the number of replicas to 0 and number of shards to 1 for new kibana indices since the `info` cluster only has 1 node in lower environments.

Log rotation is 30 days in those environments so they won't go green until then.

To update the index template, make a `PUT` request against the `info` cluster:

```
PUT _template/cwl
# content from index-template.json here
```

### Manual steps

- [x] Update the `cwl` template in lower environments
   - [x] dev
   - [x] exp1
   - [x] exp2
   - [x] exp3
   - [x] exp4
   - [x] exp5
   - [x] exp6
   - [x] exp7
   - [x] exp8
   - [x] exp9
   - [x] irs
   - [x] stg