### PR TITLE
10152 new value to test 1783525050

### DIFF
--- a/shared/src/business/entities/EntityConstants.ts
+++ b/shared/src/business/entities/EntityConstants.ts
@@ -1413,8 +1413,7 @@ export const ALL_STATE_OPTIONS = {
 };
 
 export type AbbreviatedStates =
-  | keyof typeof US_STATES
-  | keyof typeof US_STATES_OTHER;
+  keyof typeof US_STATES | keyof typeof US_STATES_OTHER;
 
 export const NOT_AVAILABLE_OPTION = 'N/A';
 export const STATE_NOT_AVAILABLE = NOT_AVAILABLE_OPTION;
@@ -1903,6 +1902,7 @@ export const PRACTITIONER_DOCUMENT_TYPES_MAP = {
   RESPONSE_TO_REFERENCE_INQUIRY: 'Response to Reference Inquiry',
   DISCIPLINARY: 'Disciplinary',
   CHANGE_OF_NAME: 'Change of Name',
+  CHANGE_OF_STATUS: 'Change of Status',
   EXAM_RELATED: 'Exam-Related',
   MISCELLANEOUS: 'Miscellaneous',
 };
@@ -1941,8 +1941,7 @@ export type FileUploadProgressType = {
 };
 
 export type FileUploadProgressValueType =
-  | FileUploadProgressType
-  | FileUploadProgressType[];
+  FileUploadProgressType | FileUploadProgressType[];
 
 export type CreatedCaseType = {
   contactPrimary: {
@@ -2065,8 +2064,7 @@ export const STATUS_REPORT_ORDERED_FOR_OPTIONS = {
   other: 'Other',
 } as const;
 export type StatusReportOrderedForOption =
-  | keyof typeof STATUS_REPORT_ORDERED_FOR_OPTIONS
-  | '';
+  keyof typeof STATUS_REPORT_ORDERED_FOR_OPTIONS | '';
 
 export const MOTION_FILED_BY_OPTIONS = {
   intervenor: 'Intervenor',


### PR DESCRIPTION
# 10152: Add Change of Status category

## Overview
https://github.com/ustaxcourt/ef-cms/issues/10152
Should add "Change of Status" value to the list of practitioner document types

## Changes
Practitioner document types:
Added a new entry, `CHANGE_OF_STATUS`, to the `PRACTITIONER_DOCUMENT_TYPES_MAP` constant.

## Verification

[TestRail](https://ustaxcourt.testrail.io/index.php?/runs/view/443&group_by=cases:section_id&group_order=asc&display=tree)

## Pull Request Checklist

_PRs that do not meet these criteria may be closed without review._

### Internal Contributors (DAWSON Team Members)

- [x] I have conducted thorough manual testing:
   - [x] Locally
   - [x] Experimental Environment (if necessary)
- [x] If this PR is for a user story, or tech debt (devex, opex, design debt, etc.) that is user-facing, I have created test case(s) in TestRail and executed them.
- [ ] I assert that all DoD criteria for this issue have been met.
- [x] If this PR includes a data migration with timing-specific manual test steps, I will coordinate the deployment with a manual tester to verify the timing-specific manual tests in real time.
- [x] All user-facing changes have been verified to be free of accessibility issues via manual testing and automated accessibility tests.
