### PR TITLE
10256 bug to test 1784737042

### DIFF
--- a/cypress/local-only/tests/integration/caseDetail/document-viewer.cy.ts
+++ b/cypress/local-only/tests/integration/caseDetail/document-viewer.cy.ts
@@ -8,6 +8,8 @@ function generateMockDocketEntries(docketNumber: string, count: number) {
   for (let i = 0; i < count; i++) {
     entries.push({
       createdAt: `2020-01-${String((i % 28) + 1).padStart(2, '0')}T12:00:00.000Z`,
+      additionalInfo:
+        'This additional information is long enough to wrap across multiple lines in the document viewer index.',
       docketEntryId: uuidv4(),
       docketNumber,
       documentStorageId: uuidv4(),
@@ -283,26 +285,33 @@ describe('DocumentViewer - virtualized index nav (>1000 docket entries)', () => 
 
     cy.wait('@getDocketEntries');
 
-    cy.get('[data-testid="index-sortable-button"]').click();
-
     cy.get('[data-testid="paginator-page-2"]').first().click();
 
-    cy.get('[data-testid="docket-entry-index-700"]')
-      .parents('tr')
-      .find('[data-testid="document-viewer-link-O"]')
-      .click();
+    cy.get('td[data-testid^="docket-entry-index-"]').then($entries => {
+      cy.wrap($entries.eq(Math.floor($entries.length / 2)))
+        .parents('tr')
+        .find('[data-testid="document-viewer-link-O"]')
+        .click();
+    });
 
     cy.get('[data-testid="document-view-container"]').should('exist');
 
-    cy.get('.attachment-viewer-button.virtualized.active').should(
-      'have.length',
-      1,
-    );
-    cy.get('.attachment-viewer-button.virtualized.active').should('be.visible');
-    cy.get('.attachment-viewer-button.virtualized.active .grid-col-2').should(
-      'contain.text',
-      '700',
-    );
+    cy.get(
+      '[data-testid="document-viewer-documents-list"] > [role="list"]',
+    ).then($list => {
+      const listRect = $list[0].getBoundingClientRect();
+      const listCenter = listRect.top + listRect.height / 2;
+
+      cy.get('.attachment-viewer-button.virtualized.active').should(
+        $activeButton => {
+          const activeButtonRect = $activeButton[0].getBoundingClientRect();
+          const activeButtonCenter =
+            activeButtonRect.top + activeButtonRect.height / 2;
+
+          expect(activeButtonCenter).to.be.closeTo(listCenter, 100);
+        },
+      );
+    });
   });
 });
 

--- a/cypress/local-only/tests/integration/caseDetail/document-viewer.cy.ts
+++ b/cypress/local-only/tests/integration/caseDetail/document-viewer.cy.ts
@@ -288,7 +288,10 @@ describe('DocumentViewer - virtualized index nav (>1000 docket entries)', () => 
     cy.get('[data-testid="paginator-page-2"]').first().click();
 
     cy.get('td[data-testid^="docket-entry-index-"]').then($entries => {
-      cy.wrap($entries.eq(Math.floor($entries.length / 2)))
+      const $selectedEntry = $entries.eq(Math.floor($entries.length / 2));
+      cy.wrap($selectedEntry.text().trim()).as('selectedDocketEntryIndex');
+
+      cy.wrap($selectedEntry)
         .parents('tr')
         .find('[data-testid="document-viewer-link-O"]')
         .click();
@@ -296,21 +299,32 @@ describe('DocumentViewer - virtualized index nav (>1000 docket entries)', () => 
 
     cy.get('[data-testid="document-view-container"]').should('exist');
 
-    cy.get(
-      '[data-testid="document-viewer-documents-list"] > [role="list"]',
-    ).then($list => {
-      const listRect = $list[0].getBoundingClientRect();
-      const listCenter = listRect.top + listRect.height / 2;
-
+    cy.get<string>('@selectedDocketEntryIndex').then(selectedIndex => {
       cy.get('.attachment-viewer-button.virtualized.active').should(
-        $activeButton => {
-          const activeButtonRect = $activeButton[0].getBoundingClientRect();
-          const activeButtonCenter =
-            activeButtonRect.top + activeButtonRect.height / 2;
-
-          expect(activeButtonCenter).to.be.closeTo(listCenter, 100);
-        },
+        'have.length',
+        1,
       );
+      cy.get('.attachment-viewer-button.virtualized.active .grid-col-2').should(
+        'have.text',
+        selectedIndex,
+      );
+
+      cy.get(
+        '[data-testid="document-viewer-documents-list"] > [role="list"]',
+      ).then($list => {
+        const listRect = $list[0].getBoundingClientRect();
+        const listCenter = listRect.top + listRect.height / 2;
+
+        cy.get('.attachment-viewer-button.virtualized.active').should(
+          $activeButton => {
+            const activeButtonRect = $activeButton[0].getBoundingClientRect();
+            const activeButtonCenter =
+              activeButtonRect.top + activeButtonRect.height / 2;
+
+            expect(activeButtonCenter).to.be.closeTo(listCenter, 100);
+          },
+        );
+      });
     });
   });
 });

--- a/web-client/src/views/DocketRecord/VirtualizedDocumentList.tsx
+++ b/web-client/src/views/DocketRecord/VirtualizedDocumentList.tsx
@@ -19,6 +19,10 @@ export const VirtualizedDocumentList: React.FC<
     width: number;
     height: number;
   } | null>(null);
+  const [isVirtualListReady, setIsVirtualListReady] = useState(false);
+  const selectedIndex = docketEntries.findIndex(
+    entry => entry.docketEntryId === viewDocumentId,
+  );
 
   // Get row height from cache or provide a generous overestimate.
   // Overestimating is safe (extra whitespace), underestimating causes overlap.
@@ -96,15 +100,15 @@ export const VirtualizedDocumentList: React.FC<
 
   // Scroll to the selected document in the virtualized list
   useEffect(() => {
-    if (viewDocumentId && listRef.current && listDimensions) {
-      const selectedIndex = docketEntries.findIndex(
-        entry => entry.docketEntryId === viewDocumentId,
-      );
-      if (selectedIndex !== -1) {
-        listRef.current.scrollToRow({ index: selectedIndex, align: 'center' });
-      }
+    if (
+      isVirtualListReady &&
+      viewDocumentId &&
+      listRef.current &&
+      selectedIndex !== -1
+    ) {
+      listRef.current.scrollToRow({ index: selectedIndex, align: 'center' });
     }
-  }, [viewDocumentId, listDimensions, docketEntries]);
+  }, [isVirtualListReady, selectedIndex, viewDocumentId]);
 
   // Row renderer for virtualized list
   const Row = ({
@@ -250,7 +254,7 @@ export const VirtualizedDocumentList: React.FC<
           rowHeight={getRowHeight}
           overscanCount={3}
           listRef={listRef}
-          onResize={setListDimensions}
+          onResize={() => setIsVirtualListReady(true)}
           rowComponent={Row}
           rowCount={docketEntries.length}
           rowProps={{} as never}


### PR DESCRIPTION
# 10256 BUG: Correct Virtualized Document Index Centering

- #10256

## Overview

Centers the selected docket entry when opening the Document Viewer for cases with more than 1,000 entries, including entries with variable-height descriptions.

## Changes

- Added `isVirtualListReady` to track when `react-window` finishes its initial viewport measurement.
- Used `onResize` to mark the virtualized list as ready.
- Located the selected row by matching `viewDocumentId` in the sorted `docketEntries` array.
- Performed one `scrollToRow({ align: 'center', index: selectedIndex })` after the list is ready.
- Added long `additionalInfo` to Cypress fixtures to produce variable-height rows.

## Reviewer Notes

- Before the fix, the page tried to center the selected entry before it knew how tall all the visible entries would be. Long descriptions made some entries taller, changing the selected entry’s final position and moving it away from the center. We now wait for the list to render, then scroll and center.
- This PR affects only virtualized lists with more than 1,000 entries.
 
The fix waits until the list fully renders on the page, then scrolls and centers the selected entry.

## Verification

- Updated Cypress coverage to verify centering with more than 1,000 variable-height entries.
- Manually verified locally.

## Manual Deployment Steps

None.

## Pull Request Checklist

### Internal Contributors (DAWSON Team Members)

- [x] I have conducted thorough manual testing:
  - [x] Locally
  - [x] Experimental Environment (if necessary)
- [ ] If this PR is for a user story, or tech debt (devex, opex, design debt, etc.) that is user-facing, I have created test case(s) in TestRail and executed them.
- [ ] I assert that all DoD criteria for this issue have been met.
- [x] If this PR includes a data migration with timing-specific manual test steps, I will coordinate the deployment with a manual tester to verify the timing-specific manual tests in real time.
- [ ] All user-facing changes have been verified to be free of accessibility issues via manual testing and automated accessibility tests.