### PR TITLE
8847 update email replacer to prod

### DIFF
--- a/scripts/emailReplacer.test.ts
+++ b/scripts/emailReplacer.test.ts
@@ -1,11 +1,19 @@
+import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
-import { sanitizeDumpFile } from './emailReplacer';
+import { sanitizeDumpFile, sanitizeEmail } from './emailReplacer';
 import * as readline from 'readline';
 
 jest.mock('fs');
 jest.mock('path');
 jest.mock('readline');
+jest.mock('crypto', () => {
+  const actualCrypto = jest.requireActual('crypto');
+  return {
+    ...actualCrypto,
+    createHash: jest.fn((...args) => actualCrypto.createHash(...args)),
+  };
+});
 
 describe('sanitizeDumpFile', () => {
   const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation();
@@ -131,5 +139,69 @@ describe('sanitizeDumpFile', () => {
 
     expect(mockConsoleError).toHaveBeenCalledWith('Error:', errorMessage);
     expect(mockProcessExit).toHaveBeenCalledWith(1);
+  });
+});
+
+describe('sanitizeEmail', () => {
+  const actualCrypto = jest.requireActual('crypto');
+
+  beforeEach(() => {
+    // Reset createHash back to the real implementation before each test
+    (crypto.createHash as jest.Mock).mockImplementation((...args) =>
+      actualCrypto.createHash(...args),
+    );
+    jest.clearAllMocks();
+  });
+
+  it('should return an empty string when given an empty string', () => {
+    expect(sanitizeEmail('')).toBe('');
+  });
+
+  it('should return a hashed email with the example.com domain', () => {
+    const result = sanitizeEmail('john@real.com');
+    expect(result).toMatch(/^[a-f0-9]+@example\.com$/);
+  });
+
+  it('should return the same hash for the same email when called multiple times', () => {
+    const first = sanitizeEmail('john@real.com');
+    const second = sanitizeEmail('john@real.com');
+    expect(first).toBe(second);
+  });
+
+  it('should return different hashes for different emails', () => {
+    const first = sanitizeEmail('john@real.com');
+    const second = sanitizeEmail('jane@real.com');
+    expect(first).not.toBe(second);
+  });
+
+  it('should produce a hash of the correct length (8 hex chars + @example.com)', () => {
+    const result = sanitizeEmail('test@test.com');
+    const [localPart] = result.split('@');
+    expect(localPart).toHaveLength(8);
+  });
+
+  it('should handle emails with special allowed characters', () => {
+    const result = sanitizeEmail('test.name+tag@sub.domain.com');
+    expect(result).toMatch(/^[a-f0-9]+@example\.com$/);
+  });
+
+  it('should handle hash collisions by generating a new unique hash', () => {
+    const mockDigest = jest
+      .fn()
+      .mockReturnValueOnce('aabbccdd') // hash for email1
+      .mockReturnValueOnce('aabbccdd') // collision for email2
+      .mockReturnValueOnce('11223344'); // resolved hash for email2
+
+    (crypto.createHash as jest.Mock).mockReturnValue({
+      update: jest.fn().mockReturnThis(),
+      digest: mockDigest,
+    });
+
+    const first = sanitizeEmail('email1@test.com');
+    const second = sanitizeEmail('email2@test.com');
+
+    expect(first).toBe('aabbccdd@example.com');
+    expect(second).toBe('11223344@example.com');
+    expect(first).not.toBe(second);
   });
 });

--- a/scripts/emailReplacer.test.ts
+++ b/scripts/emailReplacer.test.ts
@@ -157,9 +157,9 @@ describe('sanitizeEmail', () => {
     expect(sanitizeEmail('')).toBe('');
   });
 
