### PR TITLE
9839 Bug Fix

### DIFF
--- a/web-api/src/persistence/postgres/users/getPractitionersBySearchKey.ts
+++ b/web-api/src/persistence/postgres/users/getPractitionersBySearchKey.ts
@@ -1,6 +1,9 @@
 import { Role } from '@shared/business/entities/EntityConstants';
 import { getDbReader } from '@web-api/database';
-import { DbUser, fromKyselyUser } from '@web-api/persistence/postgres/users/mapper';
+import {
+  DbUser,
+  fromKyselyUser,
+} from '@web-api/persistence/postgres/users/mapper';
 import { sql } from 'kysely';
 
 export const getPractitionersBySearchKey = async ({
@@ -14,9 +17,9 @@ export const getPractitionersBySearchKey = async ({
     reader
       .selectFrom('dwUser as u')
       .where(
-        sql<boolean>`${sql.ref('u.name')} ILIKE ${searchKey} OR ${sql.ref(
+        sql<boolean>`(${sql.ref('u.name')} ILIKE ${searchKey} OR ${sql.ref(
           'u.barNumber',
-        )} ILIKE ${searchKey}`,
+        )} ILIKE ${searchKey})`,
       )
       .where('u.role', '=', role)
       .selectAll('u')


### PR DESCRIPTION
https://github.com/ustaxcourt/ef-cms/issues/9839

There is a subtle operator precedence bug in the SQL query generated by the query builder in getPractitionersBySearchKey. Because the OR clause checking name and bar number was not wrapped in parentheses, the query unintentionally evaluates to "does this user have a name like this, or do they have a bar number like this and their role is the given role?" This meant that non-practitioner users were being returned by the query if they had a matching name. These users subsequently failed entity validation since they did not have the appropriate role.

This PR wraps the initial raw SQL in parentheses to fix this.