### PR TITLE
devex: Fix Downloader Batch Job Dockerfile

### DIFF
--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -377,6 +377,13 @@ The major version of this package should match our major version of Node. We sho
 
 - Ensure the pinned version of typescript globally installed in `web-api/terraform/modules/batch/docker-image/Dockerfile` matches the project-wide version and is compatible with ts-node. On 7/08/2026, we started pulling TS7 when building this Dockerfile, and the batch job would not start up because ts-node was unable to find the TS compiler, so we pinned it to 6.0.3.
 
+### ts-node
+**Installed Version: 10.9.2**
+
+**When upgrading TypeScript, make sure that the new version is supported by ts-jest and ts-node.**
+
+- Ensure the pinned version of ts-node globally installed in `web-api/terraform/modules/batch/docker-image/Dockerfile` matches the project-wide version.
+
 ### Commander override for s3rver
 **Current Installed Version: 12.1.0 (Override Version, see notes below)**
 

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -371,9 +371,11 @@ The major version of this package should match our major version of Node. We sho
 ### TypeScript
 **Installed Version: 6.0.3**
 
-**When upgrading TypeScript, make sure that the new version is supported by ts-jest.**
+**When upgrading TypeScript, make sure that the new version is supported by ts-jest and ts-node.**
 
 - After upgrading cypress past 15.14.0, it is now compatible with TS6. Updated tsconfig for cypress to support version 6 during the week of 5/18/2026
+
+- Ensure the pinned version of typescript globally installed in `web-api/terraform/modules/batch/docker-image/Dockerfile` matches the project-wide version and is compatible with ts-node. On 7/08/2026, we started pulling TS7 when building this Dockerfile, and the batch job would not start up because ts-node was unable to find the TS compiler, so we pinned it to 6.0.3.
 
 ### Commander override for s3rver
 **Current Installed Version: 12.1.0 (Override Version, see notes below)**

--- a/web-api/terraform/modules/batch/docker-image/Dockerfile
+++ b/web-api/terraform/modules/batch/docker-image/Dockerfile
@@ -17,5 +17,5 @@ WORKDIR /usr/src/app
 COPY . .
 RUN npm install
 
-RUN npm install -g ts-node typescript
+RUN npm install -g ts-node typescript@6.0.3
 CMD ["ts-node", "src/docketEntryBatchDownloader.ts"]

--- a/web-api/terraform/modules/batch/docker-image/Dockerfile
+++ b/web-api/terraform/modules/batch/docker-image/Dockerfile
@@ -17,5 +17,5 @@ WORKDIR /usr/src/app
 COPY . .
 RUN npm install
 
-RUN npm install -g ts-node typescript@6.0.3
+RUN npm install -g ts-node@10.9.2 typescript@6.0.3
 CMD ["ts-node", "src/docketEntryBatchDownloader.ts"]


### PR DESCRIPTION
Updated the Dockerfile for the file downloader batch job to pin the globally installed typescript package to 6.0.3. Before it was pulling the latest version, and version 7.0.2 does not work with ts-node, which caused the command to run the docketEntryBatchDownloader typescript file to fail.

Also added some context to the dependency update docs. 