### PR TITLE
2026 06 01 hotfix to test 1780320334

### DIFF
--- a/scripts/archived/run-once/create-exhibits/insert-exhibits-via-sql.ts
+++ b/scripts/archived/run-once/create-exhibits/insert-exhibits-via-sql.ts
@@ -210,6 +210,7 @@ const confirmAction = async (message: string): Promise<boolean> => {
             isDraft: false,
             isFileAttached: true,
             isOnDocketRecord: true,
+            multiDocketedOn: JSON.stringify([]),
             processingStatus: 'pending',
             relationship: 'primaryDocument',
             scenario: 'Standard',

--- a/shared/src/business/entities/cases/Case.test.ts
+++ b/shared/src/business/entities/cases/Case.test.ts
@@ -18,8 +18,7 @@ import {
   TRIAL_SESSION_SCOPE_TYPES,
   UNIQUE_OTHER_FILER_TYPE,
 } from '../EntityConstants';
-import { Case, getContactPrimary } from './Case';
-import { isMemberCase } from '../../utilities/generateSelectedFilterList';
+import { Case, getContactPrimary, isMemberCase } from './Case';
 import { MOCK_CASE, MOCK_CASE_WITHOUT_PENDING } from '../../../test/mockCase';
 import {
   MOCK_DOCUMENTS,

--- a/shared/src/business/utilities/sanitizeUserHtml.test.ts
+++ b/shared/src/business/utilities/sanitizeUserHtml.test.ts
@@ -97,6 +97,21 @@ describe('sanitizeUserHtml', () => {
     expect(out).not.toContain('evil');
   });
 
+  it('preserves the indent-paragraph class used for generated order indents', () => {
+    const out = sanitizeUserHtml(
+      '<p class="indent-paragraph">ORDERED that jurisdiction is retained by the undersigned.</p>',
+    );
+    expect(out).toContain('class="indent-paragraph"');
+  });
+
+  it('keeps indent-paragraph while still dropping disallowed sibling classes', () => {
+    const out = sanitizeUserHtml(
+      '<p class="indent-paragraph evil">x</p>',
+    );
+    expect(out).toContain('indent-paragraph');
+    expect(out).not.toContain('evil');
+  });
+
   it('drops disallowed elements with their entire subtree (not just the tag)', () => {
     const out = sanitizeUserHtml(
       '<div><p>kept</p><script>var x = "leaked text"</script></div>',

--- a/shared/src/business/utilities/sanitizeUserHtml.ts
+++ b/shared/src/business/utilities/sanitizeUserHtml.ts
@@ -28,6 +28,11 @@ const ALLOWED_STYLE_PROPERTIES: ReadonlySet<string> = new Set([
 
 const QL_INDENT_CLASS = /^ql-indent-\d+$/;
 
+const ALLOWED_CLASSES: ReadonlySet<string> = new Set(['indent-paragraph']);
+
+const isAllowedClass = (token: string): boolean =>
+  QL_INDENT_CLASS.test(token) || ALLOWED_CLASSES.has(token);
+
 const DANGEROUS_STYLE_PATTERN = /expression\s*\(|url\s*\(|javascript\s*:/i;
 
 type DomNode = ReturnType<typeof parseDocument>['children'][number];
@@ -35,7 +40,7 @@ type DomNode = ReturnType<typeof parseDocument>['children'][number];
 const sanitizeClassAttr = (value: string): string | undefined => {
   const kept = value
     .split(/\s+/)
-    .filter(token => token.length > 0 && QL_INDENT_CLASS.test(token));
+    .filter(token => token.length > 0 && isAllowedClass(token));
   return kept.length > 0 ? kept.join(' ') : undefined;
 };
 


### PR DESCRIPTION
Bug: Restore indent-paragraph class in order PDF sanitizer

sanitizeUserHtml only kept ql-indent-N classes, stripping the indent-paragraph class used by Status Report Orders and Order Responses for first-line indents. Allowlist indent-paragraph so the text-indent CSS applies again. Allowlist stays fixed and safe.