### PR TITLE
9917: give internal users access to case confirmation documents for cases filed before early 2022

### DIFF
--- a/web-api/src/business/useCases/document/getDownloadPolicyUrlInteractor.test.ts
+++ b/web-api/src/business/useCases/document/getDownloadPolicyUrlInteractor.test.ts
@@ -108,7 +108,7 @@ describe('getDownloadPolicyUrlInteractor', () => {
       ).rejects.toThrow('Unauthorized');
     });
 
-    it('should throw an unauthorized error when the document being viewed is the case confirmation pdf', async () => {
+    it('should throw an unauthorized error when the document being viewed is the case confirmation pdf and the external user is not associated with the case', async () => {
       await expect(
         getDownloadPolicyUrlInteractor(
           applicationContext,
@@ -471,7 +471,7 @@ describe('getDownloadPolicyUrlInteractor', () => {
       expect(url).toEqual('localhost');
     });
 
-    it('should return the policy url when the document requested is a case confirmation pdf', async () => {
+    it('should return the policy url for an external user is associated with the case when the document requested is a case confirmation pdf', async () => {
       const url = await getDownloadPolicyUrlInteractor(
         applicationContext,
         {
@@ -479,6 +479,19 @@ describe('getDownloadPolicyUrlInteractor', () => {
           key: 'case-101-18-confirmation.pdf',
         },
         mockPetitionerUser,
+      );
+
+      expect(url).toEqual('localhost');
+    });
+
+    it('should return the policy url for an internal user when the document requested is a case confirmation pdf', async () => {
+      const url = await getDownloadPolicyUrlInteractor(
+        applicationContext,
+        {
+          docketNumber: MOCK_CASE.docketNumber,
+          key: 'case-101-18-confirmation.pdf',
+        },
+        mockDocketClerkUser,
       );
 
       expect(url).toEqual('localhost');
@@ -978,7 +991,7 @@ describe('getDownloadPolicyUrlInteractor', () => {
       expect(url).toEqual('localhost');
     });
 
-    it('should throw an error when the document requested is an available document and the user is not associated with the consolidated group', async () => {
+    it('should throw an error when the document requested is an available document and the user is external and not associated with the consolidated group', async () => {
       await expect(
         getDownloadPolicyUrlInteractor(
           applicationContext,

--- a/web-api/src/business/useCases/document/getDownloadPolicyUrlInteractor.ts
+++ b/web-api/src/business/useCases/document/getDownloadPolicyUrlInteractor.ts
@@ -33,7 +33,8 @@ export const getDownloadPolicyUrlInteractor = async (
   if (key.includes('.pdf')) {
     if (
       caseEntity.getCaseConfirmationGeneratedPdfFileName() !== key ||
-      !caseEntity.userHasAccessToCase(authorizedUser)
+      (!caseEntity.userHasAccessToCase(authorizedUser) &&
+        !User.isInternalUser(authorizedUser.role))
     ) {
       throw new UnauthorizedError('Unauthorized');
     }


### PR DESCRIPTION
- Cases filed prior to early 2022 do not have an NOTR, but have a "case confirmation pdf"
- These are accessed via the `Print Confirmation` button on the case detail
- This is throwing errors for users "not associated with the case" (not directly party to the case)
- Internal users are all associated with the case (practically speaking)