### PR TITLE
aws providers: update all aws tf providers to 6.19.0

### DIFF
--- a/shared/admin-tools/glue/glue_migrations/main.tf
+++ b/shared/admin-tools/glue/glue_migrations/main.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~>6.18.0"
+      version = "~>6.19.0"
     }
   }
 }

--- a/shared/admin-tools/glue/remote_role/main.tf
+++ b/shared/admin-tools/glue/remote_role/main.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~>6.18.0"
+      version = "~>6.19.0"
     }
   }
 }

--- a/web-api/terraform/applyables/account-specific/account-specific.tf
+++ b/web-api/terraform/applyables/account-specific/account-specific.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-       version = "~>6.18.0"
+      version = "~>6.19.0"
     }
     opensearch = {
       source  = "opensearch-project/opensearch"
@@ -36,7 +36,7 @@ module "api-gateway-global-logging-permissions" {
 }
 
 module "ci-cd" {
-  source               = "../../modules/ci-cd"
+  source                  = "../../modules/ci-cd"
   lower_env_restore_roles = var.lower_env_restore_roles
 }
 

--- a/web-api/terraform/applyables/allColors/allColors.tf
+++ b/web-api/terraform/applyables/allColors/allColors.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~>6.18.0"
+      version = "~>6.19.0"
     }
   }
 }

--- a/web-api/terraform/applyables/blue/blue.tf
+++ b/web-api/terraform/applyables/blue/blue.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-       version = "~>6.18.0"
+      version = "~>6.19.0"
     }
   }
 }
@@ -194,10 +194,10 @@ module "ui-blue" {
 }
 
 module "rds-expired-records-cleanup" {
-    source                 = "../../modules/rds-expired-records-cleanup"
-    current_color          = "blue"
-    environment            = var.environment
-    postgres_user          = data.terraform_remote_state.remote.outputs.postgres_user
-    postgres_database      = data.terraform_remote_state.remote.outputs.database_name
-    postgres_host          = data.terraform_remote_state.remote.outputs.rds_host_name
+  source            = "../../modules/rds-expired-records-cleanup"
+  current_color     = "blue"
+  environment       = var.environment
+  postgres_user     = data.terraform_remote_state.remote.outputs.postgres_user
+  postgres_database = data.terraform_remote_state.remote.outputs.database_name
+  postgres_host     = data.terraform_remote_state.remote.outputs.rds_host_name
 }

--- a/web-api/terraform/applyables/glue-cron/glue-cron-applyable.tf
+++ b/web-api/terraform/applyables/glue-cron/glue-cron-applyable.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-       version = "~>6.18.0"
+      version = "~>6.19.0"
     }
   }
 }

--- a/web-api/terraform/applyables/green/green.tf
+++ b/web-api/terraform/applyables/green/green.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-       version = "~>6.18.0"
+      version = "~>6.19.0"
     }
   }
 }
@@ -194,10 +194,10 @@ module "ui-green" {
 }
 
 module "rds-expired-records-cleanup" {
-    source                 = "../../modules/rds-expired-records-cleanup"
-    current_color          = "green"
-    environment            = var.environment
-    postgres_user          = data.terraform_remote_state.remote.outputs.postgres_user
-    postgres_database      = data.terraform_remote_state.remote.outputs.database_name
-    postgres_host          = data.terraform_remote_state.remote.outputs.rds_host_name
+  source            = "../../modules/rds-expired-records-cleanup"
+  current_color     = "green"
+  environment       = var.environment
+  postgres_user     = data.terraform_remote_state.remote.outputs.postgres_user
+  postgres_database = data.terraform_remote_state.remote.outputs.database_name
+  postgres_host     = data.terraform_remote_state.remote.outputs.rds_host_name
 }

--- a/web-api/terraform/applyables/migration-cron/migration-cron-applyable.tf
+++ b/web-api/terraform/applyables/migration-cron/migration-cron-applyable.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-       version = "~>6.18.0"
+      version = "~>6.19.0"
     }
   }
 }

--- a/web-api/terraform/applyables/migration/migration-applyable.tf
+++ b/web-api/terraform/applyables/migration/migration-applyable.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-       version = "~>6.18.0"
+      version = "~>6.19.0"
     }
   }
 }

--- a/web-api/terraform/applyables/reindex-cron/reindex-cron-applyable.tf
+++ b/web-api/terraform/applyables/reindex-cron/reindex-cron-applyable.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-       version = "~>6.18.0"
+      version = "~>6.19.0"
     }
   }
 }

