### PR TITLE
9780 Bug to Test

### DIFF
--- a/shared/src/business/entities/DocketEntry.ts
+++ b/shared/src/business/entities/DocketEntry.ts
@@ -737,7 +737,10 @@ export class DocketEntry extends JoiValidationEntity {
     if (user.role === ROLES.irsSuperuser)
       return DocketEntry.isServed(petitionDocketEntry);
 
-    if (isTerminalUser) return !DocketEntry.isSealed(entry);
+    if (isTerminalUser) {
+      if (entry.isStricken) return false;
+      return !DocketEntry.isSealed(entry);
+    }
 
     const userHasAccessToCase = Case.userHasAccessToCase(rawCase, user);
 

--- a/shared/src/business/entities/Docketentry.isDownloadable.test.ts
+++ b/shared/src/business/entities/Docketentry.isDownloadable.test.ts
@@ -409,6 +409,18 @@ describe('isDownloadable', () => {
         ),
       ).toEqual(false);
     });
+
+    it('returns false if the document is stricken', () => {
+      expect(
+        DocketEntry.isDownloadable(
+          {
+            ...baseDocketEntry,
+            isStricken: true,
+          },
+          options,
+        ),
+      ).toEqual(false);
+    });
   });
 
   describe('IRS Superuser', () => {


### PR DESCRIPTION
https://github.com/ustaxcourt/ef-cms/issues/9780

The terminal user should never be able to download a stricken document from filings and proceedings.