### PR TITLE
10132 bug crash on cities to test 1780936005

### DIFF
--- a/cypress/local-only/tests/integration/public/trialSessions/trial-sessions.cy.ts
+++ b/cypress/local-only/tests/integration/public/trialSessions/trial-sessions.cy.ts
@@ -82,4 +82,20 @@ describe('Public Trial Sessions', () => {
       'not.exist',
     );
   });
+
+  it('should apply and remove St. Louis, Missouri location filter on mobile', () => {
+    const LOCATION = 'St. Louis, Missouri';
+
+    cy.viewport('iphone-xr');
+    cy.visit('/trial-sessions');
+
+    cy.contains('button', 'Filters').click();
+    cy.get('select[name="locations"]').select(LOCATION);
+
+    cy.contains('span.blue-pill', LOCATION).should('exist');
+    cy.get(`button[aria-label="remove ${LOCATION} selection"]`).click();
+    cy.contains('span.blue-pill', LOCATION).should('not.exist');
+
+    cy.get('select[name="locations"]').should('exist');
+  });
 });

--- a/cypress/local-only/tests/integration/public/trialSessions/trial-sessions.cy.ts
+++ b/cypress/local-only/tests/integration/public/trialSessions/trial-sessions.cy.ts
@@ -65,4 +65,21 @@ describe('Public Trial Sessions', () => {
       .click();
     cy.get(`[data-testid="judges-${JUDGE}-pill-button"]`).should('not.exist');
   });
+
+  it('should render the location pill for cities containing a period without crashing the page', () => {
+    const LOCATION = 'St. Louis, Missouri';
+    selectTypeaheadInput('locations-filter-select', LOCATION);
+
+    cy.get(`[data-testid="locations-${LOCATION}-pill-button"]`).should('exist');
+    // The page should still be rendered (not a blank white screen) after selecting
+    // a city whose name contains a "." (e.g. St. Louis, St. Paul).
+    cy.get('[data-testid="location-filter"]').should('be.visible');
+
+    cy.get(`[data-testid="locations-${LOCATION}-pill-button"]`)
+      .find('button')
+      .click();
+    cy.get(`[data-testid="locations-${LOCATION}-pill-button"]`).should(
+      'not.exist',
+    );
+  });
 });

