### PR TITLE
DevEx: Improve Cypress browser launch reliability in CI

### DIFF
--- a/.github/workflows/template_app-parallel.yml
+++ b/.github/workflows/template_app-parallel.yml
@@ -107,6 +107,7 @@ jobs:
         if: ${{ inputs.is_cypress }}
         run: |
           mkdir -p /tmp/cypress/
+          mkdir -p /tmp/cypress-logs/
       - name: Create Test Execution Times Directory
         run: |
           mkdir -p /tmp/test-file-times
@@ -117,8 +118,17 @@ jobs:
         run: |
           WAIT_FOR_CLIENT=1 WAIT_FOR_PUBLIC=1 ./wait-until-services.sh
       - name: Run tests
+        shell: bash
         run: |
-          ${{ inputs.run_command }}
+          if [[ "${{ inputs.is_cypress }}" == "true" ]]; then
+            set -o pipefail
+            export DEBUG="cypress:launcher,cypress:browsers"
+            {
+              ${{ inputs.run_command }}
+            } 2>&1 | tee /tmp/cypress-logs/${{ inputs.workflow_filename }}-cypress-output-shard-${{ inputs.ci_node_index }}.txt
+          else
+            ${{ inputs.run_command }}
+          fi
       - name: Record shard test file timings
         if: ${{ success() && inputs.record_jest_test_timings }}
         run: |
@@ -131,6 +141,12 @@ jobs:
         with:
           name: ${{ inputs.workflow_filename }}-dawson-output-shard-${{ inputs.ci_node_index }}
           path: /tmp/${{ inputs.workflow_filename }}-dawson-output-shard-${{ inputs.ci_node_index }}.txt
+      - name: Upload Cypress logs
+        if: ${{ always() && inputs.is_cypress }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.workflow_filename }}-cypress-output-shard-${{ inputs.ci_node_index }}
+          path: /tmp/cypress-logs/${{ inputs.workflow_filename }}-cypress-output-shard-${{ inputs.ci_node_index }}.txt
       - name: Compile Cypress Videos
         if: ${{ always() && inputs.is_cypress }}
         run: |

--- a/.github/workflows/template_app.yml
+++ b/.github/workflows/template_app.yml
@@ -87,6 +87,7 @@ jobs:
         if: ${{ inputs.is_cypress }}
         run: |
           mkdir -p /tmp/cypress/
+          mkdir -p /tmp/cypress-logs/
       - name: Start DAWSON
         run: |
           npm run start:all:ci >> /tmp/${{ inputs.workflow_filename }}-dawson-output.txt &
@@ -94,14 +95,29 @@ jobs:
         run: |
           WAIT_FOR_CLIENT=1 WAIT_FOR_PUBLIC=1 ./wait-until-services.sh
       - name: Run tests
+        shell: bash
         run: |
-          ${{ inputs.run_command }}
+          if [[ "${{ inputs.is_cypress }}" == "true" ]]; then
+            set -o pipefail
+            export DEBUG="cypress:launcher,cypress:browsers"
+            {
+              ${{ inputs.run_command }}
+            } 2>&1 | tee /tmp/cypress-logs/${{ inputs.workflow_filename }}-cypress-output.txt
+          else
+            ${{ inputs.run_command }}
+          fi
       - name: Upload DAWSON logs
         if: ${{ always() && inputs.upload_logs }}
         uses: actions/upload-artifact@v7
         with:
           name: dawson-output
           path: /tmp/${{ inputs.workflow_filename }}-dawson-output.txt
+      - name: Upload Cypress logs
+        if: ${{ always() && inputs.is_cypress }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.workflow_filename }}-cypress-output
+          path: /tmp/cypress-logs/${{ inputs.workflow_filename }}-cypress-output.txt
       - name: Compile Cypress Videos
         if: ${{ always() && inputs.is_cypress }}
         run: |

