### PR TITLE
8877: refactor migration to avoid downtime

### DIFF
--- a/web-api/src/persistence/postgres/utils/migrate/migrations/2026-03-25T00_00_00Z-rename-paperPetitionEmail-to-contactEmailAddress.contract.ts
+++ b/web-api/src/persistence/postgres/utils/migrate/migrations/2026-03-25T00_00_00Z-rename-paperPetitionEmail-to-contactEmailAddress.contract.ts
@@ -1,6 +1,13 @@
 import { Kysely, sql } from 'kysely';
 
 export async function up(db: Kysely<any>): Promise<void> {
+  await sql`DROP TRIGGER IF EXISTS trg_sync_petitioner_email_fields ON dw_case;`.execute(
+    db,
+  );
+  await sql`DROP FUNCTION IF EXISTS sync_petitioner_email_fields();`.execute(
+    db,
+  );
+
   await sql`
     UPDATE dw_case
     SET petitioners = (
@@ -9,13 +16,6 @@ export async function up(db: Kysely<any>): Promise<void> {
     )
     WHERE petitioners::text LIKE '%paperPetitionEmail%'
   `.execute(db);
-
-  await sql`DROP TRIGGER IF EXISTS trg_sync_petitioner_email_fields ON dw_case;`.execute(
-    db,
-  );
-  await sql`DROP FUNCTION IF EXISTS sync_petitioner_email_fields();`.execute(
-    db,
-  );
 }
 
 export async function down(db: Kysely<any>): Promise<void> {

--- a/web-api/src/persistence/postgres/utils/migrate/migrations/2026-03-25T00_00_00Z-rename-paperPetitionEmail-to-contactEmailAddress.contract.ts
+++ b/web-api/src/persistence/postgres/utils/migrate/migrations/2026-03-25T00_00_00Z-rename-paperPetitionEmail-to-contactEmailAddress.contract.ts
@@ -4,18 +4,38 @@ export async function up(db: Kysely<any>): Promise<void> {
   await sql`
     UPDATE dw_case
     SET petitioners = (
-      SELECT jsonb_agg(
-        CASE
-          WHEN elem ? 'paperPetitionEmail' AND NOT elem ? 'contactEmailAddress'
-          THEN elem || jsonb_build_object('contactEmailAddress', elem->'paperPetitionEmail')
-          ELSE elem
-        END
-      )
+      SELECT jsonb_agg(elem - 'paperPetitionEmail')
       FROM jsonb_array_elements(petitioners) AS elem
     )
     WHERE petitioners::text LIKE '%paperPetitionEmail%'
   `.execute(db);
 
+  await sql`DROP TRIGGER IF EXISTS trg_sync_petitioner_email_fields ON dw_case;`.execute(
+    db,
+  );
+  await sql`DROP FUNCTION IF EXISTS sync_petitioner_email_fields();`.execute(
+    db,
+  );
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  // Recreate paperPetitionEmail from contactEmailAddress
+  await sql`
+    UPDATE dw_case
+    SET petitioners = (
+      SELECT jsonb_agg(
+        CASE
+          WHEN elem ? 'contactEmailAddress' AND NOT elem ? 'paperPetitionEmail'
+          THEN elem || jsonb_build_object('paperPetitionEmail', elem->'contactEmailAddress')
+          ELSE elem
+        END
+      )
+      FROM jsonb_array_elements(petitioners) AS elem
+    )
+    WHERE petitioners::text LIKE '%contactEmailAddress%'
+  `.execute(db);
+
+  // Recreate trigger function
   await sql`
     CREATE OR REPLACE FUNCTION sync_petitioner_email_fields()
     RETURNS trigger
@@ -38,41 +58,15 @@ export async function up(db: Kysely<any>): Promise<void> {
 
       RETURN NEW;
     END;
-    $$ LANGUAGE plpgsql
+    $$ LANGUAGE plpgsql;
   `.execute(db);
 
+  // Recreate trigger
   await sql`
-    DROP TRIGGER IF EXISTS trg_sync_petitioner_email_fields ON dw_case;
     CREATE TRIGGER trg_sync_petitioner_email_fields
     BEFORE INSERT OR UPDATE OF petitioners
     ON dw_case
     FOR EACH ROW
-    EXECUTE FUNCTION sync_petitioner_email_fields()
-  `.execute(db);
-}
-
-export async function down(db: Kysely<any>): Promise<void> {
-  await sql`
-    UPDATE dw_case
-    SET petitioners = (
-      SELECT jsonb_agg(
-        CASE
-          WHEN elem ? 'paperPetitionEmail'
-               AND elem ? 'contactEmailAddress'
-          THEN elem - 'contactEmailAddress'
-          ELSE elem
-        END
-      )
-      FROM jsonb_array_elements(petitioners) AS elem
-    )
-    WHERE petitioners::text LIKE '%contactEmailAddress%'
-  `.execute(db);
-
-  await sql`
-    DROP TRIGGER IF EXISTS trg_sync_petitioner_email_fields ON dw_case;
-  `.execute(db);
-
-  await sql`
-    DROP FUNCTION IF EXISTS sync_petitioner_email_fields();
+    EXECUTE FUNCTION sync_petitioner_email_fields();
   `.execute(db);
 }

--- a/web-api/src/persistence/postgres/utils/migrate/migrations/2026-03-25T00_00_00Z-rename-paperPetitionEmail-to-contactEmailAddress.ts
+++ b/web-api/src/persistence/postgres/utils/migrate/migrations/2026-03-25T00_00_00Z-rename-paperPetitionEmail-to-contactEmailAddress.ts
@@ -53,26 +53,19 @@ export async function up(db: Kysely<any>): Promise<void> {
 
 export async function down(db: Kysely<any>): Promise<void> {
   await sql`
-    UPDATE dw_case
-    SET petitioners = (
-      SELECT jsonb_agg(
-        CASE
-          WHEN elem ? 'paperPetitionEmail'
-               AND elem ? 'contactEmailAddress'
-          THEN elem - 'contactEmailAddress'
-          ELSE elem
-        END
-      )
-      FROM jsonb_array_elements(petitioners) AS elem
-    )
-    WHERE petitioners::text LIKE '%contactEmailAddress%'
-  `.execute(db);
-
-  await sql`
     DROP TRIGGER IF EXISTS trg_sync_petitioner_email_fields ON dw_case;
   `.execute(db);
 
   await sql`
     DROP FUNCTION IF EXISTS sync_petitioner_email_fields();
+  `.execute(db);
+
+  await sql`
+    UPDATE dw_case
+    SET petitioners = (
+      SELECT jsonb_agg(elem - 'contactEmailAddress')
+      FROM jsonb_array_elements(petitioners) AS elem
+    )
+    WHERE petitioners::text LIKE '%contactEmailAddress%'
   `.execute(db);
 }


### PR DESCRIPTION
# Summary    
                                                                                                                      
  Renames the `paperPetitionEmail` JSONB property in `dw_case.petitioners` to `contactEmailAddress` without a         
  deployment downtime window.
                                                                                                                      
  ## The problem                    
                                                                                                                      
  During a blue/green deploy, the expand migration runs while blue lambdas are still serving traffic. A simple        
  one-shot rename (delete old key, add new key) would break blue reads/writes mid-deploy, since blue still expects    
  `paperPetitionEmail`.                                                                                               
                                    
  ## The fix

  Split the rename into the expand/contract pattern the migration runner already supports.                            
  
  - **Expand** (pre-switch, runs in `migrate` job): backfills `contactEmailAddress` on existing rows and installs a   
  `BEFORE INSERT OR UPDATE OF petitioners` trigger on `dw_case` that keeps both keys in sync on every write. Blue
  continues to read/write `paperPetitionEmail` unharmed; green reads/writes `contactEmailAddress`; the trigger mirrors
   both directions so neither side sees a missing field.
  - **Contract** (`.contract.ts`, runs post-switch in `cleanup` job): drops the trigger first, then strips
  `paperPetitionEmail` from every petitioner. By the time this runs, blue is no longer serving traffic.               
   
  Result: one CI deployment, zero downtime, no code changes outside the two migration files.