### PR TITLE
Dependency updates 04 20 2026 dwt to test 1776804200

### DIFF
--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -296,7 +296,7 @@ Below is a list of dependencies that are locked down due to known issues with se
    - I debugged this by temporarily ignoring the smoketests in search.cy.ts in order for the build to pass and deploy to an exp environment. From there I ran the cypress smoketests on the exp environement locally, found the error in cloudwatch logs, tested multiple fixes and made the neccessary changes.
 
 ### DWT
-**Current Installed DWT: 19.3.2**
+**Current Installed DWT: 19.3.3**
 - Minor and patch versions of DWT _should_ be updated, but require that Court IT update the Windows clients in concert with our app. If an update is available for DWT, coordinate with Court IT to have the Dynamsoft client updated on Court-owned Windows machines. Only update DWT once the Windows clients have all been confirmed to have received the update.
 
 ### puppeteer and @sparticuz/chromium

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "deep-freeze": "0.0.1",
         "diff-arrays-of-objects": "1.1.9",
         "dom-serializer": "3.0.0",
-        "dwt": "19.3.2",
+        "dwt": "19.3.3",
         "english-ordinals": "3.4.0",
         "exceljs": "4.4.0",
         "export-to-csv": "1.4.0",
@@ -18217,9 +18217,9 @@
       }
     },
     "node_modules/dwt": {
-      "version": "19.3.2",
-      "resolved": "https://registry.npmjs.org/dwt/-/dwt-19.3.2.tgz",
-      "integrity": "sha512-RaiBbr+UTrdg8i0xeIVxJk/wUEr921sHYSj/MhUqFJ5VH/hYbLz429eMzULEn+mhhShZmJLfHcYXfFW1d1iQQQ==",
+      "version": "19.3.3",
+      "resolved": "https://registry.npmjs.org/dwt/-/dwt-19.3.3.tgz",
+      "integrity": "sha512-JfCZnRKS2RkYUFurTsE/yiOl/6ybnp8t4h9f3lK1lSYnWbtOAyi077sIaVy/PbKA3a4umeHDrPyBwJ3ymWVgew==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "dynamsoft-core": "*"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "deep-freeze": "0.0.1",
     "diff-arrays-of-objects": "1.1.9",
     "dom-serializer": "3.0.0",
-    "dwt": "19.3.2",
+    "dwt": "19.3.3",
     "english-ordinals": "3.4.0",
     "exceljs": "4.4.0",
     "export-to-csv": "1.4.0",


### PR DESCRIPTION
### SUMMARY

As part of the dependency updates, we deploy a version containing only upgrades to `dwt` to `test` to conduct regression testing and backward compatibility. 