### PR TITLE
opex: CBJ 2026 II: Electric Boogaloo

### DIFF
--- a/scripts/reports/event-codes-by-year-helpers.ts
+++ b/scripts/reports/event-codes-by-year-helpers.ts
@@ -13,16 +13,16 @@ export type EventCodeReportDocketEntry = {
 
 export const getDocketEntriesByEventCodesAndYears = async ({
   count,
+  distinct,
   eventCodes,
   fiscal,
-  groupConsolidated,
   onlyNonStricken,
   years,
 }: {
   count?: boolean;
+  distinct?: boolean;
   eventCodes: string[];
   fiscal: boolean;
-  groupConsolidated?: boolean;
   onlyNonStricken?: boolean;
   years?: number[];
 }): Promise<number | EventCodeReportDocketEntry[]> => {
@@ -30,7 +30,7 @@ export const getDocketEntriesByEventCodesAndYears = async ({
     await getDbReader(async reader => {
       let query = reader.selectFrom('dwDocketEntry as de');
       if (count) {
-        if (groupConsolidated) {
+        if (distinct) {
           query = query.select(({ ref }) =>
             sql<number>`count(distinct ${ref('de.docketEntryId')})`.as('count'),
           );
@@ -49,7 +49,7 @@ export const getDocketEntriesByEventCodesAndYears = async ({
             'c.status',
           ]);
 
-        if (groupConsolidated) {
+        if (distinct) {
           query = query
             .distinctOn('de.docketEntryId')
             .orderBy('de.servedAt', 'asc');

--- a/scripts/reports/event-codes-by-year-helpers.ts
+++ b/scripts/reports/event-codes-by-year-helpers.ts
@@ -1,5 +1,6 @@
 import { getDbReader } from '@web-api/database';
 import { getJsTimeframeForYear } from '../helpers/parseArgsAndEnvVars';
+import { sql } from 'kysely';
 
 export type EventCodeReportDocketEntry = {
   associatedJudge: string;
@@ -14,12 +15,14 @@ export const getDocketEntriesByEventCodesAndYears = async ({
   count,
   eventCodes,
   fiscal,
+  groupConsolidated,
   onlyNonStricken,
   years,
 }: {
   count?: boolean;
   eventCodes: string[];
   fiscal: boolean;
+  groupConsolidated?: boolean;
   onlyNonStricken?: boolean;
   years?: number[];
 }): Promise<number | EventCodeReportDocketEntry[]> => {
@@ -27,7 +30,13 @@ export const getDocketEntriesByEventCodesAndYears = async ({
     await getDbReader(async reader => {
       let query = reader.selectFrom('dwDocketEntry as de');
       if (count) {
-        query = query.select(reader.fn.countAll().as('count'));
+        if (groupConsolidated) {
+          query = query.select(({ ref }) =>
+            sql<number>`count(distinct ${ref('de.docketEntryId')})`.as('count'),
+          );
+        } else {
+          query = query.select(reader.fn.countAll().as('count'));
+        }
       } else {
         query = query
           .innerJoin('dwCase as c', 'de.docketNumber', 'c.docketNumber')
@@ -39,6 +48,12 @@ export const getDocketEntriesByEventCodesAndYears = async ({
             'c.caption',
             'c.status',
           ]);
+
+        if (groupConsolidated) {
+          query = query
+            .distinctOn('de.docketEntryId')
+            .orderBy('de.servedAt', 'asc');
+        }
       }
       query = query.where('de.eventCode', 'in', eventCodes);
       if (onlyNonStricken) {

--- a/scripts/reports/event-codes-by-year.ts
+++ b/scripts/reports/event-codes-by-year.ts
@@ -31,6 +31,11 @@ const scriptConfig: ScriptConfig = {
       short: 'c',
       type: 'boolean',
     },
+    distinct: {
+      default: false,
+      short: 'd',
+      type: 'boolean',
+    },
     eventCodes: {
       commaDelimited: true,
       position: 0,
@@ -41,12 +46,6 @@ const scriptConfig: ScriptConfig = {
     fiscal: {
       default: false,
       short: 'f',
-      type: 'boolean',
-    },
-    groupConsolidated: {
-      default: false,
-      long: 'group-consolidated',
-      short: 'g',
       type: 'boolean',
     },
     stricken: {
@@ -64,12 +63,12 @@ const scriptConfig: ScriptConfig = {
   },
   requireActiveAwsSession: true,
 };
-const { count, eventCodes, fiscal, groupConsolidated, stricken, years } =
+const { count, distinct, eventCodes, fiscal, stricken, years } =
   parseArgsAndEnvVars(scriptConfig) as {
     count: boolean;
+    distinct: boolean;
     eventCodes: string[];
     fiscal: boolean;
-    groupConsolidated: boolean;
     stricken: boolean;
     years: number[];
   };
@@ -90,7 +89,7 @@ const outputCsv = ({
     { header: 'Case Title', key: 'caption' },
   ];
   const filename =
-    `${OUTPUT_DIR}/${groupConsolidated ? 'distinct-' : ''}` +
+    `${OUTPUT_DIR}/${distinct ? 'distinct-' : ''}` +
     `${eventCodes.map(ec => ec.toLowerCase()).join('-')}-filed-` +
     `in-${fiscal ? 'fy-' : ''}${years.join('-')}.csv`;
   const rows = docketEntries.map(de => ({
@@ -108,31 +107,30 @@ const outputCsv = ({
   if (count) {
     const docCount: number = (await getDocketEntriesByEventCodesAndYears({
       count,
+      distinct,
       eventCodes,
       fiscal,
-      groupConsolidated,
       onlyNonStricken: !stricken,
       years,
     })) as number;
     console.log(
-      `Found ${docCount} ${groupConsolidated ? 'distinct ' : ''}` +
-        `${stricken ? '' : 'non-stricken '}` +
-        `${eventCodes.join(',')} documents filed in ${fiscal ? 'fy ' : ''}` +
-        `${years.join(',')}`,
+      `Found ${docCount} ${distinct ? 'distinct ' : ''}` +
+        `${stricken ? '' : 'non-stricken '} ${eventCodes.join(',')} ` +
+        `documents filed in ${fiscal ? 'fy ' : ''}${years.join(',')}`,
     );
     return;
   }
   const docketEntries = (await getDocketEntriesByEventCodesAndYears({
+    distinct,
     eventCodes,
     fiscal,
-    groupConsolidated,
     onlyNonStricken: !stricken,
     years,
   })) as EventCodeReportDocketEntry[];
   console.log(
-    `Found ${docketEntries.length} ${groupConsolidated ? 'distinct ' : ''}` +
-      `${stricken ? '' : 'non-stricken '}${eventCodes.join(',')} documents ` +
-      `filed in ${fiscal ? 'fy ' : ''}${years.join(',')}`,
+    `Found ${docketEntries.length} ${distinct ? 'distinct ' : ''}` +
+      `${stricken ? '' : 'non-stricken '}${eventCodes.join(',')} ` +
+      `documents filed in ${fiscal ? 'fy ' : ''}${years.join(',')}`,
   );
   outputCsv({ docketEntries });
 })();

--- a/scripts/reports/event-codes-by-year.ts
+++ b/scripts/reports/event-codes-by-year.ts
@@ -43,6 +43,12 @@ const scriptConfig: ScriptConfig = {
       short: 'f',
       type: 'boolean',
     },
+    groupConsolidated: {
+      default: false,
+      long: 'group-consolidated',
+      short: 'g',
+      type: 'boolean',
+    },
     stricken: {
       default: false,
       short: 's',
@@ -58,15 +64,15 @@ const scriptConfig: ScriptConfig = {
   },
   requireActiveAwsSession: true,
 };
-const { count, eventCodes, fiscal, stricken, years } = parseArgsAndEnvVars(
-  scriptConfig,
-) as {
-  count: boolean;
-  eventCodes: string[];
-  fiscal: boolean;
-  stricken: boolean;
-  years: number[];
-};
+const { count, eventCodes, fiscal, groupConsolidated, stricken, years } =
+  parseArgsAndEnvVars(scriptConfig) as {
+    count: boolean;
+    eventCodes: string[];
+    fiscal: boolean;
+    groupConsolidated: boolean;
+    stricken: boolean;
+    years: number[];
+  };
 
 const OUTPUT_DIR = `${process.env.HOME}/Documents`;
 
@@ -84,7 +90,8 @@ const outputCsv = ({
     { header: 'Case Title', key: 'caption' },
   ];
   const filename =
-    `${OUTPUT_DIR}/${eventCodes.map(ec => ec.toLowerCase()).join('-')}-filed-` +
+    `${OUTPUT_DIR}/${groupConsolidated ? 'distinct-' : ''}` +
+    `${eventCodes.map(ec => ec.toLowerCase()).join('-')}-filed-` +
     `in-${fiscal ? 'fy-' : ''}${years.join('-')}.csv`;
   const rows = docketEntries.map(de => ({
     ...pick(de, ['docketNumber', 'documentType', 'status']),
@@ -103,12 +110,14 @@ const outputCsv = ({
       count,
       eventCodes,
       fiscal,
+      groupConsolidated,
       onlyNonStricken: !stricken,
       years,
     })) as number;
     console.log(
-      `Found ${docCount} ${stricken ? '' : 'non-stricken '}` +
-        `${eventCodes.join(',')} documents filed in ${fiscal ? 'fy' : ''} ` +
+      `Found ${docCount} ${groupConsolidated ? 'distinct ' : ''}` +
+        `${stricken ? '' : 'non-stricken '}` +
+        `${eventCodes.join(',')} documents filed in ${fiscal ? 'fy ' : ''}` +
         `${years.join(',')}`,
     );
     return;
@@ -116,13 +125,14 @@ const outputCsv = ({
   const docketEntries = (await getDocketEntriesByEventCodesAndYears({
     eventCodes,
     fiscal,
+    groupConsolidated,
     onlyNonStricken: !stricken,
     years,
   })) as EventCodeReportDocketEntry[];
   console.log(
-    `Found ${docketEntries.length} ${stricken ? '' : 'non-stricken '}` +
-      `${eventCodes.join(',')} documents filed in ${fiscal ? 'fy' : ''} ` +
-      `${years.join(',')}`,
+    `Found ${docketEntries.length} ${groupConsolidated ? 'distinct ' : ''}` +
+      `${stricken ? '' : 'non-stricken '}${eventCodes.join(',')} documents ` +
+      `filed in ${fiscal ? 'fy ' : ''}${years.join(',')}`,
   );
   outputCsv({ docketEntries });
 })();


### PR DESCRIPTION
Added a `--distinct` flag to the `event-codes-by-year` report. When passed, it will count a document filed against more than one case in a consolidated group only once.