### PR TITLE
devex: Added 'update the ERD' to DoD for stories and bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -102,4 +102,5 @@ If the Court is not able to reproduce the bug, add the “Unable to reproduce”
  - [ ] Interactors should validate entities before calling persistence methods.
  - [ ] Types have been added to all added and updated functions.
  - [ ] Code refactored for clarity and to remove any known technical debt.
+ - [ ] Schema changes are documented in the Entity Relationship Diagram (ERD).
  - [ ] If there are special deployment instructions, they have been added to the `CHANGES.md` file and the PR description.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -102,5 +102,5 @@ If the Court is not able to reproduce the bug, add the “Unable to reproduce”
  - [ ] Interactors should validate entities before calling persistence methods.
  - [ ] Types have been added to all added and updated functions.
  - [ ] Code refactored for clarity and to remove any known technical debt.
- - [ ] Schema changes are documented in the Entity Relationship Diagram (ERD).
+ - [ ] All schema changes are documented in the Data Dictionary (DD), and the Entity Relationship Diagram (ERD) is updated as appropriate.
  - [ ] If there are special deployment instructions, they have been added to the `CHANGES.md` file and the PR description.

--- a/.github/ISSUE_TEMPLATE/ustc-story-template.md
+++ b/.github/ISSUE_TEMPLATE/ustc-story-template.md
@@ -45,5 +45,6 @@ As a _______, so that ________, I need ________.
  - [ ] Types have been added to all added and updated functions.
  - [ ] Code refactored for clarity and to remove any known technical debt.
  - [ ] Acceptance criteria for the story has been met.
+ - [ ] Schema changes are documented in the Entity Relationship Diagram (ERD).
  - [ ] If there are special deployment instructions, they have been added to the `CHANGES.md` file and the PR description.
  - [ ] Code that resides in the shared folder that only runs on the API or browser has been moved to either /web-client or /web-api.

--- a/.github/ISSUE_TEMPLATE/ustc-story-template.md
+++ b/.github/ISSUE_TEMPLATE/ustc-story-template.md
@@ -45,6 +45,6 @@ As a _______, so that ________, I need ________.
  - [ ] Types have been added to all added and updated functions.
  - [ ] Code refactored for clarity and to remove any known technical debt.
  - [ ] Acceptance criteria for the story has been met.
- - [ ] Schema changes are documented in the Entity Relationship Diagram (ERD).
+ - [ ] All schema changes are documented in the Data Dictionary (DD), and the Entity Relationship Diagram (ERD) is updated as appropriate.
  - [ ] If there are special deployment instructions, they have been added to the `CHANGES.md` file and the PR description.
  - [ ] Code that resides in the shared folder that only runs on the API or browser has been moved to either /web-client or /web-api.


### PR DESCRIPTION
I noticed in a code review that a schema update was not represented in the ERD, then wondered how many other times I should've noticed that before. I don't want to be the only line of defense, so after discussing it with @ttlenard and @cholly75, we decided to add 'update the ERD' to DoD for stories and bugs.