### PR TITLE
devex: remove the build-and-deploy-minimal workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,6 @@ parameters:
     default: true
     type: boolean
 
-  run_build_and_deploy_minimal:
-    default: false
-    type: boolean
-
   run_glue_to_test:
     default: false
     type: boolean
@@ -128,8 +124,6 @@ jobs:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
     resource_class: xlarge
-    environment:
-      DEPLOY_EMPTY_PERSISTENCE: << pipeline.parameters.run_build_and_deploy_minimal >>
     steps:
       - setup_remote_docker:
           version: docker23
@@ -176,7 +170,7 @@ jobs:
       - run:
           name: Test Users Setup
           command: |
-            if [ "${CIRCLE_BRANCH}" != "prod" ] && [ "$DEPLOY_EMPTY_PERSISTENCE" != "true" ]; then
+            if [ "${CIRCLE_BRANCH}" != "prod" ]; then
               ./scripts/user/setup-test-users.ts
             else
               echo "skipping…"
@@ -184,7 +178,7 @@ jobs:
       - run:
           name: Users Setup
           command: |
-            if [ "${CIRCLE_BRANCH}" == "prod" ] || [ "$DEPLOY_EMPTY_PERSISTENCE" == "true" ]; then
+            if [ "${CIRCLE_BRANCH}" == "prod" ]; then
               echo "skipping…"
               exit 0
             fi
@@ -995,20 +989,6 @@ workflows:
           <<: *only-prod
           requires:
             - disable-switch-colors-cron
-            - switch-colors
-
-  build-and-deploy-minimal:
-    when: << pipeline.parameters.run_build_and_deploy_minimal >>
-    jobs:
-      - deploy:
-          <<: *only-deployed-lower-environments
-      - switch-colors:
-          <<: *only-deployed-lower-environments
-          requires:
-            - deploy
-      - cleanup:
-          <<: *only-deployed-lower-environments
-          requires:
             - switch-colors
 
   glue-to-test:

--- a/scripts/git/push-current-branch-to.sh
+++ b/scripts/git/push-current-branch-to.sh
@@ -25,21 +25,11 @@ fi
 git checkout "$SOURCE"
 git pull
 
-
-if [[ -n "$2" ]] && { [[ "$2" == "--trigger" ]] || [[ "$2" == "--trigger-minimal" ]]; }; then
+if [[ -n "$2" ]] && [[ "$2" == "--trigger" ]]; then
   [[ -z "$CIRCLE_PROJECT_SLUG" ]] && echo "You must have CIRCLE_PROJECT_SLUG set in your environment to trigger a deployment" && exit 1
   [[ -z "$CIRCLE_PERSONAL_TOKEN" ]] && echo "You must have CIRCLE_PERSONAL_TOKEN set in your environment to trigger a deployment" && exit 1
-  if [[ "$2" == "--trigger" ]]; then
-    curl --request POST --url "https://circleci.com/api/v2/project/${CIRCLE_PROJECT_SLUG}/pipeline" \
-      --header "Circle-Token: ${CIRCLE_PERSONAL_TOKEN}" \
-      --header "content-type: application/json" \
-      --data "{\"branch\":\"${TARGET}\"}"
-  elif [[ "$2" == "--trigger-minimal" ]]; then
-    curl --request POST --url "https://circleci.com/api/v2/project/${CIRCLE_PROJECT_SLUG}/pipeline" \
-      --header "Circle-Token: ${CIRCLE_PERSONAL_TOKEN}" \
-      --header "content-type: application/json" \
-      --data "{\"branch\":\"${TARGET}\", \"parameters\":{ \
-        \"run_build_and_deploy\":false, \
-        \"run_build_and_deploy_minimal\":true}}"
-  fi
+  curl --request POST --url "https://circleci.com/api/v2/project/${CIRCLE_PROJECT_SLUG}/pipeline" \
+    --header "Circle-Token: ${CIRCLE_PERSONAL_TOKEN}" \
+    --header "content-type: application/json" \
+    --data "{\"branch\":\"${TARGET}\"}"
 fi


### PR DESCRIPTION
This workflow used to be part of a glue job but is no longer used for that purpose, so it should be removed.