### PR TITLE
devex: remove headSha param from compile-suite-coverage

### DIFF
--- a/.github/workflows/composite-coverage.yml
+++ b/.github/workflows/composite-coverage.yml
@@ -111,7 +111,6 @@ jobs:
         run: |
           scripts/github-actions/compile-suite-coverage.ts \
             "${STAGING_PULL_REQUEST_NUMBER}" \
-            "" \
             "coverage"
       - name: Generate API Coverage Badges
         uses: jpb06/coverage-badges-action@latest

--- a/scripts/github-actions/compile-suite-coverage.helpers.ts
+++ b/scripts/github-actions/compile-suite-coverage.helpers.ts
@@ -8,7 +8,6 @@ import {
 export type CompileSuiteCoverageConfig = {
   githubRepository: string;
   githubToken: string;
-  headSha?: string;
   outputDirectory: string;
   pullRequestNumber: number;
 };
@@ -25,7 +24,6 @@ export const compileSuiteCoverage = async (
   {
     githubRepository,
     githubToken,
-    headSha,
     outputDirectory,
     pullRequestNumber,
   }: CompileSuiteCoverageConfig,
@@ -42,7 +40,6 @@ export const compileSuiteCoverage = async (
       log(`Downloading coverage summary for ${suite}...`);
       try {
         const summary = await getCoverageSummary({
-          headSha,
           pullRequestNumber,
           repository: githubRepository,
           suite,
@@ -50,7 +47,7 @@ export const compileSuiteCoverage = async (
         });
 
         if (summary) {
-          const istanbulSummary = {
+          return {
             total: {
               branches: {
                 covered: summary.branches,
@@ -78,8 +75,6 @@ export const compileSuiteCoverage = async (
               },
             },
           };
-
-          return istanbulSummary;
         } else {
           log(`No coverage summary found for suite: ${suite}`);
           return undefined;

--- a/scripts/github-actions/compile-suite-coverage.ts
+++ b/scripts/github-actions/compile-suite-coverage.ts
@@ -14,13 +14,8 @@ const scriptConfig: ScriptConfig = {
     githubToken: 'GITHUB_TOKEN',
   },
   parameters: {
-    headSha: {
-      position: 1,
-      required: false,
-      type: 'string',
-    },
     outputDirectory: {
-      position: 2,
+      position: 1,
       required: true,
       type: 'string',
     },
@@ -36,13 +31,11 @@ const scriptConfig: ScriptConfig = {
 const {
   githubRepository,
   githubToken,
-  headSha,
   outputDirectory,
   pullRequestNumber: pullRequestNumberStr,
 } = parseArgsAndEnvVars(scriptConfig) as {
   githubRepository: string;
   githubToken: string;
-  headSha?: string;
   outputDirectory: string;
   pullRequestNumber: string;
 };
@@ -54,7 +47,6 @@ const pullRequestNumber = parseInt(pullRequestNumberStr.split(',')[0], 10);
   await runCompileSuiteCoverageScript({
     githubRepository,
     githubToken,
-    headSha,
     outputDirectory,
     pullRequestNumber,
   });


### PR DESCRIPTION
Another attempt to fix the compile-coverage workflow. [The last one](https://github.com/ustaxcourt/ef-cms/pull/10123) didn't go far enough.