### PR TITLE
8847 restrict sending emails to test domains to test 1775245876

### DIFF
--- a/web-api/src/dispatchers/ses/sendBulkTemplatedEmail.test.ts
+++ b/web-api/src/dispatchers/ses/sendBulkTemplatedEmail.test.ts
@@ -134,7 +134,7 @@ describe('sendBulkTemplatedEmail', () => {
         Destinations: [
           {
             Destination: {
-              ToAddresses: ['test.email@example.com'],
+              ToAddresses: ['test.email@example.net'],
             },
             ReplacementTemplateData: JSON.stringify({
               name: 'Roslindis Angelino',
@@ -144,7 +144,7 @@ describe('sendBulkTemplatedEmail', () => {
           },
           {
             Destination: {
-              ToAddresses: ['test.email2@example.com'],
+              ToAddresses: ['test.email2@example.net'],
             },
             ReplacementTemplateData: JSON.stringify({
               name: 'Roslindis Angelino',
@@ -154,7 +154,7 @@ describe('sendBulkTemplatedEmail', () => {
           },
           {
             Destination: {
-              ToAddresses: ['test.email3@example.com'],
+              ToAddresses: ['test.email3@example.net'],
             },
             ReplacementTemplateData: JSON.stringify({
               name: 'Roslindis Angelino',
@@ -205,17 +205,17 @@ describe('sendBulkTemplatedEmail', () => {
           Destinations: [
             {
               Destination: {
-                ToAddresses: ['test.email@example.com'],
+                ToAddresses: ['test.email@example.net'],
               },
             },
             {
               Destination: {
-                ToAddresses: ['test.email2@example.com'],
+                ToAddresses: ['test.email2@example.net'],
               },
             },
             {
               Destination: {
-                ToAddresses: ['test.email3@example.com'],
+                ToAddresses: ['test.email3@example.net'],
               },
             },
           ],
@@ -225,10 +225,36 @@ describe('sendBulkTemplatedEmail', () => {
         retryCount: 0,
       }),
     ).rejects.toEqual(
-      'Could not complete service to test.email@example.com,test.email2@example.com,test.email3@example.com',
+      'Could not complete service to test.email@example.net,test.email2@example.net,test.email3@example.net',
     );
     expect(applicationContext.getEmailClient().send).toHaveBeenCalledTimes(
       MAX_SES_RETRIES + 1,
     );
   }, 30000);
+
+  it('should not skip sending emails to specific domains', async () => {
+    await sendWithRetry({
+      applicationContext,
+      params: {
+        DefaultTemplateData: undefined,
+        Destinations: [
+          {
+            Destination: {
+              ToAddresses: ['test.email@ustc.gov'],
+            },
+            ReplacementTemplateData: JSON.stringify({
+              name: 'Roslindis Angelino',
+              welcomeMessage: 'Welcome to Flavortown',
+              whoAmI: 'The Sauce Boss',
+            }),
+          },
+        ],
+        Source: 'jest@example.com',
+        Template: 'case_served',
+      },
+      retryCount: 0,
+    });
+
+    expect(applicationContext.getEmailClient().send).not.toHaveBeenCalled();
+  });
 });

--- a/web-api/src/dispatchers/ses/sendBulkTemplatedEmail.test.ts
+++ b/web-api/src/dispatchers/ses/sendBulkTemplatedEmail.test.ts
@@ -232,7 +232,59 @@ describe('sendBulkTemplatedEmail', () => {
     );
   }, 30000);
 
-  it('should not skip sending emails to specific domains', async () => {
+  it('should filter emails to specific domains', async () => {
+    applicationContext.getEmailClient().send.mockReturnValueOnce(
+      Promise.resolve({
+        ResponseMetadata: {
+          RequestId:
+            '01000176a9ec8d81-a80255bb-8ab4-4049-ba1f-6abd5b7a8098-000000',
+        },
+        Status: [
+          {
+            MessageId:
+              '01000176a9ec8d81-a80255bb-8ab4-4049-ba1f-6abd5b7a8098-000000',
+            Status: 'Success',
+          },
+        ],
+      }),
+    );
+
+    await sendWithRetry({
+      applicationContext,
+      params: {
+        DefaultTemplateData: undefined,
+        Destinations: [
+          {
+            Destination: {
+              ToAddresses: ['test.email@ustc.gov'],
+            },
+            ReplacementTemplateData: JSON.stringify({
+              name: 'Roslindis Angelino',
+              welcomeMessage: 'Welcome to Flavortown',
+              whoAmI: 'The Sauce Boss',
+            }),
+          },
+          {
+            Destination: {
+              ToAddresses: ['test.email@example.net'],
+            },
+            ReplacementTemplateData: JSON.stringify({
+              name: 'Roslindis Angelino',
+              welcomeMessage: 'Welcome to Flavortown',
+              whoAmI: 'The Sauce Boss',
+            }),
+          },
+        ],
+        Source: 'jest@example.com',
+        Template: 'case_served',
+      },
+      retryCount: 0,
+    });
+
+    expect(applicationContext.getEmailClient().send).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not send emails to specific domains', async () => {
     await sendWithRetry({
       applicationContext,
       params: {

--- a/web-api/src/dispatchers/ses/sendBulkTemplatedEmail.ts
+++ b/web-api/src/dispatchers/ses/sendBulkTemplatedEmail.ts
@@ -68,8 +68,25 @@ export const sendWithRetry = async ({
   params: SendBulkTemplatedEmailCommandInput;
   retryCount: number;
 }) => {
+  const testEmailDomains = ['@ustc.gov', '@example.com'];
   const sesClient: SESClient = applicationContext.getEmailClient();
   const { MAX_SES_RETRIES } = applicationContext.getConstants();
+
+  let sendingToTestEmail = false;
+  params.Destinations?.forEach(bulkDestination => {
+    bulkDestination.Destination?.ToAddresses?.forEach(addr => {
+      testEmailDomains.forEach(testEmail => {
+        if (addr.includes(testEmail)) sendingToTestEmail = true;
+      });
+    });
+  });
+  if (sendingToTestEmail) {
+    applicationContext.logger.info(
+      'Skipping email, test domain found in to addresses',
+      params,
+    );
+    return;
+  }
 
   applicationContext.logger.info('Bulk Email Params', params);
 

--- a/web-api/src/dispatchers/ses/sendBulkTemplatedEmail.ts
+++ b/web-api/src/dispatchers/ses/sendBulkTemplatedEmail.ts
@@ -72,6 +72,8 @@ export const sendWithRetry = async ({
   const sesClient: SESClient = applicationContext.getEmailClient();
   const { MAX_SES_RETRIES } = applicationContext.getConstants();
 
+  applicationContext.logger.info('Bulk Email Params', params);
+
   const validDestinations: BulkEmailDestination[] = [];
   params.Destinations?.forEach(bulkDestination => {
     let sendingToTestEmail = false;
@@ -95,8 +97,6 @@ export const sendWithRetry = async ({
     return;
   }
   params.Destinations = validDestinations;
-
-  applicationContext.logger.info('Bulk Email Params', params);
 
   const cmd = new SendBulkTemplatedEmailCommand(params);
   const response = await sesClient.send(cmd);

--- a/web-api/src/dispatchers/ses/sendBulkTemplatedEmail.ts
+++ b/web-api/src/dispatchers/ses/sendBulkTemplatedEmail.ts
@@ -74,17 +74,18 @@ export const sendWithRetry = async ({
 
   const validDestinations: BulkEmailDestination[] = [];
   params.Destinations?.forEach(bulkDestination => {
+    let sendingToTestEmail = false;
     bulkDestination.Destination?.ToAddresses?.forEach(addr => {
-      let sendingToTestEmail = false;
       testEmailDomains.forEach(testEmail => {
         if (addr.includes(testEmail)) sendingToTestEmail = true;
       });
-      if (!sendingToTestEmail) validDestinations.push(bulkDestination);
+    });
+    if (!sendingToTestEmail) validDestinations.push(bulkDestination);
+    else
       applicationContext.logger.info(
         'Test destination found, removing destination',
         bulkDestination,
       );
-    });
   });
   if (validDestinations.length === 0) {
     applicationContext.logger.info(

--- a/web-api/src/dispatchers/ses/sendBulkTemplatedEmail.ts
+++ b/web-api/src/dispatchers/ses/sendBulkTemplatedEmail.ts
@@ -72,21 +72,28 @@ export const sendWithRetry = async ({
   const sesClient: SESClient = applicationContext.getEmailClient();
   const { MAX_SES_RETRIES } = applicationContext.getConstants();
 
-  let sendingToTestEmail = false;
+  const validDestinations: BulkEmailDestination[] = [];
   params.Destinations?.forEach(bulkDestination => {
     bulkDestination.Destination?.ToAddresses?.forEach(addr => {
+      let sendingToTestEmail = false;
       testEmailDomains.forEach(testEmail => {
         if (addr.includes(testEmail)) sendingToTestEmail = true;
       });
+      if (!sendingToTestEmail) validDestinations.push(bulkDestination);
+      applicationContext.logger.info(
+        'Test destination found, removing destination',
+        bulkDestination,
+      );
     });
   });
-  if (sendingToTestEmail) {
+  if (validDestinations.length === 0) {
     applicationContext.logger.info(
-      'Skipping email, test domain found in to addresses',
+      'No valid destinations found, exiting',
       params,
     );
     return;
   }
+  params.Destinations = validDestinations;
 
   applicationContext.logger.info('Bulk Email Params', params);
 


### PR DESCRIPTION
As part of 8847 we are changing the domain used by obfuscated user emails in the test environment. To be sure we don't send any errant emails out to a domain that shouldn't exist we are adding filtering on the send-email function to restrict sending emails out to this domain.