### PR TITLE
9266 rename motion to test 1767124569

### DIFF
--- a/shared/src/business/entities/docketEntry/externalFilingEvents.ts
+++ b/shared/src/business/entities/docketEntry/externalFilingEvents.ts
@@ -2109,10 +2109,10 @@ export const EXTERNAL_FILING_EVENTS: AllExternalFilingEvents = {
       allowOrderResponse: true,
     },
     {
-      documentTitle: 'Motion to Withdraw Counsel',
-      documentType: 'Motion to Withdraw Counsel (filed by petitioner)',
+      documentTitle: 'Motion to Withdraw Counsel by Party',
+      documentType: 'Motion to Withdraw Counsel by Party',
       category: 'Motion',
-      eventCode: 'M116',
+      eventCode: 'M116', 
       scenario: 'Standard',
       labelPreviousDocument: '',
       labelFreeText: '',

--- a/shared/src/business/entities/docketEntry/internalFilingEvents.ts
+++ b/shared/src/business/entities/docketEntry/internalFilingEvents.ts
@@ -2302,8 +2302,8 @@ export const INTERNAL_FILING_EVENTS: AllInteralFilingEvents = {
       allowOrderResponse: true,
     },
     {
-      documentTitle: 'Motion to Withdraw Counsel',
-      documentType: 'Motion to Withdraw Counsel (filed by petitioner)',
+      documentTitle: 'Motion to Withdraw Counsel by Party',
+      documentType: 'Motion to Withdraw Counsel by Party',
       category: 'Motion',
       eventCode: 'M116',
       scenario: 'Standard',


### PR DESCRIPTION
The Court has asked to rename the official M116 motion to "Motion to Withdraw Counsel by Party" to make it clearer where the directive to remove counsel is originating from and reduce the number of misfilings.