### PR TITLE
9584: strip whitespace-only additional order clauses; persist only real text; ui keeps one blank first field

### DIFF
--- a/web-client/src/business/entities/MotionOrderResponseForm.test.ts
+++ b/web-client/src/business/entities/MotionOrderResponseForm.test.ts
@@ -11,6 +11,21 @@ import {
 
 describe('MotionOrderResponseForm', () => {
   describe('valid cases', () => {
+    it('should be valid when no substantive additional order text is provided', () => {
+      const form = new MotionOrderResponseForm({
+        responseDate: getBusinessDateInFuture({
+          numberOfDays: 2,
+          outputFormat: FORMATS.YYYYMMDD,
+          startDate: createISODateString(),
+        }),
+        additionalOrderTextArray: [''],
+        isOnLeadCase: false,
+        issueOrderFor:
+          MOTION_ORDER_RESPONSE_OPTIONS.issueOrderOptions.THIS_CASE_ONLY,
+      });
+      expect(form.getFormattedValidationErrors()).toBeNull();
+    });
+
     it('should be valid when isOnLeadCase is false and no motionOrderResponse is provided', () => {
       const form = new MotionOrderResponseForm({
         responseDate: getBusinessDateInFuture({

--- a/web-client/src/presenter/actions/CourtIssuedOrder/submitCourtIssuedOrderAction.test.ts
+++ b/web-client/src/presenter/actions/CourtIssuedOrder/submitCourtIssuedOrderAction.test.ts
@@ -147,4 +147,52 @@ describe('submitCourtIssuedOrderAction', () => {
 
     expect(output.docketEntryId).toBe(mockDocumentStorageId);
   });
+
+  it('persists additionalOrderTextArray with only substantive clauses', async () => {
+    await runAction(submitCourtIssuedOrderAction, {
+      modules: {
+        presenter,
+      },
+      props: {
+        primaryDocumentFileId: mockDocumentStorageId,
+      },
+      state: {
+        caseDetail: { docketNumber: '111-20' },
+        form: {
+          documentType: 'Order',
+          primaryDocumentFile: {},
+          additionalOrderTextArray: ['', ' \t', 'Parties shall comply.'],
+        },
+      },
+    });
+
+    expect(
+      applicationContext.getUseCases().fileCourtIssuedOrderInteractor.mock
+        .calls[0][1].documentMetadata.additionalOrderTextArray,
+    ).toEqual(['Parties shall comply.']);
+  });
+
+  it('persists additionalOrderTextArray as empty when every slot is blank', async () => {
+    await runAction(submitCourtIssuedOrderAction, {
+      modules: {
+        presenter,
+      },
+      props: {
+        primaryDocumentFileId: mockDocumentStorageId,
+      },
+      state: {
+        caseDetail: { docketNumber: '111-20' },
+        form: {
+          documentType: 'Order',
+          primaryDocumentFile: {},
+          additionalOrderTextArray: ['', ' '],
+        },
+      },
+    });
+
+    expect(
+      applicationContext.getUseCases().fileCourtIssuedOrderInteractor.mock
+        .calls[0][1].documentMetadata.additionalOrderTextArray,
+    ).toEqual([]);
+  });
 });

--- a/web-client/src/presenter/actions/CourtIssuedOrder/submitCourtIssuedOrderAction.ts
+++ b/web-client/src/presenter/actions/CourtIssuedOrder/submitCourtIssuedOrderAction.ts
@@ -1,4 +1,5 @@
 import { CaseWithSelectionInfo } from '@web-client/business/utilities/getSelectedConsolidatedCasesToMultiDocketOn';
+import { normalizeAdditionalOrderTextArray } from '@web-client/utilities/normalizeAdditionalOrderTextArray';
 import { omit } from 'lodash';
 import { state } from '@web-client/presenter/app.cerebral';
 
@@ -37,6 +38,14 @@ export const submitCourtIssuedOrderAction = async ({
     'docketEntryIdToEdit',
   ]);
   documentMetadata.docketNumber = docketNumber;
+
+  if (Array.isArray(documentMetadata.additionalOrderTextArray)) {
+    const forPersistence = normalizeAdditionalOrderTextArray(
+      documentMetadata.additionalOrderTextArray,
+    );
+    documentMetadata.additionalOrderTextArray =
+      forPersistence.length > 0 ? forPersistence : [];
+  }
 
   documentMetadata.draftOrderState = {
     ...documentMetadata,

--- a/web-client/src/presenter/actions/MotionOrderResponse/prepareMotionOrderResponseAction.test.ts
+++ b/web-client/src/presenter/actions/MotionOrderResponse/prepareMotionOrderResponseAction.test.ts
@@ -48,6 +48,7 @@ describe('prepareMotionOrderResponseAction', () => {
     expect(result.state.form.eventCode).toEqual('O');
     expect(result.state.form.richText).not.toContain('shall file a Reply');
     expect(result.state.form.richText).toContain('shall file a Response');
+    expect(result.state.form.additionalOrderTextArray).toEqual(['']);
   });
 
   it('should handle REPLY selection', async () => {
@@ -70,6 +71,7 @@ describe('prepareMotionOrderResponseAction', () => {
     expect(result.state.form.documentTitle).toEqual('Order');
     expect(result.state.form.documentType).toEqual('Order');
     expect(result.state.form.eventCode).toEqual('O');
+    expect(result.state.form.additionalOrderTextArray).toEqual(['']);
   });
 
   it('should handle additional order text', async () => {
@@ -91,6 +93,7 @@ describe('prepareMotionOrderResponseAction', () => {
     expect(result.state.form.documentTitle).toEqual('Order');
     expect(result.state.form.documentType).toEqual('Order');
     expect(result.state.form.eventCode).toEqual('O');
+    expect(result.state.form.additionalOrderTextArray).toEqual([additionalText]);
   });
 
   it('should handle calendared case with trial session', async () => {
@@ -110,6 +113,22 @@ describe('prepareMotionOrderResponseAction', () => {
     expect(result.state.form.richText).toContain(
       'session of the Court commencing on May 1, 2024, in Houston, Texas',
     );
+  });
+
+  it('normalizes additionalOrderTextArray by removing whitespace-only entries and updates form state', async () => {
+    const result = await runAction(prepareMotionOrderResponseAction, {
+      state: {
+        caseDetail: mockCaseDetail,
+        docketEntryId: 'mock-motion-id',
+        form: {
+          ...mockForm,
+          additionalOrderTextArray: ['', ' \t\n ', 'Keep this.'],
+        },
+      },
+    });
+
+    expect(result.state.form.additionalOrderTextArray).toEqual(['Keep this.']);
+    expect(result.state.form.richText).toContain('ORDERED that Keep this.');
   });
 
   it('should handle stricken from trial sessions', async () => {

--- a/web-client/src/presenter/actions/MotionOrderResponse/prepareMotionOrderResponseAction.ts
+++ b/web-client/src/presenter/actions/MotionOrderResponse/prepareMotionOrderResponseAction.ts
@@ -11,6 +11,10 @@ import {
 } from '@shared/business/utilities/DateHandler';
 import { state } from '@web-client/presenter/app.cerebral';
 import { formatAdditionalOrderClauseForRichText } from '@web-client/utilities/formatAdditionalOrderClauseForRichText';
+import {
+  additionalOrderTextArrayWithRequiredFirstField,
+  normalizeAdditionalOrderTextArray,
+} from '@web-client/utilities/normalizeAdditionalOrderTextArray';
 
 const determineMovantAndNonMovant = ({ caseDetail, motion }) => {
   const { petitioners } = caseDetail;
@@ -63,11 +67,20 @@ export const prepareMotionOrderResponseAction = ({
 
   const isOnLeadCase = isLeadCase(caseDetail);
   const hasStrickenFromTrialSessions = !!strickenFromTrialSession;
-  const normalizedAdditionalOrderTextArray =
-    additionalOrderTextArray ||
+  const rawAdditionalOrderTextArray =
+    additionalOrderTextArray ??
     (additionalOrderText ? [additionalOrderText] : []);
+  const meaningfulAdditionalOrderTextArray = normalizeAdditionalOrderTextArray(
+    rawAdditionalOrderTextArray,
+  );
+  store.set(
+    state.form.additionalOrderTextArray,
+    additionalOrderTextArrayWithRequiredFirstField(
+      meaningfulAdditionalOrderTextArray,
+    ),
+  );
   const hasAdditionalOrderTextArray =
-    !!normalizedAdditionalOrderTextArray.filter(text => text).length;
+    meaningfulAdditionalOrderTextArray.length > 0;
 
   const dueDateFormatted = isValidDateString(dueDate, [
     FORMATS.YYYYMMDD,
@@ -122,12 +135,12 @@ export const prepareMotionOrderResponseAction = ({
 
   let additionalTextLine = '';
   if (hasAdditionalOrderTextArray) {
-    const additionalOrderTextFiltered =
-      normalizedAdditionalOrderTextArray.filter(text => text);
-    additionalOrderTextFiltered.forEach((text, index) => {
+    meaningfulAdditionalOrderTextArray.forEach((text, index) => {
       const clause = formatAdditionalOrderClauseForRichText(text);
       additionalTextLine += `<p class="indent-paragraph">ORDERED that ${clause}${
-        index < additionalOrderTextFiltered.length - 1 ? ' It is further' : ''
+        index < meaningfulAdditionalOrderTextArray.length - 1
+          ? ' It is further'
+          : ''
       }</p>`;
     });
   }

--- a/web-client/src/presenter/actions/MotionOrderResponse/setEditMotionOrderResponseFormAction.test.ts
+++ b/web-client/src/presenter/actions/MotionOrderResponse/setEditMotionOrderResponseFormAction.test.ts
@@ -24,7 +24,13 @@ describe('setEditMotionOrderResponseFormAction', () => {
       },
     });
 
-    expect(result.state.form).toEqual(mockDraftOrderState);
+    expect(result.state.form).toEqual({
+      previousDocument: {
+        docketEntryId: '123',
+      },
+      someFormField: 'value',
+      additionalOrderTextArray: [''],
+    });
     expect(result.state.docketEntryId).toEqual('123');
     expect(result.output.path).toEqual(
       '/messages/123-45/message-detail/abc/xyz/motion-order-response-edit',
@@ -52,7 +58,13 @@ describe('setEditMotionOrderResponseFormAction', () => {
       },
     });
 
-    expect(result.state.form).toEqual(mockDraftOrderState);
+    expect(result.state.form).toEqual({
+      previousDocument: {
+        docketEntryId: '123',
+      },
+      someFormField: 'value',
+      additionalOrderTextArray: [''],
+    });
     expect(result.state.docketEntryId).toEqual('123');
     expect(result.output.path).toEqual(
       '/case-detail/123-45/documents/xyz/motion-order-response-edit',
@@ -88,5 +100,29 @@ describe('setEditMotionOrderResponseFormAction', () => {
       additionalOrderTextArray: ['Some additional text'],
     });
     expect(result.state.form).not.toHaveProperty('additionalOrderText');
+  });
+
+  it('should omit legacy additionalOrderText when it contains only whitespace', async () => {
+    const mockDraftOrderState = {
+      additionalOrderText: ' \t  ',
+      previousDocument: {
+        docketEntryId: '123',
+      },
+      someFormField: 'value',
+    };
+
+    const result = await runAction(setEditMotionOrderResponseFormAction, {
+      props: {
+        caseDetail: { docketNumber: '123-45' },
+        docketEntryIdToEdit: 'xyz',
+      },
+      state: {
+        documentToEdit: {
+          draftOrderState: mockDraftOrderState,
+        },
+      },
+    });
+
+    expect(result.state.form.additionalOrderTextArray).toEqual(['']);
   });
 });

--- a/web-client/src/presenter/actions/MotionOrderResponse/setEditMotionOrderResponseFormAction.ts
+++ b/web-client/src/presenter/actions/MotionOrderResponse/setEditMotionOrderResponseFormAction.ts
@@ -1,4 +1,8 @@
 import { state } from '@web-client/presenter/app.cerebral';
+import {
+  additionalOrderTextArrayWithRequiredFirstField,
+  normalizeAdditionalOrderTextArray,
+} from '@web-client/utilities/normalizeAdditionalOrderTextArray';
 import { DocketEntry } from 'shared/src/business/entities/DocketEntry';
 
 export const setEditMotionOrderResponseFormAction = ({
@@ -27,11 +31,15 @@ export const setEditMotionOrderResponseFormAction = ({
   const { additionalOrderText: legacyAdditionalOrderText, ...draftFields } =
     draftOrderState;
 
+  const rawAdditionalOrderTextArray =
+    draftOrderState.additionalOrderTextArray ??
+    (legacyAdditionalOrderText ? [legacyAdditionalOrderText] : []);
+
   store.set(state.form, {
     ...draftFields,
-    additionalOrderTextArray:
-      draftOrderState.additionalOrderTextArray ||
-      (legacyAdditionalOrderText ? [legacyAdditionalOrderText] : ['']),
+    additionalOrderTextArray: additionalOrderTextArrayWithRequiredFirstField(
+      normalizeAdditionalOrderTextArray(rawAdditionalOrderTextArray),
+    ),
   });
   store.set(
     state.docketEntryId,

--- a/web-client/src/presenter/actions/StatusReportOrder/prepareStatusReportOrderAction.test.ts
+++ b/web-client/src/presenter/actions/StatusReportOrder/prepareStatusReportOrderAction.test.ts
@@ -59,6 +59,7 @@ describe('prepareStatusReportOrderAction,', () => {
     expect(result.state.form.documentTitle).toEqual('Order');
     expect(result.state.form.eventCode).toEqual('O');
     expect(result.state.form.richText).toEqual(expectedFiledLine);
+    expect(result.state.form.additionalOrderTextArray).toEqual(['']);
   });
 
   it('prepare status report with all options selected', async () => {
@@ -300,5 +301,33 @@ describe('prepareStatusReportOrderAction,', () => {
       },
     });
     expect(result.state.form.richText).toEqual(expectedFiledLine);
+  });
+  it('normalizes additionalOrderTextArray by removing whitespace-only entries', async () => {
+    const result = await runAction(prepareStatusReportOrderAction, {
+      modules: {
+        presenter,
+      },
+      state: {
+        caseDetail: {},
+        form: {
+          additionalOrderTextArray: ['  ', '', 'Parties shall comply.'],
+          docketEntryDescription: 'Order',
+        },
+        statusReportOrder: {
+          statusReportFilingDate,
+          statusReportIndex,
+        },
+        trialSession: {
+          sessionType: 'abc',
+        },
+      },
+    });
+
+    expect(result.state.form.additionalOrderTextArray).toEqual([
+      'Parties shall comply.',
+    ]);
+    expect(result.state.form.richText).toContain(
+      'ORDERED that Parties shall comply.',
+    );
   });
 });

--- a/web-client/src/presenter/actions/StatusReportOrder/prepareStatusReportOrderAction.ts
+++ b/web-client/src/presenter/actions/StatusReportOrder/prepareStatusReportOrderAction.ts
@@ -7,6 +7,10 @@ import {
 import { state } from '@web-client/presenter/app.cerebral';
 import { isLeadCase } from '@shared/business/entities/cases/Case';
 import { formatAdditionalOrderClauseForRichText } from '@web-client/utilities/formatAdditionalOrderClauseForRichText';
+import {
+  additionalOrderTextArrayWithRequiredFirstField,
+  normalizeAdditionalOrderTextArray,
+} from '@web-client/utilities/normalizeAdditionalOrderTextArray';
 
 export const prepareStatusReportOrderAction = ({
   applicationContext,
@@ -36,11 +40,20 @@ export const prepareStatusReportOrderAction = ({
   const hasOrderType = !!orderType;
   const hasStrickenFromTrialSessions = !!strickenFromTrialSessions;
   const hasJurisdiction = !!jurisdiction;
-  const normalizedAdditionalOrderTextArray =
-    additionalOrderTextArray ||
+  const rawAdditionalOrderTextArray =
+    additionalOrderTextArray ??
     (additionalOrderText ? [additionalOrderText] : []);
+  const meaningfulAdditionalOrderTextArray = normalizeAdditionalOrderTextArray(
+    rawAdditionalOrderTextArray,
+  );
+  store.set(
+    state.form.additionalOrderTextArray,
+    additionalOrderTextArrayWithRequiredFirstField(
+      meaningfulAdditionalOrderTextArray,
+    ),
+  );
   const hasAdditionalOrderTextArray =
-    !!normalizedAdditionalOrderTextArray.filter(text => text).length;
+    meaningfulAdditionalOrderTextArray.length > 0;
 
   const dueDateFormatted = applicationContext
     .getUtilities()
@@ -86,12 +99,12 @@ export const prepareStatusReportOrderAction = ({
 
   let additionalTextLine = '';
   if (hasAdditionalOrderTextArray) {
-    const additionalOrderTextFiltered =
-      normalizedAdditionalOrderTextArray.filter(text => text);
-    additionalOrderTextFiltered.forEach((text, index) => {
+    meaningfulAdditionalOrderTextArray.forEach((text, index) => {
       const clause = formatAdditionalOrderClauseForRichText(text);
       additionalTextLine += `<p class="indent-paragraph">ORDERED that ${clause}${
-        index < additionalOrderTextFiltered.length - 1 ? ' It is further' : ''
+        index < meaningfulAdditionalOrderTextArray.length - 1
+          ? ' It is further'
+          : ''
       }</p>`;
     });
   }

--- a/web-client/src/presenter/actions/StatusReportOrder/setEditStatusReportOrderFormAction.test.ts
+++ b/web-client/src/presenter/actions/StatusReportOrder/setEditStatusReportOrderFormAction.test.ts
@@ -40,6 +40,27 @@ describe('setEditStatusReportOrderFormAction,', () => {
     });
   });
 
+  it('omits legacy additionalOrderText when it contains only whitespace', async () => {
+    const result = await runAction(setEditStatusReportOrderFormAction, {
+      props: {
+        caseDetail: {
+          docketNumber: '1',
+        },
+        docketEntryIdToEdit: '107-19',
+      },
+      state: {
+        documentToEdit: {
+          draftOrderState: {
+            additionalOrderText: '  \n\t ',
+            docketEntryDescription: 'Order',
+          },
+        },
+      },
+    });
+
+    expect(result.state.form.additionalOrderTextArray).toEqual(['']);
+  });
+
   it('prefers additionalOrderTextArray when editing newer drafts', async () => {
     const result = await runAction(setEditStatusReportOrderFormAction, {
       props: {

--- a/web-client/src/presenter/actions/StatusReportOrder/setEditStatusReportOrderFormAction.ts
+++ b/web-client/src/presenter/actions/StatusReportOrder/setEditStatusReportOrderFormAction.ts
@@ -1,4 +1,8 @@
 import { state } from '@web-client/presenter/app.cerebral';
+import {
+  additionalOrderTextArrayWithRequiredFirstField,
+  normalizeAdditionalOrderTextArray,
+} from '@web-client/utilities/normalizeAdditionalOrderTextArray';
 
 export const setEditStatusReportOrderFormAction = ({
   get,
@@ -12,12 +16,16 @@ export const setEditStatusReportOrderFormAction = ({
     ? `/messages/${caseDetail.docketNumber}/message-detail/${props.parentMessageId}/${docketEntryIdToEdit}/status-report-order-edit`
     : `/case-detail/${caseDetail.docketNumber}/documents/${docketEntryIdToEdit}/status-report-order-edit`;
 
+  const rawAdditionalOrderTextArray =
+    documentToEdit.draftOrderState.additionalOrderTextArray ??
+    (documentToEdit.draftOrderState.additionalOrderText
+      ? [documentToEdit.draftOrderState.additionalOrderText]
+      : []);
+
   store.set(state.form, {
-    additionalOrderTextArray:
-      documentToEdit.draftOrderState.additionalOrderTextArray ||
-      (documentToEdit.draftOrderState.additionalOrderText
-        ? [documentToEdit.draftOrderState.additionalOrderText]
-        : ['']),
+    additionalOrderTextArray: additionalOrderTextArrayWithRequiredFirstField(
+      normalizeAdditionalOrderTextArray(rawAdditionalOrderTextArray),
+    ),
     docketEntryDescription:
       documentToEdit.draftOrderState.docketEntryDescription,
     dueDate: documentToEdit.draftOrderState.dueDate,

--- a/web-client/src/utilities/normalizeAdditionalOrderTextArray.test.ts
+++ b/web-client/src/utilities/normalizeAdditionalOrderTextArray.test.ts
@@ -1,0 +1,36 @@
+import {
+  additionalOrderTextArrayWithRequiredFirstField,
+  normalizeAdditionalOrderTextArray,
+} from './normalizeAdditionalOrderTextArray';
+
+describe('normalizeAdditionalOrderTextArray', () => {
+  it('returns an empty array when input is undefined, null, or empty', () => {
+    expect(normalizeAdditionalOrderTextArray(undefined)).toEqual([]);
+    expect(normalizeAdditionalOrderTextArray(null)).toEqual([]);
+    expect(normalizeAdditionalOrderTextArray([])).toEqual([]);
+  });
+
+  it('removes empty strings and whitespace-only entries', () => {
+    expect(
+      normalizeAdditionalOrderTextArray(['', ' ', '\t', '\n', '  \t  ']),
+    ).toEqual([]);
+  });
+
+  it('keeps entries with non-whitespace content and preserves spacing within the string', () => {
+    expect(
+      normalizeAdditionalOrderTextArray(['  Parties shall comply.  ', '']),
+    ).toEqual(['  Parties shall comply.  ']);
+  });
+});
+
+describe('additionalOrderTextArrayWithRequiredFirstField', () => {
+  it('returns one empty string when there are no meaningful entries', () => {
+    expect(additionalOrderTextArrayWithRequiredFirstField([])).toEqual(['']);
+  });
+
+  it('returns meaningful entries unchanged', () => {
+    expect(
+      additionalOrderTextArrayWithRequiredFirstField(['First', 'Second']),
+    ).toEqual(['First', 'Second']);
+  });
+});

--- a/web-client/src/utilities/normalizeAdditionalOrderTextArray.ts
+++ b/web-client/src/utilities/normalizeAdditionalOrderTextArray.ts
@@ -1,0 +1,25 @@
+/**
+ * Drops entries that are empty or contain only whitespace (after trim).
+ * Preserves meaningful text exactly as entered (does not trim substantive content).
+ */
+export function normalizeAdditionalOrderTextArray(
+  additionalOrderTextArray?: string[] | null,
+): string[] {
+  if (!additionalOrderTextArray?.length) {
+    return [];
+  }
+  return additionalOrderTextArray.filter(
+    text => (text ?? '').trim().length > 0,
+  );
+}
+
+/**
+ * The first additional-order text control is always shown; optional rows are only
+ * for extra clauses. When there is no substantive text in any row, the form still
+ * contains one empty string for that first control.
+ */
+export function additionalOrderTextArrayWithRequiredFirstField(
+  meaningfulEntries: string[],
+): string[] {
+  return meaningfulEntries.length > 0 ? meaningfulEntries : [''];
+}

--- a/web-client/src/views/OrderResponse/OrderResponse.tsx
+++ b/web-client/src/views/OrderResponse/OrderResponse.tsx
@@ -52,10 +52,13 @@ export const OrderResponse = connect(
     validationErrors,
     validateMotionOrderResponseSequence,
   }) {
+    const additionalOrderTextArray = form.additionalOrderTextArray?.length
+      ? form.additionalOrderTextArray
+      : [''];
     const additionalOrderTextArrayFormErrors =
       getAdditionalOrderTextArrayFormGroupErrors(
         validationErrors,
-        form.additionalOrderTextArray?.length ?? 0,
+        additionalOrderTextArray.length,
       );
 
     return (
@@ -280,7 +283,7 @@ export const OrderResponse = connect(
                         </label>
                       </div>
                     )}
-                    {form.additionalOrderTextArray?.map((text, index) => (
+                    {additionalOrderTextArray.map((text, index) => (
                       <div key={index}>
                         <label
                           className="usa-label tw:mt-4"
@@ -325,7 +328,7 @@ export const OrderResponse = connect(
                             onClick={() => {
                               updateFormValueSequence({
                                 key: 'additionalOrderTextArray',
-                                value: form.additionalOrderTextArray.filter(
+                                value: additionalOrderTextArray.filter(
                                   (_, i) => i !== index,
                                 ),
                               });
@@ -344,10 +347,7 @@ export const OrderResponse = connect(
                       onClick={() => {
                         updateFormValueSequence({
                           key: 'additionalOrderTextArray',
-                          value: [
-                            ...(form.additionalOrderTextArray || ['']),
-                            '',
-                          ],
+                          value: [...additionalOrderTextArray, ''],
                         });
                       }}
                       variant="primaryTertiary"

--- a/web-client/src/views/StatusReportOrder.tsx
+++ b/web-client/src/views/StatusReportOrder.tsx
@@ -43,10 +43,13 @@ export const StatusReportOrder = connect(
     validateStatusReportOrderSequence,
     validationErrors,
   }) {
+    const additionalOrderTextArray = form.additionalOrderTextArray?.length
+      ? form.additionalOrderTextArray
+      : [''];
     const additionalOrderTextArrayFormErrors =
       getAdditionalOrderTextArrayFormGroupErrors(
         validationErrors,
-        form.additionalOrderTextArray.length,
+        additionalOrderTextArray.length,
       );
 
     return (
@@ -383,7 +386,7 @@ export const StatusReportOrder = connect(
                     className="status-report-order-form-group"
                     errorText={additionalOrderTextArrayFormErrors}
                   >
-                    {form.additionalOrderTextArray.map((text, index) => (
+                    {additionalOrderTextArray.map((text, index) => (
                       <div key={index}>
                         <label
                           className="usa-label tw:mt-4"
@@ -427,7 +430,7 @@ export const StatusReportOrder = connect(
                             onClick={() => {
                               updateFormValueSequence({
                                 key: 'additionalOrderTextArray',
-                                value: form.additionalOrderTextArray.filter(
+                                value: additionalOrderTextArray.filter(
                                   (_, i) => i !== index,
                                 ),
                               });
@@ -446,7 +449,7 @@ export const StatusReportOrder = connect(
                       onClick={() => {
                         updateFormValueSequence({
                           key: 'additionalOrderTextArray',
-                          value: [...form.additionalOrderTextArray, ''],
+                          value: [...additionalOrderTextArray, ''],
                         });
                       }}
                       variant="primaryTertiary"


### PR DESCRIPTION
9584: strip whitespace-only additional order clauses; persist only real text; ui keeps one blank first field