### PR TITLE
devex: more cross-compatibility fixes for `post-merge`

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -5,7 +5,7 @@ function is_ide_running() {
 }
 
 function open_vscode_diff() {
-  if [[ "$OSTYPE" == "darwin"* ]]; then
+  if [[ "$(uname -s)" == "Darwin" ]]; then
     VSCODE_APP="/Applications/Visual Studio Code.app"
     if [ ! -d "$VSCODE_APP" ]; then
       VSCODE_APP="$HOME/Applications/Visual Studio Code.app"
@@ -42,7 +42,7 @@ function open_jetbrains_diff() {
   ide="$1"
   temp_file="$2"
   current_file="$3"
-  if [[ "$OSTYPE" == "darwin"* ]]; then
+  if [[ "$(uname -s)" == "Darwin" ]]; then
     if [[ "$ide" == "idea" ]]; then
       open -a "IntelliJ IDEA Ultimate.app" --args diff "$temp_file" "$current_file" 2>/dev/null || open -a "IntelliJ IDEA.app" --args diff "$temp_file" "$current_file" 2>/dev/null
     elif [[ "$ide" == "webstorm" ]]; then
@@ -62,7 +62,7 @@ function open_jetbrains_diff() {
 
 if [ -f "CHANGES.md" ]; then
   CHANGES_DIFF=$(git diff ORIG_HEAD HEAD -- CHANGES.md 2>/dev/null)
-  ADDED_LINES=$(echo "$CHANGES_DIFF" | grep -E "^[\+]" | grep -v "^[\+][\+][\+]" | grep -v "No newline")
+  ADDED_LINES=$(printf "%s\n" "$CHANGES_DIFF" | grep "^+" | grep -v "^+++" | grep -v "No newline")
 
   if [ -n "$ADDED_LINES" ]; then
     {

--- a/.husky/post-merge.test.sh
+++ b/.husky/post-merge.test.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# test-post-merge.sh: A script to simulate a git merge and test the post-merge hook.
+
+EFCMS_ROOT=$(realpath "$(dirname "$0")/..")
+
+set -e
+
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}Setting up test environment...${NC}"
+
+TEST_DIR=$(mktemp -d /tmp/git-merge-test-XXXXXX)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+cd "$TEST_DIR"
+
+git init -q
+git config user.email "test@example.com"
+git config user.name "Test User"
+
+{
+  echo "# Changes"
+  echo ""
+  echo "## First change"
+  echo "- It's good stuff"
+} > CHANGES.md
+git add CHANGES.md
+git commit -m "Initial commit to the master branch" -q
+
+git checkout -b throwaway -q
+{
+  echo ""
+  echo "## Second change"
+  echo "- It's even better"
+} >> CHANGES.md
+git add CHANGES.md
+git commit -m "Add new manual steps in the throwaway branch" -q
+
+git checkout master -q
+mkdir -p .husky
+cp "${EFCMS_ROOT}/.husky/post-merge" .husky/post-merge
+chmod +x .husky/post-merge
+
+
+echo -e "${GREEN}Simulating merge of 'throwaway' into 'master'...${NC}"
+PRE_MERGE_HEAD=$(git rev-parse HEAD)
+git merge throwaway --no-edit -q
+git update-ref ORIG_HEAD "$PRE_MERGE_HEAD"
+
+echo -e "${GREEN}Executing post-merge hook...${NC}"
+./.husky/post-merge
+echo -e "${GREEN}Test complete.${NC}"


### PR DESCRIPTION
Some updates to the botched `post-merge` cross-compatibility "fix" that broke macOS:

Evidently you can't always trust `$OSTYPE` so we'll call `uname` instead. Added a test that can simulate a merge so we can test changes to `post-merge` on both OSes without performing a bunch of merges.