### PR TITLE
9266 migration pt2 rename motion to test 1767983831

### DIFF
--- a/shared/src/business/entities/docketEntry/externalFilingEvents.ts
+++ b/shared/src/business/entities/docketEntry/externalFilingEvents.ts
@@ -2109,8 +2109,8 @@ export const EXTERNAL_FILING_EVENTS: AllExternalFilingEvents = {
       allowOrderResponse: true,
     },
     {
-      documentTitle: 'Motion to Withdraw Counsel',
-      documentType: 'Motion to Withdraw Counsel (filed by petitioner)',
+      documentTitle: 'Motion to Withdraw Counsel by Party',
+      documentType: 'Motion to Withdraw Counsel by Party',
       category: 'Motion',
       eventCode: 'M116',
       scenario: 'Standard',

--- a/shared/src/business/entities/docketEntry/internalFilingEvents.ts
+++ b/shared/src/business/entities/docketEntry/internalFilingEvents.ts
@@ -2302,8 +2302,8 @@ export const INTERNAL_FILING_EVENTS: AllInteralFilingEvents = {
       allowOrderResponse: true,
     },
     {
-      documentTitle: 'Motion to Withdraw Counsel',
-      documentType: 'Motion to Withdraw Counsel (filed by petitioner)',
+      documentTitle: 'Motion to Withdraw Counsel by Party',
+      documentType: 'Motion to Withdraw Counsel by Party',
       category: 'Motion',
       eventCode: 'M116',
       scenario: 'Standard',

--- a/web-api/src/persistence/postgres/utils/migrate/migrations/2026-01-09T15_14_46Z-document-type-expand.ts
+++ b/web-api/src/persistence/postgres/utils/migrate/migrations/2026-01-09T15_14_46Z-document-type-expand.ts
@@ -1,0 +1,31 @@
+import { Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+
+ await db
+    .updateTable('dwDocketEntry')
+    .set(eb => ({
+      documentType: eb
+        .case()
+        .when(eb('documentType', '=', 'Motion to Withdraw Counsel (filed by petitioner)')) // Or use eventCode M116
+        .then('Motion to Withdraw Counsel by Party')
+        .else(eb.ref('documentType'))
+        .end(),
+    }))
+    .execute();
+}
+
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db
+    .updateTable('dwDocketEntry')
+    .set(eb => ({
+      documentType: eb
+        .case()
+        .when(eb('documentType', '=', 'Motion to Withdraw Counsel by Party'))
+        .then('Motion to Withdraw Counsel (filed by petitioner)')
+        .else(eb.ref('documentType'))
+        .end(),
+    }))
+    .execute();
+}


### PR DESCRIPTION
PR 2: Update constants and migrate data
Step 1: Deploy constant changes
// In BOTH externalFilingEvents.ts and internalFilingEvents.ts
{
  documentTitle: 'Motion to Withdraw Counsel',
  documentType: 'Motion to Withdraw Counsel by Party', // Changed from 'Motion to Withdraw Counsel (filed by petitioner)'
  category: 'Motion',
  eventCode: 'M116',
  // ...
}
Step 2: Run migration
Run migration to swap old 'Motion to Withdraw Counsel (filed by petitioner)' value in documentType column to 'Motion to Withdraw Counsel by Party'.

  await db
    .updateTable('dwDocketEntry')
    .set(eb => ({
      documentType: eb
        .case()
        .when(eb('documentType', '=', 'Motion to Withdraw Counsel (filed by petitioner)')) // Or use eventCode M116
        .then('Motion to Withdraw Counsel by Party')
        .else(eb.ref('documentType'))
        .end(),
    }))
    .execute();