### PR TITLE
9693 order description field to test 1770059234

### DIFF
--- a/shared/src/business/utilities/getDescriptionDisplay.test.ts
+++ b/shared/src/business/utilities/getDescriptionDisplay.test.ts
@@ -65,4 +65,15 @@ describe('getDescriptionDisplay', () => {
 
     expect(result).toEqual('free text - doc title');
   });
+
+  it('should add Order prefix for order event codes', () => {
+    baseDocketEntry = {
+      ...baseDocketEntry,
+      documentTitle,
+      eventCode: 'O',
+    };
+    const result = getDescriptionDisplay(baseDocketEntry);
+
+    expect(result).toEqual('Order - doc title');
+  });
 });

--- a/shared/src/business/utilities/getDescriptionDisplay.ts
+++ b/shared/src/business/utilities/getDescriptionDisplay.ts
@@ -1,3 +1,5 @@
+import { addOrderStampPrefix } from './addOrderStampPrefix';
+
 /**
  * returns a modified document title when adding new information to a previous document title
  * especially in the case of qc'ing a docket entry
@@ -28,5 +30,5 @@ export const getDescriptionDisplay = docketEntry => {
     descriptionDisplay = `${docketEntry.freeText} - ${descriptionDisplay}`;
   }
 
-  return descriptionDisplay;
+  return addOrderStampPrefix(docketEntry.eventCode, descriptionDisplay);
 };

--- a/web-client/src/presenter/actions/CourtIssuedDocketEntry/setDefaultFreeTextForCourtIssuedDocketEntryAction.ts
+++ b/web-client/src/presenter/actions/CourtIssuedDocketEntry/setDefaultFreeTextForCourtIssuedDocketEntryAction.ts
@@ -7,17 +7,22 @@ import { state } from '@web-client/presenter/app.cerebral';
  * @param {object} providers.props the cerebral props object
  */
 export const setDefaultFreeTextForCourtIssuedDocketEntryAction = ({
+  get,
   props,
   store,
 }: ActionProps) => {
   const { key, value } = props;
   if (key === 'eventCode' && value) {
     const eventCode = value;
+    const isEditingDocketEntry = get(state.isEditingDocketEntry);
+    if (isEditingDocketEntry) {
+      return;
+    }
 
     if (eventCode === 'NOT') {
       store.set(state.form.freeText, 'Notice');
     } else if (eventCode === 'O') {
-      store.set(state.form.freeText, 'Order');
+      store.set(state.form.freeText, 'Order -');
     }
   }
 };

--- a/web-client/src/presenter/actions/CourtIssuedDocketEntry/setDefaultFreeTextForCourtIssuedDocketEntryAction.ts
+++ b/web-client/src/presenter/actions/CourtIssuedDocketEntry/setDefaultFreeTextForCourtIssuedDocketEntryAction.ts
@@ -1,4 +1,5 @@
 import { state } from '@web-client/presenter/app.cerebral';
