### PR TITLE
9432 Bug

### DIFF
--- a/web-api/src/business/useCases/trialSessions/generateNoticeOfChangeOfTrialJudgeInteractor.ts
+++ b/web-api/src/business/useCases/trialSessions/generateNoticeOfChangeOfTrialJudgeInteractor.ts
@@ -68,7 +68,7 @@ export const generateNoticeOfChangeOfTrialJudgeInteractor = async (
       data: {
         caseCaptionExtension,
         caseTitle,
-        docketNumberWithSuffix: caseDetail.docketNumber,
+        docketNumberWithSuffix: caseDetail.docketNumberWithSuffix,
         nameOfClerk: name,
         titleOfClerk: title,
         trialInfo,


### PR DESCRIPTION
https://github.com/ustaxcourt/ef-cms/issues/9432

The key change is using `docketNumberWithSuffix` instead of simply `docketNumber` in `generateNoticeOfChangeOfTrialJudgeInteractor.ts`