### PR TITLE
9725 story to test 1783630624

### DIFF
--- a/web-api/src/business/useCases/caseAdvancedSearchInteractor.test.ts
+++ b/web-api/src/business/useCases/caseAdvancedSearchInteractor.test.ts
@@ -1,6 +1,10 @@
 jest.mock('@web-api/persistence/elasticsearch/caseAdvancedSearch');
+jest.mock('@shared/sharedAppContext', () => ({
+  getUniqueId: jest.fn().mockReturnValue('mock-preference-uuid'),
+}));
 
 import '@web-api/persistence/postgres/cases/mocks.jest';
+import { getUniqueId } from '@shared/sharedAppContext';
 import {
   CASE_TYPES_MAP,
   MAX_CASE_SEARCH_RESULTS,
@@ -75,6 +79,40 @@ describe('caseAdvancedSearchInteractor', () => {
     expect(caseAdvancedSearch).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({ useNonExactQuery: true }),
+    );
+  });
+
+  it('generates a single preference UUID and passes it to every search call', async () => {
+    const inaccessibleCase = {
+      docketNumber: '100-20',
+      isSealed: true,
+      petitioners: [],
+      sort: [10, '100-20'],
+    };
+    const accessibleCase = {
+      docketNumber: '101-20',
+      petitioners: [],
+      sort: [9, '101-20'],
+    };
+
+    caseAdvancedSearch
+      .mockResolvedValueOnce([inaccessibleCase])
+      .mockResolvedValueOnce([accessibleCase]);
+
+    await caseAdvancedSearchInteractor(
+      applicationContext,
+      { petitionerName: 'test person' },
+      mockPetitionsClerkUser,
+    );
+
+    expect(getUniqueId).toHaveBeenCalledTimes(1);
+    expect(caseAdvancedSearch).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ preference: 'mock-preference-uuid' }),
+    );
+    expect(caseAdvancedSearch).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ preference: 'mock-preference-uuid' }),
     );
   });
 
