### PR TITLE
10076: Notice of Setting Case Trial case title is all in uppercase

### DIFF
--- a/shared/src/business/utilities/pdfGenerator/components/NoticeSettingCaseForTrialDocketHeader.tsx
+++ b/shared/src/business/utilities/pdfGenerator/components/NoticeSettingCaseForTrialDocketHeader.tsx
@@ -12,7 +12,7 @@ export const NoticeSettingCaseForTrialDocketHeader = ({
   return (
     <div className="order-docket-header">
       <div id="caption">
-        <div id="caption-title">{caseTitle},</div>
+        <div id="caption-title">{caseTitle.toUpperCase()},</div>
         <div id="caption-extension">{caseCaptionExtension}</div>
         <div id="caption-v">v.</div>
         <div id="caption-commissioner">


### PR DESCRIPTION
### Summary

The previous `toUpperCase` of the case title was overwritten.