### PR TITLE
9915 - removing the hard coded completed as technically its not yet c…

### DIFF
--- a/web-api/src/business/useCases/document/serveExternallyFiledDocumentInteractor.test.ts
+++ b/web-api/src/business/useCases/document/serveExternallyFiledDocumentInteractor.test.ts
@@ -492,6 +492,68 @@ describe('serveExternallyFiledDocumentInteractor', () => {
     expect(addCoversheetArgs.bypassIdempotencyGate).toBe(false);
   });
 
+  it('should bypass the addCoversheetInteractor idempotency gate when the subject docket entry is a simultaneous document type (event code), so a second service-stamped coversheet is prepended on top of the file-time coversheet', async () => {
+    getCaseByDocketNumber.mockResolvedValue({
+      ...mockCase,
+      docketEntries: [
+        {
+          docketEntryId: mockDocketEntryId,
+          documentTitle: 'fake title',
+          eventCode: SIMULTANEOUS_DOCUMENT_EVENT_CODES[0],
+          processingStatus: DOCUMENT_PROCESSING_STATUS_OPTIONS.COMPLETE,
+        } as RawDocketEntry,
+      ],
+    });
+
+    await serveExternallyFiledDocumentInteractor(
+      applicationContext,
+      {
+        clientConnectionId: '',
+        docketEntryId: mockDocketEntryId,
+        docketNumbers: [],
+        subjectCaseDocketNumber: mockCase.docketNumber,
+      },
+      mockDocketClerkUser,
+    );
+
+    const addCoversheetInteractorMock =
+      applicationContext.getUseCases().addCoversheetInteractor as jest.Mock;
+    const addCoversheetArgs = addCoversheetInteractorMock.mock.calls[0][1];
+
+    expect(addCoversheetArgs.bypassIdempotencyGate).toBe(true);
+  });
+
+  it('should bypass the addCoversheetInteractor idempotency gate when the subject docket entry title contains "Simultaneous"', async () => {
+    getCaseByDocketNumber.mockResolvedValue({
+      ...mockCase,
+      docketEntries: [
+        {
+          docketEntryId: mockDocketEntryId,
+          documentTitle: 'Simultaneous Answering Brief',
+          eventCode: 'BRF',
+          processingStatus: DOCUMENT_PROCESSING_STATUS_OPTIONS.COMPLETE,
+        } as RawDocketEntry,
+      ],
+    });
+
+    await serveExternallyFiledDocumentInteractor(
+      applicationContext,
+      {
+        clientConnectionId: '',
+        docketEntryId: mockDocketEntryId,
+        docketNumbers: [],
+        subjectCaseDocketNumber: mockCase.docketNumber,
+      },
+      mockDocketClerkUser,
+    );
+
+    const addCoversheetInteractorMock =
+      applicationContext.getUseCases().addCoversheetInteractor as jest.Mock;
+    const addCoversheetArgs = addCoversheetInteractorMock.mock.calls[0][1];
+
+    expect(addCoversheetArgs.bypassIdempotencyGate).toBe(true);
+  });
+
   it('should only serve the docket entry on the subjectCase when the subject docket entry is a simultaneous document type', async () => {
     const mockMemberCaseDocketNumber = '999-15';
 

--- a/web-api/src/business/useCases/document/serveExternallyFiledDocumentInteractor.test.ts
+++ b/web-api/src/business/useCases/document/serveExternallyFiledDocumentInteractor.test.ts
@@ -452,14 +452,14 @@ describe('serveExternallyFiledDocumentInteractor', () => {
     );
   });
 
-  it('should set the docket entry`s processing status as completed', async () => {
+  it('should not prematurely mark the docket entry as COMPLETE before the coversheet step runs, so the addCoversheetInteractor idempotency gate does not short-circuit', async () => {
     getCaseByDocketNumber.mockResolvedValue({
       ...mockCase,
       docketEntries: [
         {
           docketEntryId: mockDocketEntryId,
           documentTitle: 'fake title',
-          processingStatus: 'abc',
+          processingStatus: DOCUMENT_PROCESSING_STATUS_OPTIONS.PENDING,
         } as RawDocketEntry,
       ],
     });
@@ -478,7 +478,18 @@ describe('serveExternallyFiledDocumentInteractor', () => {
     expect(
       fileAndServeDocumentOnOneCase.mock.calls[0][0].docketEntryEntity
         .processingStatus,
-    ).toBe(DOCUMENT_PROCESSING_STATUS_OPTIONS.COMPLETE);
+    ).not.toBe(DOCUMENT_PROCESSING_STATUS_OPTIONS.COMPLETE);
+
+    const addCoversheetInteractorMock =
+      applicationContext.getUseCases().addCoversheetInteractor as jest.Mock;
+    const addCoversheetArgs = addCoversheetInteractorMock.mock.calls[0][1];
+    const docketEntryPassedToCoversheet = addCoversheetArgs.caseEntity
+      .getDocketEntryById({ docketEntryId: mockDocketEntryId });
+
+    expect(docketEntryPassedToCoversheet.processingStatus).not.toBe(
+      DOCUMENT_PROCESSING_STATUS_OPTIONS.COMPLETE,
+    );
+    expect(addCoversheetArgs.bypassIdempotencyGate).toBe(false);
   });
 
   it('should only serve the docket entry on the subjectCase when the subject docket entry is a simultaneous document type', async () => {

--- a/web-api/src/business/useCases/document/serveExternallyFiledDocumentInteractor.ts
+++ b/web-api/src/business/useCases/document/serveExternallyFiledDocumentInteractor.ts
@@ -9,7 +9,6 @@ import {
 import { Case, isLeadCase } from '@shared/business/entities/cases/Case';
 import { DocketEntry } from '@shared/business/entities/DocketEntry';
 import {
-  DOCUMENT_PROCESSING_STATUS_OPTIONS,
   DOCUMENT_SERVED_MESSAGES,
   SIMULTANEOUS_DOCUMENT_EVENT_CODES,
 } from '@shared/business/entities/EntityConstants';
@@ -140,7 +139,6 @@ export const serveExternallyFiledDocument = async (
             multiDocketedOn: docketNumbers,
             originallyFiledDocketNumber: subjectCaseDocketNumber,
             numberOfPages,
-            processingStatus: DOCUMENT_PROCESSING_STATUS_OPTIONS.COMPLETE,
           },
           { authorizedUser },
         );

--- a/web-api/src/business/useCases/document/serveExternallyFiledDocumentInteractor.ts
+++ b/web-api/src/business/useCases/document/serveExternallyFiledDocumentInteractor.ts
@@ -167,10 +167,16 @@ export const serveExternallyFiledDocument = async (
     // produce a finished, coversheet-attached PDF before the response so
     // the document is ready for service. Queueing here would require the
     // service step to wait on a poll, which we haven't built yet.
+    //
+    // Simultaneous-brief types prepend a NEW coversheet (with the service
+    // stamp) on top of the file-time coversheet, so we must bypass the
+    // idempotency gate — the file step already marked the entry COMPLETE,
+    // and without the bypass the gate would short-circuit and the served
+    // PDF would be missing the service-stamped coversheet.
     await applicationContext.getUseCases().addCoversheetInteractor(
       applicationContext,
       {
-        bypassIdempotencyGate: false,
+        bypassIdempotencyGate: subjectCaseIsSimultaneousDocType,
         caseEntity: updatedSubjectCaseEntity,
         docketEntryId: updatedSubjectDocketEntry.docketEntryId,
         docketNumber: updatedSubjectCaseEntity!.docketNumber,


### PR DESCRIPTION
recent changes for the coversheet worker adds a check to not reprocess the same coversheet, but that caused a Simultaneous Briefs to fail to add the second coversheet on serve.