### PR TITLE
9869: fix trimming of bar number and docket number in advanced search

### DIFF
--- a/web-client/src/presenter/actions/AdvancedSearch/validateCaseDocketNumberSearchAction.test.ts
+++ b/web-client/src/presenter/actions/AdvancedSearch/validateCaseDocketNumberSearchAction.test.ts
@@ -54,4 +54,21 @@ describe('validateCaseDocketNumberSearchAction', () => {
     });
     expect(successStub).not.toHaveBeenCalled();
   });
+
+  it('should store a trimmed docketNumber in state', async () => {
+    const result = await runAction(validateCaseDocketNumberSearchAction, {
+      modules: {
+        presenter,
+      },
+      state: {
+        advancedSearchForm: {
+          caseSearchByDocketNumber: { docketNumber: ' 123-20 ' },
+        },
+      },
+    });
+
+    expect(
+      result.state.advancedSearchForm.caseSearchByDocketNumber.docketNumber,
+    ).toBe('123-20');
+  });
 });

--- a/web-client/src/presenter/actions/AdvancedSearch/validateCaseDocketNumberSearchAction.ts
+++ b/web-client/src/presenter/actions/AdvancedSearch/validateCaseDocketNumberSearchAction.ts
@@ -4,10 +4,11 @@ import { DocketNumberSearchValidation } from '@shared/business/entities/DocketNu
 
 /**
  * validate case advanced search form
- * @param {object} providers the providers object
- * @param {object} providers.applicationContext the application context
  * @param {Function} providers.get the cerebral get function
- * @returns {Promise} async action
+ * @param {object} providers.path the next object in the path
+ * @param {Function} providers.store the cerebral store
+ *
+ * @returns {Promise<*>} the success or error path
  */
 export const validateCaseDocketNumberSearchAction = ({
   get,

--- a/web-client/src/presenter/actions/AdvancedSearch/validateCaseDocketNumberSearchAction.ts
+++ b/web-client/src/presenter/actions/AdvancedSearch/validateCaseDocketNumberSearchAction.ts
@@ -12,13 +12,21 @@ import { DocketNumberSearchValidation } from '@shared/business/entities/DocketNu
 export const validateCaseDocketNumberSearchAction = ({
   get,
   path,
+  store,
 }: ActionProps) => {
   const { docketNumber } = get(
     state.advancedSearchForm.caseSearchByDocketNumber,
   );
 
+  const trimmedDocketNumber = docketNumber?.trim();
+
+  store.set(
+    state.advancedSearchForm.caseSearchByDocketNumber.docketNumber,
+    trimmedDocketNumber,
+  );
+
   const errors = new DocketNumberSearchValidation({
-    docketNumber: docketNumber?.trim(),
+    docketNumber: trimmedDocketNumber,
   }).getFormattedValidationErrors();
 
   const isValid = isEmpty(errors);

--- a/web-client/src/presenter/actions/AdvancedSearch/validatePractitionerSearchByBarNumberAction.test.ts
+++ b/web-client/src/presenter/actions/AdvancedSearch/validatePractitionerSearchByBarNumberAction.test.ts
@@ -54,4 +54,24 @@ describe('validatePractitionerSearchByBarNumberAction', () => {
     });
     expect(successStub).not.toHaveBeenCalled();
   });
+
+  it('should store a trimmed barNumber in state', async () => {
+    const result = await runAction(
+      validatePractitionerSearchByBarNumberAction,
+      {
+        modules: {
+          presenter,
+        },
+        state: {
+          advancedSearchForm: {
+            practitionerSearchByBarNumber: { barNumber: ' 123 ' },
+          },
+        },
+      },
+    );
+
+    expect(
+      result.state.advancedSearchForm.practitionerSearchByBarNumber.barNumber,
+    ).toBe('123');
+  });
 });

--- a/web-client/src/presenter/actions/AdvancedSearch/validatePractitionerSearchByBarNumberAction.ts
+++ b/web-client/src/presenter/actions/AdvancedSearch/validatePractitionerSearchByBarNumberAction.ts
@@ -7,6 +7,7 @@ import { BarNumberSearchValidation } from '@shared/business/entities/BarNumberSe
  * @param {object} providers the providers object
  * @param {Function} providers.get the cerebral get function
  * @param {object} providers.path the next object in the path
+ ≈
  * @returns {Promise<*>} the success or error path
  */
 export const validatePractitionerSearchByBarNumberAction = ({

--- a/web-client/src/presenter/actions/AdvancedSearch/validatePractitionerSearchByBarNumberAction.ts
+++ b/web-client/src/presenter/actions/AdvancedSearch/validatePractitionerSearchByBarNumberAction.ts
@@ -12,13 +12,21 @@ import { BarNumberSearchValidation } from '@shared/business/entities/BarNumberSe
 export const validatePractitionerSearchByBarNumberAction = ({
   get,
   path,
+  store,
 }: ActionProps) => {
   const { barNumber } = get(
     state.advancedSearchForm.practitionerSearchByBarNumber,
   );
 
+  const trimmedBarNumber = barNumber?.trim();
+
+  store.set(
+    state.advancedSearchForm.practitionerSearchByBarNumber.barNumber,
+    trimmedBarNumber,
+  );
+
   const errors = new BarNumberSearchValidation({
-    barNumber: barNumber?.trim(),
+    barNumber: trimmedBarNumber,
   }).getFormattedValidationErrors();
 
   const isValid = isEmpty(errors);


### PR DESCRIPTION
https://github.com/ustaxcourt/ef-cms/issues/9869

This PR fixes the trimming logic for bar numbers and docket numbers in advanced search. The previous attempt did not set the search term in state to the trimmed search term.