### PR TITLE
9726 client side logging redo to test 1781032549

### DIFF
--- a/esbuildHelper.mjs
+++ b/esbuildHelper.mjs
@@ -78,6 +78,7 @@ export default async function ({
       '.woff': 'file',
       '.woff2': 'file',
     },
+    keepNames: true,
     logLevel: 'info',
     metafile: true,
     minify: process.env.USTC_ENV === 'prod',

--- a/web-client/src/app.tsx
+++ b/web-client/src/app.tsx
@@ -5,6 +5,7 @@ import '../../node_modules/@fortawesome/fontawesome-svg-core/styles.css';
 import { AppComponent } from './views/AppComponent';
 import { AppInstanceManager } from './AppInstanceManager';
 import { Container } from '@cerebral/react';
+import { ErrorBoundary } from './views/ErrorBoundary';
 import { GlobalModalWrapper } from './views/GlobalModalWrapper';
 import { IdleActivityMonitor } from './views/IdleActivityMonitor';
 import { createForceRefreshCallback } from '@web-client/presenter/utilities/createForceRefreshCallback';
@@ -296,7 +297,9 @@ const app = {
             <AppInstanceManager />
             <GlobalModalWrapper />
           </>
-          <AppComponent />
+          <ErrorBoundary>
+            <AppComponent />
+          </ErrorBoundary>
 
           {process.env.CI && <div id="ci-environment">CI Test Environment</div>}
         </Container>,

--- a/web-client/src/appPublic.tsx
+++ b/web-client/src/appPublic.tsx
@@ -177,9 +177,11 @@ const appPublic = {
       root.render(
         <Container app={cerebralApp}>
           <ErrorBoundary>
-            <AppComponentPublic />
+            <>
+              <AppComponentPublic />
+              <GlobalModalWrapper />
+            </>
           </ErrorBoundary>
-          <GlobalModalWrapper />
           {process.env.CI && <div id="ci-environment">CI Test Environment</div>}
         </Container>,
       );

--- a/web-client/src/appPublic.tsx
+++ b/web-client/src/appPublic.tsx
@@ -5,6 +5,7 @@ import '../../node_modules/@fortawesome/fontawesome-svg-core/styles.css';
 
 import { AppComponentPublic } from './views/AppComponentPublic';
 import { Container } from '@cerebral/react';
+import { ErrorBoundary } from './views/ErrorBoundary';
 import { createForceRefreshCallback } from '@web-client/presenter/utilities/createForceRefreshCallback';
 import { initializeRealUserMonitoring } from '@web-client/providers/realUserMonitoring';
 import {
@@ -175,7 +176,9 @@ const appPublic = {
 
       root.render(
         <Container app={cerebralApp}>
-          <AppComponentPublic />
+          <ErrorBoundary>
+            <AppComponentPublic />
+          </ErrorBoundary>
           <GlobalModalWrapper />
           {process.env.CI && <div id="ci-environment">CI Test Environment</div>}
         </Container>,

--- a/web-client/src/providers/realUserMonitoring.test.ts
+++ b/web-client/src/providers/realUserMonitoring.test.ts
@@ -1,11 +1,12 @@
 const mockRecordError = jest.fn();
 const mockEnable = jest.fn();
+const mockAwsRum = jest.fn().mockImplementation(() => ({
+  enable: mockEnable,
+  recordError: mockRecordError,
+}));
 
 jest.mock('aws-rum-web', () => ({
-  AwsRum: jest.fn().mockImplementation(() => ({
-    enable: mockEnable,
-    recordError: mockRecordError,
-  })),
+  AwsRum: mockAwsRum,
 }));
 
 describe('realUserMonitoring', () => {
@@ -40,5 +41,18 @@ describe('realUserMonitoring', () => {
     recordError(error);
 
     expect(mockRecordError).toHaveBeenCalledWith(error);
+  });
+
+  it('configures the http telemetry so failed HTTP requests are recorded', () => {
+    process.env.ENV = 'dev';
+    const { initializeRealUserMonitoring } = require('./realUserMonitoring');
+
+    initializeRealUserMonitoring();
+
+    const config = mockAwsRum.mock.calls[0][3];
+    expect(config.telemetries).toContainEqual([
+      'http',
+      { recordAllRequests: false },
+    ]);
   });
 });

--- a/web-client/src/providers/realUserMonitoring.test.ts
+++ b/web-client/src/providers/realUserMonitoring.test.ts
@@ -1,0 +1,44 @@
+const mockRecordError = jest.fn();
+const mockEnable = jest.fn();
+
+jest.mock('aws-rum-web', () => ({
+  AwsRum: jest.fn().mockImplementation(() => ({
+    enable: mockEnable,
+    recordError: mockRecordError,
+  })),
+}));
+
+describe('realUserMonitoring', () => {
+  const originalEnv = process.env.ENV;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    process.env.ENV = originalEnv;
+  });
+
+  it('recordError is a no-op when RUM has not been initialized', () => {
+    process.env.ENV = 'local';
+    const { recordError } = require('./realUserMonitoring');
+
+    expect(() => recordError(new Error('boom'))).not.toThrow();
+    expect(mockRecordError).not.toHaveBeenCalled();
+  });
+
+  it('forwards the error to AwsRum once initialized', () => {
+    process.env.ENV = 'dev';
+    const {
+      initializeRealUserMonitoring,
+      recordError,
+    } = require('./realUserMonitoring');
+
+    initializeRealUserMonitoring();
+    const error = new Error('boom');
+    recordError(error);
+
+    expect(mockRecordError).toHaveBeenCalledWith(error);
+  });
+});

--- a/web-client/src/providers/realUserMonitoring.test.ts
+++ b/web-client/src/providers/realUserMonitoring.test.ts
@@ -10,15 +10,26 @@ jest.mock('aws-rum-web', () => ({
 }));
 
 describe('realUserMonitoring', () => {
-  const originalEnv = process.env.ENV;
+  const originalEnv = {
+    ENV: process.env.ENV,
+    RUM_APP_MONITOR_ID: process.env.RUM_APP_MONITOR_ID,
+    RUM_IDENTITY_POOL_ID: process.env.RUM_IDENTITY_POOL_ID,
+    RUM_SAMPLE_RATE: process.env.RUM_SAMPLE_RATE,
+  };
 
   beforeEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
+    process.env.RUM_APP_MONITOR_ID = 'test-app-monitor-id';
+    process.env.RUM_IDENTITY_POOL_ID = 'us-east-1:test-identity-pool-id';
+    process.env.RUM_SAMPLE_RATE = '1';
   });
 
   afterAll(() => {
-    process.env.ENV = originalEnv;
+    process.env.ENV = originalEnv.ENV;
+    process.env.RUM_APP_MONITOR_ID = originalEnv.RUM_APP_MONITOR_ID;
+    process.env.RUM_IDENTITY_POOL_ID = originalEnv.RUM_IDENTITY_POOL_ID;
+    process.env.RUM_SAMPLE_RATE = originalEnv.RUM_SAMPLE_RATE;
   });
 
   it('recordError is a no-op when RUM has not been initialized', () => {

--- a/web-client/src/providers/realUserMonitoring.ts
+++ b/web-client/src/providers/realUserMonitoring.ts
@@ -2,15 +2,25 @@ import { AwsRum, AwsRumConfig } from 'aws-rum-web';
 
 let awsRum: AwsRum | undefined;
 
-export const initializeRealUserMonitoring = () => {
+export const initializeRealUserMonitoring = (): void => {
   if (process.env.ENV === 'local') return;
   try {
+    const identityPoolId = process.env.RUM_IDENTITY_POOL_ID;
+    const sampleRateStr = process.env.RUM_SAMPLE_RATE;
+    const appMonitorId = process.env.RUM_APP_MONITOR_ID;
+
+    if (!identityPoolId || !sampleRateStr || !appMonitorId) {
+      throw new Error(
+        'Missing required RUM environment variables: RUM_IDENTITY_POOL_ID, RUM_SAMPLE_RATE, RUM_APP_MONITOR_ID',
+      );
+    }
+
     const config: AwsRumConfig = {
       allowCookies: true,
       enableXRay: false,
       endpoint: 'https://dataplane.rum.us-east-1.amazonaws.com',
-      identityPoolId: process.env.RUM_IDENTITY_POOL_ID,
-      sessionSampleRate: Number(process.env.RUM_SAMPLE_RATE!),
+      identityPoolId,
+      sessionSampleRate: Number(sampleRateStr),
       telemetries: [
         'performance',
         'errors',
@@ -22,7 +32,7 @@ export const initializeRealUserMonitoring = () => {
       ],
     };
 
-    const APPLICATION_ID: string = process.env.RUM_APP_MONITOR_ID!;
+    const APPLICATION_ID: string = appMonitorId;
     const APPLICATION_VERSION: string = '0.0.1';
 
     awsRum = new AwsRum(

--- a/web-client/src/providers/realUserMonitoring.ts
+++ b/web-client/src/providers/realUserMonitoring.ts
@@ -1,8 +1,9 @@
 import { AwsRum, AwsRumConfig } from 'aws-rum-web';
 
+let awsRum: AwsRum | undefined;
+
 export const initializeRealUserMonitoring = () => {
   if (process.env.ENV === 'local') return;
-  let awsRum: AwsRum;
   try {
     const config: AwsRumConfig = {
       allowCookies: true,
@@ -10,7 +11,7 @@ export const initializeRealUserMonitoring = () => {
       endpoint: 'https://dataplane.rum.us-east-1.amazonaws.com',
       identityPoolId: process.env.RUM_IDENTITY_POOL_ID,
       sessionSampleRate: Number(process.env.RUM_SAMPLE_RATE!),
-      telemetries: ['performance'],
+      telemetries: ['performance', 'errors'],
     };
 
     const APPLICATION_ID: string = process.env.RUM_APP_MONITOR_ID!;
@@ -27,5 +28,18 @@ export const initializeRealUserMonitoring = () => {
   } catch (error) {
     // Ignore errors thrown during CloudWatch RUM web client initialization
     console.log('Error initializing real user monitoring: ', error);
+  }
+};
+
+/**
+ * Records an error to CloudWatch RUM. Safe to call when RUM has not been
+ * initialized (e.g. local env or failed initialization) - it is a no-op.
+ */
+export const recordError = (error: unknown): void => {
+  if (!awsRum) return;
+  try {
+    awsRum.recordError(error);
+  } catch (rumError) {
+    console.log('Error recording error to real user monitoring: ', rumError);
   }
 };

--- a/web-client/src/providers/realUserMonitoring.ts
+++ b/web-client/src/providers/realUserMonitoring.ts
@@ -11,7 +11,15 @@ export const initializeRealUserMonitoring = () => {
       endpoint: 'https://dataplane.rum.us-east-1.amazonaws.com',
       identityPoolId: process.env.RUM_IDENTITY_POOL_ID,
       sessionSampleRate: Number(process.env.RUM_SAMPLE_RATE!),
-      telemetries: ['performance', 'errors'],
+      telemetries: [
+        'performance',
+        'errors',
+        // Record failed HTTP requests (4xx/5xx and network errors). axios runs
+        // on XMLHttpRequest in the browser, which this telemetry instruments.
+        // recordAllRequests stays false so we only capture errors, not every
+        // successful request.
+        ['http', { recordAllRequests: false }],
+      ],
     };
 
     const APPLICATION_ID: string = process.env.RUM_APP_MONITOR_ID!;

--- a/web-client/src/views/AppComponent.tsx
+++ b/web-client/src/views/AppComponent.tsx
@@ -237,14 +237,6 @@ export const AppComponent = connect(
     userContactEditInProgress,
     zipInProgress,
   }) {
-    // TEMPORARY: RUM error-boundary verification hook. Visiting any page with
-    // ?rum-crash=1 throws during render to confirm the ErrorBoundary catches it
-    // and the error is reported to CloudWatch RUM with readable (keepNames)
-    // stack frames. REMOVE after verification.
-    if (new URLSearchParams(window.location.search).get('rum-crash') === '1') {
-      throw new Error('RUM-TEST render crash');
-    }
-
     const focusMain = (e?: any) => {
       e?.preventDefault();
       const header = window.document.querySelector(

--- a/web-client/src/views/AppComponent.tsx
+++ b/web-client/src/views/AppComponent.tsx
@@ -237,6 +237,14 @@ export const AppComponent = connect(
     userContactEditInProgress,
     zipInProgress,
   }) {
+    // TEMPORARY: RUM error-boundary verification hook. Visiting any page with
+    // ?rum-crash=1 throws during render to confirm the ErrorBoundary catches it
+    // and the error is reported to CloudWatch RUM with readable (keepNames)
+    // stack frames. REMOVE after verification.
+    if (new URLSearchParams(window.location.search).get('rum-crash') === '1') {
+      throw new Error('RUM-TEST render crash');
+    }
+
     const focusMain = (e?: any) => {
       e?.preventDefault();
       const header = window.document.querySelector(

--- a/web-client/src/views/ErrorBoundary.test.tsx
+++ b/web-client/src/views/ErrorBoundary.test.tsx
@@ -1,0 +1,60 @@
+import { ErrorBoundary } from './ErrorBoundary';
+import { recordError } from '@web-client/providers/realUserMonitoring';
+import React from 'react';
+
+jest.mock('@web-client/providers/realUserMonitoring', () => ({
+  recordError: jest.fn(),
+}));
+
+describe('ErrorBoundary', () => {
+  it('flags an error in state via getDerivedStateFromError', () => {
+    expect(ErrorBoundary.getDerivedStateFromError()).toEqual({
+      hasError: true,
+    });
+  });
+
+  it('renders its children when no error has occurred', () => {
+    const children = <div data-testid="child" />;
+    const boundary = new ErrorBoundary({ children });
+
+    expect(boundary.render()).toBe(children);
+  });
+
+  it('renders the default fallback when an error has occurred', () => {
+    const boundary = new ErrorBoundary({ children: <div /> });
+    boundary.state = { hasError: true };
+
+    const rendered = boundary.render() as React.ReactElement<{
+      'data-testid': string;
+    }>;
+
+    expect(rendered.props['data-testid']).toEqual('error-boundary-fallback');
+  });
+
+  it('renders a custom fallback when provided', () => {
+    const fallback = <div data-testid="custom-fallback" />;
+    const boundary = new ErrorBoundary({ children: <div />, fallback });
+    boundary.state = { hasError: true };
+
+    expect(boundary.render()).toBe(fallback);
+  });
+
+  it('logs the error and reports it to RUM in componentDidCatch', () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const boundary = new ErrorBoundary({ children: <div /> });
+    const error = new Error('boom');
+    const info = { componentStack: 'at SomeComponent' } as React.ErrorInfo;
+
+    boundary.componentDidCatch(error, info);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Unhandled UI error caught by ErrorBoundary',
+      error,
+      info,
+    );
+    expect(recordError).toHaveBeenCalledWith(error);
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/web-client/src/views/ErrorBoundary.tsx
+++ b/web-client/src/views/ErrorBoundary.tsx
@@ -1,0 +1,56 @@
+import { recordError } from '@web-client/providers/realUserMonitoring';
+import React from 'react';
+
+type ErrorBoundaryProps = {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+};
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+};
+
+/**
+ * Catches render-time errors thrown anywhere below it and renders a fallback
+ * instead of unmounting the entire React tree (which leaves a blank page).
+ *
+ * Note: error boundaries do NOT catch errors in event handlers, asynchronous
+ * code, or the boundary's own render - those still need their own handling.
+ */
+export class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    console.error('Unhandled UI error caught by ErrorBoundary', error, info);
+    recordError(error);
+  }
+
+  render(): React.ReactNode {
+    if (this.state.hasError) {
+      if (this.props.fallback !== undefined) {
+        return this.props.fallback;
+      }
+
+      return (
+        <div
+          className="grid-container margin-top-5"
+          data-testid="error-boundary-fallback"
+        >
+          <h1>Something went wrong</h1>
+          <p>
+            Please refresh the page. If the problem persists, contact support.
+          </p>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/web-client/src/views/ErrorBoundary.tsx
+++ b/web-client/src/views/ErrorBoundary.tsx
@@ -15,7 +15,7 @@ type ErrorBoundaryState = {
  * instead of unmounting the entire React tree (which leaves a blank page).
  *
  * Note: error boundaries do NOT catch errors in event handlers, asynchronous
- * code, or the boundary's own render - those still need their own handling.
+ * code, or the boundary's own render
  */
 export class ErrorBoundary extends React.Component<
   ErrorBoundaryProps,


### PR DESCRIPTION
## Summary

Adds client-side error handling and reporting so unhandled UI errors no longer
blank the page silently and are now captured in CloudWatch RUM. Three pieces:
a React error boundary, RUM error reporting, and readable production stack traces.

## Changes

**Error boundary**
- New `ErrorBoundary` component (`getDerivedStateFromError` + `componentDidCatch`)
  that renders a graceful fallback instead of unmounting the whole React tree
  (which previously left users on a blank white page).
- Wired into both entry points — `app.tsx` (`AppComponent`) and
  `appPublic.tsx` (`AppComponentPublic`) — inside the Cerebral `Container`.

**CloudWatch RUM error reporting**
- `realUserMonitoring.ts`: exposed a safe `recordError()` (no-op when RUM is not
  initialized) and call it from `ErrorBoundary.componentDidCatch`.
- Enabled the `'errors'` and `'http'` RUM telemetries so uncaught JS errors and
  failed HTTP requests (4xx/5xx and network failures, `recordAllRequests: false`)
  are captured automatically.

**Readable production stack traces**
- Added `keepNames: true` to the shared esbuild config so minified prod bundles
  preserve original function/class names — RUM traces now show `ErrorBoundary` /
  `AppComponent` instead of single-letter identifiers.

## Testing

- Unit tests for `ErrorBoundary` (error-state transition, default/custom fallback,
  `recordError` invocation) and `realUserMonitoring` (`recordError` no-op vs.
  forwarding, http telemetry config).
- **Verified end-to-end on exp6**: confirmed in the RUM console that JS errors,
  HTTP errors (incl. a real `status: 400`), and readable `keepNames` stack traces
  are all captured and ingested.