+import { EVENT_CODES_WITH_NO_ORDER } from '@shared/business/entities/EntityConstants';
 
 /**
  * defaults state.form.freeText if props.key is eventCode and props.value is NOT or O
@@ -21,8 +22,13 @@ export const setDefaultFreeTextForCourtIssuedDocketEntryAction = ({
 
     if (eventCode === 'NOT') {
       store.set(state.form.freeText, 'Notice');
-    } else if (eventCode === 'O') {
-      store.set(state.form.freeText, 'Order -');
+    } else if (!EVENT_CODES_WITH_NO_ORDER.includes(eventCode)) {
+      const text = get(state.form.freeText);
+
+      store.set(
+        state.form.freeText,
+        text.startsWith('Order') ? text : `Order - ${text}`,
+      );
     }
   }
 };

--- a/web-client/src/views/CourtIssuedDocketEntry/CourtIssuedNonstandardForm.tsx
+++ b/web-client/src/views/CourtIssuedDocketEntry/CourtIssuedNonstandardForm.tsx
@@ -52,7 +52,6 @@ export const CourtIssuedNonstandardForm = connect(
     form: state.form,
     formatAndUpdateDateFromDatePickerSequence:
       sequences.formatAndUpdateDateFromDatePickerSequence,
-    isEditingDocketEntry: state.isEditingDocketEntry,
     judgeUsers: state.judges,
     updateCourtIssuedDocketEntryFormValueSequence:
       sequences.updateCourtIssuedDocketEntryFormValueSequence,

--- a/web-client/src/views/CourtIssuedDocketEntry/CourtIssuedNonstandardForm.tsx
+++ b/web-client/src/views/CourtIssuedDocketEntry/CourtIssuedNonstandardForm.tsx
@@ -1,11 +1,10 @@
 import { DateSelector } from '@web-client/ustc-ui/DateInput/DateSelector';
 import { FormGroup } from '../../ustc-ui/FormGroup/FormGroup';
 import { TrialCityOptions } from '../TrialCityOptions';
-import { addOrderStampPrefix } from '@shared/business/utilities/addOrderStampPrefix';
 import { connect } from '@web-client/presenter/shared.cerebral';
 import { sequences } from '@web-client/presenter/app.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
-import React, { useEffect } from 'react';
+import React from 'react';
 
 const NonstandardDateInput = (props: {
   addCourtIssuedDocketEntryNonstandardHelper: any;
@@ -68,27 +67,12 @@ export const CourtIssuedNonstandardForm = connect(
     DATE_FORMATS,
     form,
     formatAndUpdateDateFromDatePickerSequence,
-    isEditingDocketEntry,
     judgeUsers,
     updateCourtIssuedDocketEntryFormValueSequence,
     updateCourtIssuedDocketEntryTitleSequence,
     validateCourtIssuedDocketEntrySequence,
     validationErrors,
   }) {
-    useEffect(() => {
-      if (isEditingDocketEntry) {
-        return;
-      }
-
-      const prefixedValue = addOrderStampPrefix(form.eventCode, form.freeText);
-
-      if (prefixedValue && prefixedValue !== form.freeText) {
-        updateCourtIssuedDocketEntryFormValueSequence({
-          key: 'freeText',
-          value: prefixedValue,
-        });
-      }
-    }, []);
     return (
       <>
         {addCourtIssuedDocketEntryNonstandardHelper.showDateFirst && (

--- a/web-client/src/views/CourtIssuedDocketEntry/CourtIssuedNonstandardForm.tsx
+++ b/web-client/src/views/CourtIssuedDocketEntry/CourtIssuedNonstandardForm.tsx
@@ -5,7 +5,7 @@ import { addOrderStampPrefix } from '@shared/business/utilities/addOrderStampPre
 import { connect } from '@web-client/presenter/shared.cerebral';
 import { sequences } from '@web-client/presenter/app.cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 const NonstandardDateInput = (props: {
   addCourtIssuedDocketEntryNonstandardHelper: any;
@@ -25,7 +25,6 @@ const NonstandardDateInput = (props: {
     validateCourtIssuedDocketEntrySequence,
     validationErrors,
   } = props;
-
   return (
     <DateSelector
       defaultValue={form.date}
@@ -54,6 +53,7 @@ export const CourtIssuedNonstandardForm = connect(
     form: state.form,
     formatAndUpdateDateFromDatePickerSequence:
       sequences.formatAndUpdateDateFromDatePickerSequence,
+    isEditingDocketEntry: state.isEditingDocketEntry,
     judgeUsers: state.judges,
     updateCourtIssuedDocketEntryFormValueSequence:
       sequences.updateCourtIssuedDocketEntryFormValueSequence,
@@ -68,12 +68,27 @@ export const CourtIssuedNonstandardForm = connect(
     DATE_FORMATS,
     form,
     formatAndUpdateDateFromDatePickerSequence,
+    isEditingDocketEntry,
     judgeUsers,
     updateCourtIssuedDocketEntryFormValueSequence,
     updateCourtIssuedDocketEntryTitleSequence,
     validateCourtIssuedDocketEntrySequence,
     validationErrors,
   }) {
+    useEffect(() => {
+      if (isEditingDocketEntry) {
+        return;
+      }
+
+      const prefixedValue = addOrderStampPrefix(form.eventCode, form.freeText);
+
+      if (prefixedValue && prefixedValue !== form.freeText) {
+        updateCourtIssuedDocketEntryFormValueSequence({
+          key: 'freeText',
+          value: prefixedValue,
+        });
+      }
+    }, []);
     return (
       <>
         {addCourtIssuedDocketEntryNonstandardHelper.showDateFirst && (
@@ -169,7 +184,7 @@ export const CourtIssuedNonstandardForm = connect(
               data-testid="document-description-input"
               id="free-text"
               name="freeText"
-              value={addOrderStampPrefix(form.eventCode, form.freeText) || ''}
+              value={form.freeText || ''}
               onBlur={() => validateCourtIssuedDocketEntrySequence()}
               onChange={e => {
                 updateCourtIssuedDocketEntryFormValueSequence({

--- a/web-client/src/views/DocketRecord/FilingsAndProceedings.tsx
+++ b/web-client/src/views/DocketRecord/FilingsAndProceedings.tsx
@@ -7,7 +7,6 @@ import { state } from '@web-client/presenter/app.cerebral';
 import React from 'react';
 import classNames from 'classnames';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
-import { addOrderStampPrefix } from '@shared/business/utilities/addOrderStampPrefix';
 
 type FilingsAndProceedingsProps = {
   entry: {
@@ -113,7 +112,7 @@ export const FilingsAndProceedings = connect<
                 });
               }}
             >
-              {addOrderStampPrefix(entry.eventCode,entry.descriptionDisplay)}
+              {entry.descriptionDisplay}
             </Button>
           </Phone>
         </>


### PR DESCRIPTION
## Summary
[Order Description Field Forcing "Order -" Text for all Order Descriptions](https://github.com/ustaxcourt/ef-cms/issues/9693)

The Pull Request includes:

- A new test case to assert the correctness of the description display when the method detects a valid order
- The "Order -" prefix set at `setDefaultFreeTextForCourtIssuedDocketEntryAction.ts` as a default value, but it allows the prefix to be removed