@@ -261,6 +299,7 @@ describe('caseAdvancedSearchInteractor', () => {
     expect(caseAdvancedSearch).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
+        preference: 'mock-preference-uuid',
         resultSize: 1,
         searchAfter: firstBatchAccessibleCases.at(-1)?.sort,
         useNonExactQuery: false,

--- a/web-api/src/business/useCases/caseAdvancedSearchInteractor.test.ts
+++ b/web-api/src/business/useCases/caseAdvancedSearchInteractor.test.ts
@@ -1,7 +1,12 @@
 jest.mock('@web-api/persistence/elasticsearch/caseAdvancedSearch');
-jest.mock('@shared/sharedAppContext', () => ({
-  getUniqueId: jest.fn().mockReturnValue('mock-preference-uuid'),
-}));
+jest.mock('@shared/sharedAppContext', () => {
+  const actual = jest.requireActual('@shared/sharedAppContext');
+
+  return {
+    ...actual,
+    getUniqueId: jest.fn().mockReturnValue('mock-preference-uuid'),
+  };
+});
 
 import '@web-api/persistence/postgres/cases/mocks.jest';
 import { getUniqueId } from '@shared/sharedAppContext';

--- a/web-api/src/business/useCases/caseAdvancedSearchInteractor.ts
+++ b/web-api/src/business/useCases/caseAdvancedSearchInteractor.ts
@@ -21,6 +21,7 @@ import {
   ROLE_PERMISSIONS,
 } from '@shared/authorization/authorizationClientService';
 import type { SearchAfter } from '@web-api/persistence/elasticsearch/caseAdvancedSearch';
+import { getUniqueId } from '@shared/sharedAppContext';
 
 type CaseAdvancedSearchResult = Awaited<
   ReturnType<typeof caseAdvancedSearch>
@@ -98,9 +99,15 @@ export const caseAdvancedSearchInteractor = async (
   let searchAfter: SearchAfter | undefined;
   let useNonExactQuery = false;
 
+  // A per-search preference key pins every search_after page to the same shard
+  // copies, keeping relevance (`_score`) ordering stable across pages so cases
+  // are not duplicated or skipped between requests.
+  const preference = getUniqueId();
+
   while (accessibleCases.length < MAX_CASE_SEARCH_RESULTS) {
     const foundCases = await caseAdvancedSearch({
       applicationContext,
+      preference,
       resultSize: MAX_CASE_SEARCH_RESULTS - accessibleCases.length,
       searchAfter,
       searchTerms,

--- a/web-api/src/persistence/elasticsearch/caseAdvancedSearch.test.ts
+++ b/web-api/src/persistence/elasticsearch/caseAdvancedSearch.test.ts
@@ -47,7 +47,24 @@ describe('caseAdvancedSearch', () => {
       { _score: { order: 'desc' } },
       { 'docketNumber.S': { order: 'asc' } },
     ]);
+    expect(
+      (search as jest.Mock).mock.calls[0][0].searchParameters.preference,
+    ).toBeUndefined();
     expect(results).toMatchObject(['some', 'matches']);
+  });
+
+  it('forwards the preference value to the search parameters', async () => {
+    (search as jest.Mock).mockReturnValue({ results: [], total: 0 });
+
+    await caseAdvancedSearch({
+      applicationContext,
+      preference: 'test-preference-uuid',
+      searchTerms: { petitionerName: 'search for this' },
+    });
+
+    expect(
+      (search as jest.Mock).mock.calls[0][0].searchParameters.preference,
+    ).toBe('test-preference-uuid');
   });
 
   it('uses the non-exact query and pagination parameters when requested', async () => {
@@ -58,6 +75,7 @@ describe('caseAdvancedSearch', () => {
 
     const results = await caseAdvancedSearch({
       applicationContext,
+      preference: 'another-uuid',
       resultSize: 25,
       searchAfter: [10, '101-20'],
       searchTerms: { petitionerName: 'search for this' },
@@ -76,6 +94,9 @@ describe('caseAdvancedSearch', () => {
       search_after: [10, '101-20'],
       size: 25,
     });
+    expect(
+      (search as jest.Mock).mock.calls[0][0].searchParameters.preference,
+    ).toBe('another-uuid');
     expect(results).toMatchObject(['other', 'matches']);
   });
 });

--- a/web-api/src/persistence/elasticsearch/caseAdvancedSearch.ts
+++ b/web-api/src/persistence/elasticsearch/caseAdvancedSearch.ts
@@ -23,12 +23,14 @@ type CaseAdvancedSearchResult = {
 
 export const caseAdvancedSearch = async ({
   applicationContext,
+  preference,
   resultSize = MAX_CASE_SEARCH_RESULTS,
   searchAfter,
   searchTerms,
   useNonExactQuery = false,
 }: {
   applicationContext: ServerApplicationContext;
+  preference?: string;
   resultSize?: number;
   searchAfter?: SearchAfter;
   searchTerms: CaseAdvancedSearchParamsRequestType;
@@ -54,8 +56,11 @@ export const caseAdvancedSearch = async ({
     ? nonExactMatchesQuery
     : exactMatchesQuery;
 
-  // The docket-number tie-breaker gives equal-scoring cases a stable order
-  // across search_after requests, preventing skipped or duplicate results
+  // Sort by relevance `_score` with docketNumber as a stable tie-breaker.
+  // The `preference` value routes every search_after page to the same shard copies,
+  // so `_score` is computed from the same segments on each request.
+  // Without it, scores are float-valued and computed per shard copy,
+  // letting a boundary document be duplicated or skipped between pages.
   const body: NonNullable<Search_Request['body']> = {
     _source: source,
     query: { bool: { must: [...matchQuery, ...commonQuery] } },
@@ -75,6 +80,7 @@ export const caseAdvancedSearch = async ({
     searchParameters: {
       body,
       index: 'efcms-case',
+      preference,
     },
   });
 


### PR DESCRIPTION
# 9725: Search By Name Improvements Feedback Fix

- #9725

## Overview

Searching by petitioner name returned duplicate rows when a name matched few cases (returned the same case many times).

**Suspected root cause:** the `search_after` cursor used `_score` as its primary key. Relevance scores are 32-bit floats recomputed per-shard-copy on every request. The same document can score differently between two requests if they land on different shard copies:

1. Page 1 returns case "123-22" as the last result with score `8.42375`. Cursor is set to `[8.42375, "123-22"]`.
2. Page 2 is served by a different shard copy. That same case now scores `8.42371` (slightly lower).
3. Since `8.42371 < 8.42375`, the case is now *after* the cursor in descending score order. OpenSearch returns it again.
4. The interactor adds it to `accessibleCases` a second time, leading to a duplicate row in the table.

**Fix:** pass a per-search `preference` UUID to every `search_after` request, pinning all pages to the same shard copies so `_score` is computed from identical segments.

## Changes

- **`caseAdvancedSearch.ts`**:  accepts optional `preference?: string`, forwards it to `searchParameters.preference`.
- **`caseAdvancedSearchInteractor.ts`**: generates one `getUniqueId()` UUID before the pagination loop and passes it as `preference` on every call.

## Verification

- Updated Jest coverage for `caseAdvancedSearch.ts` and `caseAdvancedSearchInteractor.ts`
- All `test:api` tests pass

## Notes

Addresses Testing Feedback:

Currently when a privatePractitioner creates a Case - and then searches for the petitioner Name via the advanced search while still logged in as privatePractitioner then 3 Results will show instead of 1 for the Petitioner results.

## Pull Request Checklist

### Internal Contributors (DAWSON Team Members)

- [x] I have conducted thorough manual testing:
   - [x] Locally
   - [ ] Experimental Environment (if necessary)
- [x] If this PR is for a user story, or tech debt (devex, opex, design debt, etc.) that is user-facing, I have created test case(s) in TestRail and executed them.
- [x] I assert that all DoD criteria for this issue have been met.
- [x] If this PR includes a data migration with timing-specific manual test steps, I will coordinate the deployment with a manual tester to verify the timing-specific manual tests in real time.
- [x] All user-facing changes have been verified to be free of accessibility issues via manual testing and automated accessibility tests.