### PR TITLE
9503 fix new trial session tab to test 1766154643

### DIFF
--- a/cypress/helpers/trialSession/create-trial-session.ts
+++ b/cypress/helpers/trialSession/create-trial-session.ts
@@ -67,6 +67,7 @@ export function createTrialSession(
   cy.intercept('POST', '**/trial-sessions').as('createTrialSession');
   cy.get('[data-testid="submit-trial-session"]').click();
   cy.get('[data-testid="success-alert"]').should('exist');
+  cy.get('[data-testid="tabs-menu"]').find('li:first-child').should('have.class', 'active');
 
   return cy
     .wait('@createTrialSession')

--- a/web-client/src/views/TrialSessions/TrialSessions.tsx
+++ b/web-client/src/views/TrialSessions/TrialSessions.tsx
@@ -86,7 +86,7 @@ export const TrialSessions = connect(
             )}
           </div>
           <Tabs
-            defaultActiveTab={'calendared'}
+            defaultActiveTab={trialSessionsPageFilters.currentTab}
             headingLevel="2"
             id="trial-sessions-tabs"
             value={trialSessionsPageFilters.currentTab}


### PR DESCRIPTION
#9503 Fixed issue where the "New" tab was not being highlighted when it was the default active tab after navigating to the trial sessions page. 