### PR TITLE
devex: Removed extra formatter from settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -48,8 +48,5 @@
     }
   ],
   "prettier.requireConfig": true,
-  "js/ts.tsdk.path": "./node_modules/typescript/lib",
-  "[typescript]": {
-    "editor.defaultFormatter": "vscode.typescript-language-features"
-  }
+  "js/ts.tsdk.path": "./node_modules/typescript/lib"
 }


### PR DESCRIPTION
Fixing an issue where our VS code settings have two conflicting formatters. 