### PR TITLE
opex: trial sessions report spitshine

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -8,7 +8,6 @@ on:
       - '.nvmrc'
       - '.circleci/config.yml'
       - 'docs/**'
-      - 'scripts/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/client-integration-public.yml
+++ b/.github/workflows/client-integration-public.yml
@@ -8,7 +8,6 @@ on:
       - '.nvmrc'
       - '.circleci/config.yml'
       - 'docs/**'
-      - 'scripts/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/client-integration.yml
+++ b/.github/workflows/client-integration.yml
@@ -8,7 +8,6 @@ on:
       - '.nvmrc'
       - '.circleci/config.yml'
       - 'docs/**'
-      - 'scripts/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -8,7 +8,6 @@ on:
       - '.nvmrc'
       - '.circleci/config.yml'
       - 'docs/**'
-      - 'scripts/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/e2e-cypress-accessibility.yml
+++ b/.github/workflows/e2e-cypress-accessibility.yml
@@ -8,7 +8,6 @@ on:
       - '.nvmrc'
       - '.circleci/config.yml'
       - 'docs/**'
-      - 'scripts/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/e2e-cypress-public.yml
+++ b/.github/workflows/e2e-cypress-public.yml
@@ -8,7 +8,6 @@ on:
       - '.nvmrc'
       - '.circleci/config.yml'
       - 'docs/**'
-      - 'scripts/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/e2e-cypress-smoketests-local.yml
+++ b/.github/workflows/e2e-cypress-smoketests-local.yml
@@ -8,7 +8,6 @@ on:
       - '.nvmrc'
       - '.circleci/config.yml'
       - 'docs/**'
-      - 'scripts/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/e2e-cypress.yml
+++ b/.github/workflows/e2e-cypress.yml
@@ -8,7 +8,6 @@ on:
       - '.nvmrc'
       - '.circleci/config.yml'
       - 'docs/**'
-      - 'scripts/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,6 @@ on:
       - '.nvmrc'
       - '.circleci/config.yml'
       - 'docs/**'
-      - 'scripts/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/pdfs.yml
+++ b/.github/workflows/pdfs.yml
@@ -8,7 +8,6 @@ on:
       - '.nvmrc'
       - '.circleci/config.yml'
       - 'docs/**'
-      - 'scripts/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -8,7 +8,6 @@ on:
       - '.nvmrc'
       - '.circleci/config.yml'
       - 'docs/**'
-      - 'scripts/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -8,7 +8,6 @@ on:
       - '.nvmrc'
       - '.circleci/config.yml'
       - 'docs/**'
-      - 'scripts/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/typescript-all-files-check.yml
+++ b/.github/workflows/typescript-all-files-check.yml
@@ -8,7 +8,6 @@ on:
       - '.nvmrc'
       - '.circleci/config.yml'
       - 'docs/**'
-      - 'scripts/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/typescript-error-check.yml
+++ b/.github/workflows/typescript-error-check.yml
@@ -8,7 +8,6 @@ on:
       - '.nvmrc'
       - '.circleci/config.yml'
       - 'docs/**'
-      - 'scripts/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/scripts/download-all-case-documents.ts
+++ b/scripts/download-all-case-documents.ts
@@ -9,6 +9,7 @@ import {
   type ServerApplicationContext,
   createApplicationContext,
 } from '@web-api/applicationContext';
+import { formatCaseCaption } from './helpers/formatters';
 import { getCaseByDocketNumber } from '@web-api/persistence/postgres/cases/getCaseByDocketNumber';
 import fs from 'fs';
 