--- a/web-api/terraform/applyables/stale-cases-email-cron/stale-cases-email-cron-applyable.tf
+++ b/web-api/terraform/applyables/stale-cases-email-cron/stale-cases-email-cron-applyable.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-       version = "~>6.18.0"
+      version = "~>6.19.0"
     }
   }
 }

--- a/web-api/terraform/applyables/switch-colors-cron/switch-colors-cron-applyable.tf
+++ b/web-api/terraform/applyables/switch-colors-cron/switch-colors-cron-applyable.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-       version = "~>6.18.0"
+      version = "~>6.19.0"
     }
   }
 }

--- a/web-api/terraform/applyables/wait-for-workflow/wait-for-workflow-cron-applyable.tf
+++ b/web-api/terraform/applyables/wait-for-workflow/wait-for-workflow-cron-applyable.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-       version = "~>6.18.0"
+      version = "~>6.19.0"
     }
   }
 }

--- a/web-api/terraform/modules/api/providers.tf
+++ b/web-api/terraform/modules/api/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "~>6.15"
+      version               = "~>6.19.0"
       configuration_aliases = [aws.us-east-1]
     }
   }

--- a/web-api/terraform/modules/default-vpc/providers.tf
+++ b/web-api/terraform/modules/default-vpc/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-       version = "~>6.18.0"
+      version = "~>6.19.0"
     }
   }
 }

--- a/web-api/terraform/modules/dynamo-table/providers.tf
+++ b/web-api/terraform/modules/dynamo-table/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "~>6.15"
+      version               = "~>6.19.0"
       configuration_aliases = [aws.us-west-1]
     }
   }

--- a/web-api/terraform/modules/elasticsearch/providers.tf
+++ b/web-api/terraform/modules/elasticsearch/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-       version = "~>6.18.0"
+      version = "~>6.19.0"
     }
   }
 }

--- a/web-api/terraform/modules/everything-else-deprecated/providers.tf
+++ b/web-api/terraform/modules/everything-else-deprecated/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "~>6.15"
+      version               = "~>6.19.0"
       configuration_aliases = [aws.us-west-1]
     }
   }

--- a/web-api/terraform/modules/health-alarms/providers.tf
+++ b/web-api/terraform/modules/health-alarms/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-       version = "~>6.18.0"
+      version = "~>6.19.0"
     }
   }
 }

--- a/web-api/terraform/modules/kibana/providers.tf
+++ b/web-api/terraform/modules/kibana/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-       version = "~>6.18.0"
+      version = "~>6.19.0"
     }
     opensearch = {
       source  = "opensearch-project/opensearch"

--- a/web-api/terraform/modules/kms/providers.tf
+++ b/web-api/terraform/modules/kms/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "~>6.15"
+      version               = "~>6.19.0"
       configuration_aliases = [aws.us-west-1]
     }
   }

--- a/web-api/terraform/modules/opensearch-sync/providers.tf
+++ b/web-api/terraform/modules/opensearch-sync/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-       version = "~>6.18.0"
+      version = "~>6.19.0"
     }
   }
 }

--- a/web-api/terraform/modules/rds/providers.tf
+++ b/web-api/terraform/modules/rds/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "~>6.15"
+      version               = "~>6.19.0"
       configuration_aliases = [aws.us-west-1]
     }
   }

--- a/web-api/terraform/modules/regional-log-subscription-filters/providers.tf
+++ b/web-api/terraform/modules/regional-log-subscription-filters/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-       version = "~>6.18.0"
+      version = "~>6.19.0"
     }
   }
 }

--- a/web-api/terraform/modules/ui/providers.tf
+++ b/web-api/terraform/modules/ui/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "~>6.15"
+      version               = "~>6.19.0"
       configuration_aliases = [aws.us-west-1]
     }
   }

--- a/web-api/terraform/modules/waf/providers.tf
+++ b/web-api/terraform/modules/waf/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-       version = "~>6.18.0"
+      version = "~>6.19.0"
     }
   }
 }

--- a/web-api/terraform/modules/worker/providers.tf
+++ b/web-api/terraform/modules/worker/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-       version = "~>6.18.0"
+      version = "~>6.19.0"
     }
   }
 }


### PR DESCRIPTION
Update to latest AWS Terraform provider to standardize on two-decimal notation and fix test env
