### PR TITLE
9607: style disable radio button

### DIFF
--- a/web-client/src/views/GrantDenyMotion/GrantDenyMotion.tsx
+++ b/web-client/src/views/GrantDenyMotion/GrantDenyMotion.tsx
@@ -265,6 +265,7 @@ export const GrantDenyMotion = connect(
                       <label
                         className="usa-checkbox__label"
                         htmlFor="stricken-from-trial-session"
+                        style={isCalendared ? undefined : { color: '#757575' }}
                         title={calendaredDisabledTitle}
                       >
                         This case is stricken from the trial session


### PR DESCRIPTION
## Summary
When a case is not calendared on Grant/Deny Motion, the “stricken from trial session” checkbox is disabled but its label was rendering in default black instead of the same grey used for disabled jurisdiction radios (“Restore to general docket”, etc.).

This adds a local label style (#757575) when !isCalendared, matching the pattern already used on Status Report Order. No global SCSS changes.