### PR TITLE
8546 connect order to motion revamped to test 1765402955

### DIFF
--- a/cypress/local-only/tests/integration/caseDetail/docketRecord/courtIssuedFiling/docket-clerk-applies-order-to-lead-case-motion.cy.ts
+++ b/cypress/local-only/tests/integration/caseDetail/docketRecord/courtIssuedFiling/docket-clerk-applies-order-to-lead-case-motion.cy.ts
@@ -10,6 +10,7 @@ describe('Docket clerk creates an order affecting other docket entries', functio
     const motionPurpose = 'Test motions';
     const orderTitle = 'Order to grant motion';
     const disposition = 'GRANTED';
+    const displayedDisposition = 'GRANTS';
 
     loginAsDocketClerk1();
     goToCase(leadCase);
@@ -44,7 +45,7 @@ describe('Docket clerk creates an order affecting other docket entries', functio
             .then($td => {
               cy.get('@motionIndex').then(motionIndex => {
                 expect($td.text().trim()).to.contain(
-                  `${disposition} #${motionIndex}`,
+                  `${displayedDisposition} #${motionIndex}`,
                 );
               });
             });

--- a/shared/src/business/entities/EntityConstants.ts
+++ b/shared/src/business/entities/EntityConstants.ts
@@ -98,6 +98,21 @@ export const MOTION_DISPOSITIONS = {
   GRANTED_IN_PART: 'GRANTED IN PART',
 };
 
+export const MOTION_DISPOSITION_VERBIAGE = {
+  DENIED: {
+    MOTION: 'DENIED BY',
+    ORDER: 'DENIES',
+  },
+  GRANTED: {
+    MOTION: 'GRANTED BY',
+    ORDER: 'GRANTS',
+  },
+  'GRANTED IN PART': {
+    MOTION: 'GRANTED IN PART BY',
+    ORDER: 'GRANTING IN PART',
+  },
+};
+
 export const STRICKEN_FROM_TRIAL_SESSION_MESSAGE =
   'This case is stricken from the trial session';
 

--- a/shared/src/business/utilities/aggregatePartiesForService.ts
+++ b/shared/src/business/utilities/aggregatePartiesForService.ts
@@ -22,8 +22,8 @@ export const aggregatePartiesForService = (
   } else {
     allParties = [
       ...formattedCase.petitioners,
-      ...formattedCase.privatePractitioners,
-      ...formattedCase.irsPractitioners,
+      ...(formattedCase.privatePractitioners ?? []),
+      ...(formattedCase.irsPractitioners ?? []),
     ];
   }
 

--- a/shared/src/business/utilities/setServiceIndicatorsForPetitionersOnCase.test.ts
+++ b/shared/src/business/utilities/setServiceIndicatorsForPetitionersOnCase.test.ts
@@ -262,7 +262,7 @@ describe('setServiceIndicatorsForCases', () => {
 
     const result = setServiceIndicatorsForPetitionersOnCase(caseDetail);
 
-    expect(result.privatePractitioners[0].serviceIndicator).toEqual(
+    expect(result.privatePractitioners![0].serviceIndicator).toEqual(
       SERVICE_INDICATOR_TYPES.SI_PAPER,
     );
   });
@@ -274,7 +274,7 @@ describe('setServiceIndicatorsForCases', () => {
     };
     const result = setServiceIndicatorsForPetitionersOnCase(caseDetail);
 
-    expect(result.irsPractitioners[0].serviceIndicator).toEqual(
+    expect(result.irsPractitioners![0].serviceIndicator).toEqual(
       SERVICE_INDICATOR_TYPES.SI_PAPER,
     );
   });

--- a/shared/src/business/utilities/setServiceIndicatorsForPetitionersOnCase.ts
+++ b/shared/src/business/utilities/setServiceIndicatorsForPetitionersOnCase.ts
@@ -1,7 +1,9 @@
 import { Case } from '../entities/cases/Case';
 import { SERVICE_INDICATOR_TYPES } from '../entities/EntityConstants';
 
-export const setServiceIndicatorsForPetitionersOnCase = caseDetail => {
+export const setServiceIndicatorsForPetitionersOnCase = (
+  caseDetail: RawCase,
+): RawCase => {
   const { petitioners } = caseDetail;
 
   petitioners?.forEach(petitioner => {

--- a/web-api/src/business/useCaseHelper/service/sendIrsSuperuserPetitionEmail.ts
+++ b/web-api/src/business/useCaseHelper/service/sendIrsSuperuserPetitionEmail.ts
@@ -33,7 +33,7 @@ export const sendIrsSuperuserPetitionEmail = async ({
 
   const { documentType, eventCode, filingDate, servedAt } = docketEntryEntity;
 
-  privatePractitioners.forEach(practitioner => {
+  (privatePractitioners ?? []).forEach(practitioner => {
     const representingFormatted = [];
 
     caseEntity.petitioners.forEach(p => {

--- a/web-client/src/presenter/computeds/addCourtIssuedDocketEntryHelper.test.ts
+++ b/web-client/src/presenter/computeds/addCourtIssuedDocketEntryHelper.test.ts
@@ -109,11 +109,11 @@ describe('addCourtIssuedDocketEntryHelper', () => {
 
     expect(result.caseMotions.length).toEqual(2);
     expect(result.caseMotions).toEqual([
+      { label: '3 - Motion to Dismiss', value: '789' },
       {
         label: '2 - Motion for an Order under Federal Rule of Evidence 502(d)',
         value: '456',
       },
-      { label: '3 - Motion to Dismiss', value: '789' },
     ]);
   });
 

--- a/web-client/src/presenter/computeds/addCourtIssuedDocketEntryHelper.ts
+++ b/web-client/src/presenter/computeds/addCourtIssuedDocketEntryHelper.ts
@@ -40,9 +40,9 @@ export const addCourtIssuedDocketEntryHelper = (
   );
 
   const caseMotions = flow([
-    (a: RawDocketEntry[]) =>
+    (docketEntries: RawDocketEntry[]) =>
       filter(
-        a,
+        docketEntries,
         d =>
           DocketEntry.isMotion(d.eventCode) &&
           !d.isStricken &&
@@ -53,9 +53,9 @@ export const addCourtIssuedDocketEntryHelper = (
             am => am.docketEntryId === d.docketEntryId,
           ),
       ),
-    a => orderBy(a, ['index'], ['desc']),
-    a =>
-      a.map((m: RawDocketEntry) => ({
+    docketEntries => orderBy(docketEntries, ['index'], ['desc']),
+    docketEntries =>
+      docketEntries.map((m: RawDocketEntry) => ({
         label: `${m.index} - ${m.documentTitle}`,
         value: m.docketEntryId,
       })),

--- a/web-client/src/presenter/computeds/addCourtIssuedDocketEntryHelper.ts
+++ b/web-client/src/presenter/computeds/addCourtIssuedDocketEntryHelper.ts
@@ -3,7 +3,7 @@ import { DocketEntry } from '@shared/business/entities/DocketEntry';
 import { Get } from 'cerebral';
 import { setServiceIndicatorsForPetitionersOnCase } from '@shared/business/utilities/setServiceIndicatorsForPetitionersOnCase';
 import { state } from '@web-client/presenter/app.cerebral';
-import _ from 'lodash';
+import { find, filter, orderBy, flow } from 'lodash';
 import { MOTION_DISPOSITIONS } from '@shared/business/entities/EntityConstants';
 
 export const addCourtIssuedDocketEntryHelper = (
@@ -38,30 +38,36 @@ export const addCourtIssuedDocketEntryHelper = (
   const relatedMotionDispositions = Object.values(MOTION_DISPOSITIONS).map(
     d => ({ label: d, value: d }),
   );
-  const caseMotions = caseDetail.docketEntries
-    .filter(
-      d =>
-        DocketEntry.isMotion(d.eventCode) &&
-        !d.isStricken &&
-        !d.isDraft &&
-        !_.find(
-          // Motions not already in the order
-          form.affectedDocketEntries ?? [],
-          am => am.docketEntryId === d.docketEntryId,
-        ),
-    )
-    .map((m: RawDocketEntry) => ({
-      label: `${m.index} - ${m.documentTitle}`,
-      value: m.docketEntryId,
-    }));
+
+  const caseMotions = flow([
+    (a: RawDocketEntry[]) =>
+      filter(
+        a,
+        d =>
+          DocketEntry.isMotion(d.eventCode) &&
+          !d.isStricken &&
+          !d.isDraft &&
+          !find(
+            // Motions not already in the order
+            form.affectedDocketEntries ?? [],
+            am => am.docketEntryId === d.docketEntryId,
+          ),
+      ),
+    a => orderBy(a, ['index'], ['desc']),
+    a =>
+      a.map((m: RawDocketEntry) => ({
+        label: `${m.index} - ${m.documentTitle}`,
+        value: m.docketEntryId,
+      })),
+  ])(caseDetail.docketEntries);
 
   const serviceParties = [
     ...petitioners,
-    ...caseDetail.privatePractitioners.map(practitioner => ({
+    ...(caseDetail.privatePractitioners ?? []).map(practitioner => ({
       ...practitioner,
       displayName: `${practitioner.name}, Petitioner Counsel`,
     })),
-    ...caseDetail.irsPractitioners.map(practitioner => ({
+    ...(caseDetail.irsPractitioners ?? []).map(practitioner => ({
       ...practitioner,
       displayName: `${practitioner.name}, Respondent Counsel`,
     })),

--- a/web-client/src/presenter/computeds/formattedDocketEntries.ts
+++ b/web-client/src/presenter/computeds/formattedDocketEntries.ts
@@ -1,9 +1,12 @@
 import { ClientApplicationContext } from '@web-client/applicationContext';
 import { DocketEntry } from '@shared/business/entities/DocketEntry';
 import { Get } from 'cerebral';
-import { STATE_KEYS } from '@shared/business/entities/EntityConstants';
+import {
+  MOTION_DISPOSITION_VERBIAGE,
+  STATE_KEYS,
+} from '@shared/business/entities/EntityConstants';
 import { computeIsNotServedDocument } from '@shared/business/utilities/getFormattedCaseDetail';
-import { sortBy } from 'lodash';
+import { concat, sortBy } from 'lodash';
 import { state } from '@web-client/presenter/app.cerebral';
 
 export const isSelectableForDownload = (entry: RawDocketEntry) => {
@@ -161,27 +164,57 @@ export const getFormattedDocketEntry = ({
     createdAtFormatted: entry.createdAtFormatted,
   };
 
-  if (entry.affectedDocketEntries || entry.affectedByDocketEntries) {
-    formattedResult.relatedDocketEntries = [
-      ...(entry.affectedByDocketEntries ?? []),
-      ...(entry.affectedDocketEntries ?? []),
-    ].map(affectedEntry => {
-      const { index, showDocumentViewerLink, showDownloadLink } =
-        getRelatedDocketEntryDetails(
-          entry,
-          rawCase,
-          affectedEntry.docketEntryId,
-          isExternalUser,
-          user,
-          visibilityPolicyDateFormatted,
-        );
+  formattedResult.relatedDocketEntries = [];
+  if (entry.affectedByDocketEntries) {
+    formattedResult.relatedDocketEntries = concat(
+      formattedResult.relatedDocketEntries,
+      entry.affectedByDocketEntries.map(affectedEntry => {
+        const { index, showDocumentViewerLink, showDownloadLink } =
+          getRelatedDocketEntryDetails(
+            entry,
+            rawCase,
+            affectedEntry.docketEntryId,
+            isExternalUser,
+            user,
+            visibilityPolicyDateFormatted,
+          );
 
-      affectedEntry.docketEntryIndex = index;
-      affectedEntry.showDocumentViewerLink = showDocumentViewerLink;
-      affectedEntry.showDownloadLink = showDownloadLink;
+        console.log(JSON.stringify(affectedEntry));
 
-      return affectedEntry;
-    });
+        affectedEntry.docketEntryIndex = index;
+        affectedEntry.showDocumentViewerLink = showDocumentViewerLink;
+        affectedEntry.showDownloadLink = showDownloadLink;
+        affectedEntry.disposition =
+          MOTION_DISPOSITION_VERBIAGE[affectedEntry.disposition].MOTION;
+
+        return affectedEntry;
+      }),
+    );
+  }
+
+  if (entry.affectedDocketEntries) {
+    formattedResult.relatedDocketEntries = concat(
+      formattedResult.relatedDocketEntries,
+      entry.affectedDocketEntries.map(affectedEntry => {
+        const { index, showDocumentViewerLink, showDownloadLink } =
+          getRelatedDocketEntryDetails(
+            entry,
+            rawCase,
+            affectedEntry.docketEntryId,
+            isExternalUser,
+            user,
+            visibilityPolicyDateFormatted,
+          );
+
+        affectedEntry.docketEntryIndex = index;
+        affectedEntry.showDocumentViewerLink = showDocumentViewerLink;
+        affectedEntry.showDownloadLink = showDownloadLink;
+        affectedEntry.disposition =
+          MOTION_DISPOSITION_VERBIAGE[affectedEntry.disposition].ORDER;
+
+        return affectedEntry;
+      }),
+    );
   }
 
   if (!isExternalUser) {

--- a/web-client/src/views/CourtIssuedDocketEntry/CourtIssuedDocketEntry.tsx
+++ b/web-client/src/views/CourtIssuedDocketEntry/CourtIssuedDocketEntry.tsx
@@ -186,7 +186,7 @@ export const CourtIssuedDocketEntry = connect(
                           className="usa-checkbox__label"
                           htmlFor="dispositionOrder"
                         >
-                          This order acts on at least one motion
+                          This order is dispositive for at least one motion
                         </label>
                       </div>
                     </fieldset>

--- a/web-client/src/views/DocketRecord/DocumentViewer.tsx
+++ b/web-client/src/views/DocketRecord/DocumentViewer.tsx
@@ -124,6 +124,17 @@ export const DocumentViewer = connect(
                               )}
                             >
                               {entry.descriptionDisplay}
+                              {entry.relatedDocketEntries?.map(
+                                affectedEntry => {
+                                  return (
+                                    <>
+                                      <br />
+                                      --- {affectedEntry.disposition} #
+                                      {affectedEntry.docketEntryIndex}
+                                    </>
+                                  );
+                                },
+                              )}
                             </span>
                             <span
                               className={classNames(

--- a/web-client/src/views/EditDocketEntry/EditDocketEntryMetaFormCourtIssued.tsx
+++ b/web-client/src/views/EditDocketEntry/EditDocketEntryMetaFormCourtIssued.tsx
@@ -134,7 +134,7 @@ export const EditDocketEntryMetaFormCourtIssued = connect(
                   className="usa-checkbox__label"
                   htmlFor="dispositionOrder"
                 >
-                  This order acts on at least one motion
+                  This order is dispositive for at least one motion
                 </label>
               </div>
             </fieldset>


### PR DESCRIPTION
Addressing feedback from demo to court users.

- Changed wording on checkbox when docketing an order.
- Changed verbiage of dispositions on the case details page.
- Reordered motions when docketing order so that last motion is first in list.
- - Used lodash flow to chain filter -> orderBy -> map. Could probably go without it but I wanted to chain them all together and didn't see a simpler method