### PR TITLE
10294 bug sealed contact info to test 1785180103

### DIFF
--- a/cypress/local-only/tests/integration/sealedContactInformation/sealed-contact-information.cy.ts
+++ b/cypress/local-only/tests/integration/sealedContactInformation/sealed-contact-information.cy.ts
@@ -120,4 +120,36 @@ describe('Sealed Contact Information', () => {
       cy.contains('ADC able to edit').should('exist');
     });
   });
+
+  it('should let petitioner edit own contact information when sealed', () => {
+    cy.get<string>('@docketNumber').then(docketNumber => {
+      loginAsDocketClerk();
+      goToCase(docketNumber);
+      updateCaseStatus('General Docket - At Issue (Ready for Trial)');
+      cy.get('[data-testid="tab-parties"]').click();
+      cy.get('[data-testid="edit-petitioner-button"]').click();
+      cy.get('[data-testid="seal-address-label"]').contains(
+        'Seal contact information',
+      );
+      cy.get('[data-testid="seal-address-label"]').click();
+      cy.get('[data-testid="modal-confirm"]').click();
+
+      loginAsPetitioner();
+      goToCase(docketNumber);
+      cy.get('[data-testid="tab-case-information"]').click();
+      cy.get('[data-testid="tab-parties"]').click();
+      cy.get('[data-testid="edit-petitioner-button"]').click();
+      cy.get('[data-testid="submit-contact-edit-button"]').click();
+      cy.get('[data-testid="error-alert"]').should('be.visible');
+      cy.get('[data-testid="domestic-country-btn"]').click();
+      cy.get('[data-testid="contact.address1"]').type('123 Main St');
+      cy.get('[data-testid="contact.city"]').type('Anytown');
+      cy.get('[data-testid="contact.state"]').select('NY');
+      cy.get('[data-testid="contact.postalCode"]').type('12345');
+      cy.get('[data-testid="phone-number-input"]').type('555-555-5555');
+      cy.get('[data-testid="submit-contact-edit-button"]').click();
+      cy.get('[data-testid="success-alert"]').should('be.visible');
+      cy.get('[data-testid="success-alert"]').contains('Changes saved.');
+    });
+  });
 });

--- a/shared/src/business/entities/contacts/Petitioner.test.ts
+++ b/shared/src/business/entities/contacts/Petitioner.test.ts
@@ -77,58 +77,6 @@ describe('Petitioner', () => {
       });
     });
 
