### PR TITLE
opex: script to reset all users' passwords (in lower environments)

### DIFF
--- a/scripts/helpers/batch.test.ts
+++ b/scripts/helpers/batch.test.ts
@@ -1,0 +1,103 @@
+import { runInBatches } from './batch';
+import { sleep } from '@shared/tools/helpers';
+
+jest.mock('@shared/tools/helpers', () => ({
+  sleep: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('Batch Processing', () => {
+  let consoleLogSpy;
+  let consoleErrorSpy;
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('runs all tasks in batches', async () => {
+    const tasks = [
+      jest.fn().mockResolvedValue(1),
+      jest.fn().mockResolvedValue(2),
+      jest.fn().mockResolvedValue(3),
+      jest.fn().mockResolvedValue(4),
+      jest.fn().mockResolvedValue(5),
+    ];
+
+    await runInBatches(tasks, 2, 100);
+
+    expect(tasks[0]).toHaveBeenCalled();
+    expect(tasks[1]).toHaveBeenCalled();
+    expect(tasks[2]).toHaveBeenCalled();
+    expect(tasks[3]).toHaveBeenCalled();
+    expect(tasks[4]).toHaveBeenCalled();
+
+    expect(consoleLogSpy).toHaveBeenCalledWith('running batch:', [0, 1]);
+    expect(consoleLogSpy).toHaveBeenCalledWith('running batch:', [2, 3]);
+    expect(consoleLogSpy).toHaveBeenCalledWith('running batch:', [4]);
+
+    expect(sleep).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledWith(100);
+  });
+
+  it('continues running on error if breakOnError is false', async () => {
+    const tasks = [
+      jest.fn().mockResolvedValue(1),
+      jest.fn().mockRejectedValue(new Error('Batch Error')),
+      jest.fn().mockResolvedValue(3),
+    ];
+
+    await runInBatches(tasks, 1, 0, false);
+
+    expect(tasks[0]).toHaveBeenCalled();
+    expect(tasks[1]).toHaveBeenCalled();
+    expect(tasks[2]).toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Error in batch:',
+      expect.any(Error),
+    );
+  });
+
+  it('throws on error if breakOnError is true', async () => {
+    const tasks = [
+      jest.fn().mockResolvedValue(1),
+      jest.fn().mockRejectedValue(new Error('Batch Error')),
+      jest.fn().mockResolvedValue(3),
+    ];
+
+    await expect(runInBatches(tasks, 1, 0, true)).rejects.toThrow(
+      'Batch Error',
+    );
+
+    expect(tasks[0]).toHaveBeenCalled();
+    expect(tasks[1]).toHaveBeenCalled();
+    expect(tasks[2]).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Error in batch:',
+      expect.any(Error),
+    );
+  });
+
+  it('does not sleep if rest is 0', async () => {
+    const tasks = [jest.fn().mockResolvedValue(1)];
+    await runInBatches(tasks, 1, 0);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('does not sleep if rest is negative', async () => {
+    const tasks = [jest.fn().mockResolvedValue(1)];
+    await runInBatches(tasks, 1, -1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('uses default values for concurrency and rest if no values are provided', async () => {
+    const tasks = [jest.fn().mockResolvedValue(1)];
+    await runInBatches(tasks);
+    expect(sleep).toHaveBeenCalledWith(1000);
+  });
+});

--- a/scripts/helpers/batch.ts
+++ b/scripts/helpers/batch.ts
@@ -1,0 +1,25 @@
+import { sleep } from '@shared/tools/helpers';
+
+export const runInBatches = async (
+  tasks: (() => Promise<any>)[],
+  concurrency: number = 15,
+  rest: number = 1000, // ms
+  breakOnError: boolean = false,
+) => {
+  for (let i = 0; i < tasks.length; i += concurrency) {
+    const batch = tasks.slice(i, i + concurrency);
+    console.log(
+      'running batch:',
+      batch.map((_, idx) => i + idx),
+    );
+    try {
+      await Promise.all(batch.map(fn => fn()));
+    } catch (err) {
+      console.error('Error in batch:', err);
+      if (breakOnError) {
+        throw err;
+      }
+    }
+    if (rest && rest > 0) await sleep(rest);
+  }
+};

--- a/scripts/helpers/cognito.test.ts
+++ b/scripts/helpers/cognito.test.ts
@@ -1,6 +1,6 @@
 import {
   AdminDeleteUserCommand,
-  AdminResetUserPasswordCommand,
+  AdminSetUserPasswordCommand,
   ListUsersCommand,
 } from '@aws-sdk/client-cognito-identity-provider';
 import {
@@ -220,7 +220,7 @@ describe('Cognito Helpers', () => {
       });
 
       expect(result).toBe(true);
-      expect(AdminResetUserPasswordCommand).toHaveBeenCalledWith({
+      expect(AdminSetUserPasswordCommand).toHaveBeenCalledWith({
         Password: 'newPassword123!',
         Permanent: true,
         UserPoolId: mockUserPoolId,

--- a/scripts/helpers/cognito.test.ts
+++ b/scripts/helpers/cognito.test.ts
@@ -1,0 +1,252 @@
+import {
+  AdminDeleteUserCommand,
+  AdminResetUserPasswordCommand,
+  ListUsersCommand,
+} from '@aws-sdk/client-cognito-identity-provider';
+import {
+  deleteUserFromCognito,
+  getAllCognitoUsers,
+  getEnabledCognitoUsers,
+  resetUserPassword,
+} from './cognito';
+
+jest.mock('@aws-sdk/client-cognito-identity-provider');
+
+describe('Cognito Helpers', () => {
+  const mockUserPoolId = 'us-east-1_abc123';
+  let mockCognito;
+
+  beforeEach(() => {
+    mockCognito = {
+      send: jest.fn(),
+    };
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('getAllCognitoUsers', () => {
+    it('retrieves all users from cognito with pagination', async () => {
+      mockCognito.send
+        .mockResolvedValueOnce({
+          PaginationToken: 'token1',
+          Users: [{ Username: 'user1' }],
+        })
+        .mockResolvedValueOnce({
+          PaginationToken: undefined,
+          Users: [{ Username: 'user2' }],
+        });
+
+      const users = await getAllCognitoUsers({
+        UserPoolId: mockUserPoolId,
+        cognito: mockCognito,
+      });
+
+      expect(users).toEqual([{ Username: 'user1' }, { Username: 'user2' }]);
+      expect(mockCognito.send).toHaveBeenCalledTimes(2);
+      expect(ListUsersCommand).toHaveBeenCalledWith({
+        Limit: 60,
+        PaginationToken: undefined,
+        UserPoolId: mockUserPoolId,
+      });
+      expect(ListUsersCommand).toHaveBeenCalledWith({
+        Limit: 60,
+        PaginationToken: 'token1',
+        UserPoolId: mockUserPoolId,
+      });
+    });
+
+    it('handles a response where response.Users is undefined', async () => {
+      mockCognito.send.mockResolvedValueOnce({
+        PaginationToken: undefined,
+        Users: undefined,
+      });
+
+      const users = await getAllCognitoUsers({
+        UserPoolId: mockUserPoolId,
+        cognito: mockCognito,
+      });
+
+      expect(users).toEqual([]);
+    });
+
+    it("throws an error if it can't connect to Cognito", async () => {
+      mockCognito.send.mockRejectedValue(new Error('Cognito error'));
+
+      await expect(
+        getAllCognitoUsers({
+          UserPoolId: mockUserPoolId,
+          cognito: mockCognito,
+        }),
+      ).rejects.toThrow('Cognito error');
+      expect(console.error).toHaveBeenCalledWith(
+        'Error listing users:',
+        expect.any(Error),
+      );
+    });
+
+    it('paginates results using the provided Limit', async () => {
+      mockCognito.send.mockResolvedValueOnce({
+        Users: [],
+      });
+
+      await getAllCognitoUsers({
+        Limit: 100,
+        UserPoolId: mockUserPoolId,
+        cognito: mockCognito,
+      });
+
+      expect(ListUsersCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Limit: 100,
+        }),
+      );
+    });
+  });
+
+  describe('getEnabledCognitoUsers', () => {
+    it('retrieves only enabled users from cognito', async () => {
+      mockCognito.send.mockResolvedValueOnce({
+        PaginationToken: undefined,
+        Users: [
+          { Enabled: true, Username: 'enabledUser' },
+          { Enabled: false, Username: 'disabledUser' },
+        ],
+      });
+
+      const users = await getEnabledCognitoUsers({
+        UserPoolId: mockUserPoolId,
+        cognito: mockCognito,
+      });
+
+      expect(users).toEqual([{ Enabled: true, Username: 'enabledUser' }]);
+    });
+
+    it('handles a response where response.Users is undefined', async () => {
+      mockCognito.send.mockResolvedValueOnce({
+        PaginationToken: undefined,
+        Users: undefined,
+      });
+
+      const users = await getEnabledCognitoUsers({
+        UserPoolId: mockUserPoolId,
+        cognito: mockCognito,
+      });
+
+      expect(users).toEqual([]);
+    });
+
+    it("throws an error if it can't connect to Cognito", async () => {
+      mockCognito.send.mockRejectedValue(new Error('Cognito error'));
+
+      await expect(
+        getEnabledCognitoUsers({
+          UserPoolId: mockUserPoolId,
+          cognito: mockCognito,
+        }),
+      ).rejects.toThrow('Cognito error');
+      expect(console.error).toHaveBeenCalledWith(
+        'Error listing users:',
+        expect.any(Error),
+      );
+    });
+
+    it('paginates results using the provided Limit', async () => {
+      mockCognito.send.mockResolvedValueOnce({
+        Users: [],
+      });
+
+      await getEnabledCognitoUsers({
+        Limit: 100,
+        UserPoolId: mockUserPoolId,
+        cognito: mockCognito,
+      });
+
+      expect(ListUsersCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Limit: 100,
+        }),
+      );
+    });
+  });
+
+  describe('deleteUserFromCognito', () => {
+    it('returns true when user is successfully deleted', async () => {
+      mockCognito.send.mockResolvedValueOnce({});
+
+      const result = await deleteUserFromCognito({
+        UserPoolId: mockUserPoolId,
+        cognito: mockCognito,
+        user: { Username: 'testUser' },
+      });
+
+      expect(result).toBe(true);
+      expect(AdminDeleteUserCommand).toHaveBeenCalledWith({
+        Username: 'testUser',
+        UserPoolId: mockUserPoolId,
+      });
+      expect(console.log).toHaveBeenCalledWith('Deleted user: ', 'testUser');
+    });
+
+    it('returns false and logs an error when deletion fails', async () => {
+      mockCognito.send.mockRejectedValue(new Error('Delete error'));
+
+      const result = await deleteUserFromCognito({
+        UserPoolId: mockUserPoolId,
+        cognito: mockCognito,
+        user: { Username: 'testUser' },
+      });
+
+      expect(result).toBe(false);
+      expect(console.error).toHaveBeenCalledWith(
+        'Error deleting user Username: ',
+        'testUser',
+      );
+    });
+  });
+
+  describe('resetUserPassword', () => {
+    it('returns true when password is successfully reset', async () => {
+      mockCognito.send.mockResolvedValueOnce({});
+
+      const result = await resetUserPassword({
+        Password: 'newPassword123!',
+        UserPoolId: mockUserPoolId,
+        cognito: mockCognito,
+        user: { Username: 'testUser' },
+      });
+
+      expect(result).toBe(true);
+      expect(AdminResetUserPasswordCommand).toHaveBeenCalledWith({
+        Password: 'newPassword123!',
+        Permanent: true,
+        UserPoolId: mockUserPoolId,
+        Username: 'testUser',
+      });
+      expect(console.log).toHaveBeenCalledWith(
+        'Reset password for user: ',
+        'testUser',
+      );
+    });
+
+    it('returns false and logs error when password reset fails', async () => {
+      mockCognito.send.mockRejectedValue(new Error('Reset error'));
+
+      const result = await resetUserPassword({
+        Password: 'newPassword123!',
+        UserPoolId: mockUserPoolId,
+        cognito: mockCognito,
+        user: { Username: 'testUser' },
+      });
+
+      expect(result).toBe(false);
+      expect(console.error).toHaveBeenCalledWith(
+        'Error resetting password for user: ',
+        'testUser',
+      );
+    });
+  });
+});

--- a/scripts/helpers/cognito.ts
+++ b/scripts/helpers/cognito.ts
@@ -1,0 +1,140 @@
+import {
+  AdminDeleteUserCommand,
+  AdminResetUserPasswordCommand,
+  CognitoIdentityProvider,
+  ListUsersCommand,
+  ListUsersCommandOutput,
+  UserType,
+} from '@aws-sdk/client-cognito-identity-provider';
+
+export const getAllCognitoUsers = async ({
+  cognito,
+  Limit = 60,
+  UserPoolId,
+}: {
+  cognito: CognitoIdentityProvider;
+  Limit?: number;
+  UserPoolId: string;
+}): Promise<UserType[]> => {
+  let allUsers: UserType[] = [];
+  let paginationToken: string | undefined = undefined;
+
+  do {
+    const command = new ListUsersCommand({
+      Limit,
+      PaginationToken: paginationToken,
+      UserPoolId,
+    });
+
+    try {
+      const response: ListUsersCommandOutput = await cognito.send(command);
+      if (response.Users) {
+        allUsers = allUsers.concat(response.Users);
+      }
+      paginationToken = response.PaginationToken;
+    } catch (error) {
+      console.error('Error listing users:', error);
+      throw error;
+    }
+  } while (paginationToken);
+
+  return allUsers;
+};
+
+export const getEnabledCognitoUsers = async ({
+  cognito,
+  Limit = 60,
+  UserPoolId,
+}: {
+  cognito: CognitoIdentityProvider;
+  Limit?: number;
+  UserPoolId: string;
+}): Promise<UserType[]> => {
+  let enabledUsers: UserType[] = [];
+  let paginationToken: string | undefined = undefined;
+
+  do {
+    const command = new ListUsersCommand({
+      Limit,
+      PaginationToken: paginationToken,
+      UserPoolId,
+    });
+
+    try {
+      const response: ListUsersCommandOutput = await cognito.send(command);
+      if (response.Users) {
+        enabledUsers = enabledUsers.concat(
+          response.Users.filter(u => u.Enabled),
+        );
+      }
+      paginationToken = response.PaginationToken;
+    } catch (error) {
+      console.error('Error listing users:', error);
+      throw error;
+    }
+  } while (paginationToken);
+
+  return enabledUsers;
+};
+
+export const deleteUserFromCognito = async ({
+  cognito,
+  user,
+  UserPoolId,
+}: {
+  cognito: CognitoIdentityProvider;
+  user: UserType;
+  UserPoolId: string;
+}): Promise<boolean> => {
+  const adminDeleteUserCommandInput = {
+    Username: user.Username,
+    UserPoolId,
+  };
+
+  let deleted = false;
+  try {
+    const adminDeleteUserCommand = new AdminDeleteUserCommand(
+      adminDeleteUserCommandInput,
+    );
+
+    await cognito.send(adminDeleteUserCommand);
+    console.log('Deleted user: ', user.Username);
+    deleted = true;
+  } catch (error) {
+    console.error('Error deleting user Username: ', user.Username);
+  }
+  return deleted;
+};
+
+export const resetUserPassword = async ({
+  cognito,
+  Password,
+  user,
+  UserPoolId,
+}: {
+  cognito: CognitoIdentityProvider;
+  Password: string;
+  user: UserType;
+  UserPoolId: string;
+}): Promise<boolean> => {
+  const adminResetUserPasswordCommandInput = {
+    Password,
+    Permanent: true,
+    Username: user.Username,
+    UserPoolId,
+  };
+
+  let updated = false;
+  try {
+    const adminResetUserPasswordCommand = new AdminResetUserPasswordCommand(
+      adminResetUserPasswordCommandInput,
+    );
+
+    await cognito.send(adminResetUserPasswordCommand);
+    console.log('Reset password for user: ', user.Username);
+    updated = true;
+  } catch (error) {
+    console.error('Error resetting password for user: ', user.Username);
+  }
+  return updated;
+};

--- a/scripts/helpers/cognito.ts
+++ b/scripts/helpers/cognito.ts
@@ -1,6 +1,6 @@
 import {
   AdminDeleteUserCommand,
-  AdminResetUserPasswordCommand,
+  AdminSetUserPasswordCommand,
   CognitoIdentityProvider,
   ListUsersCommand,
   ListUsersCommandOutput,
@@ -117,7 +117,7 @@ export const resetUserPassword = async ({
   user: UserType;
   UserPoolId: string;
 }): Promise<boolean> => {
-  const adminResetUserPasswordCommandInput = {
+  const adminSetUserPasswordCommandInput = {
     Password,
     Permanent: true,
     Username: user.Username,
@@ -126,11 +126,11 @@ export const resetUserPassword = async ({
 
   let updated = false;
   try {
-    const adminResetUserPasswordCommand = new AdminResetUserPasswordCommand(
-      adminResetUserPasswordCommandInput,
+    const adminSetUserPasswordCommand = new AdminSetUserPasswordCommand(
+      adminSetUserPasswordCommandInput,
     );
 
-    await cognito.send(adminResetUserPasswordCommand);
+    await cognito.send(adminSetUserPasswordCommand);
     console.log('Reset password for user: ', user.Username);
     updated = true;
   } catch (error) {

--- a/scripts/helpers/parseArgsAndEnvVars.test.ts
+++ b/scripts/helpers/parseArgsAndEnvVars.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable jest/no-conditional-expect */
-/* eslint-disable custom-rules-plugin/no-new-dates*/
+/* eslint-disable custom-rules-plugin/no-dates */
+/* eslint-disable max-lines */
 import {
   FORMATS,
   formatNow,
@@ -40,6 +41,7 @@ const ogScriptConfig: ScriptConfig = {
       type: 'string',
     },
   },
+  preventExecutionAgainst: ['prod'],
   requireActiveAwsSession: true,
 };
 const mockScriptConfig = cloneDeep(ogScriptConfig);
@@ -136,7 +138,7 @@ describe('parseArgsAndEnvVars', () => {
       } catch (err: any) {
         expect(err.toString()).toEqual('Error: caught process.exit');
       }
-      expect(mockConsoleLog).toHaveBeenCalledTimes(5);
+      expect(mockConsoleLog).toHaveBeenCalledTimes(6);
       expect(mockExit).toHaveBeenCalledWith(0);
     });
     it('generates a usage example from provided configuration', () => {
@@ -230,7 +232,7 @@ describe('parseArgsAndEnvVars', () => {
       expect(result.hostname).toEqual('jest');
       expect(mockConsoleLog).not.toHaveBeenCalled();
     });
-    it('tells the user when an active AWS session is required', () => {
+    it('tells the user the environments against which execution will be prevented', () => {
       process.argv = ['ts-node', 'some-script.ts', '-h'];
       try {
         parseArgsAndEnvVars(mockScriptConfig);
@@ -239,6 +241,32 @@ describe('parseArgsAndEnvVars', () => {
       }
       expect(mockConsoleLog).toHaveBeenNthCalledWith(
         5,
+        '\nPrevent Execution Against:',
+        ['prod'],
+      );
+    });
+    it('does not tell the user execution will be prevented if execution will not be prevented', () => {
+      process.argv = ['ts-node', 'some-script.ts', '-h'];
+      const itsScriptConfig = cloneDeep(mockScriptConfig);
+      delete itsScriptConfig.preventExecutionAgainst;
+      try {
+        parseArgsAndEnvVars(itsScriptConfig);
+      } catch (err: any) {
+        expect(err.toString()).toEqual('Error: caught process.exit');
+      }
+      expect(mockConsoleLog).not.toHaveBeenCalledWith(
+        '\nPrevent Execution Against:',
+      );
+    });
+    it('tells the user when an active AWS session is required', () => {
+      process.argv = ['ts-node', 'some-script.ts', '-h'];
+      try {
+        parseArgsAndEnvVars(mockScriptConfig);
+      } catch (err: any) {
+        expect(err.toString()).toEqual('Error: caught process.exit');
+      }
+      expect(mockConsoleLog).toHaveBeenNthCalledWith(
+        6,
         '\nActive AWS session required.',
       );
     });
@@ -267,7 +295,7 @@ describe('parseArgsAndEnvVars', () => {
         1,
         'Verbose output enabled\n',
       );
-      expect(mockConsoleLog).toHaveBeenCalledTimes(11);
+      expect(mockConsoleLog).toHaveBeenCalledTimes(12);
       expect(mockExit).not.toHaveBeenCalled();
     });
     it('only calls usage once if the verbose flag was provided and there was an error', () => {
@@ -309,7 +337,7 @@ describe('parseArgsAndEnvVars', () => {
         1,
         'Verbose output enabled\n',
       );
-      expect(mockConsoleLog).toHaveBeenCalledTimes(8);
+      expect(mockConsoleLog).toHaveBeenCalledTimes(9);
       expect(mockExit).toHaveBeenCalledWith(0);
     });
   });
@@ -609,6 +637,52 @@ describe('parseArgsAndEnvVars', () => {
       parseArgsAndEnvVars(itsScriptConfig);
       expect(mockExit).not.toHaveBeenCalled();
     });
+  });
+  describe('Execution Prevention', () => {
+    it(
+      'exits if the ENV environment variable is not set and ' +
+        "preventExecutionAgainst includes 'local'",
+      () => {
+        process.env = {};
+        const itsScriptConfig = cloneDeep(mockScriptConfig);
+        delete itsScriptConfig.environment;
+        itsScriptConfig.preventExecutionAgainst = ['local'];
+        try {
+          parseArgsAndEnvVars(itsScriptConfig);
+        } catch (err: any) {
+          expect(err.toString()).toEqual('Error: caught process.exit');
+        }
+        expect(mockConsoleLog).toHaveBeenNthCalledWith(
+          1,
+          'Execution against local is not permitted.\n',
+        );
+      },
+    );
+    it('exits if the value of the ENV environment variable is included in preventExecutionAgainst', () => {
+      process.env = { ENV: 'prod' };
+      const itsScriptConfig = cloneDeep(mockScriptConfig);
+      try {
+        parseArgsAndEnvVars(itsScriptConfig);
+      } catch (err: any) {
+        expect(err.toString()).toEqual('Error: caught process.exit');
+      }
+      expect(mockConsoleLog).toHaveBeenNthCalledWith(
+        1,
+        'Execution against prod is not permitted.\n',
+      );
+    });
+    it(
+      'does not exit if the ENV environment variable is not set and ' +
+        'preventExecutionAgainst is empty',
+      () => {
+        process.env = { AWS_SESSION_EXPIRATION: mockAwsSessionExpiration };
+        const itsScriptConfig = cloneDeep(mockScriptConfig);
+        delete itsScriptConfig.environment;
+        delete itsScriptConfig.preventExecutionAgainst;
+        parseArgsAndEnvVars(itsScriptConfig);
+        expect(mockExit).not.toHaveBeenCalled();
+      },
+    );
   });
   describe('AWS Session Expiration', () => {
     it('exits if the AWS_SESSION_EXPIRATION environment variable is not set', () => {

--- a/scripts/helpers/parseArgsAndEnvVars.ts
+++ b/scripts/helpers/parseArgsAndEnvVars.ts
@@ -14,7 +14,7 @@ export type ScriptConfig = {
     /**
      * List of environment variables that are required to be present.
      * The key is the property by which the parsed value will be
-     * returned and the value is the environment variable name
+     * returned, and the value is the environment variable name
      * (e.g. `env: 'ENV'`).
      */
     [key: string]: string;
@@ -33,6 +33,12 @@ export type ScriptConfig = {
      */
     [key: string]: ScriptParameter;
   };
+  /**
+   * The `preventExecutionAgainst` property indicates environments the script
+   * should not execute against. If 'local' is provided, execution will be
+   * prevented if the `ENV` environment variable is not present.
+   */
+  preventExecutionAgainst?: string[];
   /**
    * The `requireActiveAwsSession` property indicates whether the AWS session
    * token should be currently active.
@@ -248,6 +254,9 @@ const usage = (sc: ScriptConfig, warning?: string): void => {
       '\nRequired Environment Variables:',
       Object.values(sc.environment),
     );
+  }
+  if (sc.preventExecutionAgainst) {
+    console.log('\nPrevent Execution Against:', sc.preventExecutionAgainst);
   }
   if (sc.requireActiveAwsSession) {
     console.log('\nActive AWS session required.');
@@ -522,6 +531,21 @@ export const getEnvironmentVariables = (environment?: {
   return ret;
 };
 
+const preventExecutionAgainstEnvironment = (
+  sc: ScriptConfig,
+  verbose: boolean,
+): void => {
+  const { env } = getEnvironmentVariables({ env: 'ENV' });
+  const envToCheck = env || 'local';
+  if (sc.preventExecutionAgainst!.includes(envToCheck)) {
+    showErrorAndExit(
+      `Execution against ${envToCheck} is not permitted.`,
+      sc,
+      verbose,
+    );
+  }
+};
+
 const checkAwsSessionExpiration = (
   sc: ScriptConfig,
   verbose: boolean,
@@ -577,6 +601,10 @@ export const parseArgsAndEnvVars = (
   const environmentVariables = getEnvironmentVariables(sc.environment);
   if (parsedParameters.verbose) {
     console.log('environment variables:', environmentVariables);
+  }
+
+  if (sc.preventExecutionAgainst && sc.preventExecutionAgainst.length > 0) {
+    preventExecutionAgainstEnvironment(sc, !!parsedParameters.verbose);
   }
 
   if (sc.requireActiveAwsSession) {

--- a/scripts/user/clear-all-cognito-users.ts
+++ b/scripts/user/clear-all-cognito-users.ts
@@ -13,22 +13,18 @@ import { runInBatches } from '../helpers/batch';
 
 const scriptConfig: ScriptConfig = {
   description:
-    'clear-all-cognito-users - Deletes all cognito accounts in the test environment.',
+    'clear-all-cognito-users - Deletes all cognito accounts in the provided user pool.',
   environment: {
-    env: 'ENV',
     UserPoolId: 'USER_POOL_ID',
     region: 'REGION',
   },
+  preventExecutionAgainst: ['prod'],
   requireActiveAwsSession: true,
 };
 
-const { env, UserPoolId, region } = parseArgsAndEnvVars(scriptConfig) as {
+const { UserPoolId, region } = parseArgsAndEnvVars(scriptConfig) as {
   [k: string]: string;
 };
-if (env === 'prod') {
-  console.error('This script should not be run against prod.');
-  process.exit(1);
-}
 
 const cognito = new CognitoIdentityProvider({ region });
 

--- a/scripts/user/reset-passwords.ts
+++ b/scripts/user/reset-passwords.ts
@@ -15,22 +15,16 @@ const scriptConfig: ScriptConfig = {
   description:
     'reset-passwords - Resets the cognito password for all test users.',
   environment: {
-    env: 'ENV',
     Password: 'DEFAULT_ACCOUNT_PASS',
     UserPoolId: 'USER_POOL_ID',
     region: 'REGION',
   },
+  preventExecutionAgainst: ['prod'],
   requireActiveAwsSession: true,
 };
-const { env, Password, UserPoolId, region } = parseArgsAndEnvVars(
-  scriptConfig,
-) as {
+const { Password, UserPoolId, region } = parseArgsAndEnvVars(scriptConfig) as {
   [k: string]: string;
 };
-if (env === 'prod') {
-  console.error('This script should not be run against prod.');
-  process.exit(1);
-}
 
 const cognito = new CognitoIdentityProvider({ region });
 

--- a/scripts/user/reset-passwords.ts
+++ b/scripts/user/reset-passwords.ts
@@ -8,21 +8,23 @@ import {
   type ScriptConfig,
   parseArgsAndEnvVars,
 } from '../helpers/parseArgsAndEnvVars';
-import { deleteUserFromCognito, getAllCognitoUsers } from '../helpers/cognito';
 import { runInBatches } from '../helpers/batch';
+import { getEnabledCognitoUsers, resetUserPassword } from '../helpers/cognito';
 
 const scriptConfig: ScriptConfig = {
   description:
-    'clear-all-cognito-users - Deletes all cognito accounts in the test environment.',
+    'reset-passwords - Resets the cognito password for all test users.',
   environment: {
     env: 'ENV',
+    Password: 'DEFAULT_ACCOUNT_PASS',
     UserPoolId: 'USER_POOL_ID',
     region: 'REGION',
   },
   requireActiveAwsSession: true,
 };
-
-const { env, UserPoolId, region } = parseArgsAndEnvVars(scriptConfig) as {
+const { env, Password, UserPoolId, region } = parseArgsAndEnvVars(
+  scriptConfig,
+) as {
   [k: string]: string;
 };
 if (env === 'prod') {
@@ -34,16 +36,16 @@ const cognito = new CognitoIdentityProvider({ region });
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 (async () => {
-  const allUsers: UserType[] = await getAllCognitoUsers({
+  const enabledUsers: UserType[] = await getEnabledCognitoUsers({
     cognito,
     UserPoolId,
   });
 
-  const tasks: (() => Promise<boolean>)[] = allUsers.map(
-    user => () => deleteUserFromCognito({ cognito, user, UserPoolId }),
+  const tasks: (() => Promise<boolean>)[] = enabledUsers.map(
+    user => () => resetUserPassword({ cognito, Password, user, UserPoolId }),
   );
 
   await runInBatches(tasks);
 
-  console.log('All users deleted.');
+  console.log("All enabled users' passwords have been reset.");
 })();

--- a/scripts/user/setup-glued-users.ts
+++ b/scripts/user/setup-glued-users.ts
@@ -9,6 +9,7 @@ import {
 import { getDbReader } from '@web-api/database';
 import { pgDeleteFrom } from '@web-api/persistence/postgres/utils/operation/pgDeleteFrom';
 import { RawUser } from '@shared/business/entities/User';
+import { runInBatches } from '../helpers/batch';
 
 const scriptConfig: ScriptConfig = {
   description:
@@ -333,24 +334,9 @@ const processUser = async (userName: string, users: Users): Promise<void> => {
   const users = await getUsers();
 
   // Create task functions so work is started only when invoked
-  const taskFns: (() => Promise<void>)[] = Object.keys(users).map(
+  const tasks: (() => Promise<void>)[] = Object.keys(users).map(
     user => () => processUser(user, users),
   );
 
-  // Run tasks in chunks of 15, awaiting each batch before continuing
-  const concurrency = 15;
-  for (let i = 0; i < taskFns.length; i += concurrency) {
-    const batch = taskFns.slice(i, i + concurrency);
-    console.log(
-      'running batch:',
-      batch.map((_, idx) => i + idx),
-    );
-    try {
-      await Promise.all(batch.map(fn => fn()));
-    } catch (err) {
-      console.error('Error in batch:', err);
-    }
-    // small delay between batches to avoid bursting
-    await new Promise(resolve => setTimeout(resolve, 1000));
-  }
+  await runInBatches(tasks);
 })();

--- a/scripts/user/setup-glued-users.ts
+++ b/scripts/user/setup-glued-users.ts
@@ -19,6 +19,7 @@ const scriptConfig: ScriptConfig = {
     UserPoolId: 'USER_POOL_ID',
     region: 'REGION',
   },
+  preventExecutionAgainst: ['local', 'prod'],
   requireActiveAwsSession: true,
 };
 const { Password, UserPoolId, region } = parseArgsAndEnvVars(scriptConfig) as {

--- a/scripts/user/setup-test-users.ts
+++ b/scripts/user/setup-test-users.ts
@@ -23,20 +23,14 @@ import { settlePromises } from '@web-api/utilities/settlePromises';
 const scriptConfig: ScriptConfig = {
   description: 'setup-test-users - Creates test users.',
   environment: {
-    env: 'ENV',
     password: 'DEFAULT_ACCOUNT_PASS',
-    userPoolId: 'USER_POOL_ID',
   },
+  preventExecutionAgainst: ['prod'],
   requireActiveAwsSession: true,
 };
-const { env, password } = parseArgsAndEnvVars(scriptConfig) as {
+const { password } = parseArgsAndEnvVars(scriptConfig) as {
   [k: string]: string;
 };
-
-if (env === 'prod') {
-  console.error('ERROR: attempted to create test users in production');
-  process.exit(1);
-}
 
 const CONCURRENCY_LIMIT = 25;
 const limit = pLimit(CONCURRENCY_LIMIT);


### PR DESCRIPTION
Includes:
- A new script to reset all users' passwords
- refactored commonly-used batch processing code into a `runInBatches` helper
- refactored commonly-used cognito code into a "cognito" helper
- jest tests with [full test coverage](https://github.com/ustaxcourt/ef-cms/actions/runs/22411422268/job/64885659365?pr=9775#step:7:293) for the new helpers

Successful executions:
- [x] exp3
- [x] test