### PR TITLE
9869: fix readonly advancedsearch smoketest to use new validation

### DIFF
--- a/cypress/readonly/integration/public/advanced-search.cy.ts
+++ b/cypress/readonly/integration/public/advanced-search.cy.ts
@@ -15,10 +15,19 @@ describe('advanced search pages', () => {
 
   it('should display "No Matches Found" when case search yields no results', () => {
     cy.visit('/');
-    cy.get('input#docket-number').type('99-21');
+    cy.get('input#docket-number').type('99999-21');
     cy.get('button#docket-search-button').click();
 
     cy.get('div#no-search-results').should('exist');
+  });
+
+  it('should display "Enter a valid docket number" when an invalid docket number is entered', () => {
+    cy.visit('/');
+    cy.get('input#docket-number').type('99-21');
+    cy.get('button#docket-search-button').click();
+
+    cy.get('[data-testid="error-alert"]').should('exist');
+    cy.get('span.usa-error-message').contains('Enter a valid docket number');
   });
 
   /*


### PR DESCRIPTION
Now that we're validating docket numbers before searching for them, the read-only smoketest had to be updated.

Previously, it was using an improperly-formatted docket number for the "search for a case that doesn't exist" test case. In this PR, we are now using a properly-formatted docket number for that test case and an additional test case has been added to show that the validation fires.