-    it('should be true when petitioner is sealed and address fields are undefined', () => {
-      const entity = new Petitioner({
-        ...mockValidPetitioner,
-        sealedAndUnavailable: true,
-        address1: undefined,
-        city: undefined,
-        countryType: undefined,
-        phone: undefined,
-        postalCode: undefined,
-        state: undefined,
-      });
-
-      expect(entity.isValid()).toBe(true);
-      expect(entity.getFormattedValidationErrors()).toEqual(null);
-    });
-
-    it('should be false when petitioner is sealed and address is defined', () => {
-      const entity = new Petitioner({
-        ...mockValidPetitioner,
-        sealedAndUnavailable: true,
-        city: undefined,
-        countryType: undefined,
-        phone: undefined,
-        postalCode: undefined,
-        state: undefined,
-      });
-
-      expect(entity.isValid()).toBe(false);
-      expect(entity.getFormattedValidationErrors()).toEqual({
-        address1: '"address1" is not allowed',
-      });
-    });
-
-    it('should be false when petitioner is sealed and all address fields are defined', () => {
-      const entity = new Petitioner({
-        ...mockValidPetitioner,
-        sealedAndUnavailable: true,
-        countryType: 'USA',
-        state: 'MD',
-      });
-
-      expect(entity.isValid()).toBe(false);
-      expect(entity.getFormattedValidationErrors()).toEqual({
-        address1: '"address1" is not allowed',
-        city: '"city" is not allowed',
-        countryType: '"countryType" is not allowed',
-        phone: '"phone" is not allowed',
-        postalCode: '"postalCode" is not allowed',
-        state: '"state" is not allowed',
-      });
-    });
-
     it('should be false when petitioner is not sealed but available and address is undefined', () => {
       const entity = new Petitioner({
         ...mockValidPetitioner,

--- a/shared/src/business/entities/contacts/Petitioner.test.ts
+++ b/shared/src/business/entities/contacts/Petitioner.test.ts
@@ -77,6 +77,16 @@ describe('Petitioner', () => {
       });
     });
 
+    it('should be true when petitioner is sealed and address fields are provided', () => {
+      const entity = new Petitioner({
+        ...mockValidPetitioner,
+        isAddressSealed: true,
+        sealedAndUnavailable: true,
+      });
+      expect(entity.isValid()).toBe(true);
+      expect(entity.getFormattedValidationErrors()).toEqual(null);
+    });
+
     it('should be false when petitioner is not sealed but available and address is undefined', () => {
       const entity = new Petitioner({
         ...mockValidPetitioner,

--- a/shared/src/business/entities/contacts/Petitioner.ts
+++ b/shared/src/business/entities/contacts/Petitioner.ts
@@ -74,36 +74,6 @@ export class Petitioner extends JoiValidationEntity {
 
   static VALIDATION_RULES = {
     ...User.USER_CONTACT_VALIDATION_RULES,
-    address1: joi.when('sealedAndUnavailable', {
-      is: true,
-      then: joi.forbidden(),
-      otherwise: User.USER_CONTACT_VALIDATION_RULES.address1,
-    }),
-    city: joi.when('sealedAndUnavailable', {
-      is: true,
-      then: joi.forbidden(),
-      otherwise: User.USER_CONTACT_VALIDATION_RULES.city,
-    }),
-    countryType: joi.when('sealedAndUnavailable', {
-      is: true,
-      then: joi.forbidden(),
-      otherwise: User.USER_CONTACT_VALIDATION_RULES.countryType,
-    }),
-    phone: joi.when('sealedAndUnavailable', {
-      is: true,
-      then: joi.forbidden(),
-      otherwise: User.USER_CONTACT_VALIDATION_RULES.phone,
-    }),
-    postalCode: joi.when('sealedAndUnavailable', {
-      is: true,
-      then: joi.forbidden(),
-      otherwise: User.USER_CONTACT_VALIDATION_RULES.postalCode,
-    }),
-    state: joi.when('sealedAndUnavailable', {
-      is: true,
-      then: joi.forbidden(),
-      otherwise: User.USER_CONTACT_VALIDATION_RULES.state,
-    }),
     additionalName: JoiValidationConstants.STRING.max(200).optional().messages({
       'string.max': 'Limit is 200 characters. Enter 200 or fewer characters.',
     }),

--- a/web-client/src/presenter/actions/validateNoteOnCaseDetailAction.test.ts
+++ b/web-client/src/presenter/actions/validateNoteOnCaseDetailAction.test.ts
@@ -47,20 +47,23 @@ describe('validateNoteOnCaseDetailAction', () => {
   it('should call the error path when any errors are found', async () => {
     applicationContext
       .getUseCases()
-      .validateCaseDetailInteractor.mockReturnValue('error');
+      .validateCaseDetailInteractor.mockReturnValue({
+        caseNote: 'Limited to 9000 characters.',
+      });
+
     await runAction(validateNoteOnCaseDetailAction, {
       modules: {
         presenter,
       },
-      state: {
-        caseDetail: mockNote,
-        modal: {
-          notes: mockNote,
-        },
-      },
     });
 
     expect(errorStub.mock.calls.length).toEqual(1);
+    expect(errorStub.mock.calls[0][0]).toMatchObject({
+      alertError: {
+        title: 'Errors were found. Please correct your form and resubmit.',
+      },
+      errors: { caseNote: 'Limited to 9000 characters.' },
+    });
   });
 
   it('should call validateCaseDetailInteractor with useCaseEntity true', async () => {

--- a/web-client/src/presenter/actions/validateNoteOnCaseDetailAction.ts
+++ b/web-client/src/presenter/actions/validateNoteOnCaseDetailAction.ts
@@ -17,22 +17,26 @@ export const validateNoteOnCaseDetailAction = ({
   const note = get(state.modal.notes);
   const user = get(state.user);
 
-  const errors = applicationContext.getUseCases().validateCaseDetailInteractor(
-    {
-      caseDetail: { ...caseDetail, caseNote: note },
-      useCaseEntity: true,
-    },
-    user,
-  );
+  const validationErrors = applicationContext
+    .getUseCases()
+    .validateCaseDetailInteractor(
+      {
+        caseDetail: { ...caseDetail, caseNote: note },
+        useCaseEntity: true,
+      },
+      user,
+    );
 
-  if (!errors) {
+  const caseNoteError = validationErrors && validationErrors.caseNote;
+
+  if (!caseNoteError) {
     return path.success();
   } else {
     return path.error({
       alertError: {
         title: 'Errors were found. Please correct your form and resubmit.',
       },
-      errors,
+      errors: { caseNote: caseNoteError },
     });
   }
 };

--- a/web-client/src/views/ContactEdit.tsx
+++ b/web-client/src/views/ContactEdit.tsx
@@ -128,6 +128,7 @@ export const ContactEdit = connect(
           </div>
           <div className="button-container">
             <Button
+              data-testid="submit-contact-edit-button"
               onClick={() => {
                 submitEditContactSequence();
               }}


### PR DESCRIPTION
# 10294: Bug Sealed Contact Information

#10294 

## Overview

This pull request updates how sealed petitioner contact information is handled, allowing petitioners to edit their own contact details even when their information is sealed. Reverted validation rules for sealed petitioners. Reverted #10190 

## Changes

**Sealed Contact Information Editing**

* Petitioners can now edit their own contact information even if their contact information is sealed.
* The validation rules in `Petitioner.ts` were updated to remove restrictions that previously forbade address fields when `sealedAndUnavailable` was true.

**Testing Updates**

* Test cases that checked for forbidden address fields when sealed have been removed from `Petitioner.test.ts`, reflecting the new business logic.
* A new Cypress integration test was added to verify that petitioners can successfully edit their own sealed contact information and see appropriate success or error alerts.

**UI and Validation Improvements**

* The contact edit form's submit button now has a `data-testid` for more robust UI testing.
* Validation for case notes was refactored to only flag errors for the `caseNote` field, improving error handling and messaging.

## Verification

Steps for 10190
1. Sign in as ADC
2. Select a case & use that role to add or edit the Case Notes
3. Then logout; Sign in as Case Services Supervisor, navigate to the same case as above & Seal the Petitioner(s) addresses
4. Then Logout again; Sign back in as ADC
5. Go back to your original case try to Edit Case Notes
6. Make an edit to the case note and click save
7. The edited note saves successfully
8. Next, log back in as the CSS (or any other role that can view sealed petitioner addresses), and navigate to that same case
9. Click on the Notes tab, and click Edit note
10. Make an edit to the case note and click save
11. The edited note saves successfully

Steps for 10294
1. Log in as a Petitioner that is a party on a case. Be sure that for the case you are testing with, the Petitioner's contact information has been sealed by a docket clerk.
2.Click on the case docket number from the My Cases page
3. Click on the Case information/Parties tab
4. Address data will already be sealed for the Petitioner
5. Click on the Edit link at the top of the petitioner card
6. For parties that have sealed contact information, all of the contact fields will be blank (this is ok - this is currently how it is implemented)
7. Input fields for country, address, city, state, zip, phone
8. Click save
9. shows success alert

## Pull Request Checklist

_PRs that do not meet these criteria may be closed without review._

### Internal Contributors (DAWSON Team Members)

- [x] I have conducted thorough manual testing:
   - [x] Locally
   - [x] Experimental Environment (if necessary)
- [x] If this PR is for a user story, or tech debt (devex, opex, design debt, etc.) that is user-facing, I have created test case(s) in TestRail and executed them.
- [x] I assert that all DoD criteria for this issue have been met.
- [x] If this PR includes a data migration with timing-specific manual test steps, I will coordinate the deployment with a manual tester to verify the timing-specific manual tests in real time.
- [x] All user-facing changes have been verified to be free of accessibility issues via manual testing and automated accessibility tests.
