### PR TITLE
devex: protect the primary opensearch indices from deletion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,14 @@ parameters:
     default: false
     type: boolean
 
+  run_reindex_opensearch:
+    default: false
+    type: boolean
+
+  run_sync_s3_to_lower_env:
+    default: false
+    type: boolean
+
   run_real_user_tests:
     default: false
     type: boolean
@@ -36,14 +44,6 @@ parameters:
   lower_env_account_id:
     default: ''
     type: string
-
-  sync_early:
-    default: false
-    type: boolean
-
-  run_sync_s3_to_lower_env:
-    default: false
-    type: boolean
 
   referrer:
     default: ''
@@ -494,6 +494,42 @@ jobs:
 
   ######################## GLUE JOB: Jobs that run in a lower environment ########################
 
+  delete-and-recreate-elasticsearch-cluster:
+    docker:
+      - image: *efcms-docker-image
+        aws_auth:
+          aws_access_key_id: $AWS_ACCESS_KEY_ID
+          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
+    resource_class: medium+
+    steps:
+      - git-shallow-clone/checkout
+      - npm-install
+      - run:
+          name: Setup Env
+          command: |
+            ./scripts/env/env-for-circle.sh
+      - run:
+          name: Setup SSM
+          command: |
+            ./scripts/circleci/setup-ssm-for-glue-job.sh
+      - run:
+          name: 'Delete OpenSearch alpha/beta clusters'
+          command: |
+            ./scripts/elasticsearch/delete-alpha-and-beta-clusters.sh
+      - run:
+          no_output_timeout: 20m
+          name: 'Recreate the alpha OpenSearch cluster'
+          command: |
+            npm run deploy:allColors $ENV
+      - run:
+          name: Setup OpenSearch Index Settings and Mappings
+          command: |
+            ./web-api/setup-elasticsearch-index.sh $ENV
+      - run:
+          name: Setup OpenSearch Aliases
+          command: |
+            npx ts-node --transpile-only ./web-api/elasticsearch/elasticsearch-alias-settings.ts
+
   initiate-glue-job:
     docker:
       - image: *efcms-docker-image
@@ -501,8 +537,6 @@ jobs:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
     resource_class: medium+
-    environment:
-      SYNC_EARLY: << pipeline.parameters.sync_early >>
     steps:
       - git-shallow-clone/checkout
       - npm-install
@@ -521,16 +555,12 @@ jobs:
             echo "export SOURCE_BUCKET=${PROD_DOCUMENTS_BUCKET_NAME}" >> $BASH_ENV
             echo "export DESTINATION_BUCKET=${EFCMS_DOMAIN}-documents-${ENV}-us-east-1" >> $BASH_ENV
       - run:
-          name: Setup SSM for a glue job
+          name: 'Delete Cognito users'
           command: |
-            ./scripts/circleci/setup-ssm-for-glue-job.sh
+            REGION=us-east-1 ./scripts/user/clear-all-cognito-users.ts
       - run:
-          name: Kick off the sync-s3-to-lower-env workflow if syncing early
+          name: Kick off the sync-s3-to-lower-env workflow
           command: |
-            if [ "$SYNC_EARLY" != "true" ]; then
-              echo "skipping…"
-              exit 0
-            fi
             curl --request POST \
               --url "https://circleci.com/api/v2/project/${CIRCLE_PROJECT_SLUG}/pipeline" \
               --header "Circle-Token: ${CIRCLE_MACHINE_USER_TOKEN}" \
@@ -541,27 +571,6 @@ jobs:
                 \"referrer\":\"${CIRCLE_WORKFLOW_ID}\", \
                 \"source_bucket\":\"${SOURCE_BUCKET}\", \
                 \"destination_bucket\":\"${DESTINATION_BUCKET}\"}}"
-      - run:
-          name: 'Delete OpenSearch alpha/beta clusters'
-          command: |
-            ./scripts/elasticsearch/delete-alpha-and-beta-clusters.sh
-      - run:
-          name: 'Delete Cognito users'
-          command: |
-            REGION=us-east-1 ./scripts/user/clear-all-cognito-users.ts
-      - run:
-          no_output_timeout: 20m
-          name: 'Recreate the alpha OpenSearch cluster'
-          command: |
-            npm run deploy:allColors $ENV
-      - run:
-          name: Setup OpenSearch Index Settings and Mappings
-          command: |
-            ./web-api/setup-elasticsearch-index.sh $ENV
-      - run:
-          name: Setup OpenSearch Aliases
-          command: |
-            npx ts-node --transpile-only ./web-api/elasticsearch/elasticsearch-alias-settings.ts
       - run:
           name: Kick off the glue-to-lower-env workflow
           command: |
@@ -584,23 +593,6 @@ jobs:
           name: Enable Wait for Workflow Cron
           command: |
             ./scripts/wait-for-workflow/enable-wait-for-workflow-cron.sh
