### PR TITLE
9733 Bug to Test: Query Update and Temporary Logging

### DIFF
--- a/web-api/src/persistence/postgres/docketEntries/reports/getAllPendingMotionDocketEntriesForJudge.ts
+++ b/web-api/src/persistence/postgres/docketEntries/reports/getAllPendingMotionDocketEntriesForJudge.ts
@@ -15,8 +15,8 @@ export const getAllPendingMotionDocketEntriesForJudge = async ({
 }: {
   judgeIds: string[];
 }): Promise<{ results: FormattedPendingMotion[]; total: number }> => {
-  const results = await getDbReader(async reader =>
-    reader
+  const results = await getDbReader(async reader => {
+    const query = reader
       .selectFrom('dwDocketEntry as d')
       .innerJoin('dwCase as c', 'd.docketNumber', 'c.docketNumber')
       .where('d.pending', 'is', true)
@@ -37,7 +37,6 @@ export const getAllPendingMotionDocketEntriesForJudge = async ({
         '<=',
         calculateDate({ howMuch: -180, units: 'days' }),
       )
-
       .select([
         'c.associatedJudge',
         'c.associatedJudgeId',
@@ -52,9 +51,15 @@ export const getAllPendingMotionDocketEntriesForJudge = async ({
         'd.eventCode',
         'd.filingDate',
         'd.pending',
-      ])
-      .execute(),
-  );
+      ]);
+
+    console.log(
+      '[9733] getAllPendingMotionDocketEntriesForJudge query: ',
+      query.compile(),
+    );
+
+    return query.execute();
+  });
 
   const mappedResults = await Promise.all(
     results.map(async r => {

--- a/web-api/src/persistence/postgres/docketEntries/reports/getAllPendingMotionDocketEntriesForJudge.ts
+++ b/web-api/src/persistence/postgres/docketEntries/reports/getAllPendingMotionDocketEntriesForJudge.ts
@@ -20,12 +20,17 @@ export const getAllPendingMotionDocketEntriesForJudge = async ({
       .selectFrom('dwDocketEntry as d')
       .innerJoin('dwCase as c', 'd.docketNumber', 'c.docketNumber')
       .where('d.pending', 'is', true)
-      .where('c.associatedJudgeId', 'in', judgeIds)
       // sql.lit() is intentionally used here instead of parameterized values to
-      // work around a Kysely parameter-numbering/binding bug that occurs when
-      // many bound parameters are present (e.g., judgeIds plus MOTION_EVENT_CODES).
-      // This is safe because MOTION_EVENT_CODES is a static compile-time constant
-      // with no user input.
+      // work around a bug wherein esbuild's minifySyntax optimization causes Kysely
+      // to bind arrays as a single parameter rather than expanding them. judgeIds
+      // is safe to inline because the values originate from the database.
+      // MOTION_EVENT_CODES is safe to inline because it is a static compile-time constant.
+      .where(
+        sql<SqlBool>`c."associated_judge_id" IN (${sql.join(
+          judgeIds.map(id => sql.lit(id)),
+          sql`, `,
+        )})`,
+      )
       .where(
         sql<SqlBool>`d."event_code" IN (${sql.join(
           MOTION_EVENT_CODES.map(code => sql.lit(code)),


### PR DESCRIPTION
This PR adjusts the query in `getAllPendingMotionDocketEntriesForJudge` to work around a bug in deployed environments where Kysely binds the array of judgeIds as a single parameter rather than expanding them for this query specifically (possibly due to esbuild's minifySyntax optimization?).

It also adds temporary logging so that we can see the exact SQL query Kysley generates when the judge activity report throws a 400 error for the "All Judges" option in test.