### PR TITLE
devex: isolate throttle state between client tests

### DIFF
--- a/web-client/src/presenter/computeds/fileUploadStatusHelper.test.ts
+++ b/web-client/src/presenter/computeds/fileUploadStatusHelper.test.ts
@@ -1,4 +1,7 @@
-import { fileUploadStatusHelper } from './fileUploadStatusHelper';
+import {
+  createFileUploadStatusHelper,
+  fileUploadStatusHelper,
+} from './fileUploadStatusHelper';
 import { runCompute } from '@web-client/presenter/test.cerebral';
 
 describe('fileUploadStatusHelper', () => {
@@ -129,8 +132,22 @@ describe('fileUploadStatusHelper', () => {
   });
 
   describe('throttled messages', () => {
+    let throttledFileUploadStatusHelper: ReturnType<
+      typeof createFileUploadStatusHelper
+    >;
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      throttledFileUploadStatusHelper = createFileUploadStatusHelper();
+    });
+
+    afterEach(() => {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    });
+
     it('throttles the message inside of a three-second window', () => {
-      const result1 = runCompute(fileUploadStatusHelper, {
+      const result1 = runCompute(throttledFileUploadStatusHelper, {
         state: {
           fileUploadProgress: {
             isUploading: true,
@@ -142,7 +159,7 @@ describe('fileUploadStatusHelper', () => {
 
       expect(result1.statusMessage).toEqual('Preparing Upload');
 
-      const result2 = runCompute(fileUploadStatusHelper, {
+      const result2 = runCompute(throttledFileUploadStatusHelper, {
         state: {
           fileUploadProgress: {
             isUploading: true,
@@ -155,8 +172,8 @@ describe('fileUploadStatusHelper', () => {
       expect(result2.statusMessage).toEqual(result1.statusMessage);
     });
 
-    it('will update the message returned if executions are more than three seconds apart', async () => {
-      const result1 = runCompute(fileUploadStatusHelper, {
+    it('will update the message returned if executions are more than three seconds apart', () => {
+      const result1 = runCompute(throttledFileUploadStatusHelper, {
         state: {
           fileUploadProgress: {
             isUploading: true,
@@ -168,9 +185,9 @@ describe('fileUploadStatusHelper', () => {
 
       expect(result1.statusMessage).toEqual('Preparing Upload');
 
-      await new Promise(resolve => setTimeout(resolve, 3000));
+      jest.advanceTimersByTime(3001);
 
-      const result2 = runCompute(fileUploadStatusHelper, {
+      const result2 = runCompute(throttledFileUploadStatusHelper, {
         state: {
           fileUploadProgress: {
             isUploading: true,

--- a/web-client/src/presenter/computeds/fileUploadStatusHelper.ts
+++ b/web-client/src/presenter/computeds/fileUploadStatusHelper.ts
@@ -2,43 +2,60 @@ import { Get } from 'cerebral';
 import { state } from '@web-client/presenter/app.cerebral';
 import { throttle } from 'lodash';
 
-const throttledStatus = throttle(statusMessage => statusMessage, 3000, {
-  leading: true,
-});
+export type FileUploadStatusHelperType = {
+  isHavingSystemIssues: boolean;
+  statusMessage: string;
+};
 
-export const fileUploadStatusHelper = (get: Get): any => {
-  const timeRemaining = get(state.fileUploadProgress.timeRemaining);
-  const percentComplete = get(state.fileUploadProgress.percentComplete);
-  const isUploading = get(state.fileUploadProgress.isUploading);
-  const isHavingSystemIssues = get(
-    state.fileUploadProgress.isHavingSystemIssues,
+export const createFileUploadStatusHelper = (): ((
+  get: Get,
+) => FileUploadStatusHelperType) => {
+  const throttledStatus = throttle(
+    (statusMessage: string): string => {
+      return statusMessage;
+    },
+    3000,
+    {
+      leading: true,
+    },
   );
-  const shouldThrottle = !get(state.fileUploadProgress.noThrottle); // results WILL be throttled unless explicitly set to false
 
-  let statusMessage;
+  return (get: Get): FileUploadStatusHelperType => {
+    const timeRemaining = get(state.fileUploadProgress.timeRemaining);
+    const percentComplete = get(state.fileUploadProgress.percentComplete);
+    const isUploading = get(state.fileUploadProgress.isUploading);
+    const isHavingSystemIssues = get(
+      state.fileUploadProgress.isHavingSystemIssues,
+    );
+    const shouldThrottle = !get(state.fileUploadProgress.noThrottle); // results WILL be throttled unless explicitly set to false
 
-  if (percentComplete === 100) {
-    statusMessage = 'Just Finishing Up';
-  } else if (!Number.isFinite(timeRemaining)) {
-    statusMessage = 'Preparing Upload';
-  } else if (timeRemaining < 60) {
-    statusMessage = 'Less Than 1 Minute Left';
-  } else if (timeRemaining < 60 * 60) {
-    statusMessage = `${Math.floor(timeRemaining / 60)} Minutes Left`;
-  } else {
-    statusMessage = `${Math.floor(timeRemaining / 3600)} Hours ${Math.floor(
-      (timeRemaining % 3600) / 60,
-    )} Minutes Left`;
-  }
+    let statusMessage: string;
 
-  if (!isUploading) {
-    statusMessage = 'All Done!';
-  }
+    if (percentComplete === 100) {
+      statusMessage = 'Just Finishing Up';
+    } else if (!Number.isFinite(timeRemaining)) {
+      statusMessage = 'Preparing Upload';
+    } else if (timeRemaining < 60) {
+      statusMessage = 'Less Than 1 Minute Left';
+    } else if (timeRemaining < 60 * 60) {
+      statusMessage = `${Math.floor(timeRemaining / 60)} Minutes Left`;
+    } else {
+      statusMessage = `${Math.floor(timeRemaining / 3600)} Hours ${Math.floor(
+        (timeRemaining % 3600) / 60,
+      )} Minutes Left`;
+    }
 
-  return {
-    isHavingSystemIssues,
-    statusMessage: shouldThrottle
-      ? throttledStatus(statusMessage)
-      : statusMessage,
+    if (!isUploading) {
+      statusMessage = 'All Done!';
+    }
+
+    return {
+      isHavingSystemIssues,
+      statusMessage: shouldThrottle
+        ? throttledStatus(statusMessage)
+        : statusMessage,
+    };
   };
 };
+
+export const fileUploadStatusHelper = createFileUploadStatusHelper();

--- a/web-client/src/presenter/computeds/fileUploadStatusHelper.ts
+++ b/web-client/src/presenter/computeds/fileUploadStatusHelper.ts
@@ -27,7 +27,7 @@ export const createFileUploadStatusHelper = (): ((
     const isHavingSystemIssues = get(
       state.fileUploadProgress.isHavingSystemIssues,
     );
-    const shouldThrottle = !get(state.fileUploadProgress.noThrottle); // results WILL be throttled unless explicitly set to false
+    const shouldThrottle = !get(state.fileUploadProgress.noThrottle);
 
     let statusMessage: string;
 


### PR DESCRIPTION
## Summary
Stabilizes `web-client/src/presenter/computeds/fileUploadStatusHelper.test.ts` by removing real-time timing dependence and isolating `lodash/throttle` state between tests.

## Problem
`fileUploadStatusHelper` had throttling tests that depended on:

- a real `3000ms` wait
- a module-scoped throttled function shared across test cases

That combination made the test vulnerable to timing boundary issues and leaked throttle state between tests, which could cause intermittent failures depending on execution order, scheduler timing, or environment load.

## Root Cause
The likely cause of the failure/flakiness was:

1. **Shared throttle instance**
   - `throttledStatus` was created once at module scope in `fileUploadStatusHelper.ts`
   - `lodash/throttle` keeps internal timing/invocation state
   - throttled tests could influence one another

2. **Exact real-time boundary**
   - the test waited exactly `3000ms`
   - asserting behavior at the precise throttle boundary is fragile

## Changes

### `web-client/src/presenter/computeds/fileUploadStatusHelper.ts`
- added explicit helper return type: `FileUploadStatusHelperType`
- introduced `createFileUploadStatusHelper()`
- kept the production export as:
  - `export const fileUploadStatusHelper = createFileUploadStatusHelper();`

This preserves runtime behavior while allowing tests to create isolated helper instances.

### `web-client/src/presenter/computeds/fileUploadStatusHelper.test.ts`
- updated throttled tests to use `jest.useFakeTimers()`
- created a fresh helper instance per throttled test via `createFileUploadStatusHelper()`
- replaced real `setTimeout(..., 3000)` with:
  - `jest.advanceTimersByTime(3001)`

## Why this approach
This keeps app behavior unchanged while making the tests deterministic and isolated. It avoids relying on real clock timing and removes cross-test coupling caused by shared throttle state.