### PR TITLE
Devex run integration tests in circle to test 1786395536

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -948,7 +948,7 @@ jobs:
             mkdir -p /tmp/cypress/results
 
             set +e
-            find cypress/local-only/tests/integration/ -type f -name "*.cy.ts" | circleci tests run --split-by=timings --timings-type=filename --command "paste -sd, - | xargs -I {} ./scripts/tests/run-cypress.ts --file {} --output-file-path ${TIMINGS_JSON}"
+            find cypress/local-only/tests/integration/ -type f -name "*.cy.ts" ! -path "*/public/*" | circleci tests run --split-by=timings --timings-type=filename --command "paste -sd, - | xargs -I {} ./scripts/tests/run-cypress.ts --file {} --output-file-path ${TIMINGS_JSON}"
             CYPRESS_RESULT=$?
             set -e
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -962,6 +962,55 @@ jobs:
       - store_artifacts:
           path: /root/project/cypress/local-only/videos/
 
+  public-integration-tests:
+    docker:
+      - image: *efcms-docker-image
+        aws_auth:
+          aws_access_key_id: $AWS_ACCESS_KEY_ID
+          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
+    resource_class: medium+
+    steps:
+      - git-shallow-clone/checkout
+      - npm-and-cypress-install
+      - run:
+          name: Create Cypress Artifacts Directory
+          command: mkdir /tmp/cypress
+      - run:
+          name: Setup Env
+          command: |
+            ./scripts/env/env-for-circle.sh
+      - run:
+          name: 'Cypress Public Integration Tests'
+          command: |
+            npm run cypress:integration:public
+      - store_artifacts:
+          path: /root/project/cypress/local-only/videos/
+
+  accessibility-tests:
+    docker:
+      - image: *efcms-docker-image
+        aws_auth:
+          aws_access_key_id: $AWS_ACCESS_KEY_ID
+          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
+    resource_class: medium+
+    steps:
+      - git-shallow-clone/checkout
+      - npm-and-cypress-install
+      - run:
+          name: Create Cypress Artifacts Directory
+          command: mkdir /tmp/cypress
+      - run:
+          name: Setup Env
+          command: |
+            ./scripts/env/env-for-circle.sh
+      - run:
+          name: 'Cypress Accessibility Tests'
+          command: |
+            export TESTFILES=$(scripts/github-actions/split-tests-cypress.ts accessibility)
+            scripts/tests/run-cypress.ts --file "$TESTFILES"
+      - store_artifacts:
+          path: /root/project/cypress/local-only/videos/
+
 only-prod: &only-prod
   context: efcms-<< pipeline.git.branch >>
   filters:
@@ -1201,3 +1250,15 @@ workflows:
           <<: *only-test
           requires:
             - smoketests-readonly
+      - public-integration-tests:
+          <<: *only-test
+          requires:
+            - integration-tests
+      - accessibility-tests:
+          <<: *only-test
+          requires:
+            - public-integration-tests
+      - cypress-real-user-tests:
+          <<: *only-test
+          requires:
+            - accessibility-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -919,7 +919,7 @@ jobs:
           command: |
             TARGET_ENV="$LOWER_ENV" TARGET_ACCOUNT_ID="$LOWER_ENV_ACCOUNT_ID" ./scripts/postgres/restoreDbFromSource.ts
 
-  deployed-integration-tests:
+  integration-tests:
     parallelism: 9
     docker:
       - image: *efcms-docker-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,10 @@ parameters:
     default: false
     type: boolean
 
+  run_all_cypress_suites:
+    default: false
+    type: boolean
+
   lower_env:
     default: test
     type: string
@@ -915,6 +919,49 @@ jobs:
           command: |
             TARGET_ENV="$LOWER_ENV" TARGET_ACCOUNT_ID="$LOWER_ENV_ACCOUNT_ID" ./scripts/postgres/restoreDbFromSource.ts
 
