### PR TITLE
9852: fix spurious validation error about the missing Certificate of Service date

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We're so glad you're thinking about contributing to a U.S. Tax Court open source
 
 ## Code of Conduct
 
-We want to ensure a welcoming environment for all of our projects. Our staff follows the [18F Code of Conduct](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md) and all contributors should do the same.
+We want to ensure a welcoming environment for all of our projects. Our staff follows the [18F Code of Conduct](https://github.com/CDCgov/code-of-conduct/blob/master/code-of-conduct.md) and all contributors should do the same.
 
 ## Things to Be Familiar With
 

--- a/shared/src/business/entities/externalDocument/ExternalDocumentInformationFactory.test.ts
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentInformationFactory.test.ts
@@ -93,6 +93,11 @@ describe('ExternalDocumentInformationFactory', () => {
         expect(errors().certificateOfServiceDate).toEqual(undefined);
       });
 
+      it('should not require certificate of service date when generationType is auto', () => {
+        baseDoc.generationType = GENERATION_TYPES.AUTO;
+        expect(errors().certificateOfServiceDate).toEqual(undefined);
+      });
+
       it('should not allow certificate of service date to be in the future', () => {
         baseDoc.certificateOfServiceDate = calculateISODate({
           howMuch: 1,

--- a/shared/src/business/entities/externalDocument/ExternalDocumentInformationFactory.ts
+++ b/shared/src/business/entities/externalDocument/ExternalDocumentInformationFactory.ts
@@ -199,7 +199,10 @@ export class ExternalDocumentInformationFactory extends JoiValidationEntity {
       (this.currentUser.role === ROLES.privatePractitioner ||
         this.currentUser.role === ROLES.irsPractitioner);
 
-    if (this.certificateOfService === true) {
+    if (
+      this.certificateOfService === true &&
+      this.generationType !== GENERATION_TYPES.AUTO
+    ) {
       makeRequired('certificateOfServiceDate');
     }
 

--- a/web-client/src/presenter/actions/clearCaseAssociationWizardDataAction.test.ts
+++ b/web-client/src/presenter/actions/clearCaseAssociationWizardDataAction.test.ts
@@ -5,6 +5,26 @@ import { runAction } from '@web-client/presenter/test.cerebral';
 describe('clearCaseAssociationWizardDataAction', () => {
   const { OBJECTIONS_OPTIONS_MAP } = applicationContext.getConstants();
 
+  it('clears certificateOfService and certificateOfServiceDate when generationType changes', async () => {
+    const result = await runAction(clearCaseAssociationWizardDataAction, {
+      props: {
+        key: 'generationType',
+        value: 'auto',
+      },
+      state: {
+        form: {
+          certificateOfService: true,
+          certificateOfServiceDate: applicationContext
+            .getUtilities()
+            .createISODateString(),
+        },
+      },
+    });
+
+    expect(result.state.form.certificateOfService).toEqual(undefined);
+    expect(result.state.form.certificateOfServiceDate).toEqual(undefined);
+  });
+
   it('clears certificateOfService', async () => {
     const result = await runAction(clearCaseAssociationWizardDataAction, {
       props: {

--- a/web-client/src/presenter/actions/clearCaseAssociationWizardDataAction.ts
+++ b/web-client/src/presenter/actions/clearCaseAssociationWizardDataAction.ts
@@ -10,6 +10,10 @@ export const clearCaseAssociationWizardDataAction = ({
   store,
 }: ActionProps) => {
   switch (props.key) {
+    case 'generationType':
+      store.unset(state.form.certificateOfService);
+      store.unset(state.form.certificateOfServiceDate);
+      break;
     case 'certificateOfService':
       store.unset(state.form.certificateOfServiceDate);
       break;


### PR DESCRIPTION
https://github.com/ustaxcourt/ef-cms/issues/9852

When switching from "Upload PDF" to "Auto-Generate PDF" on the file upload page (Notice of Withdrawal of Counsel / Entry of Appearance workflows), the certificate of service form fields were not cleared from state. This caused a spurious validation error about the missing Certificate of Service date, even though that field is not applicable in auto-generate mode.

This PR fixes the issue in two layers:

1. **`clearCaseAssociationWizardDataAction`** — Added a `generationType` case to clear `certificateOfService` and `certificateOfServiceDate` from form state when the user switches generation mode.
2. **`ExternalDocumentInformationFactory`** — `certificateOfServiceDate` is now only required when `certificateOfService === true` *and* `generationType` is not `auto` (defense in depth).

Tests added for both changes.

Also fixes a broken Code of Conduct link in `CONTRIBUTING.md` (the `18F/code-of-conduct` repo no longer exists; updated to `CDCgov/code-of-conduct`).