### PR TITLE
10329 Normalize finalBriefDueDate before seeding the worksheet edit forms

### DIFF
--- a/web-client/src/presenter/actions/CaseWorksheet/setAddEditCaseWorksheetModalStateAction.test.ts
+++ b/web-client/src/presenter/actions/CaseWorksheet/setAddEditCaseWorksheetModalStateAction.test.ts
@@ -1,5 +1,8 @@
 import { MOCK_CASE } from '@shared/test/mockCase';
-import { RawCaseWorksheet } from '@shared/business/entities/caseWorksheet/CaseWorksheet';
+import {
+  CaseWorksheet,
+  RawCaseWorksheet,
+} from '@shared/business/entities/caseWorksheet/CaseWorksheet';
 import { applicationContextForClient as applicationContext } from '@web-client/test/createClientTestApplicationContext';
 import { judgeColvin } from '@shared/test/mockUsers';
 import { presenter } from '@web-client/presenter/presenter-mock';
@@ -50,5 +53,62 @@ describe('setAddEditCaseWorksheetModalStateAction', () => {
     });
 
     expect(state.form).toEqual({ docketNumber: MOCK_CASE.docketNumber });
+  });
+
+  it('should normalize a finalBriefDueDate that the API returned as an ISO timestamp to YYYY-MM-DD', async () => {
+    const mockWorksheet: RawCaseWorksheet = {
+      docketNumber: MOCK_CASE.docketNumber,
+      entityName: 'CaseWorksheet',
+      finalBriefDueDate: '2026-08-07T04:00:00.000Z',
+      judgeUserId: judgeColvin.userId,
+    };
+
+    const { state } = await runAction(setAddEditCaseWorksheetModalStateAction, {
+      props: {
+        docketNumber: MOCK_CASE.docketNumber,
+      },
+      state: {
+        submittedAndCavCases: {
+          submittedAndCavCasesByJudge: [
+            {
+              caseWorksheet: mockWorksheet,
+              docketNumber: MOCK_CASE.docketNumber,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(state.form.finalBriefDueDate).toBe('2026-08-07');
+    expect(
+      new CaseWorksheet(state.form).getFormattedValidationErrors(),
+    ).toBeNull();
+  });
+
+  it('should leave a finalBriefDueDate that is already YYYY-MM-DD untouched', async () => {
+    const mockWorksheet: RawCaseWorksheet = {
+      docketNumber: MOCK_CASE.docketNumber,
+      entityName: 'CaseWorksheet',
+      finalBriefDueDate: '2026-08-07',
+      judgeUserId: judgeColvin.userId,
+    };
+
+    const { state } = await runAction(setAddEditCaseWorksheetModalStateAction, {
+      props: {
+        docketNumber: MOCK_CASE.docketNumber,
+      },
+      state: {
+        submittedAndCavCases: {
+          submittedAndCavCasesByJudge: [
+            {
+              caseWorksheet: mockWorksheet,
+              docketNumber: MOCK_CASE.docketNumber,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(state.form.finalBriefDueDate).toBe('2026-08-07');
   });
 });

--- a/web-client/src/presenter/actions/CaseWorksheet/setAddEditCaseWorksheetModalStateAction.ts
+++ b/web-client/src/presenter/actions/CaseWorksheet/setAddEditCaseWorksheetModalStateAction.ts
@@ -1,3 +1,8 @@
+import {
+  FORMATS,
+  formatDateString,
+} from '@shared/business/utilities/DateHandler';
+import { RawCaseWorksheet } from '@shared/business/entities/caseWorksheet/CaseWorksheet';
 import { state } from '@web-client/presenter/app.cerebral';
 
 export const setAddEditCaseWorksheetModalStateAction = ({
@@ -11,9 +16,20 @@ export const setAddEditCaseWorksheetModalStateAction = ({
 
   const { submittedAndCavCasesByJudge } = get(state.submittedAndCavCases);
 
-  const caseWorksheet = submittedAndCavCasesByJudge.find(
-    ws => ws.docketNumber === docketNumber,
-  )?.caseWorksheet || { docketNumber };
+  const caseWorksheet: Partial<RawCaseWorksheet> & { docketNumber: string } =
+    submittedAndCavCasesByJudge.find(ws => ws.docketNumber === docketNumber)
+      ?.caseWorksheet || { docketNumber };
 
-  store.set(state.form, { ...caseWorksheet });
+  // The API returns finalBriefDueDate as a full ISO timestamp, while CaseWorksheet
+  // validates it as YYYY-MM-DD, so saving without touching the date picker fails
+  // validation on a date the judge never edited.
+  store.set(state.form, {
+    ...caseWorksheet,
+    ...(caseWorksheet.finalBriefDueDate && {
+      finalBriefDueDate: formatDateString(
+        caseWorksheet.finalBriefDueDate,
+        FORMATS.YYYYMMDD,
+      ),
+    }),
+  });
 };

--- a/web-client/src/presenter/actions/PendingMotion/setAddEditDocketEntryWorksheetModalStateAction.test.ts
+++ b/web-client/src/presenter/actions/PendingMotion/setAddEditDocketEntryWorksheetModalStateAction.test.ts
@@ -1,3 +1,4 @@
+import { DocketEntryWorksheet } from '@shared/business/entities/docketEntryWorksheet/DocketEntryWorksheet';
 import { runAction } from '@web-client/presenter/test.cerebral';
 import { setAddEditDocketEntryWorksheetModalStateAction } from '@web-client/presenter/actions/PendingMotion/setAddEditDocketEntryWorksheetModalStateAction';
 
@@ -43,5 +44,36 @@ describe('setAddEditDocketEntryWorksheetModalStateAction', () => {
       worksheetProp2: 'worksheetProp2',
       worksheetProp3: 'worksheetProp3',
     });
+  });
+
+  it('should normalize a finalBriefDueDate that the API returned as an ISO timestamp to YYYY-MM-DD', async () => {
+    const results = await runAction(
+      setAddEditDocketEntryWorksheetModalStateAction,
+      {
+        props: {
+          docketEntryId: TEST_DOCKET_ENTRY_ID,
+        },
+        state: {
+          form: {},
+          pendingMotions: {
+            docketEntries: [
+              {
+                docketEntryId: TEST_DOCKET_ENTRY_ID,
+                docketEntryWorksheet: {
+                  docketEntryId: TEST_DOCKET_ENTRY_ID,
+                  finalBriefDueDate: '2026-08-07T04:00:00.000Z',
+                },
+                docketNumber: TEST_DOCKET_NUMBER,
+              },
+            ],
+          },
+        },
+      },
+    );
+
+    expect(results.state.form.finalBriefDueDate).toBe('2026-08-07');
+    expect(
+      new DocketEntryWorksheet(results.state.form).getFormattedValidationErrors(),
+    ).not.toHaveProperty('finalBriefDueDate');
   });
 });

--- a/web-client/src/presenter/actions/PendingMotion/setAddEditDocketEntryWorksheetModalStateAction.ts
+++ b/web-client/src/presenter/actions/PendingMotion/setAddEditDocketEntryWorksheetModalStateAction.ts
@@ -1,3 +1,7 @@
+import {
+  FORMATS,
+  formatDateString,
+} from '@shared/business/utilities/DateHandler';
 import { state } from '@web-client/presenter/app.cerebral';
 
 export const setAddEditDocketEntryWorksheetModalStateAction = ({
@@ -14,8 +18,18 @@ export const setAddEditDocketEntryWorksheetModalStateAction = ({
     deWs => deWs.docketEntryId === docketEntryId,
   );
 
+  const worksheet = docketEntry?.docketEntryWorksheet;
+
+  // Same as the case worksheet: the API hands back an ISO timestamp and
+  // DocketEntryWorksheet validates YYYY-MM-DD.
   store.set(state.form, {
-    ...docketEntry?.docketEntryWorksheet,
+    ...worksheet,
     docketNumber: docketEntry?.docketNumber,
+    ...(worksheet?.finalBriefDueDate && {
+      finalBriefDueDate: formatDateString(
+        worksheet.finalBriefDueDate,
+        FORMATS.YYYYMMDD,
+      ),
+    }),
   });
 };


### PR DESCRIPTION
#10329

## Overview

A judge editing the Status of Matter on the Submitted/CAV or Pending Motions tab gets "Enter a valid date" on the Final Brief Due Date field, on a date they never touched. Reselecting the same date in the picker clears it, which is the workaround in the ticket.

## Cause

The postgres mapper stores `finalBriefDueDate` as a `Date` and returns it with `.toISOString()`, so the API hands the client a full timestamp. Both worksheet entities validate that field with `JoiValidationConstants.DATE`, which is `joi.date().iso().format(['YYYY-MM-DD'])`. The two modal state actions copy the worksheet straight into `state.form`, so the form starts out holding a value the entity will reject:

```
new CaseWorksheet({ finalBriefDueDate: '2026-08-07T04:00:00.000Z' })
  -> { finalBriefDueDate: 'Enter a valid due date' }
new CaseWorksheet({ finalBriefDueDate: '2026-08-07' })
  -> null
```

Touching the date picker replaces the value through `formatDateFromDatePickerAction`, which writes it back as `YYYY-MM-DD`. That is why the workaround works, and it is the same reason the error only appears when the field is left alone.

## Change

Format `finalBriefDueDate` once when seeding `state.form`, in `setAddEditCaseWorksheetModalStateAction` and `setAddEditDocketEntryWorksheetModalStateAction`, so the form starts with the shape the entity validates. The API contract is unchanged, and nothing else that reads the timestamp is affected.

`formatDateString` resolves in `America/New_York`, which is the zone `calculateDate` used when the value was stored, so the date survives the round trip. I checked both sides of daylight saving:

```
2026-08-07T04:00:00.000Z (EDT) -> 2026-08-07
2026-01-15T05:00:00.000Z (EST) -> 2026-01-15
2026-08-07                     -> 2026-08-07   (already date-only, unchanged)
```

## Testing

Unit tests added to both action test files: one asserting the ISO timestamp is normalized and the resulting form passes entity validation, one asserting an already-correct value is left alone.

Reverting only the source change and rerunning makes the new case-worksheet test fail on the assertion, so it is covering the fix rather than passing incidentally.

Ran with node 24.18.1:

```
web-client/src/presenter/actions/CaseWorksheet/setAddEditCaseWorksheetModalStateAction.test.ts   4 passed
web-client/src/presenter/actions/PendingMotion/setAddEditDocketEntryWorksheetModalStateAction.test.ts   2 passed
```

eslint and tsc are clean on the four changed files.

I did not reproduce this against a running environment, since I do not have one, so the judge-facing symptom is inferred from the entity behaviour rather than observed. Worth a manual check on Test with an existing worksheet that has a due date set, editing only Status of Matter.
