### PR TITLE
opex: added a script to read messages out of the old color's send_emails DLQ and insert them into the current color's send_emails queue.

### DIFF
--- a/docs/operations/runbooks/resend-failed-emails.md
+++ b/docs/operations/runbooks/resend-failed-emails.md
@@ -1,0 +1,24 @@
+# Troubleshooting Email Delivery Failures
+
+## Description
+
+This runbook is intended to provide a step-by-step guide for troubleshooting email delivery failures. It outlines the necessary steps to identify and resolve common issues that prevent emails from being successfully delivered to recipients.
+
+## Prerequisites
+
+- AWS console access with permissions to view SES (Simple Email Service), Lambda, SQS (Simple Queue Service), and CloudWatch.
+
+## Steps
+
+1. Determine the current color of the environment (e.g., blue or green).
+1. Log into the AWS console and navigate to the `send_emails_dl_queue_<ENV>_<COLOR>.fifo` queue.
+1. TODO: DETERMINE WHY THEY FAILED AND IF THEY SHOULD BE RETRIED
+1. If you determine that the messages should be retried, proceed differently if the DLQ belongs to the current color or the old color.
+    1. If the DLQ belongs to the current color:
+        1. Click "Start DLQ Redrive" and then click "DLQ Redrive".
+    1. If the DLQ belongs to the old color:
+        1. Run the `redrive-old-color-dlq-to-current-color-queue.sh` script to redrive the messages from the old color's DLQ to the current color's queue:
+           ```bash
+           . scripts/env/set-env.zsh <ENV>
+           scripts/email/redrive-old-color-dlq-to-current-color-queue.sh
+           ```

--- a/docs/operations/runbooks/resend-failed-emails.md
+++ b/docs/operations/runbooks/resend-failed-emails.md
@@ -1,19 +1,22 @@
-# Troubleshooting Email Delivery Failures
+# Re-Sending Emails That Failed to Deliver
 
 ## Description
 
-This runbook is intended to provide a step-by-step guide for troubleshooting email delivery failures. It outlines the necessary steps to identify and resolve common issues that prevent emails from being successfully delivered to recipients.
+This runbook is intended to provide a step-by-step guide for re-sending emails that failed to deliver.
 
 ## Prerequisites
 
 - AWS console access with permissions to view SES (Simple Email Service), Lambda, SQS (Simple Queue Service), and CloudWatch.
+- You are subscribed to the `efcms_<ENV>_<COLOR>: SendEmails-DLQueueCheck` SNS topic to receive notifications about failed email deliveries.
 
 ## Steps
 
+1. Receive an alert from the `efcms_<ENV>_<COLOR>: SendEmails-DLQueueCheck` SNS topic.
 1. Determine the current color of the environment (e.g., blue or green).
-1. Log into the AWS console and navigate to the `send_emails_dl_queue_<ENV>_<COLOR>.fifo` queue.
-1. TODO: DETERMINE WHY THEY FAILED AND IF THEY SHOULD BE RETRIED
-1. If you determine that the messages should be retried, proceed differently if the DLQ belongs to the current color or the old color.
+1. Log into the AWS console and navigate to the `send_emails_dl_queue_<ENV>_<COLOR>.fifo` queue to view the messages that failed to send.
+1. Next, navigate to the `send_emails_<ENV>_<COLOR>` lambda function to view the logs of the failed delivery attempts.
+1. Before retrying, identify the root cause of the failed deliveries and address it. Do not attempt to retry until you are sure a retry will be successful.
+1. Once you are sure you want to retry, proceed differently depending on whether the DLQ belongs to the current color or the old color.
     1. If the DLQ belongs to the current color:
         1. Click "Start DLQ Redrive" and then click "DLQ Redrive".
     1. If the DLQ belongs to the old color:

