### PR TITLE
8960 postgres migration follow ups to test 1785777482

### DIFF
--- a/web-api/src/business/useCases/trialSessions/setTrialSessionCalendarInteractor.ts
+++ b/web-api/src/business/useCases/trialSessions/setTrialSessionCalendarInteractor.ts
@@ -22,6 +22,7 @@ import { getCalendaredCasesForTrialSession } from '@web-api/persistence/postgres
 import { updateTrialSession } from '@web-api/persistence/postgres/trialSessions/updateTrialSession';
 import { createOrUpdateTrialSessionCases } from '@web-api/persistence/postgres/trialSessions/createOrUpdateTrialSessionCases';
 import { deleteCasesFromTrialSession } from '@web-api/persistence/postgres/trialSessions/deleteCasesFromTrialSession';
+import { withTransaction } from '@web-api/persistence/postgres/utils/transactions';
 
 export const setTrialSessionCalendarInteractor = async (
   applicationContext: ServerApplicationContext,
@@ -160,39 +161,41 @@ export const setTrialSessionCalendarInteractor = async (
       ...manuallyAddedQcIncompleteCaseEntities,
     ];
 
-    const updatesToPersist: Promise<any>[] = [
-      upsertCases([...caseEntitiesToCalendar, ...caseEntitiesToNotCalendar]),
-      createOrUpdateTrialSessionCases({
-        trialSessionCases: caseOrdersToAdd.map(TCO => ({
-          caseOrder: TCO,
-          trialSessionId,
-          docketNumber: TCO.docketNumber,
-          isHearing: false,
-        })),
-      }),
-      deleteCasesFromTrialSession({
-        trialSessionId,
-        docketNumbers: caseOrdersToDelete.map(CO => CO.docketNumber),
-      }),
-    ];
-
-    if (!isEmpty(caseEntitiesToCalendar)) {
-      updatesToPersist.push(
-        // We may need to update related deadlines for newly calendared cases depending on the trial session judge.
-        // TODO: These updates should NOT be done here. Instead, we should remove associatedJudge and associatedJudgeId from dwCaseDeadline and dwWorkItem and reference these columns on dwCase.
-        updateDeadlinesForCasesToCalendar({
-          casesToCalendar: caseEntitiesToCalendar,
-          trialSessionEntity,
+    await withTransaction(async () => {
+      const updatesToPersist: Promise<any>[] = [
+        upsertCases([...caseEntitiesToCalendar, ...caseEntitiesToNotCalendar]),
+        createOrUpdateTrialSessionCases({
+          trialSessionCases: caseOrdersToAdd.map(TCO => ({
+            caseOrder: TCO,
+            trialSessionId,
+            docketNumber: TCO.docketNumber,
+            isHearing: false,
+          })),
         }),
-      );
-    }
+        deleteCasesFromTrialSession({
+          trialSessionId,
+          docketNumbers: caseOrdersToDelete.map(CO => CO.docketNumber),
+        }),
+      ];
 
-    // Persist all case updates
-    await settlePromises(updatesToPersist);
+      if (!isEmpty(caseEntitiesToCalendar)) {
+        updatesToPersist.push(
+          // We may need to update related deadlines for newly calendared cases depending on the trial session judge.
+          // TODO: These updates should NOT be done here. Instead, we should remove associatedJudge and associatedJudgeId from dwCaseDeadline and dwWorkItem and reference these columns on dwCase.
+          updateDeadlinesForCasesToCalendar({
+            casesToCalendar: caseEntitiesToCalendar,
+            trialSessionEntity,
+          }),
+        );
+      }
 
-    // Persist the update to the trial session itself
-    await updateTrialSession({
-      trialSessionToUpdate: trialSessionEntity.validate().toRawObject(),
+      // Persist all case updates
+      await settlePromises(updatesToPersist);
+
+      // Persist the update to the trial session itself
+      await updateTrialSession({
+        trialSessionToUpdate: trialSessionEntity.validate().toRawObject(),
+      });
     });
 
     await applicationContext.getNotificationGateway().sendNotificationToUser({

--- a/web-api/src/business/useCases/trialSessions/setTrialSessionCalendarInteractor.ts
+++ b/web-api/src/business/useCases/trialSessions/setTrialSessionCalendarInteractor.ts
@@ -162,7 +162,7 @@ export const setTrialSessionCalendarInteractor = async (
     ];
 
     await withTransaction(async () => {
-      const updatesToPersist: Promise<any>[] = [
+      const updatesToPersist: Promise<void>[] = [
         upsertCases([...caseEntitiesToCalendar, ...caseEntitiesToNotCalendar]),
         createOrUpdateTrialSessionCases({
           trialSessionCases: caseOrdersToAdd.map(TCO => ({


### PR DESCRIPTION
# 8960: Postgres migration follow-ups

#8960 

## Overview

Most of the items in this ticket were completed as part of the original migration, or as part of the transaction support ticket #9009. All that was left was adding transaction support for `setTrialSessionCalendarInteractor`.

## Changes

Added transaction support for `setTrialSessionCalendarInteractor`.

## Verification

Local testing of calendaring a trial session and making sure all the necessary database tables are updated, and introduced a hardcoded error to make sure these changes are all rolled back after an error. 

Deployed to an experimental environment with the hardcoded error as well and ensured the data was rolled back correctly. 

## Pull Request Checklist

_PRs that do not meet these criteria may be closed without review._

### Internal Contributors (DAWSON Team Members)

- [x] I have conducted thorough manual testing:
   - [x] Locally
   - [x] Experimental Environment (if necessary)
- [x] If this PR is for a user story, or tech debt (devex, opex, design debt, etc.) that is user-facing, I have created test case(s) in TestRail and executed them.
- [x] I assert that all DoD criteria for this issue have been met.
- [x] If this PR includes a data migration with timing-specific manual test steps, I will coordinate the deployment with a manual tester to verify the timing-specific manual tests in real time.
- [x] All user-facing changes have been verified to be free of accessibility issues via manual testing and automated accessibility tests.
