### PR TITLE
revert quill to previous

### DIFF
--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -236,10 +236,12 @@ Below is a list of dependencies that are locked down due to known issues with se
 - When running npm audit, you'll see a high severity issue with ws, 'affected by a DoS when handling a request with many HTTP headers - https://github.com/advisories/GHSA-3h5v-q93c-6h6q'. This doesn't affect us as the vulnerability is on the server side and we're not using this package on the server. We tried to override this to 5.2.4 and 8.18.0 and weren't able to make this work as import paths have changed. In the mean time, we recommend skipping this issue. We could always fork the cerebral repo in the future if needed.
 
 ### quill
-**Installed Version: 2.0.3**
+**Installed Version: 1.3.7**
+**DO NOT UPDATE - TO BE REPLACED BY EMBEDDED MICROSOFT WORD**
 
 - Quill released version 2 in April 2024. It includes substantial changes. Because the focus is currently on Postgres, we have left it at a previous version.
-- January 9th, 2026: We successfully updated Quill from 1.4.3 to 2.0.3. The way Quill handles imports and props in function calls changed, requiring changes to our Quill.tsx and TextEditor.tsx.
+- January 9th, 2026: We successfully updated Quill from 1.3.7 to 2.0.3. The way Quill handles imports and props in function calls changed, requiring changes to our Quill.tsx and TextEditor.tsx.
+- January 27th, 2026: The decision was made to revert us back to 1.3.7 due to a bug where line tabing would break upon edit. No further updates to Quill should be made - there is a plan in the pipeline to swap Quill out for an embedded Microsoft Office Editor.
 
 
 ### babel-jest, babel-core

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
         "promise-retry": "2.0.1",
         "pug": "3.0.3",
         "qs": "6.14.1",
-        "quill": "2.0.3",
+        "quill": "1.3.7",
         "quill-delta-to-html": "0.12.1",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -14312,6 +14312,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clone-deep": {
       "version": "4.0.1",
       "dev": true,
@@ -15245,6 +15254,26 @@
     "node_modules/deep-diff": {
       "version": "1.0.2",
       "license": "MIT"
+    },
+    "node_modules/deep-equal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+      "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arguments": "^1.1.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
@@ -16876,7 +16905,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/extract-zip": {
@@ -16925,9 +16953,9 @@
       "license": "MIT"
     },
     "node_modules/fast-diff": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
       "license": "Apache-2.0"
     },
     "node_modules/fast-equals": {
@@ -21065,18 +21093,6 @@
       "version": "4.17.21",
       "license": "MIT"
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.22",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.22.tgz",
-      "integrity": "sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-      "license": "MIT"
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "dev": true,
@@ -22041,6 +22057,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "license": "MIT",
@@ -22370,9 +22402,9 @@
       "license": "(MIT AND Zlib)"
     },
     "node_modules/parchment": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
-      "integrity": "sha512-HUrJFQ/StvgmXRcQ1ftY6VEZUq3jA2t9ncFN4F84J/vN0/FPpQF+8FKXb3l6fLces6q0uOHj6NJn+2xvZnxO6A==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
+      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/parent-module": {
@@ -24135,32 +24167,31 @@
       "license": "MIT"
     },
     "node_modules/quill": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
-      "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
+      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "lodash-es": "^4.17.21",
-        "parchment": "^3.0.0",
-        "quill-delta": "^5.1.0"
-      },
-      "engines": {
-        "npm": ">=8.2.3"
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1",
+        "eventemitter3": "^2.0.3",
+        "extend": "^3.0.2",
+        "parchment": "^1.1.4",
+        "quill-delta": "^3.6.2"
       }
     },
     "node_modules/quill-delta": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
-      "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
+      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
       "license": "MIT",
       "dependencies": {
-        "fast-diff": "^1.3.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.isequal": "^4.5.0"
+        "deep-equal": "^1.0.1",
+        "extend": "^3.0.2",
+        "fast-diff": "1.1.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=0.10"
       }
     },
     "node_modules/quill-delta-to-html": {
@@ -24169,6 +24200,12 @@
       "dependencies": {
         "lodash.isequal": "^4.5.0"
       }
+    },
+    "node_modules/quill/node_modules/eventemitter3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+      "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg==",
+      "license": "MIT"
     },
     "node_modules/randombytes": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "promise-retry": "2.0.1",
     "pug": "3.0.3",
     "qs": "6.14.1",
-    "quill": "2.0.3",
+    "quill": "1.3.7",
     "quill-delta-to-html": "0.12.1",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/web-client/src/ustc-ui/Quill/Quill.tsx