@@ -113,7 +114,7 @@ const generateFilename = ({
     }
     try {
       const filename = generateFilename({
-        caseCaption: caseEntity.caseCaption,
+        caseCaption: formatCaseCaption(caseEntity.caseCaption),
         // @ts-ignore
         docketEntry,
       });

--- a/scripts/helpers/formatters.test.ts
+++ b/scripts/helpers/formatters.test.ts
@@ -1,0 +1,103 @@
+import {
+  alphabetizeCities,
+  formatCaseCaption,
+  formatCurrency,
+  formatDate,
+  formatJudgeName,
+  formatMMDDYYYY,
+} from './formatters';
+
+describe('formatJudgeName', () => {
+  it('should remove titles from judge names', () => {
+    expect(formatJudgeName('Chief Special Trial Judge Buch')).toBe('Buch');
+    expect(formatJudgeName('Special Trial Judge Cohen')).toBe('Cohen');
+    expect(formatJudgeName('Judge Ashford')).toBe('Ashford');
+  });
+
+  it('should handle undefined', () => {
+    expect(formatJudgeName(undefined)).toBe('');
+  });
+});
+
+describe('formatCaseCaption', () => {
+  it('should remove line breaks and trim the caption', () => {
+    expect(formatCaseCaption('Jane Doe, \n Petitioner')).toBe(
+      'Jane Doe,   Petitioner',
+    );
+  });
+
+  it('should handle undefined', () => {
+    expect(formatCaseCaption(undefined)).toBe('');
+  });
+});
+
+describe('alphabetizeCities', () => {
+  it('should sort cities by state and then by city', () => {
+    const cities = [
+      'Phoenix, Arizona',
+      'Mobile, Alabama',
+      'Birmingham, Alabama',
+      'Anchorage, Alaska',
+    ];
+    const sorted = alphabetizeCities(cities);
+    expect(sorted).toEqual([
+      'Birmingham, Alabama',
+      'Mobile, Alabama',
+      'Anchorage, Alaska',
+      'Phoenix, Arizona',
+    ]);
+  });
+
+  it('should handle cities without a state (e.g., Standalone Remote)', () => {
+    const cities = [
+      'Standalone Remote',
+      'Mobile, Alabama',
+      'Birmingham, Alabama',
+    ];
+    const sorted = alphabetizeCities(cities);
+    expect(sorted).toEqual([
+      'Birmingham, Alabama',
+      'Mobile, Alabama',
+      'Standalone Remote',
+    ]);
+  });
+});
+
+describe('formatDate', () => {
+  it('should format date strings as YYYY-MM-DD', () => {
+    expect(formatDate('2020-01-01T05:00:00Z')).toBe('2020-01-01');
+  });
+
+  it('should handle Date objects', () => {
+    // eslint-disable-next-line custom-rules-plugin/no-dates
+    const date = new Date('2020-01-01T05:00:00Z');
+    expect(formatDate(date)).toBe('2020-01-01');
+  });
+
+  it('should handle undefined', () => {
+    expect(formatDate(undefined)).toBe('');
+  });
+});
+
+describe('formatCurrency', () => {
+  it('should format numbers to two decimal places', () => {
+    expect(formatCurrency(123.4)).toBe('123.40');
+    expect(formatCurrency('123.4')).toBe('123.40');
+    expect(formatCurrency(123.399999999)).toBe('123.40');
+    expect(formatCurrency('123.400000001')).toBe('123.40');
+  });
+
+  it('should handle undefined', () => {
+    expect(formatCurrency(undefined)).toBe('0');
+  });
+});
+
+describe('formatMMDDYYYY', () => {
+  it('should format date strings as MMDDYYYY', () => {
+    expect(formatMMDDYYYY('2020-01-01T05:00:00Z')).toBe('01/01/2020');
+  });
+
+  it('should handle undefined', () => {
+    expect(formatMMDDYYYY(undefined)).toBe('');
+  });
+});

--- a/scripts/helpers/formatters.test.ts
+++ b/scripts/helpers/formatters.test.ts
@@ -1,10 +1,10 @@
+import { TRIAL_CITY_STRINGS } from '@shared/business/entities/EntityConstants';
 import {
   alphabetizeCities,
   formatCaseCaption,
   formatCurrency,
   formatDate,
   formatJudgeName,
-  formatMMDDYYYY,
 } from './formatters';
 
 describe('formatJudgeName', () => {
@@ -50,8 +50,8 @@ describe('alphabetizeCities', () => {
 
   it('should handle cities without a state (e.g., Standalone Remote)', () => {
     const cities = [
-      'Standalone Remote',
       'Mobile, Alabama',
+      'Standalone Remote',
       'Birmingham, Alabama',
     ];
     const sorted = alphabetizeCities(cities);
@@ -60,6 +60,16 @@ describe('alphabetizeCities', () => {
       'Mobile, Alabama',
       'Standalone Remote',
     ]);
+  });
+
+  it('should return all trial session cities if no array was provided', () => {
+    const sorted = alphabetizeCities();
+    expect(sorted.length).toEqual(TRIAL_CITY_STRINGS.length);
+  });
+
+  it('should return immediately if an empty array was provided', () => {
+    const sorted = alphabetizeCities([]);
+    expect(sorted.length).toEqual(0);
   });
 });
 
@@ -71,10 +81,16 @@ describe('formatDate', () => {
     expect(formatDate('2020-01-01T05:00:00Z')).toBe('2020-01-01');
   });
 
-  it('should handle Date objects', () => {
+  it('should handle valid Date objects', () => {
     // eslint-disable-next-line custom-rules-plugin/no-dates
     const date = new Date('2020-01-01T05:00:00Z');
     expect(formatDate(date)).toBe('2020-01-01');
+  });
+
+  it('should handle invalid Date objects', () => {
+    // eslint-disable-next-line custom-rules-plugin/no-dates
+    const date = new Date('invalid-date');
+    expect(formatDate(date)).toBe('');
   });
 
   it('should handle undefined', () => {
@@ -92,15 +108,5 @@ describe('formatCurrency', () => {
 
   it('should handle undefined', () => {
     expect(formatCurrency(undefined)).toBe('0');
-  });
-});
-
-describe('formatMMDDYYYY', () => {
-  it('should format date strings as MMDDYYYY', () => {
-    expect(formatMMDDYYYY('2020-01-01T05:00:00Z')).toBe('01/01/2020');
-  });
-
-  it('should handle undefined', () => {
-    expect(formatMMDDYYYY(undefined)).toBe('');
   });
 });

--- a/scripts/helpers/formatters.test.ts
+++ b/scripts/helpers/formatters.test.ts
@@ -65,6 +65,9 @@ describe('alphabetizeCities', () => {
 
 describe('formatDate', () => {
   it('should format date strings as YYYY-MM-DD', () => {
+    // 2020-01-01 01:00 UTC = 2019-12-31 20:00 EST
+    expect(formatDate('2020-01-01T01:00:00Z')).toBe('2019-12-31');
+    // 2020-01-01 05:00 UTC = 2020-01-01 00:00 EST
     expect(formatDate('2020-01-01T05:00:00Z')).toBe('2020-01-01');
   });
 

--- a/scripts/helpers/formatters.ts
+++ b/scripts/helpers/formatters.ts
@@ -28,9 +28,11 @@ export const alphabetizeCities = (
     const [bCity, bState] = b.split(', ');
 
     if (aState !== bState) {
+      if (!aState) return 1;
+      if (!bState) return -1;
       return aState.localeCompare(bState);
     }
-    return aCity.localeCompare(bCity);
+    return (aCity || '').localeCompare(bCity || '');
   });
 };
 

--- a/scripts/helpers/formatters.ts
+++ b/scripts/helpers/formatters.ts
@@ -38,14 +38,15 @@ export const alphabetizeCities = (
 
 export const formatDate = (date: string | Date | undefined): string => {
   if (!date) return '';
-  const isoDate = typeof date === 'string' ? date : getIsoFromJsDate(date);
+  const isoDate: string | null =
+    typeof date === 'string' ? date : getIsoFromJsDate(date);
   if (!isoDate) return '';
   return formatDateString(isoDate, 'YYYYMMDD');
 };
 
 export const formatCurrency = (amount: number | string | undefined): string => {
   if (!amount) return '0';
-  const numericAmount =
+  const numericAmount: number =
     typeof amount === 'string' ? parseFloat(amount) : amount;
   return numericAmount.toFixed(2);
 };

--- a/scripts/helpers/formatters.ts
+++ b/scripts/helpers/formatters.ts
@@ -1,3 +1,7 @@
+import {
+  formatDateString,
+  getIsoFromJsDate,
+} from '@shared/business/utilities/DateHandler';
 import { TRIAL_CITY_STRINGS } from '@shared/business/entities/EntityConstants';
 
 export const formatJudgeName = (name: string | undefined): string => {
@@ -28,4 +32,21 @@ export const alphabetizeCities = (
     }
     return aCity.localeCompare(bCity);
   });
+};
+
+export const formatDate = (date: string | Date | undefined): string => {
+  if (!date) return '';
+  const isoDate = typeof date === 'string' ? date : getIsoFromJsDate(date);
+  return isoDate?.split('T')[0] || '';
+};
+
+export const formatCurrency = (amount: number | string | undefined): string => {
+  if (!amount) return '0';
+  const numericAmount =
+    typeof amount === 'string' ? parseFloat(amount) : amount;
+  return numericAmount.toFixed(2);
+};
+
+export const formatMMDDYYYY = (date: string | undefined): string => {
+  return date ? formatDateString(date, 'MMDDYYYY') : '';
 };

--- a/scripts/helpers/formatters.ts
+++ b/scripts/helpers/formatters.ts
@@ -32,7 +32,7 @@ export const alphabetizeCities = (
       if (!bState) return -1;
       return aState.localeCompare(bState);
     }
-    return (aCity || '').localeCompare(bCity || '');
+    return aCity.localeCompare(bCity);
   });
 };
 

--- a/scripts/helpers/formatters.ts
+++ b/scripts/helpers/formatters.ts
@@ -39,7 +39,7 @@ export const alphabetizeCities = (
 export const formatDate = (date: string | Date | undefined): string => {
   if (!date) return '';
   const isoDate = typeof date === 'string' ? date : getIsoFromJsDate(date);
-  return isoDate?.split('T')[0] || '';
+  return formatDateString(isoDate, 'YYYYMMDD');
 };
 
 export const formatCurrency = (amount: number | string | undefined): string => {

--- a/scripts/helpers/formatters.ts
+++ b/scripts/helpers/formatters.ts
@@ -1,0 +1,31 @@
+import { TRIAL_CITY_STRINGS } from '@shared/business/entities/EntityConstants';
+
+export const formatJudgeName = (name: string | undefined): string => {
+  return (
+    name
+      ?.replace('Chief Special Trial ', '')
+      .replace('Special Trial ', '')
+      .replace('Judge ', '') ?? ''
+  );
+};
+
+export const formatCaseCaption = (caption: string | undefined): string => {
+  if (!caption) return '';
+  return caption.replace(/\r\n|\r|\n/g, ' ').trim();
+};
+
+export const alphabetizeCities = (
+  cities: string[] = TRIAL_CITY_STRINGS,
+): string[] => {
+  if (!cities || cities.length === 0) return [];
+
+  return cities.slice().sort((a, b) => {
+    const [aCity, aState] = a.split(', ');
+    const [bCity, bState] = b.split(', ');
+
+    if (aState !== bState) {
+      return aState.localeCompare(bState);
+    }
+    return aCity.localeCompare(bCity);
+  });
+};

--- a/scripts/helpers/formatters.ts
+++ b/scripts/helpers/formatters.ts
@@ -39,6 +39,7 @@ export const alphabetizeCities = (
 export const formatDate = (date: string | Date | undefined): string => {
   if (!date) return '';
   const isoDate = typeof date === 'string' ? date : getIsoFromJsDate(date);
+  if (!isoDate) return '';
   return formatDateString(isoDate, 'YYYYMMDD');
 };
 
@@ -47,8 +48,4 @@ export const formatCurrency = (amount: number | string | undefined): string => {
   const numericAmount =
     typeof amount === 'string' ? parseFloat(amount) : amount;
   return numericAmount.toFixed(2);
-};
-
-export const formatMMDDYYYY = (date: string | undefined): string => {
-  return date ? formatDateString(date, 'MMDDYYYY') : '';
 };

--- a/scripts/reports/attorneys-admitted-in-year.ts
+++ b/scripts/reports/attorneys-admitted-in-year.ts
@@ -10,6 +10,7 @@ import { fromKyselyUser } from '@web-api/persistence/postgres/users/mapper';
 import { generateCsv } from '../helpers/generate-csv';
 import { getDbReader } from '@web-api/database';
 import { pick } from 'lodash';
+import { formatDate } from '../helpers/formatters';
 
 const scriptConfig: ScriptConfig = {
   description:
@@ -68,7 +69,7 @@ const getAttorneysAdmittedInYear = async (): Promise<RawPractitioner[]> => {
   ];
   const rows = attorneys.map(attorney => ({
     ...pick(attorney, ['barNumber', 'firmName', 'name', 'practiceType']),
-    admissionsDate: attorney.admissionsDate.split('T')[0],
+    admissionsDate: formatDate(attorney.admissionsDate),
   }));
   const filename = `${OUTPUT_DIR}/attorneys-admitted-in${fiscal ? '-fiscal-year' : ''}-${year}.csv`;
   generateCsv({ columns, filename, rows });

--- a/scripts/reports/cases-closed-in-year.ts
+++ b/scripts/reports/cases-closed-in-year.ts
@@ -12,7 +12,11 @@ import {
   getJsDateFromIso,
   getNowObject,
 } from '@shared/business/utilities/DateHandler';
-import { formatCaseCaption, formatJudgeName } from '../helpers/formatters';
+import {
+  formatCaseCaption,
+  formatDate,
+  formatJudgeName,
+} from '../helpers/formatters';
 import { fromKyselyCase } from '@web-api/persistence/postgres/cases/mapper';
 import { generateCsv } from '../helpers/generate-csv';
 import { getDbReader } from '@web-api/database';
@@ -164,11 +168,10 @@ const outputCsv = ({
         )?.date ||
       c.closedDate ||
       '';
-    const closedDateHumanized = closedDateISO.split('T')[0] || '';
+    const closedDateHumanized = formatDate(closedDateISO);
     const caption = formatCaseCaption(c.caseCaption);
     const petitionServedDateISO = petitionServiceDates.get(c.docketNumber)!;
-    const petitionServedDateHumanized =
-      petitionServedDateISO?.split('T')[0] || '';
+    const petitionServedDateHumanized = formatDate(petitionServedDateISO);
     const daysOpen = calculateDifferenceInDays(
       closedDateISO,
       petitionServedDateISO,

--- a/scripts/reports/cases-closed-in-year.ts
+++ b/scripts/reports/cases-closed-in-year.ts
@@ -12,6 +12,7 @@ import {
   getJsDateFromIso,
   getNowObject,
 } from '@shared/business/utilities/DateHandler';
+import { formatCaseCaption, formatJudgeName } from '../helpers/formatters';
 import { fromKyselyCase } from '@web-api/persistence/postgres/cases/mapper';
 import { generateCsv } from '../helpers/generate-csv';
 import { getDbReader } from '@web-api/database';
@@ -151,11 +152,7 @@ const outputCsv = ({
   ];
   const totals: { [k: string]: number } = { cases: 0, daysOpen: 0 };
   const rows = casesClosedInYear.map(c => {
-    const judge =
-      c.associatedJudge
-        ?.replace('Chief Special Trial ', '')
-        .replace('Special Trial ', '')
-        .replace('Judge ', '') || '';
+    const judge = formatJudgeName(c.associatedJudge);
     const closedDateISO =
       (c.caseStatusHistory || [])
         .reverse()
@@ -168,7 +165,7 @@ const outputCsv = ({
       c.closedDate ||
       '';
     const closedDateHumanized = closedDateISO.split('T')[0] || '';
-    const caption = c.caseCaption.replace(/\r\n|\r|\n/g, ' ').trim();
+    const caption = formatCaseCaption(c.caseCaption);
     const petitionServedDateISO = petitionServiceDates.get(c.docketNumber)!;
     const petitionServedDateHumanized =
       petitionServedDateISO?.split('T')[0] || '';

--- a/scripts/reports/cases-open-on-date.ts
+++ b/scripts/reports/cases-open-on-date.ts
@@ -13,6 +13,7 @@ import {
   getNowObject,
   validateDateAndCreateISO,
 } from '@shared/business/utilities/DateHandler';
+import { formatDate } from '../helpers/formatters';
 
 const nowObject = getNowObject();
 const scriptConfig: ScriptConfig = {
@@ -108,7 +109,7 @@ const generateCsv = ({
   for (let y = thisYear - 4; y <= thisYear; y++) {
     const year = `${y}`;
     const targetDate = validateDateAndCreateISO({ day, month, year })!;
-    const targetDateHumanized = targetDate.split('T')[0];
+    const targetDateHumanized = formatDate(targetDate);
     console.log(`Retrieving cases open on ${targetDateHumanized}...`);
     const casesPotentiallyOpenOnDate = await getAllCasesOpenOnDate({
       targetDate,
@@ -139,9 +140,10 @@ const generateCsv = ({
       })
       .map(c => ({
         docketNumber: c.docketNumber,
-        noaFiledOn: noasFiledAfterDate
-          .find(noa => noa.docketNumber === c.docketNumber)!
-          .receivedAt.split('T')[0],
+        noaFiledOn: formatDate(
+          noasFiledAfterDate.find(noa => noa.docketNumber === c.docketNumber)!
+            .receivedAt,
+        ),
       }));
     if (casesToExamineManually.length) {
       console.log(
@@ -157,7 +159,7 @@ const generateCsv = ({
   let totalsOutput = '"Date","Cases Open"';
   for (const year of Object.keys(totals)) {
     const targetDate = validateDateAndCreateISO({ day, month, year })!;
-    const date = targetDate.split('T')[0];
+    const date = formatDate(targetDate);
     totalsOutput += `\n"${date}","${totals[year]}"`;
   }
   const monthAndDay = validateDateAndCreateISO({

--- a/scripts/reports/closed-dates.ts
+++ b/scripts/reports/closed-dates.ts
@@ -5,6 +5,7 @@ import {
   getJsTimeframeForYear,
   parseArgsAndEnvVars,
 } from '../helpers/parseArgsAndEnvVars';
+import { formatCaseCaption } from '../helpers/formatters';
 import { fromKyselyCase } from '@web-api/persistence/postgres/cases/mapper';
 import { generateCsv } from '../helpers/generate-csv';
 import { getDbReader } from '@web-api/database';
@@ -66,7 +67,7 @@ const getAllCasesOpenedInYear = async (): Promise<RawCase[]> => {
     { header: 'Case Type', key: 'caseType' },
   ];
   const rows = casesOpenedInYear.map(c => ({
-    caseCaption: c.caseCaption,
+    caseCaption: formatCaseCaption(c.caseCaption),
     caseType: c.caseType,
     closedHumanized: c.closedDate?.split('T')[0] || '',
     docketNumber: c.docketNumber,

--- a/scripts/reports/closed-dates.ts
+++ b/scripts/reports/closed-dates.ts
@@ -5,7 +5,7 @@ import {
   getJsTimeframeForYear,
   parseArgsAndEnvVars,
 } from '../helpers/parseArgsAndEnvVars';
-import { formatCaseCaption } from '../helpers/formatters';
+import { formatCaseCaption, formatDate } from '../helpers/formatters';
 import { fromKyselyCase } from '@web-api/persistence/postgres/cases/mapper';
 import { generateCsv } from '../helpers/generate-csv';
 import { getDbReader } from '@web-api/database';
@@ -69,9 +69,9 @@ const getAllCasesOpenedInYear = async (): Promise<RawCase[]> => {
   const rows = casesOpenedInYear.map(c => ({
     caseCaption: formatCaseCaption(c.caseCaption),
     caseType: c.caseType,
-    closedHumanized: c.closedDate?.split('T')[0] || '',
+    closedHumanized: formatDate(c.closedDate),
     docketNumber: c.docketNumber,
-    rcvdAtHumanized: c.receivedAt?.split('T')[0],
+    rcvdAtHumanized: formatDate(c.receivedAt),
     status: c.status,
   }));
   generateCsv({ columns, filename, rows });

--- a/scripts/reports/deficiencies.ts
+++ b/scripts/reports/deficiencies.ts
@@ -16,6 +16,8 @@ import { pick } from 'lodash';
 import {
   alphabetizeCities,
   formatCaseCaption,
+  formatCurrency,
+  formatDate,
   formatJudgeName,
 } from '../helpers/formatters';
 import { choose } from '../helpers/prompts';
@@ -126,7 +128,7 @@ const getDeficiencyCases = async (
     filterByTrialCity = await choose('Trial location', trialCityStrings);
   }
 
-  const today = createISODateString().split('T')[0];
+  const today = formatDate(createISODateString());
   const OUTPUT_DIR = `${home}/Documents`;
   let outputFilename = 'deficiencies_';
   if (min !== max) {
@@ -158,9 +160,7 @@ const getDeficiencyCases = async (
     ...deficiencyCases.map(result => ({
       ...pick(result, ['docketNumber', 'status']),
       caption: formatCaseCaption(result.caption),
-      irsDeficiencyAmount: result.irsDeficiencyAmount
-        ? `${result.irsDeficiencyAmount.toFixed(2)}`
-        : '0',
+      irsDeficiencyAmount: formatCurrency(result.irsDeficiencyAmount),
       judge: formatJudgeName(result.associatedJudge),
       preferredTrialCity: result.preferredTrialCity || '',
     })),

--- a/scripts/reports/deficiencies.ts
+++ b/scripts/reports/deficiencies.ts
@@ -13,6 +13,11 @@ import { sql } from 'kysely';
 import { createISODateString } from '@shared/business/utilities/DateHandler';
 import { generateCsv } from '../helpers/generate-csv';
 import { pick } from 'lodash';
+import {
+  alphabetizeCities,
+  formatCaseCaption,
+  formatJudgeName,
+} from '../helpers/formatters';
 import { choose } from '../helpers/prompts';
 
 const scriptConfig: ScriptConfig = {
@@ -61,15 +66,7 @@ type tDeficiencyCase = {
   preferredTrialCity: string;
 };
 
-const trialCityStrings = TRIAL_CITY_STRINGS.slice().sort((a, b) => {
-  const [aCity, aState] = a.split(', ');
-  const [bCity, bState] = b.split(', ');
-
-  if (aState !== bState) {
-    return aState.localeCompare(bState);
-  }
-  return aCity.localeCompare(bCity);
-});
+const trialCityStrings = alphabetizeCities(TRIAL_CITY_STRINGS);
 
 const getDeficiencyCases = async (
   filterByTrialCity: string | undefined,
@@ -159,15 +156,12 @@ const getDeficiencyCases = async (
   ];
   const rows = [
     ...deficiencyCases.map(result => ({
-      ...pick(result, ['caption', 'docketNumber', 'status']),
+      ...pick(result, ['docketNumber', 'status']),
+      caption: formatCaseCaption(result.caption),
       irsDeficiencyAmount: result.irsDeficiencyAmount
         ? `${result.irsDeficiencyAmount.toFixed(2)}`
         : '0',
-      judge:
-        result.associatedJudge
-          ?.replace('Chief Special Trial ', '')
-          .replace('Special Trial ', '')
-          .replace('Judge ', '') || '',
+      judge: formatJudgeName(result.associatedJudge),
       preferredTrialCity: result.preferredTrialCity || '',
     })),
   ];

--- a/scripts/reports/deficiency-stats.ts
+++ b/scripts/reports/deficiency-stats.ts
@@ -5,10 +5,11 @@ import {
   type ScriptConfig,
   parseArgsAndEnvVars,
 } from '../helpers/parseArgsAndEnvVars';
+import { createISODateString } from '@shared/business/utilities/DateHandler';
+import { formatCurrency, formatDate } from '../helpers/formatters';
+import { generateCsv } from '../helpers/generate-csv';
 import { getDbReader } from '@web-api/database';
 import { sql } from 'kysely';
-import { createISODateString } from '@shared/business/utilities/DateHandler';
-import { generateCsv } from '../helpers/generate-csv';
 
 const scriptConfig: ScriptConfig = {
   description:
@@ -21,7 +22,7 @@ const scriptConfig: ScriptConfig = {
 };
 const { home } = parseArgsAndEnvVars(scriptConfig) as { home: string };
 
-const today = createISODateString().split('T')[0];
+const today = formatDate(createISODateString());
 const OUTPUT_DIR = `${home}/Documents`;
 const OUTPUT_FILENAME = `${OUTPUT_DIR}/deficiency-stats_${today}.csv`;
 
@@ -97,13 +98,15 @@ const aggregateDeficiencyAmounts = async (): Promise<
     ...aggregateResults.map(result => ({
       ...result,
       smallCasesPct: `${(result.smallCases / result.openCases) * 100}%`,
-      totalOutstandingDeficiency: result.totalOutstandingDeficiency.toFixed(2),
+      totalOutstandingDeficiency: formatCurrency(
+        result.totalOutstandingDeficiency,
+      ),
     })),
     {
       openCases: totalOpenCases,
       preferredTrialCity: 'Total',
       smallCasesPct: `${(totalSmallCases / totalOpenCases) * 100}%`,
-      totalOutstandingDeficiency: totalOutstandingDeficiency.toFixed(2),
+      totalOutstandingDeficiency: formatCurrency(totalOutstandingDeficiency),
     },
   ];
   generateCsv({ columns, filename: OUTPUT_FILENAME, rows });

--- a/scripts/reports/documents-filed-by-nonattorneys.ts
+++ b/scripts/reports/documents-filed-by-nonattorneys.ts
@@ -7,11 +7,9 @@ import {
 } from '../helpers/parseArgsAndEnvVars';
 import { generateCsv } from '../helpers/generate-csv';
 import { getDbReader } from '@web-api/database';
-import {
-  getIsoFromJsDate,
-  getNowObject,
-} from '@shared/business/utilities/DateHandler';
+import { getNowObject } from '@shared/business/utilities/DateHandler';
 import { pick } from 'lodash';
+import { formatDate } from '../helpers/formatters';
 
 const thisYear = getNowObject().year;
 const scriptConfig: ScriptConfig = {
@@ -105,7 +103,7 @@ const getDocumentsFiledByNonAttorneys = async (): Promise<
   const rows = documents.map(de => ({
     ...pick(de, ['docketNumber', 'documentTitle']),
     filedBy: de.name,
-    filedOn: getIsoFromJsDate(de.receivedAt)?.split('T')[0] || '',
+    filedOn: formatDate(de.receivedAt),
   }));
   const docType = eventCode
     ? documents[0].documentType?.replace(' ', '-').toLowerCase()

--- a/scripts/reports/event-codes-by-year.ts
+++ b/scripts/reports/event-codes-by-year.ts
@@ -14,6 +14,7 @@ import {
   getNowObject,
 } from '@shared/business/utilities/DateHandler';
 import { pick } from 'lodash';
+import { formatCaseCaption, formatJudgeName } from '../helpers/formatters';
 
 const thisYear = getNowObject().year;
 const scriptConfig: ScriptConfig = {
@@ -86,13 +87,9 @@ const outputCsv = ({
     `in-${fiscal ? 'fy-' : ''}${years.join('-')}.csv`;
   const rows = docketEntries.map(de => ({
     ...pick(de, ['docketNumber', 'documentType', 'status']),
-    caption: de.caption.replace(/\r\n|\r|\n/g, ' ').trim(),
+    caption: formatCaseCaption(de.caption),
     filed: getIsoFromJsDate(de.receivedAt)?.split('T')[0] || '',
-    judge:
-      de.associatedJudge
-        ?.replace('Chief Special Trial ', '')
-        .replace('Special Trial ', '')
-        .replace('Judge ', '') || '',
+    judge: formatJudgeName(de.associatedJudge),
   }));
   generateCsv({ columns, filename, rows });
   console.log(`Generated ${filename}`);

--- a/scripts/reports/event-codes-by-year.ts
+++ b/scripts/reports/event-codes-by-year.ts
@@ -9,12 +9,13 @@ import {
   parseArgsAndEnvVars,
 } from '../helpers/parseArgsAndEnvVars';
 import { generateCsv } from '../helpers/generate-csv';
-import {
-  getIsoFromJsDate,
-  getNowObject,
-} from '@shared/business/utilities/DateHandler';
+import { getNowObject } from '@shared/business/utilities/DateHandler';
 import { pick } from 'lodash';
-import { formatCaseCaption, formatJudgeName } from '../helpers/formatters';
+import {
+  formatCaseCaption,
+  formatDate,
+  formatJudgeName,
+} from '../helpers/formatters';
 
 const thisYear = getNowObject().year;
 const scriptConfig: ScriptConfig = {
@@ -88,7 +89,7 @@ const outputCsv = ({
   const rows = docketEntries.map(de => ({
     ...pick(de, ['docketNumber', 'documentType', 'status']),
     caption: formatCaseCaption(de.caption),
-    filed: getIsoFromJsDate(de.receivedAt)?.split('T')[0] || '',
+    filed: formatDate(de.receivedAt),
     judge: formatJudgeName(de.associatedJudge),
   }));
   generateCsv({ columns, filename, rows });

--- a/scripts/reports/firms-cases.ts
+++ b/scripts/reports/firms-cases.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env -S npx ts-node --transpile-only
 
 import type { RawPractitioner } from '@shared/business/entities/Practitioner';
+import { formatCaseCaption, formatJudgeName } from '../helpers/formatters';
 import { fromKyselyCase } from '@web-api/persistence/postgres/cases/mapper';
 import { fromKyselyUser } from '@web-api/persistence/postgres/users/mapper';
 import { generateCsv } from '../helpers/generate-csv';
@@ -69,17 +70,11 @@ const getFirmsCases = async ({
     { header: 'Case Status', key: 'status' },
     { header: 'Case Title', key: 'caseCaption' },
   ];
-  const rows = firmsCases.map(fc => {
-    const judge =
-      fc.associatedJudge
-        ?.replace('Chief Special Trial ', '')
-        .replace('Special Trial ', '')
-        .replace('Judge ', '') || '';
-    return {
-      ...pick(fc, ['caseCaption', 'docketNumber', 'status']),
-      judge,
-    };
-  });
+  const rows = firmsCases.map(fc => ({
+    ...pick(fc, ['docketNumber', 'status']),
+    caseCaption: formatCaseCaption(fc.caseCaption),
+    judge: formatJudgeName(fc.associatedJudge),
+  }));
   generateCsv({ columns, filename, rows });
   console.log(`Generated ${filename}`);
 })();

--- a/scripts/reports/lea-stats.ts
+++ b/scripts/reports/lea-stats.ts
@@ -9,6 +9,7 @@ import { fromKyselyDocketEntry } from '@web-api/persistence/postgres/docketEntri
 import { generateCsv } from '../helpers/generate-csv';
 import { getCasesByDocketNumbers } from '@web-api/persistence/postgres/cases/getCasesByDocketNumbers';
 import { getDbReader } from '@web-api/database';
+import { formatDate } from '../helpers/formatters';
 
 const scriptConfig: ScriptConfig = {
   description:
@@ -105,9 +106,9 @@ const getNocFiledAfterLeaInCase = ({
     }
     rows.push({
       docketNumber: lea.docketNumber,
-      leaFiledDate: lea.receivedAt.split('T')[0],
+      leaFiledDate: formatDate(lea.receivedAt),
       leaIndex: lea.index,
-      nocFiledDate: subsequentNoc?.receivedAt.split('T')[0] ?? '',
+      nocFiledDate: formatDate(subsequentNoc?.receivedAt),
       nocIndex: subsequentNoc?.index ?? '',
       procedureType: caseCache[lea.docketNumber].procedureType,
     });

--- a/scripts/reports/lea-stats.ts
+++ b/scripts/reports/lea-stats.ts
@@ -37,7 +37,7 @@ const { fiscal, year } = parseArgsAndEnvVars(scriptConfig) as {
 const { begin, end } = getJsTimeframeForYear({ fiscal, year });
 
 const OUTPUT_DIR = `${process.env.HOME}/Documents`;
-const caseCache: { [k: string]: RawCase } = {};
+const caseCache: { [k: string]: Omit<RawCase, 'consolidatedCases'> } = {};
 
 const getLEAsFiledInYear = async (): Promise<RawDocketEntry[]> => {
   return (

--- a/scripts/reports/lea-stats.ts
+++ b/scripts/reports/lea-stats.ts
@@ -7,9 +7,8 @@ import {
 } from '../helpers/parseArgsAndEnvVars';
 import { fromKyselyDocketEntry } from '@web-api/persistence/postgres/docketEntries/mapper';
 import { generateCsv } from '../helpers/generate-csv';
-import { getCaseByDocketNumber } from '@web-api/persistence/postgres/cases/getCaseByDocketNumber';
+import { getCasesByDocketNumbers } from '@web-api/persistence/postgres/cases/getCasesByDocketNumbers';
 import { getDbReader } from '@web-api/database';
-import PQueue from 'p-queue';
 
 const scriptConfig: ScriptConfig = {
   description:
@@ -38,7 +37,6 @@ const { begin, end } = getJsTimeframeForYear({ fiscal, year });
 
 const OUTPUT_DIR = `${process.env.HOME}/Documents`;
 const caseCache: { [k: string]: RawCase } = {};
-const concurrency = 50;
 
 const getLEAsFiledInYear = async (): Promise<RawDocketEntry[]> => {
   return (
@@ -53,20 +51,6 @@ const getLEAsFiledInYear = async (): Promise<RawDocketEntry[]> => {
         .execute(),
     )
   ).map(fromKyselyDocketEntry) as RawDocketEntry[];
-};
-
-const getCaseEntity = async ({
-  docketNumber,
-}: {
-  docketNumber: string;
-}): Promise<RawCase> => {
-  if (!(docketNumber in caseCache)) {
-    caseCache[docketNumber] = await getCaseByDocketNumber({
-      docketNumber,
-      includeConsolidatedCases: false,
-    });
-  }
-  return caseCache[docketNumber];
 };
 
 const getNocFiledAfterLeaInCase = ({
@@ -96,11 +80,11 @@ const getNocFiledAfterLeaInCase = ({
       `in ${fiscal ? 'fiscal' : 'calendar'} year ${year}.`,
   );
   const docketNumbers = [...new Set(leas.map(de => de.docketNumber))];
-  const queue = new PQueue({ concurrency });
-  const funcs = docketNumbers.map(
-    (docketNumber: string) => async () => await getCaseEntity({ docketNumber }),
-  );
-  await queue.addAll(funcs);
+
+  const cases = await getCasesByDocketNumbers({ docketNumbers });
+  cases.forEach(c => {
+    caseCache[c.docketNumber] = c;
+  });
 
   const procedureTypeAggs: { [k: string]: number } = {};
   for (const caseEntity of Object.values(caseCache)) {

--- a/scripts/reports/non-attorney-practitioners.ts
+++ b/scripts/reports/non-attorney-practitioners.ts
@@ -10,7 +10,7 @@ import {
   parseArgsAndEnvVars,
 } from '../helpers/parseArgsAndEnvVars';
 import { calculateDifferenceInDays } from '@shared/business/utilities/DateHandler';
-import { formatCaseCaption, formatMMDDYYYY } from '../helpers/formatters';
+import { formatCaseCaption, formatDate } from '../helpers/formatters';
 import { fromKyselyUser } from '@web-api/persistence/postgres/users/mapper';
 import { getCasesByDocketNumbers } from '@web-api/persistence/postgres/cases/getCasesByDocketNumbers';
 import { getDbReader } from '@web-api/database';
@@ -157,12 +157,12 @@ const getUsersCases = ({
       ]),
       caseCaption: formatCaseCaption(caseRecord.caseCaption),
       closedByStipulatedDecision: closedByStipulatedDecision(caseRecord),
-      closedDateFormatted: formatMMDDYYYY(caseRecord.closedDate),
+      closedDateFormatted: formatDate(caseRecord.closedDate),
       duration: calculateCaseDuration(caseRecord),
       hasNoticeOfAppeal: hasNoticeOfAppeal(caseRecord),
-      noticeOfTrialDateFormatted: formatMMDDYYYY(caseRecord.noticeOfTrialDate),
-      receivedAtFormatted: formatMMDDYYYY(caseRecord.receivedAt),
-      trialDateFormatted: formatMMDDYYYY(caseRecord.trialDate),
+      noticeOfTrialDateFormatted: formatDate(caseRecord.noticeOfTrialDate),
+      receivedAtFormatted: formatDate(caseRecord.receivedAt),
+      trialDateFormatted: formatDate(caseRecord.trialDate),
       userFiledPretrialMemorandum: userFiledPretrialMemorandum(
         caseRecord,
         userId,

--- a/scripts/reports/non-attorney-practitioners.ts
+++ b/scripts/reports/non-attorney-practitioners.ts
@@ -9,11 +9,8 @@ import {
   type ScriptConfig,
   parseArgsAndEnvVars,
 } from '../helpers/parseArgsAndEnvVars';
-import {
-  calculateDifferenceInDays,
-  formatDateString,
-} from '@shared/business/utilities/DateHandler';
-import { formatCaseCaption } from '../helpers/formatters';
+import { calculateDifferenceInDays } from '@shared/business/utilities/DateHandler';
+import { formatCaseCaption, formatMMDDYYYY } from '../helpers/formatters';
 import { fromKyselyUser } from '@web-api/persistence/postgres/users/mapper';
 import { getCasesByDocketNumbers } from '@web-api/persistence/postgres/cases/getCasesByDocketNumbers';
 import { getDbReader } from '@web-api/database';
@@ -160,20 +157,12 @@ const getUsersCases = ({
       ]),
       caseCaption: formatCaseCaption(caseRecord.caseCaption),
       closedByStipulatedDecision: closedByStipulatedDecision(caseRecord),
-      closedDateFormatted: caseRecord.closedDate
-        ? formatDateString(caseRecord.closedDate, 'MMDDYYYY')
-        : '',
+      closedDateFormatted: formatMMDDYYYY(caseRecord.closedDate),
       duration: calculateCaseDuration(caseRecord),
       hasNoticeOfAppeal: hasNoticeOfAppeal(caseRecord),
-      noticeOfTrialDateFormatted: caseRecord.noticeOfTrialDate
-        ? formatDateString(caseRecord.noticeOfTrialDate, 'MMDDYYYY')
-        : '',
-      receivedAtFormatted: caseRecord.receivedAt
-        ? formatDateString(caseRecord.receivedAt, 'MMDDYYYY')
-        : '',
-      trialDateFormatted: caseRecord.trialDate
-        ? formatDateString(caseRecord.trialDate, 'MMDDYYYY')
-        : '',
+      noticeOfTrialDateFormatted: formatMMDDYYYY(caseRecord.noticeOfTrialDate),
+      receivedAtFormatted: formatMMDDYYYY(caseRecord.receivedAt),
+      trialDateFormatted: formatMMDDYYYY(caseRecord.trialDate),
       userFiledPretrialMemorandum: userFiledPretrialMemorandum(
         caseRecord,
         userId,

--- a/scripts/reports/non-attorney-practitioners.ts
+++ b/scripts/reports/non-attorney-practitioners.ts
@@ -13,6 +13,7 @@ import {
   calculateDifferenceInDays,
   formatDateString,
 } from '@shared/business/utilities/DateHandler';
+import { formatCaseCaption } from '../helpers/formatters';
 import { fromKyselyUser } from '@web-api/persistence/postgres/users/mapper';
 import { getCasesByDocketNumbers } from '@web-api/persistence/postgres/cases/getCasesByDocketNumbers';
 import { getDbReader } from '@web-api/database';
@@ -148,7 +149,6 @@ const getUsersCases = ({
   for (const caseRecord of casesFiltered) {
     usersCases.push({
       ...pick(caseRecord, [
-        'caseCaption',
         'closedDate',
         'docketNumber',
         'noticeOfTrialDate',
@@ -158,6 +158,7 @@ const getUsersCases = ({
         'trialDate',
         'trialSessionId',
       ]),
+      caseCaption: formatCaseCaption(caseRecord.caseCaption),
       closedByStipulatedDecision: closedByStipulatedDecision(caseRecord),
       closedDateFormatted: caseRecord.closedDate
         ? formatDateString(caseRecord.closedDate, 'MMDDYYYY')

--- a/scripts/reports/stale-cases.helpers.ts
+++ b/scripts/reports/stale-cases.helpers.ts
@@ -9,7 +9,11 @@ import {
   subtractISODates,
 } from '@shared/business/utilities/DateHandler';
 import { compareStrings } from '@shared/business/utilities/sortFunctions';
-import { formatCaseCaption, formatJudgeName } from '../helpers/formatters';
+import {
+  formatCaseCaption,
+  formatDate,
+  formatJudgeName,
+} from '../helpers/formatters';
 import { fromKyselyCase } from '@web-api/persistence/postgres/cases/mapper';
 import { generateCsv } from '../helpers/generate-csv';
 import { getDbReader } from '@web-api/database';
@@ -89,12 +93,12 @@ export const generateStaleCasesReport = async ({
         caption: formatCaseCaption(aCase.caseCaption),
         deAge,
         judge: formatJudgeName(aCase.associatedJudge),
-        lastFilingDate: deFiled!.split('T')[0],
+        lastFilingDate: formatDate(deFiled),
         preferredTrialCity: aCase.preferredTrialCity || '',
       });
       console.log(
         `Docket number ${aCase.docketNumber} is stale! Most recent document ` +
-          `is ${deAge} days old, last filed on ${deFiled!.split('T')[0]}`,
+          `is ${deAge} days old, last filed on ${formatDate(deFiled)}`,
       );
     }
   }

--- a/scripts/reports/stale-cases.helpers.ts
+++ b/scripts/reports/stale-cases.helpers.ts
@@ -9,14 +9,13 @@ import {
   subtractISODates,
 } from '@shared/business/utilities/DateHandler';
 import { compareStrings } from '@shared/business/utilities/sortFunctions';
+import { formatCaseCaption, formatJudgeName } from '../helpers/formatters';
 import { fromKyselyCase } from '@web-api/persistence/postgres/cases/mapper';
-import { fromKyselyDocketEntry } from '@web-api/persistence/postgres/docketEntries/mapper';
 import { generateCsv } from '../helpers/generate-csv';
 import { getDbReader } from '@web-api/database';
-import PQueue from 'p-queue';
+import { pick } from 'lodash';
 
 const todayISO = createISODateString();
-const CONCURRENCY = 5;
 const YEAR_IN_DAYS = 365;
 const excludedCaseStatuses = [
   CASE_STATUS_TYPES.closed,
@@ -24,82 +23,48 @@ const excludedCaseStatuses = [
   CASE_STATUS_TYPES.onAppeal,
 ];
 
+type RawCaseWithLastFilingDate = RawCase & { lastFilingDate?: Date };
 type StaleCase = {
   caption: string;
   deAge: number;
-  deRcvdAt: string;
   docketNumber: string;
   judge: string;
+  lastFilingDate: string;
   preferredTrialCity: string;
   status: CaseStatus;
 };
 
-const staleCases: StaleCase[] = [];
-
-const getAllCasesNotInExcludedStatus = async (): Promise<RawCase[]> => {
+const getAllCasesNotInExcludedStatus = async (): Promise<
+  RawCaseWithLastFilingDate[]
+> => {
   const oneYearAgo = getJsDateFromIso(
     subtractISODates(todayISO, { day: YEAR_IN_DAYS }),
   );
-  return (
-    await getDbReader(reader =>
-      reader
-        .selectFrom('dwCase as c')
-        .selectAll('c')
-        .where('c.status', 'not in', excludedCaseStatuses)
-        .where('c.receivedAt', '<=', oneYearAgo)
-        .orderBy('c.sortableDocketNumber', 'asc')
-        .execute(),
-    )
-  ).map(fromKyselyCase) as RawCase[];
-};
+  return await getDbReader(async reader => {
+    const results = await reader
+      .selectFrom('dwCase as c')
+      .selectAll('c')
+      .select(eb => [
+        eb
+          .selectFrom('dwDocketEntry as de')
+          .select('de.filingDate')
+          .whereRef('de.docketNumber', '=', 'c.docketNumber')
+          .where('de.isDraft', '!=', true)
+          .where('de.filingDate', 'is not', null)
+          .orderBy('de.filingDate', 'desc')
+          .limit(1)
+          .as('lastFilingDate'),
+      ])
+      .where('c.status', 'not in', excludedCaseStatuses)
+      .where('c.receivedAt', '<=', oneYearAgo)
+      .orderBy('c.sortableDocketNumber', 'asc')
+      .execute();
 
-const getMostRecentDocketEntry = async ({
-  docketNumber,
-}: {
-  docketNumber: string;
-}): Promise<RawDocketEntry | undefined> => {
-  const results = (
-    await getDbReader(reader =>
-      reader
-        .selectFrom('dwDocketEntry as de')
-        .selectAll('de')
-        .where('de.docketNumber', '=', docketNumber)
-        .where('de.isDraft', '!=', true)
-        .where('de.filingDate', 'is not', null)
-        .orderBy('de.receivedAt', 'desc')
-        .limit(1)
-        .execute(),
-    )
-  ).map(fromKyselyDocketEntry) as RawDocketEntry[];
-  return results[0];
-};
-
-const isCaseStale = async ({ aCase }: { aCase: RawCase }): Promise<void> => {
-  const mostRecentDocketEntry = await getMostRecentDocketEntry({
-    docketNumber: aCase.docketNumber,
+    return results.map(record => ({
+      ...fromKyselyCase(record),
+      lastFilingDate: record.lastFilingDate || undefined,
+    })) as RawCaseWithLastFilingDate[];
   });
-  const deRcvdAt = mostRecentDocketEntry?.receivedAt;
-  const deAge = deRcvdAt ? calculateDifferenceInDays(todayISO, deRcvdAt) : 0;
-  if (deAge >= YEAR_IN_DAYS) {
-    const judge =
-      aCase.associatedJudge
-        ?.replace('Chief Special Trial ', '')
-        .replace('Special Trial ', '')
-        .replace('Judge ', '') ?? '';
-    staleCases.push({
-      caption: aCase.caseCaption.replace(/\r\n|\r|\n/g, ' '),
-      deAge,
-      deRcvdAt: deRcvdAt!.split('T')[0],
-      docketNumber: aCase.docketNumber,
-      judge,
-      preferredTrialCity: aCase.preferredTrialCity || '',
-      status: aCase.status,
-    });
-    console.log(
-      `Docket number ${aCase.docketNumber} is stale! Most recent document is` +
-        ` ${deAge} days old, last filed on ${deRcvdAt!.split('T')[0]}`,
-    );
-  }
 };
 
 export const generateStaleCasesReport = async ({
@@ -112,11 +77,28 @@ export const generateStaleCasesReport = async ({
     `Found ${casesNotClosedOrOnAppeal.length} cases not closed or on ` +
       'appeal that were received at least a year ago.',
   );
-  const queue = new PQueue({ concurrency: CONCURRENCY });
-  const funcs = casesNotClosedOrOnAppeal.map(
-    (aCase: RawCase) => async () => await isCaseStale({ aCase }),
-  );
-  await queue.addAll(funcs);
+
+  const staleCases: StaleCase[] = [];
+
+  for (const aCase of casesNotClosedOrOnAppeal) {
+    const deFiled = aCase.lastFilingDate?.toISOString();
+    const deAge = deFiled ? calculateDifferenceInDays(todayISO, deFiled) : 0;
+    if (deAge >= YEAR_IN_DAYS) {
+      staleCases.push({
+        ...pick(aCase, ['docketNumber', 'status']),
+        caption: formatCaseCaption(aCase.caseCaption),
+        deAge,
+        judge: formatJudgeName(aCase.associatedJudge),
+        lastFilingDate: deFiled!.split('T')[0],
+        preferredTrialCity: aCase.preferredTrialCity || '',
+      });
+      console.log(
+        `Docket number ${aCase.docketNumber} is stale! Most recent document ` +
+          `is ${deAge} days old, last filed on ${deFiled!.split('T')[0]}`,
+      );
+    }
+  }
+
   console.log(`Found ${staleCases.length} stale cases.`);
 
   console.log(`Writing CSV to ${filename}...`);
@@ -125,7 +107,7 @@ export const generateStaleCasesReport = async ({
     { header: 'Docket Number', key: 'docketNumber' },
     { header: 'Caption', key: 'caption' },
     { header: 'Status', key: 'status' },
-    { header: 'Last Filed', key: 'deRcvdAt' },
+    { header: 'Last Filed', key: 'lastFilingDate' },
     { header: 'Age in Days', key: 'deAge' },
     { header: 'Preferred Trial City', key: 'preferredTrialCity' },
   ];

--- a/scripts/reports/stale-cases.ts
+++ b/scripts/reports/stale-cases.ts
@@ -5,6 +5,7 @@ import {
   parseArgsAndEnvVars,
 } from '../helpers/parseArgsAndEnvVars';
 import { createISODateString } from '@shared/business/utilities/DateHandler';
+import { formatDate } from '../helpers/formatters';
 import { generateStaleCasesReport } from './stale-cases.helpers';
 
 const scriptConfig: ScriptConfig = {
@@ -18,7 +19,7 @@ const scriptConfig: ScriptConfig = {
 };
 parseArgsAndEnvVars(scriptConfig);
 
-const today = createISODateString().split('T')[0];
+const today = formatDate(createISODateString());
 const OUTPUT_DIR = `${process.env.HOME}/Documents`;
 const OUTPUT_FILENAME = `${OUTPUT_DIR}/12-month-inactivity_${today}.csv`;
 

--- a/scripts/reports/trial-sessions-report-helpers.test.ts
+++ b/scripts/reports/trial-sessions-report-helpers.test.ts
@@ -1,6 +1,7 @@
 import { MOCK_TRIAL_REGULAR, MOCK_TRIAL_REMOTE } from '@shared/test/mockTrial';
 import '@web-api/persistence/postgres/trialSessions/mocks.jest';
 import {
+  clearTrialSessionsCache,
   getUniqueValues,
   trialSessionsReport,
 } from './trial-sessions-report-helpers';
@@ -66,6 +67,15 @@ describe('getUniqueValues', () => {
     expect(uniqueSongwriters).toEqual(expectedUniqueSongwriters);
     expect(Object.keys(uniqueYears).length).toEqual(6);
   });
+
+  it('handles missing keys in objects', () => {
+    const arrayOfObjects = [{ key1: 'value1' }, { key2: 'value2' }];
+    const result = getUniqueValues({
+      arrayOfObjects,
+      keyToFilter: 'key1',
+    });
+    expect(result).toEqual({ value1: 1 });
+  });
 });
 
 describe('trialSessionsReport', () => {
@@ -77,10 +87,35 @@ describe('trialSessionsReport', () => {
 
   beforeAll(() => {
     getTrialSessions.mockResolvedValue(mockTrialSessions);
-    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  beforeEach(() => {
+    clearTrialSessionsCache();
   });
 
   it('retrieves trial sessions and outputs a CSV file', async () => {
+    getTrialSessions.mockResolvedValue([
+      {
+        ...MOCK_TRIAL_REMOTE,
+        startDate: '2020-05-01T05:00:00Z',
+        trialClerk: { name: 'Test Clerk', userId: '123' },
+      },
+      {
+        ...MOCK_TRIAL_REGULAR,
+        alternateTrialClerkName: 'Alternate Clerk',
+        judge: { name: 'Judge Buch', userId: '456' },
+        startDate: '2020-06-01T05:00:00Z',
+        trialClerk: undefined,
+      },
+      {
+        ...MOCK_TRIAL_REGULAR,
+        alternateTrialClerkName: undefined,
+        judge: { name: 'Judge Cohen', userId: '789' },
+        startDate: '2020-07-01T05:00:00Z',
+        trialClerk: {} as any,
+      },
+    ]);
+
     await trialSessionsReport({
       begin,
       end,
@@ -93,12 +128,127 @@ describe('trialSessionsReport', () => {
   });
 
   it('retrieves trial sessions and returns aggregated statistics', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    getTrialSessions.mockResolvedValue([
+      {
+        ...MOCK_TRIAL_REGULAR,
+        judge: { name: 'Judge Cohen', userId: '1' },
+        proceedingType: 'In Person',
+        sessionType: 'Regular',
+        startDate: '2020-01-10T05:00:00Z',
+        trialLocation: 'Z-City, Alabama',
+      },
+      {
+        ...MOCK_TRIAL_REGULAR,
+        judge: { name: 'Judge Buch', userId: '2' },
+        proceedingType: 'In Person',
+        sessionType: 'Small',
+        startDate: '2020-01-11T05:00:00Z',
+        trialLocation: 'Mobile, Alabama',
+      },
+      {
+        ...MOCK_TRIAL_REGULAR,
+        judge: undefined,
+        proceedingType: 'Remote',
+        sessionType: 'Small',
+        startDate: '2020-01-12T05:00:00Z',
+        trialLocation: 'Mobile, Alabama',
+      },
+      {
+        ...MOCK_TRIAL_REGULAR,
+        judge: { name: '', userId: '3' },
+        proceedingType: 'Remote',
+        sessionType: 'Small',
+        startDate: '2020-01-13T05:00:00Z',
+        trialLocation: 'Mobile, Alabama',
+      },
+      {
+        ...MOCK_TRIAL_REGULAR,
+        judge: { name: 'Judge Aardvark', userId: '4' },
+        proceedingType: 'Remote',
+        sessionType: 'Small',
+        startDate: '2020-01-14T05:00:00Z',
+        trialLocation: 'Anchorage, Alaska',
+      },
+    ]);
+
     await trialSessionsReport({
       begin,
       end,
       filename,
       stats: true,
     });
-    expect(getTrialSessions).not.toHaveBeenCalled(); // because the results were cached
+
+    const outputCall = logSpy.mock.calls.find(
+      call => call[0] && call[0].total === 5,
+    );
+    if (!outputCall) {
+      console.log('Log calls:', logSpy.mock.calls);
+      throw new Error('Could not find expected log call');
+    }
+    const stats = outputCall[0];
+
+    expect(Object.keys(stats.locations)).toEqual([
+      'Mobile, Alabama',
+      'Z-City, Alabama',
+      'Anchorage, Alaska',
+    ]);
+
+    expect(Object.keys(stats.sessionTypes)).toEqual(['Small', 'Regular']);
+
+    expect(Object.keys(stats.proceedingTypes)).toEqual(['In Person', 'Remote']);
+
+    expect(Object.keys(stats.judges)).toEqual([
+      'Aardvark',
+      'Buch',
+      'Cohen',
+      '',
+    ]);
+
+    logSpy.mockClear();
+    getTrialSessions.mockResolvedValue([
+      {
+        ...MOCK_TRIAL_REGULAR,
+        judge: undefined,
+        startDate: '2020-01-10T05:00:00Z',
+      },
+      {
+        ...MOCK_TRIAL_REGULAR,
+        judge: { name: 'Judge Buch', userId: '2' },
+        startDate: '2020-01-11T05:00:00Z',
+      },
+    ]);
+    clearTrialSessionsCache();
+    await trialSessionsReport({
+      begin,
+      end,
+      filename,
+      stats: true,
+    });
+    const { judges } = logSpy.mock.calls[0][0];
+    expect(Object.keys(judges)).toEqual(['Buch', '']); // sessions without a judge appear last in the stats
+  });
+
+  it('verifies that trial sessions are cached', async () => {
+    getTrialSessions.mockClear();
+    getTrialSessions.mockResolvedValue([
+      { ...MOCK_TRIAL_REGULAR, startDate: begin },
+    ]);
+
+    await trialSessionsReport({
+      begin,
+      end,
+      filename,
+      stats: true,
+    });
+    expect(getTrialSessions).toHaveBeenCalledTimes(1);
+
+    await trialSessionsReport({
+      begin,
+      end,
+      filename,
+      stats: true,
+    });
+    expect(getTrialSessions).toHaveBeenCalledTimes(1); // not called a second time because the results are cached
   });
 });

--- a/scripts/reports/trial-sessions-report-helpers.ts
+++ b/scripts/reports/trial-sessions-report-helpers.ts
@@ -3,11 +3,16 @@ import {
   formatDateString,
 } from '@shared/business/utilities/DateHandler';
 import { type RawTrialSession } from '@shared/business/entities/trialSessions/TrialSession';
+import { alphabetizeCities, formatJudgeName } from '../helpers/formatters';
 import { generateCsv } from '../helpers/generate-csv';
-import { pick } from 'lodash';
 import { getTrialSessions } from '@web-api/persistence/postgres/trialSessions/getTrialSessions';
+import { pick } from 'lodash';
 
 let trialSessionsCache: RawTrialSession[] = [];
+
+export const clearTrialSessionsCache = (): void => {
+  trialSessionsCache = [];
+};
 
 export const getUniqueValues = ({
   arrayOfObjects,
@@ -78,7 +83,7 @@ const outputTrialSessionsReport = ({
     } else if (s.alternateTrialClerkName) {
       trialClerk = s.alternateTrialClerkName;
     }
-    const judge = s.judge?.name ?? '';
+    const judge = formatJudgeName(s.judge?.name);
     return {
       ...pick(s, ['proceedingType', 'sessionType', 'trialLocation']),
       judge,
@@ -95,24 +100,55 @@ const outputTrialSessionsStats = ({
 }: {
   trialSessions: RawTrialSession[];
 }): void => {
-  const locations = getUniqueValues({
+  const unsortedLocations = getUniqueValues({
     arrayOfObjects: trialSessions,
     keyToFilter: 'trialLocation',
   });
-  const sessionTypes = getUniqueValues({
+  const unsortedSessionTypes = getUniqueValues({
     arrayOfObjects: trialSessions,
     keyToFilter: 'sessionType',
   });
-  const proceedingTypes = getUniqueValues({
+  const unsortedProceedingTypes = getUniqueValues({
     arrayOfObjects: trialSessions,
     keyToFilter: 'proceedingType',
   });
-  const judges = getUniqueValues({
-    arrayOfObjects: trialSessions.map(s => {
-      return { judgeName: s.judge?.name || '' };
-    }),
+  const unsortedJudges = getUniqueValues({
+    arrayOfObjects: trialSessions.map(s => ({
+      judgeName: formatJudgeName(s.judge?.name),
+    })),
     keyToFilter: 'judgeName',
   });
+
+  const locations = {};
+  alphabetizeCities(Object.keys(unsortedLocations)).forEach(key => {
+    locations[key] = unsortedLocations[key];
+  });
+
+  const sessionTypes = {};
+  Object.keys(unsortedSessionTypes)
+    .sort((a, b) => unsortedSessionTypes[b] - unsortedSessionTypes[a])
+    .forEach(key => {
+      sessionTypes[key] = unsortedSessionTypes[key];
+    });
+
+  const proceedingTypes = {};
+  Object.keys(unsortedProceedingTypes)
+    .sort((a, b) => a.localeCompare(b))
+    .forEach(key => {
+      proceedingTypes[key] = unsortedProceedingTypes[key];
+    });
+
+  const judges = {};
+  Object.keys(unsortedJudges)
+    .sort((a, b) => {
+      if (a === '') return 1;
+      if (b === '') return -1;
+      return a.localeCompare(b);
+    })
+    .forEach(key => {
+      judges[key] = unsortedJudges[key];
+    });
+
   console.log({
     judges,
     locations,

--- a/scripts/reports/trial-sessions-report-helpers.ts
+++ b/scripts/reports/trial-sessions-report-helpers.ts
@@ -78,7 +78,7 @@ const outputTrialSessionsReport = ({
   const rows = trialSessions.map(s => {
     const startDate = formatDateString(s.startDate, FORMATS['MMDDYYYY_DASHED']);
     let trialClerk = '';
-    if (s.trialClerk && 'name' in s.trialClerk && s.trialClerk.name) {
+    if (s.trialClerk && s.trialClerk?.name) {
       trialClerk = s.trialClerk.name.trim();
     } else if (s.alternateTrialClerkName) {
       trialClerk = s.alternateTrialClerkName.trim();
@@ -120,7 +120,7 @@ const outputTrialSessionsStats = ({
   });
   const justClerks: { trialClerk: string }[] = trialSessions.map(s => {
     let trialClerk = '';
-    if (s.trialClerk && 'name' in s.trialClerk && s.trialClerk.name) {
+    if (s.trialClerk && s.trialClerk?.name) {
       trialClerk = s.trialClerk.name.trim();
     } else if (s.alternateTrialClerkName) {
       trialClerk = s.alternateTrialClerkName.trim();

--- a/scripts/reports/trial-sessions-report-helpers.ts
+++ b/scripts/reports/trial-sessions-report-helpers.ts
@@ -79,9 +79,9 @@ const outputTrialSessionsReport = ({
     const startDate = formatDateString(s.startDate, FORMATS['MMDDYYYY_DASHED']);
     let trialClerk = '';
     if (s.trialClerk && 'name' in s.trialClerk && s.trialClerk.name) {
-      trialClerk = s.trialClerk.name;
+      trialClerk = s.trialClerk.name.trim();
     } else if (s.alternateTrialClerkName) {
-      trialClerk = s.alternateTrialClerkName;
+      trialClerk = s.alternateTrialClerkName.trim();
     }
     const judge = formatJudgeName(s.judge?.name);
     return {
@@ -118,6 +118,19 @@ const outputTrialSessionsStats = ({
     })),
     keyToFilter: 'judgeName',
   });
+  const justClerks: { trialClerk: string }[] = trialSessions.map(s => {
+    let trialClerk = '';
+    if (s.trialClerk && 'name' in s.trialClerk && s.trialClerk.name) {
+      trialClerk = s.trialClerk.name.trim();
+    } else if (s.alternateTrialClerkName) {
+      trialClerk = s.alternateTrialClerkName.trim();
+    }
+    return { trialClerk };
+  });
+  const unsortedTrialClerks = getUniqueValues({
+    arrayOfObjects: justClerks,
+    keyToFilter: 'trialClerk',
+  });
 
   const locations = {};
   alphabetizeCities(Object.keys(unsortedLocations)).forEach(key => {
@@ -149,11 +162,23 @@ const outputTrialSessionsStats = ({
       judges[key] = unsortedJudges[key];
     });
 
+  const trialClerks = {};
+  Object.keys(unsortedTrialClerks)
+    .sort((a, b) => {
+      if (a === '') return 1;
+      if (b === '') return -1;
+      return a.localeCompare(b);
+    })
+    .forEach(key => {
+      trialClerks[key] = unsortedTrialClerks[key];
+    });
+
   console.log({
     judges,
     locations,
     proceedingTypes,
     sessionTypes,
+    trialClerks,
     total: trialSessions.length,
   });
 };

--- a/shared/src/business/utilities/DateHandler.ts
+++ b/shared/src/business/utilities/DateHandler.ts
@@ -118,7 +118,7 @@ export const getJsDateFromIso = (isoDate: string): Date => {
 };
 
 export const getIsoFromJsDate = (jsDate: Date): string | null => {
-  return DateTime.fromJSDate(jsDate).toISO();
+  return DateTime.fromJSDate(jsDate).setZone('utc').toISO();
 };
 
 export const getNowObject = (): ToObjectOutput => {
@@ -775,11 +775,7 @@ export const getWeeksInRange = ({
 };
 
 export const roundDateDownToNearestHour = (isoDateString: string) => {
-  const formattedDate = calculateDate({ dateString: isoDateString });
-  formattedDate.setMinutes(0);
-  formattedDate.setSeconds(0);
-  formattedDate.setMilliseconds(0);
-  return formattedDate;
+  return prepareDateFromString(isoDateString).startOf('hour').toJSDate();
 };
 
 export const getCurrentDateTimeInMillis = (): number => {

--- a/web-api/src/lambdas/staleCasesEmail/staleCasesEmailLambda.ts
+++ b/web-api/src/lambdas/staleCasesEmail/staleCasesEmailLambda.ts
@@ -1,11 +1,11 @@
 import type { Handler } from 'aws-lambda';
 import { applicationContext } from '@web-api/applicationContext';
-import { createISODateString } from '@shared/business/utilities/DateHandler';
+import { FORMATS, formatNow } from '@shared/business/utilities/DateHandler';
 import { generateStaleCasesReport } from '../../../../scripts/reports/stale-cases.helpers';
 import { existsSync } from 'fs';
 import { sendEmailWithAttachment } from '@web-api/dispatchers/ses/sendEmailWithAttachment';
 
-const today = createISODateString().split('T')[0];
+const today = formatNow(FORMATS.YYYYMMDD);
 const filename = `/tmp/12-month-inactivity_${today}.csv`;
 const subject = `12 Month Inactivity List - ${today}`;
 const body =


### PR DESCRIPTION
## Trial Sessions Report Spitshine

This PR introduces a suite of improvements to CLI reports. The primary focus is on standardizing data formatting, optimizing database performance of some reports, and enhancing the Trial Sessions report with better sorting and test coverage.

#### 1. Centralized Formatting Utility & Robust Sorting
A new helper module, `scripts/helpers/formatters.ts`, has been created to centralize and standardize common formatting tasks across CLI scripts. This ensures consistent output and prevents common errors:
*   **Judge Names**: Consistent removal of titles like "Chief Special Trial" or "Judge".
*   **Case Captions**: Standardized removal of line breaks and whitespace trimming.
*   **Dates**: Standardized date formatting for reports.
*   **Currency**: Fixed-point formatting for financial amounts.
*   **Locations**: Alphabetical sorting by state and then city, hardened to handle non-standard locations (e.g., "Standalone Remote") without crashing.
*   **New Test Suite**: Created `scripts/helpers/formatters.test.ts` to provide 100% unit test coverage for all formatting helpers, including edge cases for location sorting and date formatting.

#### 2. Performance Enhancements (Bulk Fetching & Optimized Queries)
A pair of reports have been refactored to significantly reduce execution time and database load:
*   **LEA Stats Report (`lea-stats.ts`)**: Replaced a high-concurrency queue of individual case lookups with a single bulk query (`getCasesByDocketNumbers`).
*   **Stale Cases Report (`stale-cases.helpers.ts`)**: Optimized by integrating a subquery into the main case selection query to fetch the `lastFilingDate` for all cases simultaneously, eliminating thousands of subsequent queries.

#### 3. Trial Sessions Report Improvements
*   **Sane Sorting**: Summary statistics are now sorted logically:
    *   Locations are sorted by state and city (locations without a comma appear alphabetically at the end).
    *   Session Types are ranked by frequency.
    *   Proceeding Types and Judges are sorted alphabetically (trial sessions without assigned judges appear at the end).
    *  Trial Clerks are sorted alphabetically (trial sessions without assigned trial clerks appear at the end).
*   **Testability & Coverage**: Added `clearTrialSessionsCache` to reset state between tests. Updated Jest tests for `trial-sessions-report-helpers.ts` to achieve 100% code coverage.

#### 4. Broad Script Standardization
The following scripts have been updated to utilize the new formatting helpers and optimized data fetching patterns:
*   `attorneys-admitted-in-year.ts`
*   `cases-closed-in-year.ts`
*   `cases-open-on-date.ts`
*   `closed-dates.ts`
*   `deficiencies.ts`
*   `deficiency-stats.ts`
*   `documents-filed-by-nonattorneys.ts`
*   `event-codes-by-year.ts`
*   `firms-cases.ts`
*   `lea-stats.ts`
*   `non-attorney-practitioners.ts`
*   `stale-cases.ts`
*   `download-all-case-documents.ts`

These changes ensure that all reports generate clean, consistent data while operating much more efficiently against the postgresql database and handling edge cases gracefully.