### PR TITLE
10293 fix free taxpayer help url address to test 1785960384

### DIFF
--- a/web-client/src/views/Dashboards/DashboardExternalUser.tsx
+++ b/web-client/src/views/Dashboards/DashboardExternalUser.tsx
@@ -107,7 +107,7 @@ export const DashboardExternalUser = connect(
                     <p>
                       <a
                         className="usa-link--external"
-                        href="https://ustaxcourt.gov/clinics.html"
+                        href="https://ustaxcourt.gov/clinics-and-pro-bono-programs/"
                         rel="noopener noreferrer"
                         target="_blank"
                       >


### PR DESCRIPTION
# 10293: Link Change on Petitioner Welcome/My Cases Page

#10293

## Overview

On the petitioner dashboard, the **Free Taxpayer Help** card linked to an outdated U.S. Tax Court URL (`https://ustaxcourt.gov/clinics.html`). This change updates the hyperlink to the correct destination (`https://ustaxcourt.gov/clinics-and-pro-bono-programs/`) so petitioners reach the current clinics and pro bono programs page.

## Changes

- Updated the external link `href` in `DashboardExternalUser.tsx` for the **View Information on Clinics & Pro Bono Programs** anchor shown to petitioners on the Welcome/My Cases dashboard.

## Verification

- Confirmed the diff updates only the target URL; link text, accessibility attributes (`rel`, `target`), and surrounding markup are unchanged.
- Manual verification to perform after merge:
    - Log in locally as a **petitioner**.
    - Open the dashboard and use the **Free Taxpayer Help** link.
    - Confirm a new tab opens to `https://ustaxcourt.gov/clinics-and-pro-bono-programs/`.