### PR TITLE
10201 mislable bug to test 1783359762

### DIFF
--- a/web-client/src/presenter/actions/FileDocument/clearWizardDataAction.test.ts
+++ b/web-client/src/presenter/actions/FileDocument/clearWizardDataAction.test.ts
@@ -92,4 +92,94 @@ describe('clearWizardDataAction', () => {
       documentType: 'other',
     });
   });
+
+  it('clears unrelated form fields when secondaryDocument.documentType changes, preserving only primary document fields', async () => {
+    const result = await runAction(clearWizardDataAction, {
+      props: {
+        key: 'secondaryDocument.documentType',
+      },
+      state: {
+        form: {
+          category: 'Motion',
+          documentTitle: 'Motion for Leave to File',
+          documentType: 'Motion for Leave to File',
+          eventCode: 'MCLF',
+          scenario: 'Standard',
+          primaryDocumentFile: { name: 'test.pdf' },
+          supportingDocuments: [{ documentTitle: 'Brief' }],
+          freeText: 'some old text',
+          ordinalValue: '1st',
+          previousDocument: { documentTitle: 'Old Document' },
+          secondaryDocument: {
+            category: 'Information',
+            documentType: 'Statement',
+            freeText: 'stale secondary text',
+            previousDocument: { documentTitle: 'Stale Ref' },
+          },
+        },
+      },
+    });
+
+    expect(result.state.form).toEqual({
+      category: 'Motion',
+      documentTitle: 'Motion for Leave to File',
+      documentType: 'Motion for Leave to File',
+      eventCode: 'MCLF',
+      scenario: 'Standard',
+      secondaryDocument: {
+        category: 'Information',
+        documentType: 'Statement',
+      },
+    });
+  });
+
+  it('does not retain uploaded document files or free-text fields after secondaryDocument.documentType change', async () => {
+    const result = await runAction(clearWizardDataAction, {
+      props: {
+        key: 'secondaryDocument.documentType',
+      },
+      state: {
+        form: {
+          category: 'Motion',
+          documentTitle: 'Motion to Dismiss',
+          documentType: 'Motion to Dismiss',
+          eventCode: 'MTD',
+          scenario: 'Standard',
+          primaryDocumentFile: { name: 'motion.pdf', size: 12345 },
+          primaryDocumentFileSize: 12345,
+          secondaryDocumentFile: { name: 'exhibit.pdf', size: 99999 },
+          secondaryDocumentFileSize: 99999,
+          supportingDocuments: [
+            { documentTitle: 'Declaration', supportingDocumentFile: {} },
+          ],
+          freeText: 'retained in error',
+          freeText2: 'also retained in error',
+          secondaryDocument: {
+            category: 'Supporting Document',
+            documentType: 'Declaration',
+            freeText: 'secondary free text',
+          },
+        },
+      },
+    });
+
+    expect(result.state.form.primaryDocumentFile).toBeUndefined();
+    expect(result.state.form.primaryDocumentFileSize).toBeUndefined();
+    expect(result.state.form.secondaryDocumentFile).toBeUndefined();
+    expect(result.state.form.secondaryDocumentFileSize).toBeUndefined();
+    expect(result.state.form.supportingDocuments).toBeUndefined();
+    expect(result.state.form.freeText).toBeUndefined();
+    expect(result.state.form.freeText2).toBeUndefined();
+    expect(result.state.form.secondaryDocument.freeText).toBeUndefined();
+
+    expect(result.state.form.category).toBe('Motion');
+    expect(result.state.form.documentType).toBe('Motion to Dismiss');
+    expect(result.state.form.documentTitle).toBe('Motion to Dismiss');
+    expect(result.state.form.eventCode).toBe('MTD');
+    expect(result.state.form.scenario).toBe('Standard');
+    expect(result.state.form.secondaryDocument).toEqual({
+      category: 'Supporting Document',
+      documentType: 'Declaration',
+    });
+  });
 });

--- a/web-client/src/presenter/actions/FileDocument/clearWizardDataAction.ts
+++ b/web-client/src/presenter/actions/FileDocument/clearWizardDataAction.ts
@@ -34,13 +34,22 @@ export const clearWizardDataAction = ({ get, props, store }: ActionProps) => {
       store.set(state.form.secondaryDocument, pickedDocument);
 
       break;
-    case 'secondaryDocument.documentType':
+    case 'secondaryDocument.documentType': {
       pickedDocument = pick(get(state.form.secondaryDocument), [
         'category',
         'documentType',
       ]);
-      store.set(state.form.secondaryDocument, pickedDocument);
-
+      const { category, documentType, documentTitle, eventCode, scenario } =
+        get(state.form);
+      store.set(state.form, {
+        category,
+        documentType,
+        documentTitle,
+        eventCode,
+        scenario,
+        secondaryDocument: pickedDocument,
+      });
       break;
+    }
   }
 };


### PR DESCRIPTION
#10201 

## Overview

This pull request updates the logic for clearing wizard form data in `clearWizardDataAction.ts`. The main change improves how the form state is reset when the `secondaryDocument.documentType` field is cleared, ensuring that key fields on the main form are preserved.

## Changes

When clearing `secondaryDocument.documentType`, the action now resets the entire `state.form` object, preserving the main document fields (`category`, `documentType`, `documentTitle`, `eventCode`, `scenario`) and updating `secondaryDocument` with only the relevant fields.

## Verification

- login as a private practitioner and click on any ongoing case
- click file a document
- for the primary select 'motion for leave to file out of time', and the secondary select 'answer' and click continue
- fill out as many fields as you can on this form page and then click the back button
- if we click continue again, you should see some fields that you previously filled out
- click back again and for the secondary document select 'administrative record' and click continue
- all values in this form should be reset


## Pull Request Checklist

_PRs that do not meet these criteria may be closed without review._

### Internal Contributors (DAWSON Team Members)

- [x] I have conducted thorough manual testing:
   - [x] Locally
   - [x] Experimental Environment (if necessary)
- [x] If this PR is for a user story, or tech debt (devex, opex, design debt, etc.) that is user-facing, I have created test case(s) in TestRail and executed them.
- [ ] I assert that all DoD criteria for this issue have been met.
- [x] If this PR includes a data migration with timing-specific manual test steps, I will coordinate the deployment with a manual tester to verify the timing-specific manual tests in real time.
- [x] All user-facing changes have been verified to be free of accessibility issues via manual testing and automated accessibility tests.
