### PR TITLE
9745 - amgen support huge cases to test

### DIFF
--- a/web-api/terraform/modules/api/pdf-generation.tf
+++ b/web-api/terraform/modules/api/pdf-generation.tf
@@ -8,7 +8,7 @@ module "pdf_generation_lambda" {
   role           = var.lambda_role_arn
   environment    = var.lambda_environment
   timeout        = "900"
-  memory_size    = "6508"
+  memory_size    = "10240"
   layers = [
     aws_lambda_layer_version.puppeteer_layer.arn
   ]


### PR DESCRIPTION
increase max memory for html to pdf lambda which was running out of memory for amgen download docket entry