### PR TITLE
8827: remove trial session migration from CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,16 +280,6 @@ jobs:
           command: |
             cd ./scripts/postgres
             DB_HOST="$POSTGRES_HOST" ./create-rds-users.sh
-      - run:
-          name: Migrate Trial Sessions
-          command: |
-            NUM_TRIAL_SESSIONS=$(./scripts/postgres/connect.sh --quiet --yes \
-              --command="SELECT COUNT(*) FROM dw_trial_session;")
-            if [[ "$NUM_TRIAL_SESSIONS" -ne 0 ]]; then
-              echo "Already migrated trial sessions"
-              exit 0
-            fi
-            ./scripts/run-once-scripts/postgres-migration/migrate-trial-session-information.ts
 
   smoketests:
     parallelism: 9


### PR DESCRIPTION
This migration has definitely run everywhere and can be removed from the CircleCI config.