### PR TITLE
opex: docket number suffix in the event-codes-by-year report

### DIFF
--- a/scripts/git/prod-release-pr-description.helpers.test.ts
+++ b/scripts/git/prod-release-pr-description.helpers.test.ts
@@ -1,4 +1,8 @@
 /* eslint-disable max-lines */
+jest.mock('../entity-validation/entityValidation', () => ({
+  haveValidationRulesChanged: jest.fn(),
+}));
+
 import {
   extractBashCodeBlocks,
   extractDockerImageTag,
@@ -11,6 +15,7 @@ import {
   resolveTicketTask,
   resolveType,
 } from './prod-release-pr-description.helpers';
+import { haveValidationRulesChanged } from '../entity-validation/entityValidation';
 import type { CoverageSummary } from '../github-actions/suite-coverage.helpers';
 import type {
   GitHubClient,
@@ -692,9 +697,7 @@ describe('prod-release-pr-description', () => {
           ]),
       };
 
-      jest.mock('../../scripts/entity-validation/entityValidation', () => ({
-        haveValidationRulesChanged: jest.fn().mockResolvedValue(true),
-      }));
+      jest.mocked(haveValidationRulesChanged).mockResolvedValue(true);
 
       const description = await generateProdReleasePrDescription({
         circleConfig,
@@ -737,9 +740,7 @@ describe('prod-release-pr-description', () => {
           .mockResolvedValue([dockerDependencyPullRequest]),
       };
 
-      jest.mock('../../scripts/entity-validation/entityValidation', () => ({
-        haveValidationRulesChanged: jest.fn().mockResolvedValue(false),
-      }));
+      jest.mocked(haveValidationRulesChanged).mockResolvedValue(false);
 
       const description = await generateProdReleasePrDescription({
         circleConfig: 'version: 2.1\n',
@@ -764,9 +765,7 @@ describe('prod-release-pr-description', () => {
           .mockResolvedValue([dependencyPullRequest]),
       };
 
-      jest.mock('../../scripts/entity-validation/entityValidation', () => ({
-        haveValidationRulesChanged: jest.fn().mockResolvedValue(false),
-      }));
+      jest.mocked(haveValidationRulesChanged).mockResolvedValue(false);
 
       const description = await generateProdReleasePrDescription({
         circleConfig,

--- a/scripts/helpers/formatters.test.ts
+++ b/scripts/helpers/formatters.test.ts
@@ -4,6 +4,7 @@ import {
   formatCaseCaption,
   formatCurrency,
   formatDate,
+  formatDocketNumber,
   formatJudgeName,
 } from './formatters';
 
@@ -108,5 +109,16 @@ describe('formatCurrency', () => {
 
   it('should handle undefined', () => {
     expect(formatCurrency(undefined)).toBe('0');
+  });
+});
+
+describe('formatDocketNumber', () => {
+  it('returns the docket number when no suffix is provided', () => {
+    expect(formatDocketNumber('101-21')).toBe('101-21');
+    expect(formatDocketNumber('102-21', '')).toBe('102-21');
+  });
+
+  it('returns the docket number with suffix when a suffix is provided', () => {
+    expect(formatDocketNumber('101-21', 'S')).toBe('101-21S');
   });
 });

--- a/scripts/helpers/formatters.ts
+++ b/scripts/helpers/formatters.ts
@@ -50,3 +50,11 @@ export const formatCurrency = (amount: number | string | undefined): string => {
     typeof amount === 'string' ? parseFloat(amount) : amount;
   return numericAmount.toFixed(2);
 };
+
+export const formatDocketNumber = (
+  docketNumber: string,
+  docketNumberSuffix?: string,
+): string => {
+  if (!docketNumberSuffix) return docketNumber;
+  return `${docketNumber}${docketNumberSuffix}`;
+};

--- a/scripts/helpers/formatters.ts
+++ b/scripts/helpers/formatters.ts
@@ -53,7 +53,7 @@ export const formatCurrency = (amount: number | string | undefined): string => {
 
 export const formatDocketNumber = (
   docketNumber: string,
-  docketNumberSuffix?: string,
+  docketNumberSuffix?: string | null,
 ): string => {
   if (!docketNumberSuffix) return docketNumber;
   return `${docketNumber}${docketNumberSuffix}`;

--- a/scripts/reports/event-codes-by-year-helpers.ts
+++ b/scripts/reports/event-codes-by-year-helpers.ts
@@ -6,6 +6,7 @@ export type EventCodeReportDocketEntry = {
   associatedJudge: string;
   caption: string;
   docketNumber: string;
+  docketNumberSuffix?: string;
   documentType: string;
   receivedAt: Date;
   status: string;
@@ -82,6 +83,7 @@ export const getDocketEntriesByEventCodesAndYears = async ({
           'de.receivedAt',
           'c.associatedJudge',
           'c.caption',
+          'c.docketNumberSuffix',
           'c.status',
         ]);
 

--- a/scripts/reports/event-codes-by-year-helpers.ts
+++ b/scripts/reports/event-codes-by-year-helpers.ts
@@ -6,7 +6,7 @@ export type EventCodeReportDocketEntry = {
   associatedJudge: string;
   caption: string;
   docketNumber: string;
-  docketNumberSuffix?: string;
+  docketNumberSuffix?: string | null;
   documentType: string;
   receivedAt: Date;
   status: string;

--- a/scripts/reports/event-codes-by-year.ts
+++ b/scripts/reports/event-codes-by-year.ts
@@ -14,6 +14,7 @@ import { pick } from 'lodash';
 import {
   formatCaseCaption,
   formatDate,
+  formatDocketNumber,
   formatJudgeName,
 } from '../helpers/formatters';
 
@@ -93,8 +94,9 @@ const outputCsv = ({
     `${eventCodes.map(ec => ec.toLowerCase()).join('-')}-filed-` +
     `in-${fiscal ? 'fy-' : ''}${years.join('-')}.csv`;
   const rows = docketEntries.map(de => ({
-    ...pick(de, ['docketNumber', 'documentType', 'status']),
+    ...pick(de, ['documentType', 'status']),
     caption: formatCaseCaption(de.caption),
+    docketNumber: formatDocketNumber(de.docketNumber, de.docketNumberSuffix),
     filed: formatDate(de.receivedAt),
     judge: formatJudgeName(de.associatedJudge),
   }));


### PR DESCRIPTION
# opex: Append docket number suffix in the `event-codes-by-year` report

## Overview

Update the `event-codes-by-year` CSV export so docket numbers include their suffix when one exists. This was requested by Case Services because it makes "small" cases easier to identify at a glance.

## Changes

- Added a shared `formatDocketNumber()` helper to consistently render docket numbers with an optional suffix.
- Updated `scripts/reports/event-codes-by-year.ts` to:
  - fetch `docketNumberSuffix` from the case record
  - use the new formatter when building CSV rows
- Extended `scripts/reports/event-codes-by-year-helpers.ts` so the report’s docket entry type includes `docketNumberSuffix`.
- Added unit coverage for the new formatter behavior in `scripts/helpers/formatters.test.ts`.

## Bonus, unrelated change

- Updated `scripts/git/prod-release-pr-description.helpers.test.ts` to use a centralized mock for `haveValidationRulesChanged`.

## Verification

- `npm run test:scripts:file -- scripts/helpers/formatters.test.ts`
- `npm run test:scripts:file -- scripts/git/prod-release-pr-description.helpers.test.ts`

## Pull Request Checklist

- [x] I have conducted thorough manual testing:
  - [x] Locally
  - [x] Prod
