### PR TITLE
9733 Bug to Test: coerce query string params to arrays in lambdas

### DIFF
--- a/web-api/src/business/useCases/pendingMotion/getPendingMotionDocketEntriesForCurrentJudgeInteractor.ts
+++ b/web-api/src/business/useCases/pendingMotion/getPendingMotionDocketEntriesForCurrentJudgeInteractor.ts
@@ -36,11 +36,6 @@ export const getPendingMotionDocketEntriesForCurrentJudgeInteractor = async (
 }> => {
   const { judgeIds } = params;
 
-  console.log(
-    '[9733] params received by getPendingMotionDocketEntriesForCurrentJudgeInteractor:',
-    JSON.stringify(params),
-  );
-
   if (!isAuthorized(authorizedUser, ROLE_PERMISSIONS.PENDING_MOTIONS_TABLE)) {
     throw new UnauthorizedError('Unauthorized');
   }

--- a/web-api/src/lambdas/pendingMotion/getPendingMotionDocketEntriesForCurrentJudgeLambda.ts
+++ b/web-api/src/lambdas/pendingMotion/getPendingMotionDocketEntriesForCurrentJudgeLambda.ts
@@ -9,9 +9,11 @@ export const getPendingMotionDocketEntriesForCurrentJudgeLambda = (
   const rawJudgeIds = event.queryStringParameters?.judgeIds;
   const judgeIds = Array.isArray(rawJudgeIds)
     ? rawJudgeIds
-    : rawJudgeIds
+    : typeof rawJudgeIds === 'object' && rawJudgeIds !== null
       ? Object.values(rawJudgeIds)
-      : [];
+      : rawJudgeIds
+        ? [rawJudgeIds]
+        : [];
 
   return genericHandler(event, () =>
     getPendingMotionDocketEntriesForCurrentJudgeInteractor(

--- a/web-api/src/lambdas/pendingMotion/getPendingMotionDocketEntriesForCurrentJudgeLambda.ts
+++ b/web-api/src/lambdas/pendingMotion/getPendingMotionDocketEntriesForCurrentJudgeLambda.ts
@@ -6,18 +6,16 @@ export const getPendingMotionDocketEntriesForCurrentJudgeLambda = (
   event,
   authorizedUser: UnknownAuthUser,
 ) => {
-  console.log(
-    '[9733] lambda event.queryStringParameters:',
-    JSON.stringify(event.queryStringParameters),
-  );
-  console.log(
-    '[9733] lambda event.multiValueQueryStringParameters:',
-    JSON.stringify(event.multiValueQueryStringParameters),
-  );
+  const rawJudgeIds = event.queryStringParameters?.judgeIds;
+  const judgeIds = Array.isArray(rawJudgeIds)
+    ? rawJudgeIds
+    : rawJudgeIds
+      ? Object.values(rawJudgeIds)
+      : [];
 
   return genericHandler(event, () =>
     getPendingMotionDocketEntriesForCurrentJudgeInteractor(
-      event.queryStringParameters,
+      { judgeIds },
       authorizedUser,
     ),
   );

--- a/web-api/src/lambdas/reports/getCaseWorksheetsByJudgeLambda.ts
+++ b/web-api/src/lambdas/reports/getCaseWorksheetsByJudgeLambda.ts
@@ -5,15 +5,29 @@ import { getCaseWorksheetsByJudgeInteractor } from '@web-api/business/useCases/j
 export const getCaseWorksheetsByJudgeLambda = (
   event,
   authorizedUser: UnknownAuthUser,
-) =>
-  genericHandler(
-    event,
+) => {
+  const rawJudges = event.queryStringParameters?.judges;
+  const judges = Array.isArray(rawJudges)
+    ? rawJudges
+    : rawJudges
+      ? Object.values(rawJudges)
+      : [];
 
+  const rawStatuses = event.queryStringParameters?.statuses;
+  const statuses = Array.isArray(rawStatuses)
+    ? rawStatuses
+    : rawStatuses
+      ? Object.values(rawStatuses)
+      : [];
+
+  return genericHandler(
+    event,
     async () => {
       return await getCaseWorksheetsByJudgeInteractor(
-        event.queryStringParameters,
+        { judges, statuses },
         authorizedUser,
       );
     },
     { logResults: false },
   );
+};

--- a/web-api/src/lambdas/reports/getCaseWorksheetsByJudgeLambda.ts
+++ b/web-api/src/lambdas/reports/getCaseWorksheetsByJudgeLambda.ts
@@ -9,16 +9,20 @@ export const getCaseWorksheetsByJudgeLambda = (
   const rawJudges = event.queryStringParameters?.judges;
   const judges = Array.isArray(rawJudges)
     ? rawJudges
-    : rawJudges
+    : typeof rawJudges === 'object' && rawJudges !== null
       ? Object.values(rawJudges)
-      : [];
+      : rawJudges
+        ? [rawJudges]
+        : [];
 
   const rawStatuses = event.queryStringParameters?.statuses;
   const statuses = Array.isArray(rawStatuses)
     ? rawStatuses
-    : rawStatuses
+    : typeof rawStatuses === 'object' && rawStatuses !== null
       ? Object.values(rawStatuses)
-      : [];
+      : rawStatuses
+        ? [rawStatuses]
+        : [];
 
   return genericHandler(
     event,

--- a/web-api/src/persistence/postgres/docketEntries/reports/getAllPendingMotionDocketEntriesForJudge.ts
+++ b/web-api/src/persistence/postgres/docketEntries/reports/getAllPendingMotionDocketEntriesForJudge.ts
@@ -15,11 +15,6 @@ export const getAllPendingMotionDocketEntriesForJudge = async ({
 }: {
   judgeIds: string[];
 }): Promise<{ results: FormattedPendingMotion[]; total: number }> => {
-  console.log(
-    '[9733] params received by getPendingMotionDocketEntriesForCurrentJudgeInteractor:',
-    JSON.stringify(judgeIds),
-  );
-
   const results = await getDbReader(async reader => {
     const query = reader
       .selectFrom('dwDocketEntry as d')
@@ -62,11 +57,6 @@ export const getAllPendingMotionDocketEntriesForJudge = async ({
         'd.filingDate',
         'd.pending',
       ]);
-
-    console.log(
-      '[9733] getAllPendingMotionDocketEntriesForJudge query: ',
-      query.compile(),
-    );
 
     return query.execute();
   });


### PR DESCRIPTION
Logging revealed that, when the "All Judges" option on the judge activity report is selected (resulting in 35+ judge IDs), the query string parameters hit the lambdas as an object instead of an array:

```
{
    "judgeIds[]": "some_id",
    "judgeIds": {
        "0": "some_other_id",
        "1": "yet_another_id",
        // ...
        "34": "and_another_id"
    }
}
```
With fewer IDs (<20), it correctly arrives as an array:

```
{
    "judgeIds[]": "some_id",
    "judgeIds": ["some_other_id", "yet_another_id"]
}
```

The root cause appears to be a threshold in the query string parser where it switches from array to object representation at ~20+ repeated parameters. This PR adds logic to coerce both formats to arrays in the affected lambdas so the persistence layer receives consistent data structures.