### PR TITLE
devex: increase no-output timeout for postgres restoration step during glue jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -861,6 +861,7 @@ jobs:
               exit 1
             fi
       - run:
+          no_output_timeout: 40m
           name: Restore Postgres Data
           command: |
             TARGET_ENV="$LOWER_ENV" TARGET_ACCOUNT_ID="$LOWER_ENV_ACCOUNT_ID" ./scripts/postgres/restoreDbFromSource.ts


### PR DESCRIPTION
increases timeout from 10m -> 40m