### PR TITLE
9607 stamp to test 1781276032

### DIFF
--- a/cypress/helpers/fileAPetition/create-and-serve-paper-petition-petitioner-and-spouse.ts
+++ b/cypress/helpers/fileAPetition/create-and-serve-paper-petition-petitioner-and-spouse.ts
@@ -78,17 +78,22 @@ export function createAndServePaperPetitionMultipleParties(
     selectorToAwaitOnSuccess: '[data-testid="remove-pdf"]',
   });
   cy.get('[data-testid="submit-paper-petition"]').click();
+  cy.url({ timeout: SLOW_CI_TIMEOUT }).should('match', /\/case-detail\/[^/]+/);
   return cy
-    .get('.docket-number-header a', { timeout: SLOW_CI_TIMEOUT })
+    .get('[data-testid="docket-number-header"] a', { timeout: SLOW_CI_TIMEOUT })
     .invoke('attr', 'href')
     .then(href => {
-      const docketNumber = href!.split('/').pop();
+      const match = href?.match(/\/case-detail\/([^/]+)/);
+      if (!match?.[1]) {
+        throw new Error(`Unable to parse docket number from href: ${href}`);
+      }
+      const docketNumber = match[1];
       cy.get('[data-testid="serve-case-to-irs"]').click();
       cy.get('[data-testid="modal-confirm"]').click();
       cy.get('[data-testid="done-viewing-paper-petition-receipt-button"]', {
         timeout: SLOW_CI_TIMEOUT,
       }).click();
       cy.get('.usa-alert__text').should('have.text', 'Petition served to IRS.');
-      return cy.wrap({ docketNumber: docketNumber!, name, spouseName });
+      return cy.wrap({ docketNumber, name, spouseName });
     });
 }

--- a/cypress/helpers/fileAPetition/create-and-serve-paper-petition-petitioner-and-spouse.ts
+++ b/cypress/helpers/fileAPetition/create-and-serve-paper-petition-petitioner-and-spouse.ts
@@ -7,6 +7,8 @@ import { attachFile } from '../file/upload-file';
 import { faker } from '@faker-js/faker';
 import { getCurrentDateTimeInMillis } from '@shared/business/utilities/DateHandler';
 
+const SLOW_CI_TIMEOUT = 120000;
+
 export function createAndServePaperPetitionMultipleParties(
   options = { yearReceived: '2021' },
 ) {
@@ -77,13 +79,15 @@ export function createAndServePaperPetitionMultipleParties(
   });
   cy.get('[data-testid="submit-paper-petition"]').click();
   return cy
-    .get('.docket-number-header a')
+    .get('.docket-number-header a', { timeout: SLOW_CI_TIMEOUT })
     .invoke('attr', 'href')
     .then(href => {
       const docketNumber = href!.split('/').pop();
       cy.get('[data-testid="serve-case-to-irs"]').click();
       cy.get('[data-testid="modal-confirm"]').click();
-      cy.get('#done-viewing-paper-petition-receipt-button').click();
+      cy.get('[data-testid="done-viewing-paper-petition-receipt-button"]', {
+        timeout: SLOW_CI_TIMEOUT,
+      }).click();
       cy.get('.usa-alert__text').should('have.text', 'Petition served to IRS.');
       return cy.wrap({ docketNumber: docketNumber!, name, spouseName });
     });

--- a/cypress/helpers/fileAPetition/create-and-serve-paper-petition.ts
+++ b/cypress/helpers/fileAPetition/create-and-serve-paper-petition.ts
@@ -3,6 +3,8 @@ import { attachFile } from '../file/upload-file';
 import { loginAsPetitionsClerk1 } from '../authentication/login-as-helpers';
 import { getCurrentDateTimeInMillis } from '@shared/business/utilities/DateHandler';
 
