### PR TITLE
9733 Bug to Test: Decrease Number of Postgres Parameters in getAllPendingMotionDocketEntriesForJudge

### DIFF
--- a/web-api/src/persistence/postgres/docketEntries/reports/getAllPendingMotionDocketEntriesForJudge.ts
+++ b/web-api/src/persistence/postgres/docketEntries/reports/getAllPendingMotionDocketEntriesForJudge.ts
@@ -22,10 +22,10 @@ export const getAllPendingMotionDocketEntriesForJudge = async ({
       .where('d.pending', 'is', true)
       .where('c.associatedJudgeId', 'in', judgeIds)
       // sql.lit() is intentionally used here instead of parameterized values to
-      // avoid exceeding Postgres's bind parameter limit: when combined with the
-      // judgeIds array, MOTION_EVENT_CODES balloons the number of parameters to
-      // >100. This is safe because MOTION_EVENT_CODES is a static compile-time
-      // constant with no user input.
+      // work around a Kysely parameter-numbering/binding bug that occurs when
+      // many bound parameters are present (e.g., judgeIds plus MOTION_EVENT_CODES).
+      // This is safe because MOTION_EVENT_CODES is a static compile-time constant
+      // with no user input.
       .where(
         sql<SqlBool>`d."event_code" IN (${sql.join(
           MOTION_EVENT_CODES.map(code => sql.lit(code)),

--- a/web-api/src/persistence/postgres/docketEntries/reports/getAllPendingMotionDocketEntriesForJudge.ts
+++ b/web-api/src/persistence/postgres/docketEntries/reports/getAllPendingMotionDocketEntriesForJudge.ts
@@ -8,6 +8,7 @@ import {
 import { fromKyselyCase } from '@web-api/persistence/postgres/cases/mapper';
 import { getConsolidatedCasesCount } from '@web-api/persistence/postgres/cases/getConsolidatedCasesCount';
 import { getDbReader } from '@web-api/database';
+import { sql, SqlBool } from 'kysely';
 
 export const getAllPendingMotionDocketEntriesForJudge = async ({
   judgeIds,
@@ -20,7 +21,17 @@ export const getAllPendingMotionDocketEntriesForJudge = async ({
       .innerJoin('dwCase as c', 'd.docketNumber', 'c.docketNumber')
       .where('d.pending', 'is', true)
       .where('c.associatedJudgeId', 'in', judgeIds)
-      .where('d.eventCode', 'in', MOTION_EVENT_CODES)
+      // sql.lit() is intentionally used here instead of parameterized values to
+      // avoid exceeding Postgres's bind parameter limit: when combined with the
+      // judgeIds array, MOTION_EVENT_CODES balloons the number of parameters to
+      // >100. This is safe because MOTION_EVENT_CODES is a static compile-time
+      // constant with no user input.
+      .where(
+        sql<SqlBool>`d."eventCode" IN (${sql.join(
+          MOTION_EVENT_CODES.map(code => sql.lit(code)),
+          sql`, `,
+        )})`,
+      )
       .where(
         'd.filingDate',
         '<=',

--- a/web-api/src/persistence/postgres/docketEntries/reports/getAllPendingMotionDocketEntriesForJudge.ts
+++ b/web-api/src/persistence/postgres/docketEntries/reports/getAllPendingMotionDocketEntriesForJudge.ts
@@ -27,7 +27,7 @@ export const getAllPendingMotionDocketEntriesForJudge = async ({
       // >100. This is safe because MOTION_EVENT_CODES is a static compile-time
       // constant with no user input.
       .where(
-        sql<SqlBool>`d."eventCode" IN (${sql.join(
+        sql<SqlBool>`d."event_code" IN (${sql.join(
           MOTION_EVENT_CODES.map(code => sql.lit(code)),
           sql`, `,
         )})`,


### PR DESCRIPTION
https://github.com/ustaxcourt/ef-cms/issues/9733

This PR reworks getAllPendingMotionDocketEntriesForJudge to avoid passing MOTION_EVENT_CODES as bind parameters. In test, logs indicate a Postgres syntax error when MOTION_EVENT_CODES (~99 parameters) is combined with a large judgeIds array (~35 parameters), suggesting a Kysely bug with parameter numbering at that scale. Since MOTION_EVENT_CODES is a static compile-time constant, it's safe to inline the values as SQL literals instead.