-  it('should return a hashed email with the example.com domain', () => {
+  it('should return a hashed email with the ustc.gov domain', () => {
     const result = sanitizeEmail('john@real.com');
-    expect(result).toMatch(/^[a-f0-9]+@example\.com$/);
+    expect(result).toMatch(/^[a-f0-9]+@ustc\.gov$/);
   });
 
   it('should return the same hash for the same email when called multiple times', () => {
@@ -174,7 +174,7 @@ describe('sanitizeEmail', () => {
     expect(first).not.toBe(second);
   });
 
-  it('should produce a hash of the correct length (8 hex chars + @example.com)', () => {
+  it('should produce a hash of the correct length (8 hex chars + @ustc.gov)', () => {
     const result = sanitizeEmail('test@test.com');
     const [localPart] = result.split('@');
     expect(localPart).toHaveLength(8);
@@ -182,7 +182,7 @@ describe('sanitizeEmail', () => {
 
   it('should handle emails with special allowed characters', () => {
     const result = sanitizeEmail('test.name+tag@sub.domain.com');
-    expect(result).toMatch(/^[a-f0-9]+@example\.com$/);
+    expect(result).toMatch(/^[a-f0-9]+@ustc\.gov$/);
   });
 
   it('should handle hash collisions by generating a new unique hash', () => {
@@ -200,8 +200,8 @@ describe('sanitizeEmail', () => {
     const first = sanitizeEmail('email1@test.com');
     const second = sanitizeEmail('email2@test.com');
 
-    expect(first).toBe('aabbccdd@example.com');
-    expect(second).toBe('11223344@example.com');
+    expect(first).toBe('aabbccdd@ustc.gov');
+    expect(second).toBe('11223344@ustc.gov');
     expect(first).not.toBe(second);
   });
 });

--- a/scripts/emailReplacer.ts
+++ b/scripts/emailReplacer.ts
@@ -2,13 +2,13 @@ import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as readline from 'readline';
 
-const DOMAIN_REPLACER = 'example.com';
+const DOMAIN_REPLACER = 'ustc.gov';
 // Use a negative look-behind to avoid \nSOMEEMAIL --> \SOMEEMAIL
 const emailRegex = /(?<!\\)[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
 
-const usedEmails = {};
+const usedEmails: Record<string, string> = {};
 
-const alreadyHashedEmails = {};
+const alreadyHashedEmails: Record<string, string> = {};
 
 export function sanitizeEmail(email: string) {
   if (email === '') {

--- a/scripts/emailReplacer.ts
+++ b/scripts/emailReplacer.ts
@@ -2,12 +2,49 @@ import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as readline from 'readline';
 
-const DOMAIN_REPLACER = 'ef-cms.ustaxcourt.gov';
+const DOMAIN_REPLACER = 'example.com';
 // Use a negative look-behind to avoid \nSOMEEMAIL --> \SOMEEMAIL
 const emailRegex = /(?<!\\)[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
 
+const usedEmails = {};
+
+const alreadyHashedEmails = {};
+
 export function sanitizeEmail(email: string) {
-  const hash = crypto.createHash('md5').update(email).digest('hex');
+  if (email === '') {
+    return '';
+  }
+  const originalEmail = email;
+
+  // same email, return the same hash
+  if (alreadyHashedEmails[originalEmail]) {
+    const storedHash = alreadyHashedEmails[originalEmail];
+    return `${storedHash}@${DOMAIN_REPLACER}`;
+  }
+
+  let hash = crypto
+    .createHash('shake256', { outputLength: 4 })
+    .update(email)
+    .digest('hex');
+
+  // handle hash collision, generate a new hash until we find one that is not used
+  if (usedEmails[hash]) {
+    let running = true;
+    while (running) {
+      hash = crypto
+        .createHash('shake256', { outputLength: 4 })
+        .update(hash)
+        .digest('hex');
+      if (!usedEmails[hash]) {
+        usedEmails[hash] = originalEmail;
+        alreadyHashedEmails[originalEmail] = hash;
+        running = false;
+      }
+    }
+  } else {
+    usedEmails[hash] = originalEmail;
+    alreadyHashedEmails[originalEmail] = hash;
+  }
   return `${hash}@${DOMAIN_REPLACER}`;
 }
 

--- a/scripts/user/setup-glued-users.ts
+++ b/scripts/user/setup-glued-users.ts
@@ -264,7 +264,7 @@ const getUsers = async (): Promise<Users> => {
       }
 
       let sourceOfUser = emailDomain;
-      if (emailDomain === 'ef-cms.ustaxcourt.gov') {
+      if (emailDomain === 'example.com') {
         sourceOfUser = 'gluedUserId';
       } else if (emailDomain === 'dawson.ustaxcourt.gov') {
         sourceOfUser = 'bulkImportedUserId';

--- a/scripts/user/setup-glued-users.ts
+++ b/scripts/user/setup-glued-users.ts
@@ -264,7 +264,7 @@ const getUsers = async (): Promise<Users> => {
       }
 
       let sourceOfUser = emailDomain;
-      if (emailDomain === 'example.com') {
+      if (emailDomain === 'ustc.gov') {
         sourceOfUser = 'gluedUserId';
       } else if (emailDomain === 'dawson.ustaxcourt.gov') {
         sourceOfUser = 'bulkImportedUserId';


### PR DESCRIPTION
This ticket updates existing emailReplacer email sanitization logic to significantly shorten obfuscated emails by using a new shorter domain and moving from a 32 bit hash for emails to an 8 bit hex hash complete with collision handling.

Email obfuscation happens in the production environment, to test email obfuscation and entity validation with shorter emails, this piece neeeds to be pushed to production beforehand.