### PR TITLE
devex: fix api-hosted-environment-test failures

### DIFF
--- a/web-api/hostedEnvironmentTests/jest-hosted-environment.ts
+++ b/web-api/hostedEnvironmentTests/jest-hosted-environment.ts
@@ -17,6 +17,7 @@ const config: Config = {
   transform: {
     '\\.[jt]sx?$': ['babel-jest', { rootMode: 'upward' }],
   },
+  transformIgnorePatterns: ['node_modules/(?!(@nodable/entities)/)'],
 };
 
 export default config;


### PR DESCRIPTION
We are now seeing this failure in the API hosted environment Cypress tests in some builds in CircleCI:

```
> ef-cms@0.1.0 test:api:hosted-environment
> jest --config web-api/hostedEnvironmentTests/jest-hosted-environment.ts

 FAIL  web-api/hostedEnvironmentTests/irsSuperUser.test.ts
  ● Test suite failed to run

    Jest encountered an unexpected token

    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.

    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.

    By default "node_modules" folder is ignored by transformers.

    Here's what you can do:
     • If you are trying to use ECMAScript Modules, see https://jestjs.io/docs/ecmascript-modules for how to enable it.
     • If you are trying to use TypeScript, see https://jestjs.io/docs/getting-started#using-typescript
     • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.
     • If you need a custom transformation, specify a "transform" option in your config.
     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.

    You'll find more details and examples of these config options in the docs:
    https://jestjs.io/docs/configuration
    For information about custom transformations, see:
    https://jestjs.io/docs/code-transformation

    Details:

    /root/project/node_modules/@nodable/entities/src/index.js:9
    export { default as EntityDecoder } from './EntityDecoder.js';
    ^^^^^^

    SyntaxError: Unexpected token 'export'

      1 | /* eslint-disable prefer-destructuring */
    > 2 | import {
        | ^
      3 |   AuthFlowType,
      4 |   ChallengeNameType,
      5 |   CognitoIdentityProvider,

      at Runtime.createScriptFromCode (../../node_modules/jest-runtime/build/index.js:1314:40)
      at Object.<anonymous> (../../node_modules/@aws-sdk/xml-builder/dist-cjs/xml-parser.js:4:20)
      at Object.<anonymous> (../../node_modules/@aws-sdk/xml-builder/dist-cjs/index.js:3:17)
      at Object.<anonymous> (../../node_modules/@aws-sdk/core/dist-cjs/submodules/protocols/index.js:10:18)
      at Object.<anonymous> (../../node_modules/@aws-sdk/client-cognito-identity-provider/dist-cjs/runtimeConfig.shared.js:5:21)
      at Object.<anonymous> (../../node_modules/@aws-sdk/client-cognito-identity-provider/dist-cjs/runtimeConfig.js:19:32)
      at Object.<anonymous> (../../node_modules/@aws-sdk/client-cognito-identity-provider/dist-cjs/index.js:15:21)
      at Object.require (irsSuperUser.test.ts:2:1)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        1.092 s
Ran all test suites.

Exited with code exit status 1
```

This PR resolves that error.