### PR TITLE
devex: backfill historical code coverage reports

### DIFF
--- a/.github/workflows/upload-release-coverage-summary.yml
+++ b/.github/workflows/upload-release-coverage-summary.yml
@@ -1,0 +1,72 @@
+name: Upload Release Coverage Summary
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number whose release coverage artifact should be created
+        required: true
+        type: string
+      suite:
+        description: Coverage suite name
+        required: true
+        type: choice
+        options:
+          - api
+          - client
+          - scripts
+          - shared
+      branches:
+        description: Branch coverage percentage
+        required: true
+        type: string
+      functions:
+        description: Function coverage percentage
+        required: true
+        type: string
+      lines:
+        description: Line coverage percentage
+        required: true
+        type: string
+      statements:
+        description: Statement coverage percentage
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  upload-release-coverage-summary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write standardized release coverage summary
+        env:
+          BRANCHES: ${{ inputs.branches }}
+          FUNCTIONS: ${{ inputs.functions }}
+          LINES: ${{ inputs.lines }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          STATEMENTS: ${{ inputs.statements }}
+          SUITE: ${{ inputs.suite }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+
+          summary = {
+              'branches': float(os.environ['BRANCHES']),
+              'functions': float(os.environ['FUNCTIONS']),
+              'lines': float(os.environ['LINES']),
+              'statements': float(os.environ['STATEMENTS']),
+              'suite': os.environ['SUITE'],
+          }
+
+          with open('coverage-summary.json', 'w', encoding='utf-8') as summary_file:
+              json.dump(summary, summary_file, indent=2)
+              summary_file.write('\n')
+          PY
+      - name: Upload release coverage summary artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-summary-${{ inputs.suite }}-pr-${{ inputs.pr_number }}
+          path: ./coverage-summary.json

--- a/.github/workflows/upload-release-coverage-summary.yml
+++ b/.github/workflows/upload-release-coverage-summary.yml
@@ -34,6 +34,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
@@ -45,7 +46,6 @@ jobs:
           BRANCHES: ${{ inputs.branches }}
           FUNCTIONS: ${{ inputs.functions }}
           LINES: ${{ inputs.lines }}
-          PR_NUMBER: ${{ inputs.pr_number }}
           STATEMENTS: ${{ inputs.statements }}
           SUITE: ${{ inputs.suite }}
         run: |


### PR DESCRIPTION
We are soon going to start storing composite code coverage reports in github actions for tests that emit coverage reports.

This PR adds a workflow that we can call manually to backfill historical code coverage reports for actions that have already completed. It will be deleted after the specific reports are backfilled.