+  deployed-integration-tests:
+    parallelism: 9
+    docker:
+      - image: *efcms-docker-image
+        aws_auth:
+          aws_access_key_id: $AWS_ACCESS_KEY_ID
+          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
+    resource_class: large
+    steps:
+      - setup_remote_docker:
+          version: docker29
+          docker_layer_caching: true
+      - git-shallow-clone/checkout
+      - npm-and-cypress-install
+      - run:
+          name: Create Cypress Artifacts Directory
+          command: mkdir /tmp/cypress
+      - run:
+          name: Setup Env
+          command: |
+            ./scripts/env/env-for-circle.sh
+      - run:
+          name: 'Cypress Integration Tests'
+          command: |
+            TIMINGS_JSON="/tmp/cypress/cypress-integration-tests-${CIRCLE_NODE_INDEX}.json"
+            TIMINGS_XML="/tmp/cypress/results/cypress-integration-tests-${CIRCLE_NODE_INDEX}.xml"
+            mkdir -p /tmp/cypress/results
+
+            set +e
+            find cypress/local-only/tests/integration/ -type f -name "*.cy.ts" | circleci tests run --split-by=timings --timings-type=filename --command "paste -sd, - | xargs -I {} ./scripts/tests/run-cypress.ts --file {} --output-file-path ${TIMINGS_JSON}"
+            CYPRESS_RESULT=$?
+            set -e
+
+            if [ "${CYPRESS_RESULT}" -eq 0 ] && [ -f "${TIMINGS_JSON}" ]; then
+              ./scripts/tests/test-file-times-to-junit.ts "${TIMINGS_JSON}" "${TIMINGS_XML}" "cypress-integration-tests-${CIRCLE_NODE_INDEX}"
+            fi
+
+            exit "${CYPRESS_RESULT}"
+      - store_test_results:
+          path: /tmp/cypress/results
+      - store_artifacts:
+          path: /root/project/cypress/local-only/videos/
+
 only-prod: &only-prod
   context: efcms-<< pipeline.git.branch >>
   filters:
@@ -1140,3 +1187,17 @@ workflows:
     jobs:
       - cypress-real-user-tests:
           <<: *only-test
+
+  all-cypress-suites:
+    when: << pipeline.parameters.run_all_cypress_suites >>
+    jobs:
+      - smoketests:
+          <<: *only-test
+      - smoketests-readonly:
+          <<: *only-test
+          requires:
+            - smoketests
+      - integration-tests:
+          <<: *only-test
+          requires:
+            - smoketests-readonly


### PR DESCRIPTION
# DevEx: Add CircleCI workflow for deployed Cypress integration tests

## Overview

Add a new CircleCI workflow for running Cypress integration tests against a deployed `test` environment.

## Changes

- Added the `run_all_cypress_suites` pipeline parameter.
- Added a parallelized `integration-tests` job that:
  - Installs dependencies and Cypress.
  - Configures the CircleCI environment.
  - Splits Cypress integration specs across nine executors based on historical timings.
  - Stores JUnit test results and Cypress video artifacts.
- Added the `all-cypress-suites` workflow to run smoke, read-only smoke, and integration test suites sequentially.

## Verification

- Ran `circleci config validate .circleci/config.yml` successfully.
- Compared the feature branch against `test`; only `.circleci/config.yml` is modified.

## Pull Request Checklist

- [ ] I have conducted thorough manual testing:
   - [ ] Locally
   - [ ] Experimental Environment (if necessary)
- [ ] If this PR is for a user story, or tech debt (devex, opex, design debt, etc.) that is user-facing, I have created test case(s) in TestRail and executed them.
- [ ] I assert that all DoD criteria for this issue have been met.
- [ ] If this PR includes a data migration with timing-specific manual test steps, I will coordinate the deployment with a manual tester to verify the timing-specific manual tests in real time.
- [ ] All user-facing changes have been verified to be free of accessibility issues via manual testing and automated accessibility tests.