--- a/web-client/src/views/Public/TrialSessions/PublicTrialSessions.tsx
+++ b/web-client/src/views/Public/TrialSessions/PublicTrialSessions.tsx
@@ -248,10 +248,13 @@ function MobilePublicTrialSessions({
               key={sessionTypeLabel}
               text={sessionTypeLabel}
               onRemove={() => {
+                const remainingValues = { ...sessionTypes };
+                delete remainingValues[sessionTypeKey];
+
                 publicTrialSessionUpdateFormValueSequence({
-                  key: `sessionTypes.${sessionTypeKey}`,
+                  key: 'sessionTypes',
                   root: PUBLIC_TRIAL_SESSIONS_DATA_KEY,
-                  value: undefined,
+                  value: remainingValues,
                 });
               }}
             />
@@ -266,10 +269,13 @@ function MobilePublicTrialSessions({
               key={sessionTypeLabel}
               text={sessionTypeLabel}
               onRemove={() => {
+                const remainingValues = { ...locations };
+                delete remainingValues[sessionTypeKey];
+
                 publicTrialSessionUpdateFormValueSequence({
-                  key: `locations.${sessionTypeKey}`,
+                  key: 'locations',
                   root: PUBLIC_TRIAL_SESSIONS_DATA_KEY,
-                  value: undefined,
+                  value: remainingValues,
                 });
               }}
             />
@@ -284,10 +290,13 @@ function MobilePublicTrialSessions({
               key={sessionTypeLabel}
               text={sessionTypeLabel}
               onRemove={() => {
+                const remainingValues = { ...judges };
+                delete remainingValues[sessionTypeKey];
+
                 publicTrialSessionUpdateFormValueSequence({
-                  key: `judges.${sessionTypeKey}`,
+                  key: 'judges',
                   root: PUBLIC_TRIAL_SESSIONS_DATA_KEY,
-                  value: undefined,
+                  value: remainingValues,
                 });
               }}
             />

--- a/web-client/src/views/Public/TrialSessions/PublicTrialSessionsFilters.tsx
+++ b/web-client/src/views/Public/TrialSessions/PublicTrialSessionsFilters.tsx
@@ -172,7 +172,11 @@ function FilterSelect({ label, name, onChange, options, selectedValues }) {
               value: '',
             }}
             onChange={option =>
-              option && onChange(`${name}.${option.value}`, option.label)
+              option &&
+              onChange(name, {
+                ...selectedValues,
+                [option.value]: option.label,
+              })
             }
           />{' '}
         </NonPhone>
@@ -187,7 +191,7 @@ function FilterSelect({ label, name, onChange, options, selectedValues }) {
             value={MULTI_SELECT_PLACEHOLDER}
             onChange={value => {
               if (value) {
-                onChange(`${name}.${value}`, value);
+                onChange(name, { ...selectedValues, [value]: value });
               }
             }}
           />
@@ -205,7 +209,9 @@ function FilterSelect({ label, name, onChange, options, selectedValues }) {
               key={optionLabel}
               text={optionLabel}
               onRemove={() => {
-                onChange(`${name}.${optionKey}`, undefined);
+                const remaining = { ...selectedValues };
+                delete remaining[optionKey];
+                onChange(name, remaining);
               }}
             />
           ))}

--- a/web-client/src/views/Public/TrialSessions/PublicTrialSessionsFilters.tsx
+++ b/web-client/src/views/Public/TrialSessions/PublicTrialSessionsFilters.tsx
@@ -11,9 +11,9 @@ import { SelectSearch } from '@web-client/ustc-ui/Select/SelectSearch';
 import React from 'react';
 
 type PublicTrialSessionsFiltersProps = {
-  judges: { [key: string]: string };
-  locations: { [key: string]: string };
-  sessionTypes: { [key: string]: string };
+  judges: SelectedFilterValues;
+  locations: SelectedFilterValues;
+  sessionTypes: SelectedFilterValues;
   proceedingType: string;
   displayProgressSpinnerSequence: (props: { timeInSeconds: number }) => void;
   updateFormValueSequence: (props: {
@@ -34,6 +34,14 @@ type PublicTrialSessionsFiltersProps = {
   trialSessionJudgeOptions: Array<{ label: string; value: string }>;
 };
 
+type SelectedFilterValues = Record<string, string>;
+type FilterValue = string | SelectedFilterValues;
+type FlatFilterOption = { label: string; value: string };
+type GroupedFilterOption = {
+  label: string;
+  options: FlatFilterOption[];
+};
+
 export const PublicTrialSessionsFilters = function ({
   displayProgressSpinnerSequence,
   judges,
@@ -50,7 +58,7 @@ export const PublicTrialSessionsFilters = function ({
     ...TRIAL_SESSION_PROCEEDING_TYPES,
   });
 
-  const handleUpdateFormValue = (key: string, value: string | undefined) => {
+  const handleUpdateFormValue = (key: string, value: FilterValue) => {
     displayProgressSpinnerSequence({ timeInSeconds: 0.25 });
     updateFormValueSequence({
       key,
@@ -152,7 +160,21 @@ export const PublicTrialSessionsFilters = function ({
   );
 };
 
-function FilterSelect({ label, name, onChange, options, selectedValues }) {
+type FilterSelectProps = {
+  label: string;
+  name: string;
+  onChange: (key: string, value: FilterValue) => void;
+  options: FlatFilterOption[] | GroupedFilterOption[];
+  selectedValues: SelectedFilterValues;
+};
+
+function FilterSelect({
+  label,
+  name,
+  onChange,
+  options,
+  selectedValues,
+}: FilterSelectProps) {
   return (
     <>
       <div className="margin-bottom-2">
@@ -199,11 +221,7 @@ function FilterSelect({ label, name, onChange, options, selectedValues }) {
       </div>
       <NonPhone>
         <div className="margin-bottom-1">
-          {Object.entries(
-            selectedValues as {
-              [key: string]: string;
-            },
-          ).map(([optionKey, optionLabel]) => (
+          {Object.entries(selectedValues).map(([optionKey, optionLabel]) => (
             <PillButton
               data-testid={`${name}-${optionLabel}-pill-button`}
               key={optionLabel}


### PR DESCRIPTION
Fixes a crash where public users see a blank white page after selecting a trial-session location whose name contains a period (e.g. St. Paul or St. Louis) in the Location filter.

Root cause
In PublicTrialSessionsFilters.tsx, the selected filter value was being embedded into the Cerebral state path:


onChange(`${name}.${option.value}`, option.label)
// → "locations.St. Louis, Missouri"
Cerebral splits state paths on ., so a city like "St. Louis, Missouri" was parsed as nested path segments, producing a malformed nested object:


locations: { St: { " Louis, Missouri": "St. Louis, Missouri" } 

The filter pill loop then tried to render that nested object as a React child, throwing:

Uncaught Error: Objects are not valid as a React child (found: object with keys { Louis, Missouri})

which crashed the React tree and forced a page refresh.