### PR TITLE
opex: grant RDS access to the stale cases lambda

### DIFF
--- a/web-api/terraform/applyables/stale-cases-email-cron/stale-cases-email-cron-applyable.tf
+++ b/web-api/terraform/applyables/stale-cases-email-cron/stale-cases-email-cron-applyable.tf
@@ -16,10 +16,12 @@ terraform {
 
 module "stale-cases-email-cron" {
   source                       = "../../modules/stale-cases-email-cron"
-  aws_region                   = "us-east-1"
   environment                  = var.environment
+  aws_region                   = "us-east-1"
+  database_name                = var.database_name
   disable_emails               = "false"
-  elasticsearch_endpoint       = var.elasticsearch_endpoint
   email_source                 = var.email_source
   inactivity_report_recipients = var.inactivity_report_recipients
+  postgres_host                = var.postgres_host
+  postgres_user                = var.postgres_user
 }

--- a/web-api/terraform/applyables/stale-cases-email-cron/variables.tf
+++ b/web-api/terraform/applyables/stale-cases-email-cron/variables.tf
@@ -1,12 +1,16 @@
+variable "aws_region" {
+  default = "us-east-1"
+}
+
 variable "environment" {
   type = string
 }
 
-variable "disable_emails" {
+variable "database_name" {
   type = string
 }
 
-variable "elasticsearch_endpoint" {
+variable "disable_emails" {
   type = string
 }
 
@@ -15,5 +19,13 @@ variable "email_source" {
 }
 
 variable "inactivity_report_recipients" {
+  type = string
+}
+
+variable "postgres_host" {
+  type = string
+}
+
+variable "postgres_user" {
   type = string
 }

--- a/web-api/terraform/bin/deploy-stale-cases-email-cron.sh
+++ b/web-api/terraform/bin/deploy-stale-cases-email-cron.sh
@@ -4,10 +4,12 @@
 ENVIRONMENT=$1
 export ENVIRONMENT="$ENVIRONMENT"
 
-[ -z "${ENVIRONMENT}" ] && echo "You must pass in ENVIRONMENT as command line argument 1" && exit 1
-[ -z "${ELASTICSEARCH_ENDPOINT}" ] && echo "You must set ELASTICSEARCH_ENDPOINT as an environment variable" && exit 1
-[ -z "${INACTIVITY_REPORT_RECIPIENTS}" ] && echo "You must set INACTIVITY_REPORT_RECIPIENTS as an environment variable" && exit 1
+[ -z "$ENVIRONMENT" ] && echo "You must pass in ENVIRONMENT as command line argument 1" && exit 1
+[ -z "$DATABASE_NAME" ] && echo "You must set DATABASE_NAME as an environment variable" && exit 1
 [ -z "$EFCMS_DOMAIN" ] && echo "You must set EFCMS_DOMAIN as an environment variable" && exit 1
+[ -z "$INACTIVITY_REPORT_RECIPIENTS" ] && echo "You must set INACTIVITY_REPORT_RECIPIENTS as an environment variable" && exit 1
+[ -z "$POSTGRES_HOST" ] && echo "You must set POSTGRES_HOST as an environment variable" && exit 1
+[ -z "$POSTGRES_USER" ] && echo "You must set POSTGRES_USER as an environment variable" && exit 1
 
 if [ -z "$EMAIL_SOURCE" ]; then
   EMAIL_SOURCE="U.S. Tax Court <noreply@${EFCMS_DOMAIN}>"
@@ -15,9 +17,12 @@ fi
 
 echo "Running terraform with the following environment configs:"
 echo "  - ENVIRONMENT=${ENVIRONMENT}"
-echo "  - ELASTICSEARCH_ENDPOINT=${ELASTICSEARCH_ENDPOINT}"
+echo "  - DATABASE_NAME=${DATABASE_NAME}"
+echo "  - EFCMS_DOMAIN=${EFCMS_DOMAIN}"
 echo "  - EMAIL_SOURCE=${EMAIL_SOURCE}"
 echo "  - INACTIVITY_REPORT_RECIPIENTS=${INACTIVITY_REPORT_RECIPIENTS}"
+echo "  - POSTGRES_HOST=${POSTGRES_HOST}"
+echo "  - POSTGRES_USER=${POSTGRES_USER}"
 
 ../../../../scripts/verify-terraform-version.sh
 
@@ -31,10 +36,12 @@ rm -rf .terraform
 rm -f .terraform.lock.hcl
 
 export TF_VAR_environment="$ENVIRONMENT"
-export TF_VAR_elasticsearch_endpoint="$ELASTICSEARCH_ENDPOINT"
+export TF_VAR_database_name="$DATABASE_NAME"
 export TF_VAR_disable_emails="false"
 export TF_VAR_email_source="$EMAIL_SOURCE"
 export TF_VAR_inactivity_report_recipients="$INACTIVITY_REPORT_RECIPIENTS"
+export TF_VAR_postgres_host="$POSTGRES_HOST"
+export TF_VAR_postgres_user="$POSTGRES_USER"
 
 npm run build:assets
 

--- a/web-api/terraform/modules/stale-cases-email-cron/stale-cases-email-cron.tf
+++ b/web-api/terraform/modules/stale-cases-email-cron/stale-cases-email-cron.tf
@@ -54,13 +54,10 @@ resource "aws_iam_role_policy" "stale_cases_email_lambda_policy" {
     {
       "Effect": "Allow",
       "Action": [
-        "es:ESHttpDelete",
-        "es:ESHttpGet",
-        "es:ESHttpPost",
-        "es:ESHttpPut"
+        "rds-db:connect"
       ],
       "Resource": [
-        "arn:aws:es:us-east-1:${data.aws_caller_identity.current.account_id}:domain/efcms-search-${var.environment}-*"
+        "arn:aws:rds-db:*:${data.aws_caller_identity.current.account_id}:dbuser:*/${var.postgres_user}"
       ]
     },
     {
@@ -88,10 +85,12 @@ module "stale_cases_email_lambda" {
     STAGE                        = var.environment
     NODE_ENV                     = "production"
     ACCOUNT_ID                   = data.aws_caller_identity.current.account_id
+    DATABASE_NAME                = var.database_name
     DISABLE_EMAILS               = "false"
-    ELASTICSEARCH_ENDPOINT       = var.elasticsearch_endpoint
     EMAIL_SOURCE                 = var.email_source
     INACTIVITY_REPORT_RECIPIENTS = var.inactivity_report_recipients
+    POSTGRES_HOST                = var.postgres_host
+    POSTGRES_USER                = var.postgres_user
   }
   timeout = "900"
 }

--- a/web-api/terraform/modules/stale-cases-email-cron/variables.tf
+++ b/web-api/terraform/modules/stale-cases-email-cron/variables.tf
@@ -6,11 +6,11 @@ variable "environment" {
   type = string
 }
 
-variable "disable_emails" {
+variable "database_name" {
   type = string
 }
 
-variable "elasticsearch_endpoint" {
+variable "disable_emails" {
   type = string
 }
 
@@ -19,5 +19,13 @@ variable "email_source" {
 }
 
 variable "inactivity_report_recipients" {
+  type = string
+}
+
+variable "postgres_host" {
+  type = string
+}
+
+variable "postgres_user" {
   type = string
 }


### PR DESCRIPTION
Context:
- The stale cases report generates a CSV.
- The stale cases lambda runs the stale cases report and emails the CSV to Court stakeholders.
- This lambda runs on the first of every month.
- The stale cases report was recently rewritten to use postgres instead of OpenSearch.

This month's execution of the stale cases lambda failed because the stale cases lambda was not granted access to RDS. This diff replaces the OpenSearch access with RDS access in the lambda's policy and adds the environment variables necessary to generate an RDS token.