### PR TITLE
9733 Bug to Test: Explicitly Set Query String Array Length Limit

### DIFF
--- a/web-api/src/app-public.ts
+++ b/web-api/src/app-public.ts
@@ -5,11 +5,29 @@ import { lambdaWrapper } from './lambdaWrapper';
 import { set } from 'lodash';
 import cors from 'cors';
 import express from 'express';
+import qs from 'qs';
 
 export const app = express();
 
-// This was default in express 4.x. The default changed in express 5.x, so we have to specify it here
-app.set('query parser', 'extended');
+// We explicitly use qs as our query parser: it was the default in express 4.x.,
+// but was no longer the default in express 5.x, so we need to explicitly set it
+// here. See https://github.com/ustaxcourt/ef-cms/pull/6020
+//
+// By default, qs limits arrays to a maximum of 20:
+//
+// > qs will also limit arrays to a maximum of 20 elements. Any array members
+// > with an index of 20 or greater will instead be converted to an object with
+// > the index as the key. This is needed to handle cases when someone sent,
+// > for example, a[999999999] and it will take significant time to iterate over
+// > this huge array. (https://www.npmjs.com/package/qs)
+//
+// Some API requests involve more than 20 query string parameters by necessity
+// due to the number of judges (for example, searching for all judges using
+// getPendingMotionDocketEntriesForCurrentJudgeInteractor). Here we set the
+// array length to 200 to prohibit DoS attacks, while at the same time
+// accommodating cases when we need to pass more than 20 items in an array as
+// query string parameters.
+app.set('query parser', str => qs.parse(str, { arrayLimit: 200 }));
 
 app.use(cors());
 app.use(json());

--- a/web-api/src/app.ts
+++ b/web-api/src/app.ts
@@ -204,6 +204,7 @@ import { validatePdfLambda } from './lambdas/documents/validatePdfLambda';
 import { verifyPendingCaseForUserLambda } from './lambdas/cases/verifyPendingCaseForUserLambda';
 import cors from 'cors';
 import express from 'express';
+import qs from 'qs';
 import { getTrialSessionOpenCasesCountLambda } from '@web-api/lambdas/trialSessions/getTrialSessionOpenCasesCountLambda';
 import { getConsolidatedCaseDeadlinesLambda } from '@web-api/lambdas/caseDeadline/getConsolidatedCaseDeadlinesLambda';
 import { removePetitionerEmailLambda } from '@web-api/lambdas/cases/removePetitionerEmailLambda';
@@ -216,8 +217,25 @@ import { validateCaseForNewMinuteSheetLambda } from './lambdas/trialSessionMinut
 
 export const app = express();
 
-// This was default in express 4.x. The default changed in express 5.x, so we have to specify it here
-app.set('query parser', 'extended');
+// We explicitly use qs as our query parser: it was the default in express 4.x.,
+// but was no longer the default in express 5.x, so we need to explicitly set it
+// here. See https://github.com/ustaxcourt/ef-cms/pull/6020
+//
+// By default, qs limits arrays to a maximum of 20:
+//
+// > qs will also limit arrays to a maximum of 20 elements. Any array members
+// > with an index of 20 or greater will instead be converted to an object with
+// > the index as the key. This is needed to handle cases when someone sent,
+// > for example, a[999999999] and it will take significant time to iterate over
+// > this huge array. (https://www.npmjs.com/package/qs)
+//
+// Some API requests involve more than 20 query string parameters by necessity
+// due to the number of judges (for example, searching for all judges using
+// getPendingMotionDocketEntriesForCurrentJudgeInteractor). Here we set the
+// array length to 200 to prohibit DoS attacks, while at the same time
+// accommodating cases when we need to pass more than 20 items in an array as
+// query string parameters.
+app.set('query parser', str => qs.parse(str, { arrayLimit: 200 }));
 
 const allowAccessOriginFunction = (origin, callback) => {
   //Origin header wasn't provided

--- a/web-api/src/persistence/postgres/docketEntries/reports/getAllPendingMotionDocketEntriesForJudge.ts
+++ b/web-api/src/persistence/postgres/docketEntries/reports/getAllPendingMotionDocketEntriesForJudge.ts
@@ -8,40 +8,25 @@ import {
 import { fromKyselyCase } from '@web-api/persistence/postgres/cases/mapper';
 import { getConsolidatedCasesCount } from '@web-api/persistence/postgres/cases/getConsolidatedCasesCount';
 import { getDbReader } from '@web-api/database';
-import { sql, SqlBool } from 'kysely';
 
 export const getAllPendingMotionDocketEntriesForJudge = async ({
   judgeIds,
 }: {
   judgeIds: string[];
 }): Promise<{ results: FormattedPendingMotion[]; total: number }> => {
-  const results = await getDbReader(async reader => {
-    const query = reader
+  const results = await getDbReader(async reader =>
+    reader
       .selectFrom('dwDocketEntry as d')
       .innerJoin('dwCase as c', 'd.docketNumber', 'c.docketNumber')
       .where('d.pending', 'is', true)
-      // sql.lit() is intentionally used here instead of parameterized values to
-      // work around a bug wherein esbuild's minifySyntax optimization causes Kysely
-      // to bind arrays as a single parameter rather than expanding them. judgeIds
-      // is safe to inline because the values originate from the database.
-      // MOTION_EVENT_CODES is safe to inline because it is a static compile-time constant.
-      .where(
-        sql<SqlBool>`c."associated_judge_id" IN (${sql.join(
-          judgeIds.map(id => sql.lit(id)),
-          sql`, `,
-        )})`,
-      )
-      .where(
-        sql<SqlBool>`d."event_code" IN (${sql.join(
-          MOTION_EVENT_CODES.map(code => sql.lit(code)),
-          sql`, `,
-        )})`,
-      )
+      .where('c.associatedJudgeId', 'in', judgeIds)
+      .where('d.eventCode', 'in', MOTION_EVENT_CODES)
       .where(
         'd.filingDate',
         '<=',
         calculateDate({ howMuch: -180, units: 'days' }),
       )
+
       .select([
         'c.associatedJudge',
         'c.associatedJudgeId',
@@ -56,10 +41,9 @@ export const getAllPendingMotionDocketEntriesForJudge = async ({
         'd.eventCode',
         'd.filingDate',
         'd.pending',
-      ]);
-
-    return query.execute();
-  });
+      ])
+      .execute(),
+  );
 
   const mappedResults = await Promise.all(
     results.map(async r => {


### PR DESCRIPTION
This PR explicitly sets the maximum length of query string parameter arrays to 200 instead of the default of 20. See comments in the diffs for rationale.

This PR also reverts `getAllPendingMotionDocketEntriesForJudge` to its previous state since ultimately that function was not the culprit for the "All Judges" option in the judge activity report not working.