-      - run:
-          name: Kick off the sync-s3-to-lower-env workflow if not syncing early
-          command: |
-            if [ "$SYNC_EARLY" == "true" ]; then
-              echo "skipping…"
-              exit 0
-            fi
-            curl --request POST \
-              --url "https://circleci.com/api/v2/project/${CIRCLE_PROJECT_SLUG}/pipeline" \
-              --header "Circle-Token: ${CIRCLE_MACHINE_USER_TOKEN}" \
-              --header "content-type: application/json" \
-              --data "{\"branch\":\"${CIRCLE_BRANCH}\", \"parameters\":{ \
-                \"run_build_and_deploy\":false, \
-                \"run_sync_s3_to_lower_env\":true, \
-                \"referrer\":\"${CIRCLE_WORKFLOW_ID}\", \
-                \"source_bucket\":\"${SOURCE_BUCKET}\", \
-                \"destination_bucket\":\"${DESTINATION_BUCKET}\"}}"
 
   migrate-restored-postgres-data:
     docker:
@@ -1040,17 +1032,21 @@ workflows:
         - equal: [glue-to-test-schedule, << pipeline.schedule.name >>]
         - << pipeline.parameters.run_glue_to_test >>
     jobs:
+      - delete-and-recreate-elasticsearch-cluster:
+          <<: *only-test
       - initiate-glue-job:
           <<: *only-test
       - wait-for-s3-sync-workflow:
           <<: *only-test
           type: approval
           requires:
+            - delete-and-recreate-elasticsearch-cluster
             - initiate-glue-job
       - wait-for-glue-workflow:
           <<: *only-test
           type: approval
           requires:
+            - delete-and-recreate-elasticsearch-cluster
             - initiate-glue-job
       - migrate-restored-postgres-data:
           <<: *only-test
@@ -1096,6 +1092,24 @@ workflows:
     jobs:
       - sync-s3-buckets-with-timeout:
           <<: *only-deployed-lower-environments
+
+  reindex-opensearch:
+    when: << pipeline.parameters.run_reindex_opensearch >>
+    jobs:
+      - delete-and-recreate-elasticsearch-cluster:
+          <<: *only-deployed-lower-environments
+      - index-cases:
+          <<: *only-deployed-lower-environments
+          requires:
+            - delete-and-recreate-elasticsearch-cluster
+      - index-users:
+          <<: *only-deployed-lower-environments
+          requires:
+            - index-cases
+      - index-docket-entries:
+          <<: *only-deployed-lower-environments
+          requires:
+            - index-users
 
   real-user-tests:
     when: << pipeline.parameters.run_real_user_tests >>

--- a/web-api/elasticsearch/elasticsearch-index-settings.helpers.test.ts
+++ b/web-api/elasticsearch/elasticsearch-index-settings.helpers.test.ts
@@ -124,4 +124,22 @@ describe('deleteUnaliasedIndices', () => {
       index: mockUnaliasedIndices,
     });
   });
+
+  it('does NOT delete a protected index even if it is unaliased', async () => {
+    const mockProtectedIndices = mockIndices
+      .map(i => i.index)
+      .filter(i => i.includes('efcms'));
+    expect(mockProtectedIndices.length).toBeGreaterThan(0);
+
+    aliases.mockReturnValue({ body: [], statusCode: 200 }); // mock no aliases (the protected indices are unaliased)
+    await deleteUnaliasedIndices({ client: mockedClient });
+
+    expect(mockedClient.indices.delete).toHaveBeenCalledTimes(1);
+    expect(mockedClient.indices.delete).toHaveBeenCalledWith({
+      index: mockUnaliasedIndices, // the protected indices are not included in this mock
+    });
+    expect(mockedClient.indices.delete).not.toHaveBeenCalledWith({
+      index: expect.arrayContaining(mockProtectedIndices), // explicitly ensure the protected indices are not deleted
+    });
+  });
 });

--- a/web-api/elasticsearch/elasticsearch-index-settings.helpers.ts
+++ b/web-api/elasticsearch/elasticsearch-index-settings.helpers.ts
@@ -82,9 +82,13 @@ export const deleteUnaliasedIndices = async ({
     })
     .map(a => a.index)
     .filter(i => typeof i === 'string');
+  const aliasedAndProtectedIndices = [
+    ...aliasedIndices,
+    ...elasticsearchIndexes,
+  ];
   const unaliasedIndices =
     indices.filter(index => {
-      return !aliasedIndices.includes(index);
+      return !aliasedAndProtectedIndices.includes(index);
     }) || [];
   if (unaliasedIndices.length) {
     try {


### PR DESCRIPTION
Somehow we're losing our OpenSearch aliases. That's a separate thing to figure out, but when we do (as the `staging` environment has presently), the `delete-unaliased-elasticsearch-indices` script is deleting our primary OpenSearch indices because by the time it runs, our primary indices have lost their aliases.

Here I've added code to `delete-unaliased-elasticsearch-indices` to not delete any of our primary OpenSearch indices and added code to the test to ensure that protected indices are not deleted even when they are unaliased.

After this is merged, we will need to delete the existing indices and run a reindex in `staging`, so I've added a CircleCI workflow to accomplish that.