--- a/scripts/tests/run-cypress.helpers.test.ts
+++ b/scripts/tests/run-cypress.helpers.test.ts
@@ -41,6 +41,7 @@ jest.mock('../github-actions/test-file-times.helpers');
 
 import {
   determineSuiteFromSpecs,
+  isRetryableCypressLaunchFailure,
   onOpen,
   onSpecs,
   onSuite,
@@ -60,6 +61,8 @@ describe('run-cypress', () => {
       env: {} as NodeJS.ProcessEnv,
       exit: jest.fn(),
       getCypressTestFileTimes: jest.fn(),
+      log: jest.fn(),
+      sleep: jest.fn().mockResolvedValue(undefined),
       writeTestFileTimes: jest.fn(),
     };
   };
@@ -170,6 +173,55 @@ describe('run-cypress', () => {
     expect(cypress.run).toHaveBeenCalled();
     expect(exitSpy).toHaveBeenCalled();
     exitSpy.mockRestore();
+  });
+
+  it('runCypressWithTiming uses the default retry sleep path when Cypress launch fails transiently', async () => {
+    const cypress = require('cypress');
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {
+      return undefined;
+    });
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+      return undefined as never;
+    });
+    const setTimeoutSpy = jest
+      .spyOn(global, 'setTimeout')
+      .mockImplementation((handler: TimerHandler): NodeJS.Timeout => {
+        if (typeof handler === 'function') {
+          handler();
+        }
+
+        return {} as NodeJS.Timeout;
+      });
+    const originalCi = process.env.CI;
+
+    process.env.CI = 'true';
+    cypress.run
+      .mockResolvedValueOnce({
+        failures: 1,
+        message: 'Timed out waiting for the browser to connect.',
+      })
+      .mockResolvedValueOnce({
+        runs: [],
+        totalFailed: 0,
+      });
+
+    await runCypressWithTiming({
+      configFile: 'cypress.config.ts',
+      current: false,
+      outputFilePath: 'results.json',
+    });
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5000);
+    expect(cypress.run).toHaveBeenCalledTimes(2);
+
+    if (originalCi === undefined) {
+      delete process.env.CI;
+    } else {
+      process.env.CI = originalCi;
+    }
+    setTimeoutSpy.mockRestore();
+    exitSpy.mockRestore();
+    consoleLogSpy.mockRestore();
   });
 
   it('disables command logs and forwards ENV', async () => {
@@ -328,6 +380,234 @@ describe('run-cypress', () => {
     expect(dependencies.getCypressTestFileTimes).not.toHaveBeenCalled();
     expect(dependencies.writeTestFileTimes).not.toHaveBeenCalled();
     expect(dependencies.exit).not.toHaveBeenCalled();
+  });
+
+  it('retries a transient browser launch failure in CI and succeeds on the second Edge attempt', async () => {
+    const dependencies = createDependencies();
+    dependencies.env.CI = 'true';
+    dependencies.cypressRunner.run
+      .mockResolvedValueOnce({
+        failures: 1,
+        message:
+          'Still waiting to connect to Edge, retrying in 1 second (attempt 51/62)\nTimed out waiting for the browser to connect. Retrying...\nError: connect ECONNREFUSED 127.0.0.1:33785',
+      })
+      .mockResolvedValueOnce({
+        runs: [],
+        totalFailed: 0,
+      });
+    dependencies.getCypressTestFileTimes.mockReturnValue({});
+
+    await runCypressWithTiming({
+      configFile: 'cypress.config.ts',
+      current: false,
+      dependencies,
+      outputFilePath: 'timings.json',
+    });
+
+    expect(dependencies.cypressRunner.run).toHaveBeenNthCalledWith(1, {
+      browser: 'edge',
+      configFile: 'cypress.config.ts',
+    });
+    expect(dependencies.sleep).toHaveBeenCalledWith(5000);
+    expect(dependencies.cypressRunner.run).toHaveBeenNthCalledWith(2, {
+      browser: 'edge',
+      configFile: 'cypress.config.ts',
+    });
+    expect(dependencies.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('falls back to Chrome after repeated Edge launch failures in CI when browser is not explicitly provided', async () => {
+    const dependencies = createDependencies();
+    dependencies.env.CI = 'true';
+    dependencies.cypressRunner.run
+      .mockResolvedValueOnce({
+        failures: 1,
+        message:
+          'Still waiting to connect to Edge, retrying in 1 second (attempt 51/62)',
+      })
+      .mockResolvedValueOnce({
+        failures: 1,
+        message:
+          'There was an error reconnecting to the Chrome DevTools protocol. Please restart the browser.',
+      })
+      .mockResolvedValueOnce({
+        runs: [],
+        totalFailed: 0,
+      });
+    dependencies.getCypressTestFileTimes.mockReturnValue({});
+
+    await runCypressWithTiming({
+      configFile: 'cypress.config.ts',
+      current: false,
+      dependencies,
+      outputFilePath: 'timings.json',
+      specs: 'example.cy.ts',
+    });
+
+    expect(dependencies.cypressRunner.run).toHaveBeenNthCalledWith(1, {
+      browser: 'edge',
+      configFile: 'cypress.config.ts',
+      spec: 'example.cy.ts',
+    });
+    expect(dependencies.cypressRunner.run).toHaveBeenNthCalledWith(2, {
+      browser: 'edge',
+      configFile: 'cypress.config.ts',
+      spec: 'example.cy.ts',
+    });
+    expect(dependencies.cypressRunner.run).toHaveBeenNthCalledWith(3, {
+      browser: 'chrome',
+      configFile: 'cypress.config.ts',
+      spec: 'example.cy.ts',
+    });
+    expect(dependencies.sleep).toHaveBeenCalledTimes(2);
+    expect(dependencies.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('does not fall back to Chrome when the browser was explicitly provided', async () => {
+    const dependencies = createDependencies();
+    dependencies.env.CI = 'true';
+    dependencies.cypressRunner.run
+      .mockResolvedValueOnce({
+        failures: 1,
+        message: 'Timed out waiting for the browser to connect.',
+      })
+      .mockResolvedValueOnce({
+        failures: 1,
+        message:
+          'There was an error reconnecting to the Chrome DevTools protocol. Please restart the browser.',
+      });
+
+    await expect(
+      runCypressWithTiming({
+        browserArg: 'edge',
+        configFile: 'cypress.config.ts',
+        current: false,
+        dependencies,
+        outputFilePath: 'timings.json',
+      }),
+    ).rejects.toThrow(
+      'There was an error reconnecting to the Chrome DevTools protocol. Please restart the browser.',
+    );
+
+    expect(dependencies.cypressRunner.run).toHaveBeenCalledTimes(2);
+    expect(dependencies.cypressRunner.run).toHaveBeenNthCalledWith(1, {
+      browser: 'edge',
+      configFile: 'cypress.config.ts',
+    });
+    expect(dependencies.cypressRunner.run).toHaveBeenNthCalledWith(2, {
+      browser: 'edge',
+      configFile: 'cypress.config.ts',
+    });
+  });
+
+  it('retries when Cypress throws a retryable browser launch error', async () => {
+    const dependencies = createDependencies();
+    dependencies.env.CI = 'true';
+    dependencies.cypressRunner.run
+      .mockRejectedValueOnce(
+        new Error('The browser never connected. Attempting to reconnect...'),
+      )
+      .mockResolvedValueOnce({
+        runs: [],
+        totalFailed: 0,
+      });
+    dependencies.getCypressTestFileTimes.mockReturnValue({});
+
+    await runCypressWithTiming({
+      configFile: 'cypress.config.ts',
+      current: false,
+      dependencies,
+      outputFilePath: 'timings.json',
+    });
+
+    expect(dependencies.cypressRunner.run).toHaveBeenCalledTimes(2);
+    expect(dependencies.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('retries when Cypress throws a retryable non-Error browser launch value', async () => {
+    const dependencies = createDependencies();
+    dependencies.env.CI = 'true';
+    dependencies.cypressRunner.run
+      .mockRejectedValueOnce('The browser never connected.')
+      .mockResolvedValueOnce({
+        runs: [],
+        totalFailed: 0,
+      });
+    dependencies.getCypressTestFileTimes.mockReturnValue({});
+
+    await runCypressWithTiming({
+      configFile: 'cypress.config.ts',
+      current: false,
+      dependencies,
+      outputFilePath: 'timings.json',
+    });
+
+    expect(dependencies.cypressRunner.run).toHaveBeenCalledTimes(2);
+    expect(dependencies.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('does not retry non-browser-launch failures', async () => {
+    const dependencies = createDependencies();
+    dependencies.env.CI = 'true';
+    dependencies.cypressRunner.run.mockResolvedValue({
+      failures: 1,
+      message:
+        'Cypress could not verify that this server is running: http://localhost:1234',
+    });
+
+    await expect(
+      runCypressWithTiming({
+        configFile: 'cypress.config.ts',
+        current: false,
+        dependencies,
+        outputFilePath: 'timings.json',
+      }),
+    ).rejects.toThrow(
+      'Cypress could not verify that this server is running: http://localhost:1234',
+    );
+
+    expect(dependencies.cypressRunner.run).toHaveBeenCalledTimes(1);
+    expect(dependencies.sleep).not.toHaveBeenCalled();
+  });
+
+  it('rethrows non-retryable thrown values from Cypress', async () => {
+    const dependencies = createDependencies();
+    dependencies.env.CI = 'true';
+    dependencies.cypressRunner.run.mockRejectedValue('plain string failure');
+
+    await expect(
+      runCypressWithTiming({
+        configFile: 'cypress.config.ts',
+        current: false,
+        dependencies,
+        outputFilePath: 'timings.json',
+      }),
+    ).rejects.toBe('plain string failure');
+
+    expect(dependencies.cypressRunner.run).toHaveBeenCalledTimes(1);
+  });
+
+  describe('isRetryableCypressLaunchFailure', () => {
+    it('returns true for DevTools connection failures', () => {
+      expect(
+        isRetryableCypressLaunchFailure(
+          'There was an error reconnecting to the Chrome DevTools protocol. Please restart the browser.',
+        ),
+      ).toBe(true);
+      expect(
+        isRetryableCypressLaunchFailure(
+          'Error: connect ECONNREFUSED 127.0.0.1:33785',
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false for application readiness failures', () => {
+      expect(
+        isRetryableCypressLaunchFailure(
+          'Cypress could not verify that this server is running: http://localhost:1234',
+        ),
+      ).toBe(false);
+    });
   });
 
   describe('determineSuiteFromSpecs', () => {

--- a/scripts/tests/run-cypress.helpers.ts
+++ b/scripts/tests/run-cypress.helpers.ts
@@ -44,6 +44,8 @@ type RunCypressTestsWithTimingDependencies = {
   env: NodeJS.ProcessEnv;
   exit: (code: number) => void;
   getCypressTestFileTimes: typeof getCypressTestFileTimes;
+  log: (message: string) => void;
+  sleep: (ms: number) => Promise<void>;
   writeTestFileTimes: typeof writeTestFileTimes;
 };
 
@@ -53,7 +55,165 @@ const defaultDependencies: RunCypressTestsWithTimingDependencies = {
   env: process.env,
   exit: (code: number) => process.exit(code),
   getCypressTestFileTimes,
+  log: (message: string) => console.log(message),
+  sleep: async (ms: number) =>
+    await new Promise(resolve => setTimeout(resolve, ms)),
   writeTestFileTimes,
+};
+
+const BROWSER_CONNECT_RETRY_DELAY_MS = 5000;
+
+const RETRYABLE_CYPRESS_LAUNCH_FAILURE_PATTERNS: RegExp[] = [
+  /still waiting to connect to (edge|chrome)/i,
+  /there was an error reconnecting to the chrome devtools protocol/i,
+  /the browser never connected/i,
+  /timed out waiting for the browser to connect/i,
+  /browser.*failed to start/i,
+  /error:\s*connect\s+econnrefused\s+127\.0\.0\.1:\d+/i,
+];
+
+type BrowserLaunchAttempt = {
+  browser: string;
+  description: string;
+  waitBeforeMs?: number;
+};
+
+const getErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+};
+
+export const isRetryableCypressLaunchFailure = (message: string): boolean => {
+  return RETRYABLE_CYPRESS_LAUNCH_FAILURE_PATTERNS.some(
+    (pattern: RegExp): boolean => pattern.test(message),
+  );
+};
+
+const getBrowserLaunchAttempts = ({
+  browser,
+  browserWasExplicitlyProvided,
+  isCi,
+}: {
+  browser: string;
+  browserWasExplicitlyProvided: boolean;
+  isCi: boolean;
+}): BrowserLaunchAttempt[] => {
+  const attempts: BrowserLaunchAttempt[] = [
+    {
+      browser,
+      description: 'initial browser launch',
+    },
+  ];
+
+  if (!isCi) {
+    return attempts;
+  }
+
+  attempts.push({
+    browser,
+    description: 'retrying browser launch after transient connection failure',
+    waitBeforeMs: BROWSER_CONNECT_RETRY_DELAY_MS,
+  });
+
+  if (!browserWasExplicitlyProvided && browser === 'edge') {
+    attempts.push({
+      browser: 'chrome',
+      description:
+        'falling back to chrome after repeated Edge connection failures',
+      waitBeforeMs: BROWSER_CONNECT_RETRY_DELAY_MS,
+    });
+  }
+
+  return attempts;
+};
+
+const runCypressWithBrowserRetries = async ({
+  browser,
+  browserWasExplicitlyProvided,
+  configFile,
+  dependencies,
+  specs,
+}: {
+  browser: string;
+  browserWasExplicitlyProvided: boolean;
+  configFile: string;
+  dependencies: RunCypressTestsWithTimingDependencies;
+  specs?: string;
+}): Promise<CypressSuccessfulRunResult> => {
+  const attempts = getBrowserLaunchAttempts({
+    browser,
+    browserWasExplicitlyProvided,
+    isCi: Boolean(dependencies.env.CI),
+  });
+  let lastError: Error = new Error(
+    'Cypress browser launch failed unexpectedly.',
+  );
+
+  for (const [index, attempt] of attempts.entries()) {
+    if (attempt.waitBeforeMs) {
+      dependencies.log(
+        `Cypress ${attempt.description}; waiting ${attempt.waitBeforeMs}ms before attempt ${index + 1}/${attempts.length}.`,
+      );
+      await dependencies.sleep(attempt.waitBeforeMs);
+    }
+
+    dependencies.log(
+      `Starting Cypress attempt ${index + 1}/${attempts.length} with browser ${attempt.browser} using config ${configFile}.`,
+    );
+
+    try {
+      const results = specs
+        ? await dependencies.cypressRunner.run({
+            browser: attempt.browser,
+            configFile,
+            spec: specs,
+          })
+        : await dependencies.cypressRunner.run({
+            browser: attempt.browser,
+            configFile,
+          });
+
+      if ('failures' in results) {
+        const errorMessage = results.message;
+
+        if (
+          isRetryableCypressLaunchFailure(errorMessage) &&
+          index < attempts.length - 1
+        ) {
+          dependencies.log(
+            `Retryable Cypress browser launch failure on attempt ${index + 1}/${attempts.length}: ${errorMessage}`,
+          );
+          lastError = new Error(errorMessage);
+          continue;
+        }
+
+        lastError = new Error(errorMessage);
+        break;
+      }
+
+      return results;
+    } catch (error: unknown) {
+      const errorMessage = getErrorMessage(error);
+
+      if (
+        isRetryableCypressLaunchFailure(errorMessage) &&
+        index < attempts.length - 1
+      ) {
+        dependencies.log(
+          `Caught retryable Cypress browser launch error on attempt ${index + 1}/${attempts.length}: ${errorMessage}`,
+        );
+        lastError = error instanceof Error ? error : new Error(errorMessage);
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  throw lastError;
 };
 
 export const determineSuiteFromSpecs = ({
@@ -308,20 +468,22 @@ export const runCypressWithTiming = async ({
   specs?: string;
 }): Promise<void> => {
   setEnvironmentVariables({ configFile, current, dependencies });
-  const browser =
-    browserArg && browserArg.length > 0
-      ? browserArg
-      : dependencies.dawson.isPublic
-        ? 'chrome'
-        : 'edge';
+  const browserWasExplicitlyProvided = !!browserArg && browserArg.length > 0;
+  let browser: string;
 
-  const results = specs
-    ? await dependencies.cypressRunner.run({ browser, configFile, spec: specs })
-    : await dependencies.cypressRunner.run({ browser, configFile });
-
-  if ('failures' in results) {
-    throw new Error(results.message);
+  if (browserWasExplicitlyProvided) {
+    browser = browserArg;
+  } else {
+    browser = dependencies.dawson.isPublic ? 'chrome' : 'edge';
   }
+
+  const results = await runCypressWithBrowserRetries({
+    browser,
+    browserWasExplicitlyProvided,
+    configFile,
+    dependencies,
+    specs,
+  });
 
   dependencies.writeTestFileTimes({
     filePath: outputFilePath,


### PR DESCRIPTION
# DevEx: Improve Cypress browser launch reliability in CI

## Overview

This PR improves the reliability of Cypress test runs in CI by handling transient browser launch failures more gracefully. The Cypress runner now retries browser startup issues that are likely environmental/transient, falls back from Edge to Chrome when repeated Edge launch failures occur and no browser was explicitly specified, and preserves Cypress output logs so failures are easier to diagnose.

## Changes

- Added retry logic to the Cypress test runner for transient browser launch failures in CI.
- Implemented a fallback path from Edge to Chrome after repeated Edge startup failures when the browser was not explicitly provided.
- Preserved the existing behavior when a browser is explicitly provided, so the runner does not silently change browsers in that case.
- Updated the GitHub Actions Cypress workflow templates to:
  - create a dedicated Cypress log directory,
  - capture Cypress output to a log file,
  - upload those logs as workflow artifacts for troubleshooting.
- Added unit coverage for the new retry and fallback behavior in `scripts/tests/run-cypress.helpers.test.ts`.

## Verification

- Added/updated Jest coverage for:
  - transient Cypress browser launch retries,
  - Edge-to-Chrome fallback behavior in CI,
  - explicit-browser handling.
- Updated workflow templates to surface Cypress logs as artifacts for easier diagnosis of launch failures.

## Pull Request Checklist

_PRs that do not meet these criteria may be closed without review._

- [x] I have conducted thorough manual testing:
   - [x] Locally
   - [ ] Experimental Environment (if necessary)
- [ ] If this PR is for a user story, or tech debt (devex, opex, design debt, etc.) that is user-facing, I have created test case(s) in TestRail and executed them.
- [ ] I assert that all DoD criteria for this issue have been met.
- [ ] If this PR includes a data migration with timing-specific manual test steps, I will coordinate the deployment with a manual tester to verify the timing-specific manual tests in real time.
- [ ] All user-facing changes have been verified to be free of accessibility issues via manual testing and automated accessibility tests.