+++ b/web-client/src/ustc-ui/Quill/Quill.tsx
@@ -10,20 +10,18 @@ There are a few areas that type error exist but are being ignored as we are tryi
 import React from 'react';
 import isEqual from 'lodash/isEqual';
 import Quill, {
-  QuillOptions as QuillOptionsStatic,
-  Range as RangeStatic,
-  Bounds as BoundsStatic,
-  EmitterSource as Sources,
+  QuillOptionsStatic,
+  DeltaStatic,
+  RangeStatic,
+  BoundsStatic,
+  StringMap,
+  Sources,
 } from 'quill';
-import Delta from 'quill-delta';
-import type { AttributeMap as StringMap } from 'quill-delta';
-
-type DeltaStatic = Delta;
 
 type Value = string | DeltaStatic;
 type Range = RangeStatic | null;
 
-interface QuillOptions extends Omit<QuillOptionsStatic, 'tabIndex'> {
+interface QuillOptions extends QuillOptionsStatic {
   tabIndex?: number;
 }
 
@@ -69,8 +67,8 @@ interface UnprivilegedEditor {
   getLength(): number;
   getText(index?: number, length?: number): string;
   getHTML(): string;
-  getBounds(index: number, length?: number): BoundsStatic | null;
-  getSelection(focus?: boolean): RangeStatic | null;
+  getBounds(index: number, length?: number): BoundsStatic;
+  getSelection(focus?: boolean): RangeStatic;
   getContents(index?: number, length?: number): DeltaStatic;
 }
 
@@ -321,7 +319,7 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
   configuration, have its events bound,
   */
   createEditor(element: Element, config: QuillOptions) {
-    const editor = new Quill(element as HTMLElement, config);
+    const editor = new Quill(element, config);
     if (config.tabIndex != null) {
       this.setEditorTabIndex(editor, config.tabIndex);
     }
@@ -376,7 +374,7 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
     this.value = value;
     const sel = this.getEditorSelection();
     if (typeof value === 'string') {
-      editor.setContents(editor.clipboard.convert({ html: value }));
+      editor.setContents(editor.clipboard.convert(value));
     } else {
       editor.setContents(value);
     }

--- a/web-client/src/views/CreateOrder/TextEditor.tsx
+++ b/web-client/src/views/CreateOrder/TextEditor.tsx
@@ -10,7 +10,7 @@ const inlineStylesFontSizes = {};
 const fontSizes = ['10px', '12px', '14px', '16px', '18px', '20px'];
 
 const ReactQuill = React.lazy(async () => {
-  const Size = (await Quill.import('formats/size')) as any;
+  const Size = await Quill.import('attributors/style/size');
   Size.whitelist = fontSizes;
   Quill.register(Size, true);
   fontSizes.forEach(item => {
@@ -51,14 +51,14 @@ export const TextEditor = ({
   updateFormValueSequence,
   updateScreenMetadataSequence,
 }) => {
-  const quillEscapeRef = useRef<HTMLButtonElement>(null);
+  const quillEscapeRef = useRef(null);
   const defaultValueWithIndentation = addQuillIndentationClasses(defaultValue);
 
   const onKeyboard = event => {
     const pressedESC = event.keyCode === 27;
     const inEditor = event.target.classList.contains('ql-editor');
     if (pressedESC && inEditor) {
-      quillEscapeRef.current?.focus();
+      quillEscapeRef.current.focus();
     }
   };
 

--- a/web-client/src/views/CreateOrder/TextEditor.tsx
+++ b/web-client/src/views/CreateOrder/TextEditor.tsx
@@ -51,14 +51,14 @@ export const TextEditor = ({
   updateFormValueSequence,
   updateScreenMetadataSequence,
 }) => {
-  const quillEscapeRef = useRef(null);
+  const quillEscapeRef = useRef<HTMLButtonElement>(null);
   const defaultValueWithIndentation = addQuillIndentationClasses(defaultValue);
 
   const onKeyboard = event => {
     const pressedESC = event.keyCode === 27;
     const inEditor = event.target.classList.contains('ql-editor');
     if (pressedESC && inEditor) {
-      quillEscapeRef.current.focus();
+      quillEscapeRef.current?.focus();
     }
   };
 


### PR DESCRIPTION
https://github.com/ustaxcourt/ef-cms/issues/9679

# Summary
This PR reverts Quill back to `1.3.7`, to address a current bug where tabbing gets broken when a draft order is edited. We also update the documentation to note that no further updates to Quill should be made, in favor of replacing with embedded Microsoft Word (which is currently planned in the pipeline).