--- a/scripts/email/redrive-old-color-dlq-to-current-color-queue.sh
+++ b/scripts/email/redrive-old-color-dlq-to-current-color-queue.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -e
+
+./check-env-variables.sh \
+   "AWS_ACCOUNT_ID" \
+   "CURRENT_COLOR" \
+   "ENV" \
+   "REGION"
+
+[ "$CURRENT_COLOR" = "green" ] && OLD_COLOR="blue" || OLD_COLOR="green"
+
+SOURCE_DLQ_URL="https://sqs.${REGION}.amazonaws.com/${AWS_ACCOUNT_ID}/send_emails_dl_queue_${ENV}_${OLD_COLOR}.fifo"
+TARGET_QUEUE_URL="https://sqs.${REGION}.amazonaws.com/${AWS_ACCOUNT_ID}/send_emails_queue_${ENV}_${CURRENT_COLOR}.fifo"
+VISIBILITY_TIMEOUT=300
+
+# Set a group ID for the forwarded messages
+MESSAGE_GROUP_ID="dlq-redrive-group"
+
+echo "Replaying FIFO messages from ${OLD_COLOR} DLQ to ${CURRENT_COLOR} queue..."
+
+while true; do
+  # 1. Receive up to 10 messages (including FIFO attributes)
+  RESPONSE=$(aws sqs receive-message \
+    --queue-url "$SOURCE_DLQ_URL" \
+    --max-number-of-messages 10 \
+    --visibility-timeout "$VISIBILITY_TIMEOUT" \
+    --attribute-names All \
+    --message-attribute-names All \
+    --output json)
+
+  if [ -z "$RESPONSE" ]; then
+    echo "No response received. Finished."
+    break
+  fi
+
+  MESSAGES=$(echo "$RESPONSE" | jq -c '.Messages // []')
+  COUNT=$(echo "$MESSAGES" | jq 'length')
+  COUNT=${COUNT:-0}
+
+  if [ "$COUNT" -eq 0 ]; then
+    echo "No more visible messages in DLQ. Done!"
+    break
+  fi
+
+  echo "Processing batch of $COUNT FIFO messages..."
+
+  # 2. Format batch payload with FIFO-required parameters:
+  #    - Uses existing MessageGroupId if present, otherwise falls back to MESSAGE_GROUP_ID
+  #    - Uses MessageId as MessageDeduplicationId to ensure unique delivery
+  BATCH_PAYLOAD=$(echo "$MESSAGES" | jq -c --arg group_id "$MESSAGE_GROUP_ID" 'map({
+    Id: .MessageId,
+    MessageBody: .Body,
+    MessageGroupId: (.Attributes.MessageGroupId // $group_id),
+    MessageDeduplicationId: .MessageId
+  })')
+
+  # 3. Send batch to the target FIFO queue
+  aws sqs send-message-batch \
+    --queue-url "$TARGET_QUEUE_URL" \
+    --entries "$BATCH_PAYLOAD" > /dev/null
+
+  echo "Successfully forwarded ${COUNT} messages from the ${OLD_COLOR} DLQ to the ${CURRENT_COLOR} queue."
+
+  sleep 1
+done


### PR DESCRIPTION
# OpEx: Redrive messages from old color's `send_emails` DLQ to current color's `send_emails` queue

## Overview

Provide an operational script to redrive messages from the old color's `send_emails` dead-letter queue into the active color's `send_emails` queue.

## Changes

- Added `scripts/email/redrive-old-color-dlq-to-current-color-queue.sh`.
- Derives the retired source color from `CURRENT_COLOR`.
- Reads up to 10 messages at a time from the source DLQ.
- Forwards messages to the active FIFO queue using `send-message-batch`.
- Preserves the existing `MessageGroupId` when available and uses `MessageId` as the deduplication ID.
- Requires `AWS_ACCOUNT_ID`, `CURRENT_COLOR`, `ENV`, and `REGION` environment variables.

## Verification

- Manual verification should be performed by confirming that messages are received by the active email queue and processed successfully.

## Notes and Limitations

- This is an act-quickly operational change with no associated ticket.
- The script makes source messages invisible for 300 seconds but does not delete them from the source DLQ. Source-message cleanup must be handled separately.
- Message attributes are requested from SQS but are not copied into the target messages; the message body and FIFO grouping metadata are forwarded.

## Pull Request Checklist

_PRs that do not meet these criteria may be closed without review._

- [x] I have conducted thorough manual testing:
   - [ ] Locally
   - [x] Experimental Environment (exp2)
   - [x] Prod
- [x] If this PR is for a user story, or tech debt (devex, opex, design debt, etc.) that is user-facing, I have created test case(s) in TestRail and executed them.
- [x] I assert that all DoD criteria for this issue have been met.
- [x] If this PR includes a data migration with timing-specific manual test steps, I will coordinate the deployment with a manual tester to verify the timing-specific manual tests in real time.
- [x] All user-facing changes have been verified to be free of accessibility issues via manual testing and automated accessibility tests.