### PR TITLE
10329 fix worksheet dates to test 1786384372

### DIFF
--- a/cypress/local-only/tests/accessibility/dashboard/judge.cy.ts
+++ b/cypress/local-only/tests/accessibility/dashboard/judge.cy.ts
@@ -16,7 +16,7 @@ describe('Dashboard - Judge Accessibility', () => {
     it('should be free of a11y issues when adding/editing case worksheet', () => {
       loginAsColvin();
       cy.get('[data-testid="tab-case-worksheets"]').click();
-      cy.get('button[data-testid="add-edit-case-worksheet"]').first().click();
+      cy.get('[data-testid^="add-edit-case-worksheet-"]').first().click();
       cy.get('.modal-screen').should('exist');
       cy.get('#confirm').click();
 

--- a/cypress/local-only/tests/integration/judgeActivityReport/pending-motions-table-judge-and-chamber-dashboard.cy.ts
+++ b/cypress/local-only/tests/integration/judgeActivityReport/pending-motions-table-judge-and-chamber-dashboard.cy.ts
@@ -2,6 +2,7 @@ import {
   loginAsColvin,
   loginAsColvinChambers,
 } from 'cypress/helpers/authentication/login-as-helpers';
+import { logout } from '../../../../helpers/authentication/logout';
 
 describe('Pending Motions Table', () => {
   it('should display the pending motion table for Judge Colvin', () => {
@@ -19,7 +20,16 @@ describe('Pending Motions Table', () => {
 
     cy.get('[class="modal-screen"]').should('be.visible');
 
-    const finalBriefDueDate = generateRandomDate();
+    // test cancel
+    cy.get('[data-testid="confirm-modal-cancel-btn"]').click();
+
+    cy.get('@pendingMotions')
+      .first()
+      .as('firstRow')
+      .find('[data-testid="add-edit-pending-motion-worksheet"]')
+      .click();
+
+    let finalBriefDueDate = generateRandomDate();
     selectRandomStatusOfMatterEntry(
       '[data-testid^="select-status-of-matter-"]',
     ).then(([statusOfMatterKey, statusOfMatterLabel]) => {
@@ -52,6 +62,61 @@ describe('Pending Motions Table', () => {
         .eq(7)
         .should('contain.text', statusOfMatterLabel);
       cy.get('@pendingMotions').eq(1).should('contain.text', primaryIssue);
+
+      // leave and come back to test hydrating form from DB
+      logout();
+      loginAsColvin();
+      cy.get('[data-testid="pending-motions-tab"]').click();
+      cy.get('@pendingMotions')
+        .first()
+        .as('firstRow')
+        .find('[data-testid="add-edit-pending-motion-worksheet"]')
+        .click();
+
+      // test that hydrated date saves properly
+      cy.get('[data-testid="modal-confirm').click();
+      cy.get('@pendingMotions')
+        .first()
+        .as('firstRow')
+        .find('[data-testid="add-edit-pending-motion-worksheet"]')
+        .click();
+
+      finalBriefDueDate = generateRandomDate();
+      selectRandomStatusOfMatterEntry(
+        '[data-testid^="select-status-of-matter-"]',
+      ).then(([statusOfMatterKey, statusOfMatterLabel]) => {
+        const primaryIssue = finalBriefDueDate.longFormat + statusOfMatterLabel;
+        cy.get(
+          '#final-brief-due-date-6d499aeb-7a4a-4dbc-afa8-5f8bbb71e44d-picker',
+        ).clear();
+
+        cy.get(
+          '#final-brief-due-date-6d499aeb-7a4a-4dbc-afa8-5f8bbb71e44d-picker',
+        ).type(finalBriefDueDate.longFormat);
+
+        cy.get('#status-of-matter-6d499aeb-7a4a-4dbc-afa8-5f8bbb71e44d').select(
+          statusOfMatterKey,
+        );
+
+        cy.get(
+          '#primary-issue-label-6d499aeb-7a4a-4dbc-afa8-5f8bbb71e44d',
+        ).type(primaryIssue);
+
+        cy.get('[data-testid="modal-confirm"]').click();
+
+        cy.get('@firstRow')
+          .find('td')
+          .eq(6)
+          .should('contain.text', finalBriefDueDate.shortFormat);
+
+        cy.get('@firstRow')
+          .find('td')
+          .eq(7)
+          .should('contain.text', statusOfMatterLabel);
+        cy.get('@pendingMotions')
+          .eq(1)
+          .should('contain.text', `${primaryIssue}`);
+      });
     });
   });
 
@@ -70,7 +135,16 @@ describe('Pending Motions Table', () => {
 
     cy.get('[class="modal-screen"]').should('be.visible');
 
-    const finalBriefDueDate = generateRandomDate();
+    // test cancel
+    cy.get('[data-testid="confirm-modal-cancel-btn"]').click();
+
+    cy.get('@pendingMotions')
+      .first()
+      .as('firstRow')
+      .find('[data-testid="add-edit-pending-motion-worksheet"]')
+      .click();
+
+    let finalBriefDueDate = generateRandomDate();
     selectRandomStatusOfMatterEntry(
       '[data-testid^="select-status-of-matter-"]',
     ).then(([statusOfMatterKey, statusOfMatterLabel]) => {
@@ -103,6 +177,61 @@ describe('Pending Motions Table', () => {
         .eq(7)
         .should('contain.text', statusOfMatterLabel);
       cy.get('@pendingMotions').eq(1).should('contain.text', primaryIssue);
+
+      // leave and come back to test hydrating form from DB
+      logout();
+      loginAsColvinChambers();
+      cy.get('[data-testid="pending-motions-tab"]').click();
+      cy.get('@pendingMotions')
+        .first()
+        .as('firstRow')
+        .find('[data-testid="add-edit-pending-motion-worksheet"]')
+        .click();
+
+      // test that hydrated date saves properly
+      cy.get('[data-testid="modal-confirm').click();
+      cy.get('@pendingMotions')
+        .first()
+        .as('firstRow')
+        .find('[data-testid="add-edit-pending-motion-worksheet"]')
+        .click();
+
+      finalBriefDueDate = generateRandomDate();
+      selectRandomStatusOfMatterEntry(
+        '[data-testid^="select-status-of-matter-"]',
+      ).then(([statusOfMatterKey, statusOfMatterLabel]) => {
+        const primaryIssue = finalBriefDueDate.longFormat + statusOfMatterLabel;
+        cy.get(
+          '#final-brief-due-date-6d499aeb-7a4a-4dbc-afa8-5f8bbb71e44d-picker',
+        ).clear();
+
+        cy.get(
+          '#final-brief-due-date-6d499aeb-7a4a-4dbc-afa8-5f8bbb71e44d-picker',
+        ).type(finalBriefDueDate.longFormat);
+
+        cy.get('#status-of-matter-6d499aeb-7a4a-4dbc-afa8-5f8bbb71e44d').select(
+          statusOfMatterKey,
+        );
+
+        cy.get(
+          '#primary-issue-label-6d499aeb-7a4a-4dbc-afa8-5f8bbb71e44d',
+        ).type(primaryIssue);
+
+        cy.get('[data-testid="modal-confirm"]').click();
+
+        cy.get('@firstRow')
+          .find('td')
+          .eq(6)
+          .should('contain.text', finalBriefDueDate.shortFormat);
+
+        cy.get('@firstRow')
+          .find('td')
+          .eq(7)
+          .should('contain.text', statusOfMatterLabel);
+        cy.get('@pendingMotions')
+          .eq(1)
+          .should('contain.text', `${primaryIssue}`);
+      });
     });
   });
 });

--- a/cypress/local-only/tests/integration/judgeActivityReport/submitted-cav-cases-table-judge-and-chamber-dashboard.cy.ts
+++ b/cypress/local-only/tests/integration/judgeActivityReport/submitted-cav-cases-table-judge-and-chamber-dashboard.cy.ts
@@ -1,0 +1,167 @@
+import { CaseWorksheet } from '@shared/business/entities/caseWorksheet/CaseWorksheet';
+import {
+  loginAsDocketClerk1,
+  loginAsColvin,
+  loginAsColvinChambers,
+} from '../../../../helpers/authentication/login-as-helpers';
+import { logout } from '../../../../helpers/authentication/logout';
+import { updateCaseStatus } from '../../../../helpers/caseDetail/caseInformation/update-case-status';
+import { goToCase } from '../../../../helpers/caseDetail/go-to-case';
+import { createAndServePaperPetition } from '../../../../helpers/fileAPetition/create-and-serve-paper-petition';
+
+describe('Submitted/CAV table', () => {
+  it('should create a submitted case and allow the judge to add and edit the case worksheet', () => {
+    createAndServePaperPetition().then(({ docketNumber }) => {
+      loginAsDocketClerk1();
+      goToCase(docketNumber);
+      updateCaseStatus('Submitted', 'Colvin');
+
+      loginAsColvin();
+      cy.get('[data-testid="tab-case-worksheets"]').click();
+      cy.get(`[data-testid="add-edit-case-worksheet-${docketNumber}"`).click();
+
+      // test cancel
+      cy.get('[data-testid="confirm-modal-cancel-btn"]').click();
+
+      cy.get(`[data-testid="add-edit-case-worksheet-${docketNumber}"`).click();
+      cy.get(
+        '.usa-date-picker__wrapper > [data-testid="final-brief-due-date-picker"]',
+      ).type('08/10/2026');
+      cy.get('#status-of-matter').select(
+        CaseWorksheet.STATUS_OF_MATTER_OPTIONS[0],
+      );
+      cy.get('#primary-issue').type('the primary issue');
+      cy.get('[data-testid="modal-confirm').click();
+
+      cy.get(`[data-testid="submitted-cav-case-${docketNumber}"`)
+        .find('td')
+        .eq(7)
+        .should('contain.text', '08/10/26');
+
+      cy.get(`[data-testid="submitted-cav-case-${docketNumber}"`)
+        .find('td')
+        .eq(8)
+        .should('contain.text', CaseWorksheet.STATUS_OF_MATTER_OPTIONS[0]);
+
+      cy.get(`[data-testid="submitted-cav-case-issue-${docketNumber}"`)
+        .find('td')
+        .eq(1)
+        .should('contain.text', 'the primary issue');
+
+      // leave and come back to test hydrating form from DB
+      logout();
+      loginAsColvin();
+      cy.get('[data-testid="tab-case-worksheets"]').click();
+      cy.get(`[data-testid="add-edit-case-worksheet-${docketNumber}"`).click();
+
+      // test that hydrated date saves properly
+      cy.get('[data-testid="modal-confirm').click();
+      cy.get(`[data-testid="add-edit-case-worksheet-${docketNumber}"`).click();
+
+      cy.get(
+        '.usa-date-picker__wrapper > [data-testid="final-brief-due-date-picker"]',
+      ).clear();
+      cy.get(
+        '.usa-date-picker__wrapper > [data-testid="final-brief-due-date-picker"]',
+      ).type('09/10/2026');
+      cy.get('#status-of-matter').select(
+        CaseWorksheet.STATUS_OF_MATTER_OPTIONS[1],
+      );
+      cy.get('#primary-issue').type(' updated');
+      cy.get('[data-testid="modal-confirm').click();
+
+      cy.get(`[data-testid="submitted-cav-case-${docketNumber}"`)
+        .find('td')
+        .eq(7)
+        .should('contain.text', '09/10/26');
+
+      cy.get(`[data-testid="submitted-cav-case-${docketNumber}"`)
+        .find('td')
+        .eq(8)
+        .should('contain.text', CaseWorksheet.STATUS_OF_MATTER_OPTIONS[1]);
+
+      cy.get(`[data-testid="submitted-cav-case-issue-${docketNumber}"`)
+        .find('td')
+        .eq(1)
+        .should('contain.text', 'the primary issue updated');
+    });
+  });
+
+  it('should create a submitted case and allow the chambers to add and edit the case worksheet', () => {
+    createAndServePaperPetition().then(({ docketNumber }) => {
+      loginAsDocketClerk1();
+      goToCase(docketNumber);
+      updateCaseStatus('Submitted', 'Colvin');
+
+      loginAsColvinChambers();
+      cy.get('[data-testid="submitted-cav-cases-tab"]').click();
+      cy.get(`[data-testid="add-edit-case-worksheet-${docketNumber}"`).click();
+
+      // test cancel
+      cy.get('[data-testid="confirm-modal-cancel-btn"]').click();
+
+      cy.get(`[data-testid="add-edit-case-worksheet-${docketNumber}"`).click();
+      cy.get(
+        '.usa-date-picker__wrapper > [data-testid="final-brief-due-date-picker"]',
+      ).type('08/10/2026');
+      cy.get('#status-of-matter').select(
+        CaseWorksheet.STATUS_OF_MATTER_OPTIONS[0],
+      );
+      cy.get('#primary-issue').type('the primary issue');
+      cy.get('[data-testid="modal-confirm').click();
+
+      cy.get(`[data-testid="submitted-cav-case-${docketNumber}"`)
+        .find('td')
+        .eq(7)
+        .should('contain.text', '08/10/26');
+
+      cy.get(`[data-testid="submitted-cav-case-${docketNumber}"`)
+        .find('td')
+        .eq(8)
+        .should('contain.text', CaseWorksheet.STATUS_OF_MATTER_OPTIONS[0]);
+
+      cy.get(`[data-testid="submitted-cav-case-issue-${docketNumber}"`)
+        .find('td')
+        .eq(1)
+        .should('contain.text', 'the primary issue');
+
+      // leave and come back to test hydrating form from DB
+      logout();
+      loginAsColvinChambers();
+
+      cy.get('[data-testid="submitted-cav-cases-tab"]').click();
+      cy.get(`[data-testid="add-edit-case-worksheet-${docketNumber}"`).click();
+
+      // test that hydrated date saves properly
+      cy.get('[data-testid="modal-confirm').click();
+      cy.get(`[data-testid="add-edit-case-worksheet-${docketNumber}"`).click();
+
+      cy.get(
+        '.usa-date-picker__wrapper > [data-testid="final-brief-due-date-picker"]',
+      ).clear();
+      cy.get(
+        '.usa-date-picker__wrapper > [data-testid="final-brief-due-date-picker"]',
+      ).type('09/10/2026');
+      cy.get('#status-of-matter').select(
+        CaseWorksheet.STATUS_OF_MATTER_OPTIONS[1],
+      );
+      cy.get('#primary-issue').type(' updated');
+      cy.get('[data-testid="modal-confirm').click();
+
+      cy.get(`[data-testid="submitted-cav-case-${docketNumber}"`)
+        .find('td')
+        .eq(7)
+        .should('contain.text', '09/10/26');
+
+      cy.get(`[data-testid="submitted-cav-case-${docketNumber}"`)
+        .find('td')
+        .eq(8)
+        .should('contain.text', CaseWorksheet.STATUS_OF_MATTER_OPTIONS[1]);
+
+      cy.get(`[data-testid="submitted-cav-case-issue-${docketNumber}"`)
+        .find('td')
+        .eq(1)
+        .should('contain.text', 'the primary issue updated');
+    });
+  });
+});

--- a/shared/src/business/entities/caseWorksheet/CaseWorksheet.test.ts
+++ b/shared/src/business/entities/caseWorksheet/CaseWorksheet.test.ts
@@ -1,7 +1,20 @@
-import { CaseWorksheet } from './CaseWorksheet';
+import { CaseWorksheet, RawCaseWorksheet } from './CaseWorksheet';
 
 describe('CaseWorksheet', () => {
   describe('validation', () => {
+    const VALID_ENTITY_DATA: RawCaseWorksheet = {
+      docketNumber: '101-26',
+      finalBriefDueDate: '2023-07-29T00:00:00.000-04:00',
+      primaryIssue: 'SOME PRIMARY ISSUE',
+      statusOfMatter: 'Awaiting Consideration',
+      judgeUserId: '208a959f-9526-4db5-b262-e58c476a4604',
+    };
+
+    it('should create a valid entity', () => {
+      const worksheet = new CaseWorksheet(VALID_ENTITY_DATA);
+      expect(worksheet.getFormattedValidationErrors()).toEqual(null);
+    });
+
     it('should be invalid when the final brief due date is NOT a date string', () => {
       const worksheet = new CaseWorksheet({
         finalBriefDueDate: 'abcdef',

--- a/shared/src/business/entities/caseWorksheet/CaseWorksheet.ts
+++ b/shared/src/business/entities/caseWorksheet/CaseWorksheet.ts
@@ -32,7 +32,7 @@ export class CaseWorksheet extends JoiValidationEntity {
 
   static VALIDATION_RULES = {
     docketNumber: JoiValidationConstants.DOCKET_NUMBER.required(),
-    finalBriefDueDate: JoiValidationConstants.DATE.allow('')
+    finalBriefDueDate: JoiValidationConstants.ISO_DATE.allow('')
       .optional()
       .messages({
         '*': 'Enter a valid due date',

--- a/shared/src/business/entities/docketEntryWorksheet/DocketEntryWorksheet.test.ts
+++ b/shared/src/business/entities/docketEntryWorksheet/DocketEntryWorksheet.test.ts
@@ -6,7 +6,7 @@ import {
 describe('DocketEntryWorksheet', () => {
   const VALID_ENTITY_DATA: RawDocketEntryWorksheet = {
     docketEntryId: '208a959f-9526-4db5-b262-e58c476a4604',
-    finalBriefDueDate: '2023-07-29',
+    finalBriefDueDate: '2023-07-29T00:00:00.000-04:00',
     primaryIssue: 'SOME PRIMARY ISSUE',
     statusOfMatter: 'AwaitingConsideration',
   };

--- a/shared/src/business/entities/docketEntryWorksheet/DocketEntryWorksheet.ts
+++ b/shared/src/business/entities/docketEntryWorksheet/DocketEntryWorksheet.ts
@@ -31,7 +31,7 @@ export class DocketEntryWorksheet extends JoiValidationEntity {
 
   static VALIDATION_RULES = {
     docketEntryId: DOCKET_ENTRY_VALIDATION_RULE_KEYS.docketEntryId,
-    finalBriefDueDate: JoiValidationConstants.DATE.allow('')
+    finalBriefDueDate: JoiValidationConstants.ISO_DATE.allow('')
       .optional()
       .messages({
         '*': 'Enter a valid due date',

--- a/shared/src/test/mockCaseWorksheet.ts
+++ b/shared/src/test/mockCaseWorksheet.ts
@@ -8,7 +8,7 @@ import { judgeColvin } from '@shared/test/mockUsers';
 export const MOCK_CASE_WORKSHEET: RawCaseWorksheet = {
   docketNumber: MOCK_CASE.docketNumber,
   entityName: 'CaseWorksheet',
-  finalBriefDueDate: '2023-07-29',
+  finalBriefDueDate: '2023-07-29T00:00:00.000-04:00',
   judgeUserId: judgeColvin.userId,
   primaryIssue: 'anything',
   statusOfMatter: CaseWorksheet.STATUS_OF_MATTER_OPTIONS[0],

--- a/web-api/src/business/useCases/caseWorksheet/updateCaseWorksheetInteractor.test.ts
+++ b/web-api/src/business/useCases/caseWorksheet/updateCaseWorksheetInteractor.test.ts
@@ -49,7 +49,7 @@ describe('updateCaseWorksheetInteractor', () => {
   });
 
   it('should persist and return the updated case worksheet when the updates are valid', async () => {
-    const mockFinalBriefDueDate = '2023-08-29';
+    const mockFinalBriefDueDate = '2023-08-29T00:00:00.000-04:00';
     getCaseWorksheetsByDocketNumber.mockResolvedValue([mockCaseWorksheet]);
 
     const result = await updateCaseWorksheetInteractor(
@@ -73,7 +73,7 @@ describe('updateCaseWorksheetInteractor', () => {
   });
 
   it('should persist the updated case worksheet when the updates are valid, using the judge`s userId in the section when the current user is a chambers user', async () => {
-    const mockFinalBriefDueDate = '2023-08-29';
+    const mockFinalBriefDueDate = '2023-08-29T00:00:00.000-04:00';
     getCaseWorksheetsByDocketNumber.mockResolvedValue([mockCaseWorksheet]);
 
     const result = await updateCaseWorksheetInteractor(

--- a/web-api/src/business/useCases/pendingMotion/updateDocketEntryWorksheetInteractor.test.ts
+++ b/web-api/src/business/useCases/pendingMotion/updateDocketEntryWorksheetInteractor.test.ts
@@ -20,7 +20,7 @@ describe('updateDocketEntryWorksheetInteractor', () => {
 
   const VALID_WORKSHEET: RawDocketEntryWorksheet = {
     docketEntryId: TEST_DOCKET_ENTRY_ID,
-    finalBriefDueDate: '2023-07-29',
+    finalBriefDueDate: '2023-07-29T00:00:00.000-04:00',
     primaryIssue: 'tests primaryIssue',
     statusOfMatter: 'AwaitingConsideration',
   };
@@ -77,7 +77,7 @@ describe('updateDocketEntryWorksheetInteractor', () => {
       {
         docketEntryId: TEST_DOCKET_ENTRY_ID,
         entityName: 'DocketEntryWorksheet',
-        finalBriefDueDate: '2023-07-29',
+        finalBriefDueDate: '2023-07-29T00:00:00.000-04:00',
         primaryIssue: 'tests primaryIssue',
         statusOfMatter: 'AwaitingConsideration',
       },
@@ -86,7 +86,7 @@ describe('updateDocketEntryWorksheetInteractor', () => {
     expect(results).toEqual({
       docketEntryId: TEST_DOCKET_ENTRY_ID,
       entityName: 'DocketEntryWorksheet',
-      finalBriefDueDate: '2023-07-29',
+      finalBriefDueDate: '2023-07-29T00:00:00.000-04:00',
       primaryIssue: 'tests primaryIssue',
       statusOfMatter: 'AwaitingConsideration',
     });

--- a/web-client/integration-tests/caseWorksheetsJourney.test.ts
+++ b/web-client/integration-tests/caseWorksheetsJourney.test.ts
@@ -193,7 +193,7 @@ describe('Case Worksheets Journey', () => {
       'formatAndUpdateDateFromDatePickerSequence',
       {
         key: 'finalBriefDueDate',
-        toFormat: FORMATS.YYYYMMDD,
+        toFormat: FORMATS.ISO,
         value: briefDueDate,
       },
     );
@@ -210,7 +210,7 @@ describe('Case Worksheets Journey', () => {
       docketNumber: cerebralTest.docketNumber,
       status: CASE_STATUS_TYPES.cav,
       worksheet: {
-        finalBriefDueDate: '2023-08-29',
+        finalBriefDueDate: '2023-08-29T00:00:00.000-04:00',
       },
     });
 
@@ -232,7 +232,7 @@ describe('Case Worksheets Journey', () => {
       'formatAndUpdateDateFromDatePickerSequence',
       {
         key: 'finalBriefDueDate',
-        toFormat: FORMATS.YYYYMMDD,
+        toFormat: FORMATS.ISO,
         value: 'abcdefghi', // not a valid date
       },
     );
@@ -269,7 +269,7 @@ describe('Case Worksheets Journey', () => {
       status: CASE_STATUS_TYPES.cav,
       worksheet: {
         docketNumber: cerebralTest.docketNumber,
-        finalBriefDueDate: '2023-08-29',
+        finalBriefDueDate: '2023-08-29T00:00:00.000-04:00',
         statusOfMatter: CaseWorksheet.STATUS_OF_MATTER_OPTIONS[0],
       },
     });

--- a/web-client/src/business/useCases/pendingMotion/validateDocketEntryWorksheetInteractor.test.ts
+++ b/web-client/src/business/useCases/pendingMotion/validateDocketEntryWorksheetInteractor.test.ts
@@ -5,7 +5,7 @@ describe('validateDocketEntryWorksheetInteractor', () => {
   const TEST_DOCKET_ENTRY_ID = '06f60736-5f37-4590-b62a-5c7edf84ffc6';
   const VALID_WORKSHEET: RawDocketEntryWorksheet = {
     docketEntryId: TEST_DOCKET_ENTRY_ID,
-    finalBriefDueDate: '2023-07-29',
+    finalBriefDueDate: '2023-07-29T00:00:00.000-04:00',
     primaryIssue: 'tests primaryIssue',
     statusOfMatter: 'AwaitingConsideration',
   };

--- a/web-client/src/presenter/sequences/dismissAddEditCaseWorksheetModalSequence.ts
+++ b/web-client/src/presenter/sequences/dismissAddEditCaseWorksheetModalSequence.ts
@@ -1,12 +1,10 @@
 import { clearAlertsAction } from '../actions/clearAlertsAction';
-import { clearFormAction } from '../actions/clearFormAction';
 import { clearModalAction } from '../actions/clearModalAction';
 import { clearModalStateAction } from '../actions/clearModalStateAction';
 import { stopShowValidationAction } from '../actions/stopShowValidationAction';
 
 export const dismissAddEditCaseWorksheetModalSequence = [
   stopShowValidationAction,
-  clearFormAction,
   clearAlertsAction,
   clearModalAction,
   clearModalStateAction,

--- a/web-client/src/views/CaseWorksheet/AddEditCaseWorksheetModal.tsx
+++ b/web-client/src/views/CaseWorksheet/AddEditCaseWorksheetModal.tsx
@@ -55,7 +55,7 @@ export const AddEditCaseWorksheetModal = connect(
           onChange={e => {
             formatAndUpdateDateFromDatePickerSequence({
               key: 'finalBriefDueDate',
-              toFormat: DATE_FORMATS.YYYYMMDD,
+              toFormat: DATE_FORMATS.ISO,
               value: e.target.value,
             });
             validateCaseWorksheetSequence();

--- a/web-client/src/views/CaseWorksheet/CaseWorksheets.tsx
+++ b/web-client/src/views/CaseWorksheet/CaseWorksheets.tsx
@@ -55,7 +55,9 @@ export const CaseWorksheets = connect(
             {caseWorksheetsHelper.caseWorksheetsFormatted.map(formattedCase => {
               return (
                 <React.Fragment key={`info-${formattedCase.docketNumber}`}>
-                  <tr>
+                  <tr
+                    data-testid={`submitted-cav-case-${formattedCase.docketNumber}`}
+                  >
                     <td className="consolidated-case-column">
                       <ConsolidatedCaseIcon
                         consolidatedIconTooltipText={
@@ -82,7 +84,7 @@ export const CaseWorksheets = connect(
                     <td>
                       <Button
                         link
-                        data-testid="add-edit-case-worksheet"
+                        data-testid={`add-edit-case-worksheet-${formattedCase.docketNumber}`}
                         icon="edit"
                         onClick={() => {
                           openAddEditCaseWorksheetModalSequence({
@@ -94,7 +96,9 @@ export const CaseWorksheets = connect(
                       </Button>
                     </td>
                   </tr>
-                  <tr>
+                  <tr
+                    data-testid={`submitted-cav-case-issue-${formattedCase.docketNumber}`}
+                  >
                     <td colSpan={3}></td>
                     <td colSpan={7}>
                       <span className="text-semibold margin-right-1">

--- a/web-client/src/views/PendingMotion/AddEditDocketEntryWorksheetModal.tsx
+++ b/web-client/src/views/PendingMotion/AddEditDocketEntryWorksheetModal.tsx
@@ -59,7 +59,7 @@ export const AddEditDocketEntryWorksheetModal = connect(
           onChange={e => {
             formatAndUpdateDateFromDatePickerSequence({
               key: 'finalBriefDueDate',
-              toFormat: DATE_FORMATS.YYYYMMDD,
+              toFormat: DATE_FORMATS.ISO,
               value: e.target.value,
             });
             validateDocketEntryWorksheetSequence();


### PR DESCRIPTION
# 10329: Fix date issues in case worksheet and docket entry worksheet

#10329 

## Overview

The `finalBriefDueDate` column for both case and docket entry worksheets is read from the database as an ISO date, but the validation on both entities was looking for the `yyyy-mm-dd` format. Updated the entity validation and date picker conversion on both forms to use ISO date format

## Changes

- Update `CaseWorksheet` and `DocketEntryWorksheet` entities to check for ISO date format
- Updated date pickers in both forms to convert entered date into ISO format
- Removed `clearFormAction` from the dismiss modal sequence to prevent an uncaught error from being throw from `addEditDocketEntryWorksheetModalHelper`

## Verification

Local testing and unit tests

## Pull Request Checklist

_PRs that do not meet these criteria may be closed without review._

### Internal Contributors (DAWSON Team Members)

- [x] I have conducted thorough manual testing:
   - [x] Locally
- [x] If this PR is for a user story, or tech debt (devex, opex, design debt, etc.) that is user-facing, I have created test case(s) in TestRail and executed them.
- [x] I assert that all DoD criteria for this issue have been met.
- [x] If this PR includes a data migration with timing-specific manual test steps, I will coordinate the deployment with a manual tester to verify the timing-specific manual tests in real time.
- [x] All user-facing changes have been verified to be free of accessibility issues via manual testing and automated accessibility tests.
