### PR TITLE
9266 migration pt3 rename motion to test 1767983898

### DIFF
--- a/shared/src/business/entities/EntityConstants.ts
+++ b/shared/src/business/entities/EntityConstants.ts
@@ -501,11 +501,6 @@ export const INTERNAL_DOCUMENT_TYPES = flatten(
   Object.values(INTERNAL_FILING_EVENTS),
 ).map(t => t.documentType);
 
-// Part 1 of migration related to 9266
-EXTERNAL_DOCUMENT_TYPES.push("Motion to Withdraw Counsel by Party")
-INTERNAL_DOCUMENT_TYPES.push("Motion to Withdraw Counsel by Party")
-
-
 export const COURT_ISSUED_DOCUMENT_TYPES = COURT_ISSUED_EVENT_CODES.map(
   t => t.documentType,
 );

--- a/shared/src/business/entities/docketEntry/externalFilingEvents.ts
+++ b/shared/src/business/entities/docketEntry/externalFilingEvents.ts
@@ -2109,8 +2109,8 @@ export const EXTERNAL_FILING_EVENTS: AllExternalFilingEvents = {
       allowOrderResponse: true,
     },
     {
-      documentTitle: 'Motion to Withdraw Counsel',
-      documentType: 'Motion to Withdraw Counsel (filed by petitioner)',
+      documentTitle: 'Motion to Withdraw Counsel by Party',
+      documentType: 'Motion to Withdraw Counsel by Party',
       category: 'Motion',
       eventCode: 'M116',
       scenario: 'Standard',

--- a/shared/src/business/entities/docketEntry/internalFilingEvents.ts
+++ b/shared/src/business/entities/docketEntry/internalFilingEvents.ts
@@ -2302,8 +2302,8 @@ export const INTERNAL_FILING_EVENTS: AllInteralFilingEvents = {
       allowOrderResponse: true,
     },
     {
-      documentTitle: 'Motion to Withdraw Counsel',
-      documentType: 'Motion to Withdraw Counsel (filed by petitioner)',
+      documentTitle: 'Motion to Withdraw Counsel by Party',
+      documentType: 'Motion to Withdraw Counsel by Party',
       category: 'Motion',
       eventCode: 'M116',
       scenario: 'Standard',

--- a/web-api/src/persistence/postgres/utils/migrate/migrations/2026-01-09T15_14_46Z-document-type-expand.ts
+++ b/web-api/src/persistence/postgres/utils/migrate/migrations/2026-01-09T15_14_46Z-document-type-expand.ts
@@ -1,0 +1,31 @@
+import { Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+
+ await db
+    .updateTable('dwDocketEntry')
+    .set(eb => ({
+      documentType: eb
+        .case()
+        .when(eb('documentType', '=', 'Motion to Withdraw Counsel (filed by petitioner)')) // Or use eventCode M116
+        .then('Motion to Withdraw Counsel by Party')
+        .else(eb.ref('documentType'))
+        .end(),
+    }))
+    .execute();
+}
+
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db
+    .updateTable('dwDocketEntry')
+    .set(eb => ({
+      documentType: eb
+        .case()
+        .when(eb('documentType', '=', 'Motion to Withdraw Counsel by Party'))
+        .then('Motion to Withdraw Counsel (filed by petitioner)')
+        .else(eb.ref('documentType'))
+        .end(),
+    }))
+    .execute();
+}


### PR DESCRIPTION
Step 3: Verify migration ( we did this locally )
 

Remove the .push() lines added in PR 1. Now only the new documentType is valid.