+const SLOW_CI_TIMEOUT = 120000;
+
 export function createAndServePaperPetition(
   {
     name = 'rick james ' + getCurrentDateTimeInMillis(),
@@ -130,13 +132,15 @@ export function createAndServePaperPetition(
 
   cy.get('[data-testid="submit-paper-petition"]').click();
   return cy
-    .get('.docket-number-header a')
+    .get('.docket-number-header a', { timeout: SLOW_CI_TIMEOUT })
     .invoke('attr', 'href')
     .then(href => {
       const docketNumber = href!.split('/').pop();
       cy.get('[data-testid="serve-case-to-irs"]').click();
       cy.get('[data-testid="modal-confirm"]').click();
-      cy.get('#done-viewing-paper-petition-receipt-button').click();
+      cy.get('[data-testid="done-viewing-paper-petition-receipt-button"]', {
+        timeout: SLOW_CI_TIMEOUT,
+      }).click();
       cy.get('.usa-alert__text').should('have.text', 'Petition served to IRS.');
 
       cy.get('[data-testid="docket-number-search-input"]').type(
@@ -281,15 +285,15 @@ export function createAndServePaperPetitionMyselfAndSpouse(
   cy.get('[data-testid="submit-paper-petition"]').click();
 
   return cy
-    .get('.docket-number-header a')
+    .get('.docket-number-header a', { timeout: SLOW_CI_TIMEOUT })
     .invoke('attr', 'href')
     .then(href => {
       const docketNumber = href!.split('/').pop();
       cy.get('[data-testid="serve-case-to-irs"]').click();
       cy.get('[data-testid="modal-confirm"]').click();
-      cy.get(
-        '[data-testid="done-viewing-paper-petition-receipt-button"]',
-      ).click();
+      cy.get('[data-testid="done-viewing-paper-petition-receipt-button"]', {
+        timeout: SLOW_CI_TIMEOUT,
+      }).click();
 
       cy.get('[data-testid="success-alert"]').contains(
         'Petition served to IRS.',

--- a/cypress/helpers/fileAPetition/create-and-serve-paper-petition.ts
+++ b/cypress/helpers/fileAPetition/create-and-serve-paper-petition.ts
@@ -5,6 +5,33 @@ import { getCurrentDateTimeInMillis } from '@shared/business/utilities/DateHandl
 
 const SLOW_CI_TIMEOUT = 120000;
 
+const assertOnCaseDetailPage = (docketNumber: string): void => {
+  cy.get('[data-testid="docket-number-header"] a', {
+    timeout: SLOW_CI_TIMEOUT,
+  }).should('have.attr', 'href', `/case-detail/${docketNumber}`);
+};
+
+const getDocketNumberAfterPaperPetitionSubmit =
+  (): Cypress.Chainable<string> => {
+    cy.url({ timeout: SLOW_CI_TIMEOUT }).should(
+      'match',
+      /\/case-detail\/[^/]+/,
+    );
+
+    return cy
+      .get('[data-testid="docket-number-header"] a', {
+        timeout: SLOW_CI_TIMEOUT,
+      })
+      .invoke('attr', 'href')
+      .then(href => {
+        const match = href?.match(/\/case-detail\/([^/]+)/);
+        if (!match?.[1]) {
+          throw new Error(`Unable to parse docket number from href: ${href}`);
+        }
+        return match[1];
+      });
+  };
+
 export function createAndServePaperPetition(
   {
     name = 'rick james ' + getCurrentDateTimeInMillis(),
@@ -131,89 +158,86 @@ export function createAndServePaperPetition(
   }
 
   cy.get('[data-testid="submit-paper-petition"]').click();
-  return cy
-    .get('.docket-number-header a', { timeout: SLOW_CI_TIMEOUT })
-    .invoke('attr', 'href')
-    .then(href => {
-      const docketNumber = href!.split('/').pop();
-      cy.get('[data-testid="serve-case-to-irs"]').click();
-      cy.get('[data-testid="modal-confirm"]').click();
-      cy.get('[data-testid="done-viewing-paper-petition-receipt-button"]', {
-        timeout: SLOW_CI_TIMEOUT,
-      }).click();
-      cy.get('.usa-alert__text').should('have.text', 'Petition served to IRS.');
+  return getDocketNumberAfterPaperPetitionSubmit().then(docketNumber => {
+    cy.get('[data-testid="serve-case-to-irs"]').click();
+    cy.get('[data-testid="modal-confirm"]').click();
+    cy.get('[data-testid="done-viewing-paper-petition-receipt-button"]', {
+      timeout: SLOW_CI_TIMEOUT,
+    }).click();
+    cy.get('.usa-alert__text').should('have.text', 'Petition served to IRS.');
 
-      cy.get('[data-testid="docket-number-search-input"]').type(
-        `${docketNumber}`,
-      );
-      cy.get('.usa-search-submit-text').click();
+    cy.get('[data-testid="docket-number-search-input"]').clear();
+    cy.get('[data-testid="docket-number-search-input"]').type(docketNumber);
+    cy.get('[data-testid="search-docket-number"]').click();
+    assertOnCaseDetailPage(docketNumber);
 
-      cy.get('[data-testid="case-status"]').should(
+    cy.get('[data-testid="case-status"]').should(
+      'have.text',
+      'General Docket - Not at Issue',
+    );
+
+    const expectedDocuments = [
+      { eventCode: 'P', servedTo: 'R', index: 1 },
+      { eventCode: 'ATP', servedTo: 'R', index: 2 },
+      { eventCode: 'DISC', servedTo: 'R', index: includeApwDocument ? 4 : 3 },
+      { eventCode: 'RQT', servedTo: 'R', index: includeApwDocument ? 5 : 4 },
+      { eventCode: 'NOTR', servedTo: 'P', index: includeApwDocument ? 6 : 5 },
+    ];
+    if (includeApwDocument) {
+      expectedDocuments.splice(1, 0, {
+        eventCode: 'APW',
+        servedTo: 'R',
+        index: 3,
+      });
+    }
+
+    expectedDocuments.forEach(({ eventCode, index, servedTo }) => {
+      cy.get(`[data-testid="docket-entry-eventCode-${index}"]`).should(
         'have.text',
-        'General Docket - Not at Issue',
+        eventCode,
       );
+      cy.get(`[data-testid="docket-entry-servedPartiesCode-${index}"]`).should(
+        'have.text',
+        servedTo,
+      );
+    });
 
-      const expectedDocuments = [
-        { eventCode: 'P', servedTo: 'R', index: 1 },
-        { eventCode: 'ATP', servedTo: 'R', index: 2 },
-        { eventCode: 'DISC', servedTo: 'R', index: includeApwDocument ? 4 : 3 },
-        { eventCode: 'RQT', servedTo: 'R', index: includeApwDocument ? 5 : 4 },
-        { eventCode: 'NOTR', servedTo: 'P', index: includeApwDocument ? 6 : 5 },
-      ];
-      if (includeApwDocument) {
-        expectedDocuments.splice(1, 0, {
-          eventCode: 'APW',
-          servedTo: 'R',
-          index: 3,
-        });
-      }
+    cy.get('[data-testid="tab-drafts"] > .button-text').click();
 
-      expectedDocuments.forEach(({ eventCode, index, servedTo }) => {
-        cy.get(`[data-testid="docket-entry-eventCode-${index}"]`).should(
-          'have.text',
-          eventCode,
-        );
-        cy.get(
-          `[data-testid="docket-entry-servedPartiesCode-${index}"]`,
-        ).should('have.text', servedTo);
-      });
+    const expectedDescriptions = [
+      'Notice of Attachments in the Nature of Evidence',
+      'Order',
+      'Order',
+      'Order to Show Cause',
+    ];
 
-      cy.get('[data-testid="tab-drafts"] > .button-text').click();
+    cy.get('[data-testid^="docket-entry-description-"]').should($els => {
+      const actualDescriptions = Array.from($els).map(el => el.textContent);
 
-      const expectedDescriptions = [
-        'Notice of Attachments in the Nature of Evidence',
-        'Order',
-        'Order',
-        'Order to Show Cause',
-      ];
+      expect(actualDescriptions).to.have.length(expectedDescriptions.length);
 
-      cy.get('[data-testid^="docket-entry-description-"]').should($els => {
-        const actualDescriptions = Array.from($els).map(el => el.textContent);
-
-        expect(actualDescriptions).to.have.length(expectedDescriptions.length);
-
-        expectedDescriptions.forEach(expected => {
-          const expectedCount = expectedDescriptions.filter(
-            desc => desc === expected,
-          ).length;
-          const actualCount = actualDescriptions.filter(
-            desc => desc === expected,
-          ).length;
-          expect(
-            actualCount,
-            `Should have ${expectedCount} occurrence(s) of "${expected}"`,
-          ).to.equal(expectedCount);
-        });
-      });
-
-      cy.get('[data-testid="tab-docket-record"]').click();
-
-      return cy.wrap({
-        docketNumber: docketNumber!,
-        documentsCreated: expectedDocuments,
-        name,
+      expectedDescriptions.forEach(expected => {
+        const expectedCount = expectedDescriptions.filter(
+          desc => desc === expected,
+        ).length;
+        const actualCount = actualDescriptions.filter(
+          desc => desc === expected,
+        ).length;
+        expect(
+          actualCount,
+          `Should have ${expectedCount} occurrence(s) of "${expected}"`,
+        ).to.equal(expectedCount);
       });
     });
+
+    cy.get('[data-testid="tab-docket-record"]').click();
+
+    return cy.wrap({
+      docketNumber,
+      documentsCreated: expectedDocuments,
+      name,
+    });
+  });
 }
 
 export function createAndServePaperPetitionMyselfAndSpouse(
@@ -284,27 +308,20 @@ export function createAndServePaperPetitionMyselfAndSpouse(
 
   cy.get('[data-testid="submit-paper-petition"]').click();
 
-  return cy
-    .get('.docket-number-header a', { timeout: SLOW_CI_TIMEOUT })
-    .invoke('attr', 'href')
-    .then(href => {
-      const docketNumber = href!.split('/').pop();
-      cy.get('[data-testid="serve-case-to-irs"]').click();
-      cy.get('[data-testid="modal-confirm"]').click();
-      cy.get('[data-testid="done-viewing-paper-petition-receipt-button"]', {
-        timeout: SLOW_CI_TIMEOUT,
-      }).click();
+  return getDocketNumberAfterPaperPetitionSubmit().then(docketNumber => {
+    cy.get('[data-testid="serve-case-to-irs"]').click();
+    cy.get('[data-testid="modal-confirm"]').click();
+    cy.get('[data-testid="done-viewing-paper-petition-receipt-button"]', {
+      timeout: SLOW_CI_TIMEOUT,
+    }).click();
 
-      cy.get('[data-testid="success-alert"]').contains(
-        'Petition served to IRS.',
-      );
+    cy.get('[data-testid="success-alert"]').contains('Petition served to IRS.');
 
-      cy.get('[data-testid="docket-number-search-input"]').type(
-        `${docketNumber}`,
-      );
+    cy.get('[data-testid="docket-number-search-input"]').clear();
+    cy.get('[data-testid="docket-number-search-input"]').type(docketNumber);
+    cy.get('[data-testid="search-docket-number"]').click();
+    assertOnCaseDetailPage(docketNumber);
 
-      cy.get('[data-testid="search-docket-number"]').click();
-
-      return cy.wrap({ docketNumber: docketNumber! });
-    });
+    return cy.wrap({ docketNumber });
+  });
 }

--- a/cypress/helpers/fileAPetition/petitioner-creates-electronic-case.ts
+++ b/cypress/helpers/fileAPetition/petitioner-creates-electronic-case.ts
@@ -2,6 +2,8 @@ import { PROCEDURE_TYPES_MAP } from '../../../shared/src/business/entities/Entit
 import { attachSamplePdfFile } from '../file/upload-file';
 import { faker } from '@faker-js/faker';
 
+const SLOW_CI_TIMEOUT = 120000;
+
 export function externalUserCreatesElectronicCase(
   primaryFilerName: string = faker.person.firstName(),
 ) {
@@ -43,7 +45,9 @@ export function externalUserCreatesElectronicCase(
   cy.get('[data-testid="step-6-next-button"]').click();
 
   return cy
-    .get('[data-testid="case-link-docket-number"]')
+    .get('[data-testid="case-link-docket-number"]', {
+      timeout: SLOW_CI_TIMEOUT,
+    })
     .should('be.visible')
     .invoke('text')
     .then(docketNumberWithSuffix => {
@@ -96,7 +100,9 @@ export function petitionerCreatesElectronicCaseWithDeceasedSpouse(
   cy.get('[data-testid="step-6-next-button"]').click();
 
   return cy
-    .get('[data-testid="case-link-docket-number"]')
+    .get('[data-testid="case-link-docket-number"]', {
+      timeout: SLOW_CI_TIMEOUT,
+    })
     .invoke('text')
     .then(docketNumberWithSuffix => {
       cy.get('[data-testid="case-link"]').click();
@@ -148,7 +154,9 @@ export function petitionerCreatesElectronicCaseWithSpouse(
   cy.get('[data-testid="step-6-next-button"]').click();
 
   return cy
-    .get('[data-testid="case-link-docket-number"]')
+    .get('[data-testid="case-link-docket-number"]', {
+      timeout: SLOW_CI_TIMEOUT,
+    })
     .invoke('text')
     .then(docketNumberWithSuffix => {
       cy.get('[data-testid="case-link"]').click();
@@ -211,7 +219,9 @@ export function externalUserCreatesElectronicCaseWithSpouseDifferentAddress(
   cy.get('[data-testid="step-6-next-button"]').click();
 
   return cy
-    .get('[data-testid="case-link-docket-number"]')
+    .get('[data-testid="case-link-docket-number"]', {
+      timeout: SLOW_CI_TIMEOUT,
+    })
     .invoke('text')
     .then(docketNumberWithSuffix => {
       cy.get('[data-testid="case-link"]').click();
@@ -258,7 +268,9 @@ export function petitionerCreatesElectronicCaseForBusiness() {
   cy.get('[data-testid="step-6-next-button"]').click();
 
   return cy
-    .get('[data-testid="case-link-docket-number"]')
+    .get('[data-testid="case-link-docket-number"]', {
+      timeout: SLOW_CI_TIMEOUT,
+    })
     .invoke('text')
     .then(docketNumberWithSuffix => {
       cy.get('[data-testid="button-back-to-dashboard"]').click();

--- a/cypress/helpers/fileAPetition/petitioner-creates-electronic-case.ts
+++ b/cypress/helpers/fileAPetition/petitioner-creates-electronic-case.ts
@@ -48,11 +48,10 @@ export function externalUserCreatesElectronicCase(
     .get('[data-testid="case-link-docket-number"]', {
       timeout: SLOW_CI_TIMEOUT,
     })
-    .should('be.visible')
     .invoke('text')
-    .then(docketNumberWithSuffix => {
+    .then(docketNumber => {
       cy.get('[data-testid="button-back-to-dashboard"]').click();
-      return cy.wrap<string>(docketNumberWithSuffix);
+      return cy.wrap<string>(docketNumber);
     });
 }
 

--- a/cypress/local-only/tests/integration/documentQC/docket-clerk-qcs-paper-filing.cy.ts
+++ b/cypress/local-only/tests/integration/documentQC/docket-clerk-qcs-paper-filing.cy.ts
@@ -13,6 +13,7 @@ import { selectTypeaheadInput } from '../../../../helpers/components/typeAhead/s
  * When a docket clerk QCs a paper filing, changing the event code
  * Then they should see the document title was updated
  */
+
 describe('Docket clerk QC-ing a paper filing', () => {
   it('should see the document title was updated when they change the event code while QC-ing', () => {
     loginAsPetitioner();

--- a/cypress/local-only/tests/integration/documentQC/docket-clerk-qcs-paper-filing.cy.ts
+++ b/cypress/local-only/tests/integration/documentQC/docket-clerk-qcs-paper-filing.cy.ts
@@ -1,13 +1,14 @@
-import { attachFile } from '../../../../helpers/file/upload-file';
-import { externalUserCreatesElectronicCase } from '../../../../helpers/fileAPetition/petitioner-creates-electronic-case';
+import { attachFile } from 'cypress/helpers/file/upload-file';
+import { externalUserCreatesElectronicCase } from 'cypress/helpers/fileAPetition/petitioner-creates-electronic-case';
 import {
   loginAsDocketClerk1,
   loginAsPetitioner,
-} from '../../../../helpers/authentication/login-as-helpers';
-import { logout } from '../../../../helpers/authentication/logout';
-import { petitionsClerkServesPetition } from '../../../../helpers/documentQC/petitionsclerk-serves-petition';
-import { selectTypeaheadInput } from '../../../../helpers/components/typeAhead/select-typeahead-input';
+} from 'cypress/helpers/authentication/login-as-helpers';
+import { logout } from 'cypress/helpers/authentication/logout';
+import { petitionsClerkServesPetition } from 'cypress/helpers/documentQC/petitionsclerk-serves-petition';
+import { selectTypeaheadInput } from 'cypress/helpers/components/typeAhead/select-typeahead-input';
 
+const SLOW_CI_TIMEOUT = 120000;
 /**
  * Given a case
  * When a docket clerk QCs a paper filing, changing the event code
@@ -89,11 +90,11 @@ describe('Docket clerk QC-ing a paper filing', () => {
       // duplicates the coversheet shows up as a page-count change here.
       cy.get('[data-testid="docket-number-search-input"]').type(docketNumber);
       cy.get('[data-testid="search-docket-number"]').click();
-      cy.get('[data-testid="docket-record-table"]', { timeout: 120000 }).should(
-        'exist',
-      );
+      cy.get('[data-testid="docket-record-table"]', {
+        timeout: SLOW_CI_TIMEOUT,
+      }).should('exist');
       cy.contains('[data-testid^="docket-entry-eventCode-"]', 'M115', {
-        timeout: 120000,
+        timeout: SLOW_CI_TIMEOUT,
       })
         .parents('tr')
         .find('.number-of-pages')

--- a/cypress/local-only/tests/integration/documentQC/docket-clerk-qcs-paper-filing.cy.ts
+++ b/cypress/local-only/tests/integration/documentQC/docket-clerk-qcs-paper-filing.cy.ts
@@ -52,7 +52,7 @@ describe('Docket clerk QC-ing a paper filing', () => {
 
       cy.get('[data-testid="filed-by-option"]').contains('Petitioner').click();
 
-      cy.get('[data-testid="objections-No"').click();
+      cy.get('[data-testid="objections-No"]').click();
 
       cy.get('[data-testid="upload-pdf-button"]').click();
       attachFile({
@@ -88,7 +88,12 @@ describe('Docket clerk QC-ing a paper filing', () => {
       // duplicates the coversheet shows up as a page-count change here.
       cy.get('[data-testid="docket-number-search-input"]').type(docketNumber);
       cy.get('[data-testid="search-docket-number"]').click();
-      cy.contains('[data-testid^="docket-entry-eventCode-"]', 'M115')
+      cy.get('[data-testid="docket-record-table"]', { timeout: 120000 }).should(
+        'exist',
+      );
+      cy.contains('[data-testid^="docket-entry-eventCode-"]', 'M115', {
+        timeout: 120000,
+      })
         .parents('tr')
         .find('.number-of-pages')
         .should('have.text', '2');

--- a/web-client/src/app.tsx
+++ b/web-client/src/app.tsx
@@ -51,6 +51,7 @@ import { faCheck } from '@fortawesome/free-solid-svg-icons/faCheck';
 import { faCheckCircle } from '@fortawesome/free-solid-svg-icons/faCheckCircle';
 import { faChevronUp } from '@fortawesome/free-solid-svg-icons/faChevronUp';
 import { faCircle } from '@fortawesome/free-solid-svg-icons/faCircle';
+import { faCircleXmark } from '@fortawesome/free-solid-svg-icons/faCircleXmark';
 import { faClipboardList } from '@fortawesome/free-solid-svg-icons/faClipboardList';
 import { faClock as faClockSolid } from '@fortawesome/free-solid-svg-icons/faClock';
 import { faCloudDownloadAlt } from '@fortawesome/free-solid-svg-icons/faCloudDownloadAlt';
@@ -171,6 +172,7 @@ const app = {
       faCheckCircle,
       faCheckCircleRegular,
       faCircle,
+      faCircleXmark,
       faClipboardList,
       faClock,
       faClockSolid,

--- a/web-client/src/styles/forms.scss
+++ b/web-client/src/styles/forms.scss
@@ -665,12 +665,36 @@ label.ustc-upload {
     }
   }
 
-  .grant-deny-motion-status-report-fields {
-    .grant-deny-motion-form-group {
-      margin: 1rem 1rem 0 0;
+  .grant-deny-motion-jurisdiction-options {
+    .usa-radio {
+      margin-bottom: 0;
 
-      &:first-child {
-        margin-top: 0;
+      + .usa-radio {
+        margin-top: 0.25rem;
+      }
+    }
+  }
+
+  .grant-deny-motion-optional-options {
+    // Match USWDS radio/checkbox label text offset (padding-left: 2rem).
+    .usa-radio__label,
+    .usa-checkbox__label {
+      &::before {
+        position: absolute;
+        display: block;
+      }
+    }
+  }
+
+  .grant-deny-motion-status-report-fields {
+    padding-left: 2rem;
+    margin-top: 0.5rem;
+
+    .usa-form-group {
+      margin: 0 0 1rem;
+
+      &:last-child {
+        margin-bottom: 0;
       }
     }
   }

--- a/web-client/src/ustc-ui/CharactersRemainingHint/CharactersRemainingHint.tsx
+++ b/web-client/src/ustc-ui/CharactersRemainingHint/CharactersRemainingHint.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 
 export const CharactersRemainingHint = ({
+  className,
   id,
   maxCharacters,
   stringToCount = '',
 }: {
+  className?: string;
   id?: string;
   maxCharacters: number;
   stringToCount: string | null | undefined;
@@ -14,7 +16,7 @@ export const CharactersRemainingHint = ({
   return (
     <span
       aria-live="polite"
-      className="usa-hint usa-character-count__message"
+      className={`usa-hint usa-character-count__message ${className || ''}`}
       id={id || 'with-hint-textarea-info'}
     >
       {charactersRemaining} characters remaining

--- a/web-client/src/views/GrantDenyMotion/GrantDenyMotion.tsx
+++ b/web-client/src/views/GrantDenyMotion/GrantDenyMotion.tsx
@@ -2,10 +2,13 @@ import { Button } from '../../ustc-ui/Button/Button';
 import { Button as DawsonButton } from '@web-client/dawson-ui/ui/button';
 import { CaseDetailHeader } from '../CaseDetail/CaseDetailHeader';
 import { CharactersRemainingHint } from '@web-client/ustc-ui/CharactersRemainingHint/CharactersRemainingHint';
-import { DateSelector } from '@web-client/ustc-ui/DateInput/DateSelector';
 import { ErrorNotification } from '../ErrorNotification';
 import { FormGroup } from '../../ustc-ui/FormGroup/FormGroup';
 import { PdfPreview } from '@web-client/ustc-ui/PdfPreview/PdfPreview';
+import { StatusReportDueDateFields } from './StatusReportDueDateFields';
+import type { StatusReportDueDateFieldsProps } from './StatusReportDueDateFields';
+import { updateGrantDenyMotionFormValueSequence } from '@web-client/presenter/sequences/GrantDenyMotion/updateGrantDenyMotionFormValueSequence';
+import { validateGrantDenyMotionSequence as validateGrantDenyMotionSequenceFn } from '@web-client/presenter/sequences/GrantDenyMotion/validateGrantDenyMotionSequence';
 import { connect } from '@web-client/presenter/shared.cerebral';
 import { sequences, state } from '@web-client/presenter/app.cerebral';
 import React from 'react';
@@ -63,64 +66,22 @@ export const GrantDenyMotion = connect(
         : '';
     const deniedOptionsDisabledTitle = isDenied ? '' : 'Select "DENIED" first';
     const grantDenyOptions = constants.GRANT_DENY_MOTION_OPTIONS;
-    const { filingPartyOptions } = grantDenyOptions;
     const docketEntryPreview = 'Order';
 
-    const renderStatusReportDueDateFields = (): React.ReactNode => (
-      <div
-        className="grant-deny-motion-status-report-fields"
-        data-testid="status-report-due-date-fields"
-      >
-        <FormGroup errorText={validationErrors.filingParty}>
-          <label className="usa-label" htmlFor="filing-party">
-            Filing Party
-          </label>
-          <select
-            className="usa-select"
-            data-testid="filing-party"
-            id="filing-party"
-            name="filingParty"
-            value={form.filingParty || ''}
-            onChange={e =>
-              updateFormValueSequence({
-                key: e.target.name,
-                value: e.target.value,
-              })
-            }
-          >
-            <option value="">- Select -</option>
-            <option value={filingPartyOptions.petitioners}>
-              {filingPartyOptions.petitioners}
-            </option>
-            <option value={filingPartyOptions.respondent}>
-              {filingPartyOptions.respondent}
-            </option>
-            <option value={filingPartyOptions.joint}>
-              {filingPartyOptions.joint}
-            </option>
-          </select>
-        </FormGroup>
-
-        <FormGroup errorText={validationErrors.dueDate}>
-          <DateSelector
-            defaultValue={form.dueDate}
-            formGroupClassNames="display-inline-block padding-0"
-            id="grant-deny-due-date"
-            label="Due Date:"
-            minDate={grantDenyMotionFormHelper.minDate}
-            placeHolderText="MM/DD/YYYY"
-            onChange={e => {
-              formatAndUpdateDateFromDatePickerSequence({
-                key: 'dueDate',
-                toFormat: constants.DATE_FORMATS.YYYYMMDD,
-                value: e.target.value,
-              });
-              validateGrantDenyMotionSequence();
-            }}
-          />
-        </FormGroup>
-      </div>
-    );
+    const statusReportDueDateFieldsProps: StatusReportDueDateFieldsProps = {
+      constants,
+      dueDate: form.dueDate ?? undefined,
+      dueDateErrorText: validationErrors.dueDate,
+      filingParty: form.filingParty,
+      filingPartyErrorText: validationErrors.filingParty,
+      filingPartyOptions: grantDenyOptions.filingPartyOptions,
+      formatAndUpdateDateFromDatePickerSequence,
+      minDate: grantDenyMotionFormHelper.minDate,
+      updateFormValueSequence:
+        updateFormValueSequence as typeof updateGrantDenyMotionFormValueSequence,
+      validateGrantDenyMotionSequence:
+        validateGrantDenyMotionSequence as typeof validateGrantDenyMotionSequenceFn,
+    };
 
     return (
       <>
@@ -456,8 +417,11 @@ export const GrantDenyMotion = connect(
                         </label>
                       </div>
                       {form.dueDateMessage ===
-                        grantDenyOptions.dueDateMessageOptions.statusReport &&
-                        renderStatusReportDueDateFields()}
+                        grantDenyOptions.dueDateMessageOptions.statusReport && (
+                        <StatusReportDueDateFields
+                          {...statusReportDueDateFieldsProps}
+                        />
+                      )}
                       <div className="usa-checkbox">
                         <input
                           aria-label="file status report or proposed stipulated decision"
@@ -493,8 +457,11 @@ export const GrantDenyMotion = connect(
                       </div>
                       {form.dueDateMessage ===
                         grantDenyOptions.dueDateMessageOptions
-                          .statusReportOrStipulatedDecision &&
-                        renderStatusReportDueDateFields()}
+                          .statusReportOrStipulatedDecision && (
+                        <StatusReportDueDateFields
+                          {...statusReportDueDateFieldsProps}
+                        />
+                      )}
                     </div>
                   </FormGroup>
 

--- a/web-client/src/views/GrantDenyMotion/GrantDenyMotion.tsx
+++ b/web-client/src/views/GrantDenyMotion/GrantDenyMotion.tsx
@@ -7,8 +7,6 @@ import { FormGroup } from '../../ustc-ui/FormGroup/FormGroup';
 import { PdfPreview } from '@web-client/ustc-ui/PdfPreview/PdfPreview';
 import { StatusReportDueDateFields } from './StatusReportDueDateFields';
 import type { StatusReportDueDateFieldsProps } from './StatusReportDueDateFields';
-import { updateGrantDenyMotionFormValueSequence } from '@web-client/presenter/sequences/GrantDenyMotion/updateGrantDenyMotionFormValueSequence';
-import { validateGrantDenyMotionSequence as validateGrantDenyMotionSequenceFn } from '@web-client/presenter/sequences/GrantDenyMotion/validateGrantDenyMotionSequence';
 import { connect } from '@web-client/presenter/shared.cerebral';
 import { sequences, state } from '@web-client/presenter/app.cerebral';
 import React from 'react';
@@ -77,10 +75,8 @@ export const GrantDenyMotion = connect(
       filingPartyOptions: grantDenyOptions.filingPartyOptions,
       formatAndUpdateDateFromDatePickerSequence,
       minDate: grantDenyMotionFormHelper.minDate,
-      updateFormValueSequence:
-        updateFormValueSequence as typeof updateGrantDenyMotionFormValueSequence,
-      validateGrantDenyMotionSequence:
-        validateGrantDenyMotionSequence as typeof validateGrantDenyMotionSequenceFn,
+      updateFormValueSequence,
+      validateGrantDenyMotionSequence,
     };
 
     return (
@@ -485,7 +481,6 @@ export const GrantDenyMotion = connect(
                           Additional order text
                         </label>
                         <textarea
-                          aria-describedby={`additional-order-text-label-${index}`}
                           aria-label={`additional order text ${index + 1}`}
                           autoCapitalize="none"
                           className="usa-textarea maxw-none height-8 usa-character-count__field textarea-resize-vertical"

--- a/web-client/src/views/GrantDenyMotion/GrantDenyMotion.tsx
+++ b/web-client/src/views/GrantDenyMotion/GrantDenyMotion.tsx
@@ -1,4 +1,5 @@
 import { Button } from '../../ustc-ui/Button/Button';
+import { Button as DawsonButton } from '@web-client/dawson-ui/ui/button';
 import { CaseDetailHeader } from '../CaseDetail/CaseDetailHeader';
 import { CharactersRemainingHint } from '@web-client/ustc-ui/CharactersRemainingHint/CharactersRemainingHint';
 import { DateSelector } from '@web-client/ustc-ui/DateInput/DateSelector';
@@ -48,7 +49,6 @@ export const GrantDenyMotion = connect(
   }) {
     const additionalOrderText: string[] = form.additionalOrderText || [''];
     const isDenied = form.disposition === constants.MOTION_DISPOSITIONS.DENIED;
-    const dueDateMessageSelected = !!form.dueDateMessage;
     const { isCalendared } = grantDenyMotionFormHelper;
     const isStrickenFromTrialSessionSelected = !!form.strickenFromTrialSession;
     const jurisdictionOptionsEnabled =
@@ -65,6 +65,62 @@ export const GrantDenyMotion = connect(
     const grantDenyOptions = constants.GRANT_DENY_MOTION_OPTIONS;
     const { filingPartyOptions } = grantDenyOptions;
     const docketEntryPreview = 'Order';
+
+    const renderStatusReportDueDateFields = (): React.ReactNode => (
+      <div
+        className="grant-deny-motion-status-report-fields"
+        data-testid="status-report-due-date-fields"
+      >
+        <FormGroup errorText={validationErrors.filingParty}>
+          <label className="usa-label" htmlFor="filing-party">
+            Filing Party
+          </label>
+          <select
+            className="usa-select"
+            data-testid="filing-party"
+            id="filing-party"
+            name="filingParty"
+            value={form.filingParty || ''}
+            onChange={e =>
+              updateFormValueSequence({
+                key: e.target.name,
+                value: e.target.value,
+              })
+            }
+          >
+            <option value="">- Select -</option>
+            <option value={filingPartyOptions.petitioners}>
+              {filingPartyOptions.petitioners}
+            </option>
+            <option value={filingPartyOptions.respondent}>
+              {filingPartyOptions.respondent}
+            </option>
+            <option value={filingPartyOptions.joint}>
+              {filingPartyOptions.joint}
+            </option>
+          </select>
+        </FormGroup>
+
+        <FormGroup errorText={validationErrors.dueDate}>
+          <DateSelector
+            defaultValue={form.dueDate}
+            formGroupClassNames="display-inline-block padding-0"
+            id="grant-deny-due-date"
+            label="Due Date:"
+            minDate={grantDenyMotionFormHelper.minDate}
+            placeHolderText="MM/DD/YYYY"
+            onChange={e => {
+              formatAndUpdateDateFromDatePickerSequence({
+                key: 'dueDate',
+                toFormat: constants.DATE_FORMATS.YYYYMMDD,
+                value: e.target.value,
+              });
+              validateGrantDenyMotionSequence();
+            }}
+          />
+        </FormGroup>
+      </div>
+    );
 
     return (
       <>
@@ -258,255 +314,211 @@ export const GrantDenyMotion = connect(
                       <span className="usa-hint">(optional)</span>
                     </label>
 
-                    <div className="usa-checkbox">
-                      <input
-                        aria-label="this case is stricken from the trial session"
-                        checked={!!form.strickenFromTrialSession}
-                        className="usa-checkbox__input"
-                        data-testid="stricken-from-trial-session"
-                        disabled={!isCalendared}
-                        id="stricken-from-trial-session"
-                        name="strickenFromTrialSession"
-                        type="checkbox"
-                        onChange={e =>
-                          updateFormValueSequence({
-                            key: e.target.name,
-                            value: e.target.checked,
-                          })
-                        }
-                      />
-                      <label
-                        className="usa-checkbox__label"
-                        htmlFor="stricken-from-trial-session"
-                        style={isCalendared ? undefined : { color: '#757575' }}
-                        title={calendaredDisabledTitle}
-                      >
-                        This case is stricken from the trial session
-                      </label>
-                    </div>
-
-                    <hr className="border-top-2px border-base-lighter tw:my-3" />
-
-                    <div className="usa-radio">
-                      <input
-                        aria-label="restore to general docket"
-                        checked={
-                          form.jurisdiction ===
-                          grantDenyOptions.jurisdictionOptions.restored
-                        }
-                        className="usa-radio__input"
-                        data-testid="jurisdiction-restored"
-                        disabled={!jurisdictionOptionsEnabled}
-                        id="jurisdiction-restored"
-                        name="jurisdiction"
-                        type="radio"
-                        value={grantDenyOptions.jurisdictionOptions.restored}
-                        onChange={e =>
-                          updateFormValueSequence({
-                            key: e.target.name,
-                            value: e.target.value,
-                          })
-                        }
-                      />
-                      <label
-                        className="usa-radio__label"
-                        htmlFor="jurisdiction-restored"
-                        style={
-                          jurisdictionOptionsEnabled
-                            ? undefined
-                            : { color: '#757575' }
-                        }
-                        title={jurisdictionDisabledTitle}
-                      >
-                        Restore to general docket
-                      </label>
-                    </div>
-                    <div className="usa-radio">
-                      <input
-                        aria-label="jurisdiction retained"
-                        checked={
-                          form.jurisdiction ===
-                          grantDenyOptions.jurisdictionOptions.retained
-                        }
-                        className="usa-radio__input"
-                        data-testid="jurisdiction-retained"
-                        disabled={!jurisdictionOptionsEnabled}
-                        id="jurisdiction-retained"
-                        name="jurisdiction"
-                        type="radio"
-                        value={grantDenyOptions.jurisdictionOptions.retained}
-                        onChange={e =>
-                          updateFormValueSequence({
-                            key: e.target.name,
-                            value: e.target.value,
-                          })
-                        }
-                      />
-                      <label
-                        className="usa-radio__label"
-                        htmlFor="jurisdiction-retained"
-                        style={
-                          jurisdictionOptionsEnabled
-                            ? undefined
-                            : { color: '#757575' }
-                        }
-                        title={jurisdictionDisabledTitle}
-                      >
-                        Jurisdiction retained
-                      </label>
-                    </div>
-
-                    <hr className="border-top-2px border-base-lighter tw:my-3" />
-
-                    <div className="usa-checkbox">
-                      <input
-                        aria-label="file status report"
-                        checked={
-                          form.dueDateMessage ===
-                          grantDenyOptions.dueDateMessageOptions.statusReport
-                        }
-                        className="usa-checkbox__input"
-                        data-testid="due-date-message-status-report"
-                        id="due-date-message-status-report"
-                        name="dueDateMessage"
-                        type="checkbox"
-                        onChange={() => {
-                          const optionValue =
-                            grantDenyOptions.dueDateMessageOptions.statusReport;
-                          updateFormValueSequence({
-                            key: 'dueDateMessage',
-                            value:
-                              form.dueDateMessage === optionValue
-                                ? null
-                                : optionValue,
-                          });
-                        }}
-                      />
-                      <label
-                        className="usa-checkbox__label"
-                        htmlFor="due-date-message-status-report"
-                      >
-                        File Status Report
-                      </label>
-                    </div>
-                    <div className="usa-checkbox">
-                      <input
-                        aria-label="file status report or proposed stipulated decision"
-                        checked={
-                          form.dueDateMessage ===
-                          grantDenyOptions.dueDateMessageOptions
-                            .statusReportOrStipulatedDecision
-                        }
-                        className="usa-checkbox__input"
-                        data-testid="due-date-message-stip"
-                        id="due-date-message-stip"
-                        name="dueDateMessage"
-                        type="checkbox"
-                        onChange={() => {
-                          const optionValue =
-                            grantDenyOptions.dueDateMessageOptions
-                              .statusReportOrStipulatedDecision;
-                          updateFormValueSequence({
-                            key: 'dueDateMessage',
-                            value:
-                              form.dueDateMessage === optionValue
-                                ? null
-                                : optionValue,
-                          });
-                        }}
-                      />
-                      <label
-                        className="usa-checkbox__label"
-                        htmlFor="due-date-message-stip"
-                      >
-                        File Status Report/Proposed Stip Decision
-                      </label>
-                    </div>
-
-                    {dueDateMessageSelected && (
-                      <div
-                        className="grant-deny-motion-status-report-fields tw:pl-7 tw:mt-3"
-                        data-testid="status-report-due-date-fields"
-                      >
-                        <FormGroup
-                          className="grant-deny-motion-form-group"
-                          errorText={validationErrors.filingParty}
+                    <div className="grant-deny-motion-optional-options">
+                      <div className="usa-checkbox">
+                        <input
+                          aria-label="this case is stricken from the trial session"
+                          checked={!!form.strickenFromTrialSession}
+                          className="usa-checkbox__input"
+                          data-testid="stricken-from-trial-session"
+                          disabled={!isCalendared}
+                          id="stricken-from-trial-session"
+                          name="strickenFromTrialSession"
+                          type="checkbox"
+                          onChange={e =>
+                            updateFormValueSequence({
+                              key: e.target.name,
+                              value: e.target.checked,
+                            })
+                          }
+                        />
+                        <label
+                          className="usa-checkbox__label"
+                          htmlFor="stricken-from-trial-session"
+                          style={
+                            isCalendared ? undefined : { color: '#757575' }
+                          }
+                          title={calendaredDisabledTitle}
                         >
-                          <label className="usa-label" htmlFor="filing-party">
-                            Filing Party
-                          </label>
-                          <select
-                            className="usa-select"
-                            data-testid="filing-party"
-                            id="filing-party"
-                            name="filingParty"
-                            value={form.filingParty || ''}
+                          This case is stricken from the trial session
+                        </label>
+                      </div>
+
+                      <hr className="border-top-2px border-base-lighter tw:my-2" />
+
+                      <div className="grant-deny-motion-jurisdiction-options">
+                        <div className="usa-radio">
+                          <input
+                            aria-label="restore to general docket"
+                            checked={
+                              form.jurisdiction ===
+                              grantDenyOptions.jurisdictionOptions.restored
+                            }
+                            className="usa-radio__input"
+                            data-testid="jurisdiction-restored"
+                            disabled={!jurisdictionOptionsEnabled}
+                            id="jurisdiction-restored"
+                            name="jurisdiction"
+                            type="radio"
+                            value={
+                              grantDenyOptions.jurisdictionOptions.restored
+                            }
                             onChange={e =>
                               updateFormValueSequence({
                                 key: e.target.name,
                                 value: e.target.value,
                               })
                             }
-                          >
-                            <option value="">- Select -</option>
-                            <option value={filingPartyOptions.petitioners}>
-                              {filingPartyOptions.petitioners}
-                            </option>
-                            <option value={filingPartyOptions.respondent}>
-                              {filingPartyOptions.respondent}
-                            </option>
-                            <option value={filingPartyOptions.joint}>
-                              {filingPartyOptions.joint}
-                            </option>
-                          </select>
-                        </FormGroup>
-
-                        <FormGroup
-                          className="grant-deny-motion-form-group"
-                          errorText={validationErrors.dueDate}
-                        >
-                          <DateSelector
-                            defaultValue={form.dueDate}
-                            formGroupClassNames="display-inline-block padding-0"
-                            id="grant-deny-due-date"
-                            label="Due Date:"
-                            minDate={grantDenyMotionFormHelper.minDate}
-                            placeHolderText="MM/DD/YYYY"
-                            onChange={e => {
-                              formatAndUpdateDateFromDatePickerSequence({
-                                key: 'dueDate',
-                                toFormat: constants.DATE_FORMATS.YYYYMMDD,
-                                value: e.target.value,
-                              });
-                              validateGrantDenyMotionSequence();
-                            }}
                           />
-                        </FormGroup>
+                          <label
+                            className="usa-radio__label"
+                            htmlFor="jurisdiction-restored"
+                            style={
+                              jurisdictionOptionsEnabled
+                                ? undefined
+                                : { color: '#757575' }
+                            }
+                            title={jurisdictionDisabledTitle}
+                          >
+                            Restore to general docket
+                          </label>
+                        </div>
+                        <div className="usa-radio">
+                          <input
+                            aria-label="jurisdiction retained"
+                            checked={
+                              form.jurisdiction ===
+                              grantDenyOptions.jurisdictionOptions.retained
+                            }
+                            className="usa-radio__input"
+                            data-testid="jurisdiction-retained"
+                            disabled={!jurisdictionOptionsEnabled}
+                            id="jurisdiction-retained"
+                            name="jurisdiction"
+                            type="radio"
+                            value={
+                              grantDenyOptions.jurisdictionOptions.retained
+                            }
+                            onChange={e =>
+                              updateFormValueSequence({
+                                key: e.target.name,
+                                value: e.target.value,
+                              })
+                            }
+                          />
+                          <label
+                            className="usa-radio__label"
+                            htmlFor="jurisdiction-retained"
+                            style={
+                              jurisdictionOptionsEnabled
+                                ? undefined
+                                : { color: '#757575' }
+                            }
+                            title={jurisdictionDisabledTitle}
+                          >
+                            Jurisdiction retained
+                          </label>
+                        </div>
                       </div>
-                    )}
+
+                      <hr className="border-top-2px border-base-lighter tw:my-2" />
+
+                      <div className="usa-checkbox">
+                        <input
+                          aria-label="file status report"
+                          checked={
+                            form.dueDateMessage ===
+                            grantDenyOptions.dueDateMessageOptions.statusReport
+                          }
+                          className="usa-checkbox__input"
+                          data-testid="due-date-message-status-report"
+                          id="due-date-message-status-report"
+                          name="dueDateMessage"
+                          type="checkbox"
+                          onChange={() => {
+                            const optionValue =
+                              grantDenyOptions.dueDateMessageOptions
+                                .statusReport;
+                            updateFormValueSequence({
+                              key: 'dueDateMessage',
+                              value:
+                                form.dueDateMessage === optionValue
+                                  ? null
+                                  : optionValue,
+                            });
+                          }}
+                        />
+                        <label
+                          className="usa-checkbox__label"
+                          htmlFor="due-date-message-status-report"
+                        >
+                          File Status Report
+                        </label>
+                      </div>
+                      {form.dueDateMessage ===
+                        grantDenyOptions.dueDateMessageOptions.statusReport &&
+                        renderStatusReportDueDateFields()}
+                      <div className="usa-checkbox">
+                        <input
+                          aria-label="file status report or proposed stipulated decision"
+                          checked={
+                            form.dueDateMessage ===
+                            grantDenyOptions.dueDateMessageOptions
+                              .statusReportOrStipulatedDecision
+                          }
+                          className="usa-checkbox__input"
+                          data-testid="due-date-message-stip"
+                          id="due-date-message-stip"
+                          name="dueDateMessage"
+                          type="checkbox"
+                          onChange={() => {
+                            const optionValue =
+                              grantDenyOptions.dueDateMessageOptions
+                                .statusReportOrStipulatedDecision;
+                            updateFormValueSequence({
+                              key: 'dueDateMessage',
+                              value:
+                                form.dueDateMessage === optionValue
+                                  ? null
+                                  : optionValue,
+                            });
+                          }}
+                        />
+                        <label
+                          className="usa-checkbox__label"
+                          htmlFor="due-date-message-stip"
+                        >
+                          File Status Report/Proposed Stip Decision
+                        </label>
+                      </div>
+                      {form.dueDateMessage ===
+                        grantDenyOptions.dueDateMessageOptions
+                          .statusReportOrStipulatedDecision &&
+                        renderStatusReportDueDateFields()}
+                    </div>
                   </FormGroup>
 
                   <hr className="border-top-2px border-base-lighter" />
 
                   <FormGroup
-                    className="grant-deny-motion-form-group"
                     errorText={
                       grantDenyMotionFormHelper.additionalOrderTextErrorText
                     }
                   >
-                    <label
-                      className="usa-label"
-                      htmlFor="additional-order-text-0"
-                    >
-                      Additional order text
-                    </label>
                     {additionalOrderText.map((value, index) => (
                       <div
-                        className="tw:mb-3"
                         data-testid={`additional-order-text-row-${index}`}
                         key={index}
                       >
+                        <label
+                          className="usa-label tw:mt-4"
+                          htmlFor={`additional-order-text-${index}`}
+                          id={`additional-order-text-label-${index}`}
+                        >
+                          Additional order text
+                        </label>
                         <textarea
+                          aria-describedby={`additional-order-text-label-${index}`}
                           aria-label={`additional order text ${index + 1}`}
                           autoCapitalize="none"
                           className="usa-textarea maxw-none height-8 usa-character-count__field textarea-resize-vertical"
@@ -525,35 +537,40 @@ export const GrantDenyMotion = connect(
                           }
                         />
                         <CharactersRemainingHint
+                          className="tw:mb-0"
                           maxCharacters={MAX_ADDITIONAL_TEXT_CHARS}
                           stringToCount={value}
                         />
-                        {additionalOrderText.length > 1 && (
-                          <Button
-                            link
+                        {index > 0 && (
+                          <DawsonButton
+                            className="tw:block"
                             data-testid={`remove-additional-order-text-${index}`}
-                            icon="times"
+                            icon="circle-xmark"
+                            iconPosition="left"
+                            variant="destructiveTertiary"
                             onClick={e => {
                               e.preventDefault();
                               removeAdditionalOrderTextSequence({ index });
                             }}
                           >
                             Remove
-                          </Button>
+                          </DawsonButton>
                         )}
                       </div>
                     ))}
-                    <Button
-                      link
+                    <hr />
+                    <DawsonButton
                       data-testid="add-additional-order-text"
                       icon="plus"
+                      iconPosition="left"
+                      variant="primaryTertiary"
                       onClick={e => {
                         e.preventDefault();
                         addAdditionalOrderTextSequence();
                       }}
                     >
                       Add additional order text
-                    </Button>
+                    </DawsonButton>
                   </FormGroup>
                 </div>
               </div>

--- a/web-client/src/views/GrantDenyMotion/StatusReportDueDateFields.tsx
+++ b/web-client/src/views/GrantDenyMotion/StatusReportDueDateFields.tsx
@@ -1,0 +1,101 @@
+import { TimeFormats } from '@shared/business/utilities/DateHandler';
+import { DateSelector } from '@web-client/ustc-ui/DateInput/DateSelector';
+import { FormGroup } from '@web-client/ustc-ui/FormGroup/FormGroup';
+import { formatAndUpdateDateFromDatePickerSequence } from '@web-client/presenter/sequences/formatAndUpdateDateFromDatePickerSequence';
+import { updateGrantDenyMotionFormValueSequence } from '@web-client/presenter/sequences/GrantDenyMotion/updateGrantDenyMotionFormValueSequence';
+import { validateGrantDenyMotionSequence } from '@web-client/presenter/sequences/GrantDenyMotion/validateGrantDenyMotionSequence';
+import React from 'react';
+
+export type StatusReportDueDateFieldsProps = {
+  constants: {
+    DATE_FORMATS: {
+      YYYYMMDD: TimeFormats;
+    };
+  };
+  dueDate: string | undefined;
+  dueDateErrorText?: string;
+  filingParty: string | null | undefined;
+  filingPartyErrorText?: string;
+  filingPartyOptions: {
+    joint: string;
+    petitioners: string;
+    respondent: string;
+  };
+  formatAndUpdateDateFromDatePickerSequence: typeof formatAndUpdateDateFromDatePickerSequence;
+  minDate: string;
+  updateFormValueSequence: typeof updateGrantDenyMotionFormValueSequence;
+  validateGrantDenyMotionSequence: typeof validateGrantDenyMotionSequence;
+};
+
+export const StatusReportDueDateFields: React.FC<
+  StatusReportDueDateFieldsProps
+> = ({
+  constants,
+  dueDate,
+  dueDateErrorText,
+  filingParty,
+  filingPartyErrorText,
+  filingPartyOptions,
+  formatAndUpdateDateFromDatePickerSequence,
+  minDate,
+  updateFormValueSequence,
+  validateGrantDenyMotionSequence,
+}) => {
+  return (
+    <div
+      className="grant-deny-motion-status-report-fields"
+      data-testid="status-report-due-date-fields"
+    >
+      <FormGroup errorText={filingPartyErrorText}>
+        <label className="usa-label" htmlFor="filing-party">
+          Filing Party
+        </label>
+        <select
+          className="usa-select"
+          data-testid="filing-party"
+          id="filing-party"
+          name="filingParty"
+          value={filingParty || ''}
+          onChange={e =>
+            updateFormValueSequence({
+              key: e.target.name,
+              value: e.target.value,
+            })
+          }
+        >
+          <option value="">- Select -</option>
+          <option value={filingPartyOptions.petitioners}>
+            {filingPartyOptions.petitioners}
+          </option>
+          <option value={filingPartyOptions.respondent}>
+            {filingPartyOptions.respondent}
+          </option>
+          <option value={filingPartyOptions.joint}>
+            {filingPartyOptions.joint}
+          </option>
+        </select>
+      </FormGroup>
+
+      <FormGroup errorText={dueDateErrorText}>
+        <DateSelector
+          defaultValue={dueDate}
+          formGroupClassNames="display-inline-block padding-0"
+          id="grant-deny-due-date"
+          label="Due Date:"
+          minDate={minDate}
+          placeHolderText="MM/DD/YYYY"
+          onChange={e => {
+            formatAndUpdateDateFromDatePickerSequence({
+              key: 'dueDate',
+              toFormat: constants.DATE_FORMATS.YYYYMMDD,
+              value: e.target.value,
+            });
+            validateGrantDenyMotionSequence();
+          }}
+        />
+      </FormGroup>
+    </div>
+  );
+};
+
+StatusReportDueDateFields.displayName = 'StatusReportDueDateFields';

--- a/web-client/src/views/GrantDenyMotion/StatusReportDueDateFields.tsx
+++ b/web-client/src/views/GrantDenyMotion/StatusReportDueDateFields.tsx
@@ -1,9 +1,7 @@
-import { TimeFormats } from '@shared/business/utilities/DateHandler';
+import type { TimeFormats } from '@shared/business/utilities/DateHandler';
 import { DateSelector } from '@web-client/ustc-ui/DateInput/DateSelector';
 import { FormGroup } from '@web-client/ustc-ui/FormGroup/FormGroup';
-import { formatAndUpdateDateFromDatePickerSequence } from '@web-client/presenter/sequences/formatAndUpdateDateFromDatePickerSequence';
-import { updateGrantDenyMotionFormValueSequence } from '@web-client/presenter/sequences/GrantDenyMotion/updateGrantDenyMotionFormValueSequence';
-import { validateGrantDenyMotionSequence } from '@web-client/presenter/sequences/GrantDenyMotion/validateGrantDenyMotionSequence';
+import { RunableSequence as RunnableSequence } from 'cerebral';
 import React from 'react';
 
 export type StatusReportDueDateFieldsProps = {
@@ -21,10 +19,10 @@ export type StatusReportDueDateFieldsProps = {
     petitioners: string;
     respondent: string;
   };
-  formatAndUpdateDateFromDatePickerSequence: typeof formatAndUpdateDateFromDatePickerSequence;
+  formatAndUpdateDateFromDatePickerSequence: Function | RunnableSequence;
   minDate: string;
-  updateFormValueSequence: typeof updateGrantDenyMotionFormValueSequence;
-  validateGrantDenyMotionSequence: typeof validateGrantDenyMotionSequence;
+  updateFormValueSequence: Function | RunnableSequence;
+  validateGrantDenyMotionSequence: Function | RunnableSequence;
 };
 
 export const StatusReportDueDateFields: React.FC<


### PR DESCRIPTION
## [TestRail Run](https://ustaxcourt.testrail.io/index.php?/runs/view/390&group_by=cases:section_id&group_order=asc&display=tree&group_id=56)
## Summary
Replaces the legacy **Apply Stamp** workflow with **Grant/Deny Motion**. Instead of overlaying a stamp on the motion PDF, judges and clerks create a separate court-issued order that is drafted, signed, and served — same court outcome, cleaner docket record.
## Before → After
| Before | After |
|--------|-------|
| "Apply Stamp" on eligible motions | **Grant/Deny** button (`stamp` icon) |
| Stamp drawn onto motion PDF | Standalone order draft via standard court-issued order flow |
| Form state in `stamp_data` | Form state in `draft_order_state` |
| `generateDraftStampOrder` API | Standard court-issued order pipeline |
## What's included
- **Grant/Deny Motion workflow** — new form entity, view, Cerebral actions/sequences, PDF preview, and edit support for unsigned drafts
- **Disposition logic** — grant/deny (incl. moot / without prejudice), jurisdiction options, status-report due dates, filing party, additional order text, consolidated-case handling
- **UI polish**
  - Grant/Deny entry points use `stamp` icon instead of `gavel` (document viewer + messages)
  - Optional-section layout aligned with PR #10045 patterns (nested filing party/due date under each checkbox, Dawson remove/add buttons for additional order text)
  - `StatusReportDueDateFields` extracted as a reusable subcomponent
  - `CharactersRemainingHint` accepts optional `className`
- **Data migration** — expand/contract backfill of `draft_order_state` from legacy `stamp_data`; `stamp_data` deprecated but preserved for served stamped orders
- **Removed** — Apply Stamp UI, stamp interactors, draft stamp order lambda, stamped coversheet helpers, and related tests
