### PR TITLE
9507 docket clerk report to test 1786459673

### DIFF
--- a/cypress/local-only/tests/integration/docketClerkReport/docket-clerk-report.cy.ts
+++ b/cypress/local-only/tests/integration/docketClerkReport/docket-clerk-report.cy.ts
@@ -63,6 +63,27 @@ describe('Docket Clerk Report', () => {
   });
 
   describe('Case Services Supervisor', () => {
+    function runReportForFirstAvailableClerk(
+      pageType: 'documentQC' | 'messages',
+    ): void {
+      loginAsCaseServicesSupervisor();
+      cy.visit('/reports/docket-clerk-report');
+
+      cy.get('[data-testid="docket-clerk-report-clerk-select"]')
+        .find('option')
+        .should('have.length.at.least', 2);
+      cy.get('[data-testid="docket-clerk-report-clerk-select"]').then(
+        $select => {
+          cy.wrap($select).select($select.find('option').eq(1).val() as string);
+        },
+      );
+
+      cy.get('[data-testid="docket-clerk-report-page-type-select"]').select(
+        pageType,
+      );
+      cy.get('[data-testid="docket-clerk-report-run-button"]').click();
+    }
+
     describe('Reports menu entry', () => {
       it('should show the Docket Clerk Report link at the top of the Reports menu', () => {
         loginAsCaseServicesSupervisor();
@@ -120,27 +141,7 @@ describe('Docket Clerk Report', () => {
 
     describe('Document QC page type', () => {
       it('should show the Document QC result section with Inbox, In Progress, and Processed tabs', () => {
-        loginAsCaseServicesSupervisor();
-
-        cy.visit('/reports/docket-clerk-report');
-
-        // Select the first available clerk
-        cy.get('[data-testid="docket-clerk-report-clerk-select"]')
-          .find('option')
-          .should('have.length.at.least', 2);
-        cy.get('[data-testid="docket-clerk-report-clerk-select"]').then(
-          $select => {
-            cy.wrap($select).select(
-              $select.find('option').eq(1).val() as string,
-            );
-          },
-        );
-
-        cy.get('[data-testid="docket-clerk-report-page-type-select"]').select(
-          'documentQC',
-        );
-
-        cy.get('[data-testid="docket-clerk-report-run-button"]').click();
+        runReportForFirstAvailableClerk('documentQC');
 
         cy.get('[data-testid="docket-clerk-report-title"]')
           .should('be.visible')
@@ -158,21 +159,7 @@ describe('Docket Clerk Report', () => {
       });
 
       it('should switch to the In Progress tab when clicked', () => {
-        loginAsCaseServicesSupervisor();
-
-        cy.visit('/reports/docket-clerk-report');
-
-        cy.get('[data-testid="docket-clerk-report-clerk-select"]').then(
-          $select => {
-            cy.wrap($select).select(
-              $select.find('option').eq(1).val() as string,
-            );
-          },
-        );
-        cy.get('[data-testid="docket-clerk-report-page-type-select"]').select(
-          'documentQC',
-        );
-        cy.get('[data-testid="docket-clerk-report-run-button"]').click();
+        runReportForFirstAvailableClerk('documentQC');
 
         cy.get('[data-testid="docket-clerk-report-qc-inbox-tab"]').should(
           'be.visible',
@@ -183,50 +170,39 @@ describe('Docket Clerk Report', () => {
         ).click();
 
         cy.get('#docket-clerk-report-qc-in-progress').should('exist');
+        cy.get('#docket-clerk-report-qc-in-progress').within(() => {
+          cy.get('thead th').should('have.length', 6);
+          cy.get('thead th').eq(0).should('be.empty');
+          cy.get('thead th').eq(1).should('contain', 'Docket No.');
+          cy.get('thead th').eq(2).should('contain', 'Received');
+          cy.get('thead th').eq(3).should('contain', 'Case Title');
+          cy.get('thead th').eq(4).should('contain', 'Document');
+          cy.get('thead th').eq(5).should('contain', 'Filed By');
+        });
       });
 
       it('should switch to the Processed tab when clicked', () => {
-        loginAsCaseServicesSupervisor();
-
-        cy.visit('/reports/docket-clerk-report');
-
-        cy.get('[data-testid="docket-clerk-report-clerk-select"]').then(
-          $select => {
-            cy.wrap($select).select(
-              $select.find('option').eq(1).val() as string,
-            );
-          },
-        );
-        cy.get('[data-testid="docket-clerk-report-page-type-select"]').select(
-          'documentQC',
-        );
-        cy.get('[data-testid="docket-clerk-report-run-button"]').click();
+        runReportForFirstAvailableClerk('documentQC');
 
         cy.get('[data-testid="docket-clerk-report-qc-processed-tab"]').click();
 
         cy.get('#docket-clerk-report-qc-processed').should('exist');
+        cy.get('#docket-clerk-report-qc-processed').within(() => {
+          cy.get('thead th').should('have.length', 7);
+          cy.get('thead th').eq(0).should('be.empty');
+          cy.get('thead th').eq(1).should('contain', 'Docket No.');
+          cy.get('thead th').eq(2).should('contain', 'Case Title');
+          cy.get('thead th').eq(3).should('contain', 'Document');
+          cy.get('thead th').eq(4).should('contain', 'Filed By');
+          cy.get('thead th').eq(5).should('contain', 'Case Status');
+          cy.get('thead th').eq(6).should('contain', 'Processed Date');
+        });
       });
     });
 
     describe('Messages page type', () => {
       it('should show the Messages result section with Inbox, Sent, and Completed tabs', () => {
-        loginAsCaseServicesSupervisor();
-
-        cy.visit('/reports/docket-clerk-report');
-
-        cy.get('[data-testid="docket-clerk-report-clerk-select"]').then(
-          $select => {
-            cy.wrap($select).select(
-              $select.find('option').eq(1).val() as string,
-            );
-          },
-        );
-
-        cy.get('[data-testid="docket-clerk-report-page-type-select"]').select(
-          'messages',
-        );
-
-        cy.get('[data-testid="docket-clerk-report-run-button"]').click();
+        runReportForFirstAvailableClerk('messages');
 
         cy.get('[data-testid="docket-clerk-report-title"]')
           .should('be.visible')
@@ -244,21 +220,7 @@ describe('Docket Clerk Report', () => {
       });
 
       it('should switch to the Sent tab when clicked', () => {
-        loginAsCaseServicesSupervisor();
-
-        cy.visit('/reports/docket-clerk-report');
-
-        cy.get('[data-testid="docket-clerk-report-clerk-select"]').then(
-          $select => {
-            cy.wrap($select).select(
-              $select.find('option').eq(1).val() as string,
-            );
-          },
-        );
-        cy.get('[data-testid="docket-clerk-report-page-type-select"]').select(
-          'messages',
-        );
-        cy.get('[data-testid="docket-clerk-report-run-button"]').click();
+        runReportForFirstAvailableClerk('messages');
 
         cy.get('[data-testid="docket-clerk-report-messages-sent-tab"]').click();
 
@@ -266,27 +228,23 @@ describe('Docket Clerk Report', () => {
       });
 
       it('should switch to the Completed tab when clicked', () => {
-        loginAsCaseServicesSupervisor();
-
-        cy.visit('/reports/docket-clerk-report');
-
-        cy.get('[data-testid="docket-clerk-report-clerk-select"]').then(
-          $select => {
-            cy.wrap($select).select(
-              $select.find('option').eq(1).val() as string,
-            );
-          },
-        );
-        cy.get('[data-testid="docket-clerk-report-page-type-select"]').select(
-          'messages',
-        );
-        cy.get('[data-testid="docket-clerk-report-run-button"]').click();
+        runReportForFirstAvailableClerk('messages');
 
         cy.get(
           '[data-testid="docket-clerk-report-messages-completed-tab"]',
         ).click();
 
         cy.get('#docket-clerk-report-messages-completed').should('exist');
+        cy.get('[data-testid="table-filters-component"]').should('not.exist');
+        cy.get('#docket-clerk-report-messages-completed').within(() => {
+          cy.get('thead th').should('have.length', 6);
+          cy.get('thead th').eq(0).should('be.empty');
+          cy.get('thead th').eq(1).should('contain', 'Docket No.');
+          cy.get('thead th').eq(2).should('contain', 'Completed');
+          cy.get('thead th').eq(3).should('contain', 'Last Message');
+          cy.get('thead th').eq(4).should('contain', 'Comment');
+          cy.get('thead th').eq(5).should('contain', 'Case Title');
+        });
       });
     });
   });

--- a/web-client/src/presenter/computeds/DocketClerkReport/docketClerkReportMessagesHelper.ts
+++ b/web-client/src/presenter/computeds/DocketClerkReport/docketClerkReportMessagesHelper.ts
@@ -10,7 +10,6 @@ import { state } from '@web-client/presenter/app.cerebral';
 
 export type DocketClerkReportMessageBox = {
   caseStatuses: string[];
-  completedByUsers: string[];
   fromSections: string[];
   fromUsers: string[];
   messages: any[];
@@ -64,18 +63,16 @@ export const docketClerkReportMessagesHelper = (
       screenMetadata,
     });
 
-    const { filterValues: completedFilterValues, filteredCompletedMessages } =
-      applyFiltersToCompletedMessages({
-        completedMessages: formattedCompleted,
-        screenMetadata,
-      });
+    const { filteredCompletedMessages } = applyFiltersToCompletedMessages({
+      completedMessages: formattedCompleted,
+      screenMetadata,
+    });
 
     const isCompletedOnlyBox =
       rawMessages.length > 0 && rawMessages.every(m => m.isCompleted);
 
     return {
       ...filterValues,
-      ...completedFilterValues,
       messages: isCompletedOnlyBox
         ? filteredCompletedMessages
         : filteredMessages.map(message => ({

--- a/web-client/src/views/DocketClerkReport/DocketClerkReportDocumentQc.tsx
+++ b/web-client/src/views/DocketClerkReport/DocketClerkReportDocumentQc.tsx
@@ -21,12 +21,18 @@ const DocketClerkReportWorkItemTable = ({
   ariaLabelId,
   emptyText,
   id,
+  showCaseStatus = true,
+  showProcessedDate = false,
+  showReceived = true,
   showStatusIcon = false,
   workItems,
 }: {
   ariaLabelId: string;
   emptyText: string;
   id: string;
+  showCaseStatus?: boolean;
+  showProcessedDate?: boolean;
+  showReceived?: boolean;
   showStatusIcon?: boolean;
   workItems: FormattedWorkItemWithCaseInfo[];
 }) => {
@@ -45,10 +51,10 @@ const DocketClerkReportWorkItemTable = ({
         <thead>
           <tr>
             <th aria-hidden="true" className="consolidated-case-column"></th>
-            <th aria-label="Docket Number" className="small">
+            <th aria-label="Docket Number">
               <span className="padding-left-2px">Docket No.</span>
             </th>
-            <th className="small">Received</th>
+            {showReceived && <th>Received</th>}
             <th>Case Title</th>
             {showStatusIcon && (
               <th aria-label="Status Icon" className="padding-right-0">
@@ -57,7 +63,8 @@ const DocketClerkReportWorkItemTable = ({
             )}
             <th>Document</th>
             <th>Filed By</th>
-            <th>Case Status</th>
+            {showCaseStatus && <th>Case Status</th>}
+            {showProcessedDate && <th>Processed Date</th>}
           </tr>
         </thead>
         <tbody>
@@ -103,7 +110,7 @@ const DocketClerkReportWorkItemTable = ({
                 )}
               </td>
               <td
-                className="message-queue-row small"
+                className="message-queue-row"
                 data-testid={`docket-clerk-report-docket-number-${item.docketNumber}`}
               >
                 {item.groupedMemberCases ? (
@@ -121,9 +128,11 @@ const DocketClerkReportWorkItemTable = ({
                   <CaseLink formattedCase={item} />
                 )}
               </td>
-              <td className="message-queue-row small">
-                <span className="no-wrap">{item.received}</span>
-              </td>
+              {showReceived && (
+                <td className="message-queue-row">
+                  <span className="no-wrap">{item.received}</span>
+                </td>
+              )}
               <td className="message-queue-row message-queue-case-title">
                 {item.caseTitle}
               </td>
@@ -163,7 +172,16 @@ const DocketClerkReportWorkItemTable = ({
                 </div>
               </td>
               <td className="message-queue-row">{item.docketEntry.filedBy}</td>
-              <td className="message-queue-row">{item.formattedCaseStatus}</td>
+              {showCaseStatus && (
+                <td className="message-queue-row">
+                  {item.formattedCaseStatus}
+                </td>
+              )}
+              {showProcessedDate && (
+                <td className="message-queue-row">
+                  {item.completedAtFormatted}
+                </td>
+              )}
             </tr>
           ))}
         </tbody>
@@ -212,6 +230,7 @@ export const DocketClerkReportDocumentQc = connect(
             ariaLabelId="qc-tabs"
             emptyText="There are no documents."
             id="docket-clerk-report-qc-in-progress"
+            showCaseStatus={false}
             workItems={documentQc.inProgress}
           />
         </Tab>
@@ -224,6 +243,8 @@ export const DocketClerkReportDocumentQc = connect(
             ariaLabelId="qc-tabs"
             emptyText="There are no documents."
             id="docket-clerk-report-qc-processed"
+            showProcessedDate={true}
+            showReceived={false}
             workItems={documentQc.processed}
           />
         </Tab>

--- a/web-client/src/views/DocketClerkReport/DocketClerkReportMessages.tsx
+++ b/web-client/src/views/DocketClerkReport/DocketClerkReportMessages.tsx
@@ -128,24 +128,6 @@ const COLUMNS: Record<string, ColumnConfig[]> = {
       sortField: 'caseTitle',
       sortType: 'string',
     },
-    {
-      label: 'Case Status',
-      render: m => m.caseStatus,
-      sortField: 'caseStatus',
-      sortType: 'string',
-    },
-    {
-      label: 'Completed By',
-      render: m => m.completedBy,
-      sortField: 'completedBy',
-      sortType: 'string',
-    },
-    {
-      label: 'Section',
-      render: m => m.completedBySection,
-      sortField: 'completedBySection',
-      sortType: 'string',
-    },
   ],
   inbox: [
     {
@@ -243,14 +225,7 @@ const COLUMNS: Record<string, ColumnConfig[]> = {
 };
 
 const FILTERS: Record<string, FilterConfig[]> = {
-  completed: [
-    { key: 'caseStatus', label: 'Case Status', optionsField: 'caseStatuses' },
-    {
-      key: 'completedBy',
-      label: 'Completed By',
-      optionsField: 'completedByUsers',
-    },
-  ],
+  completed: [],
   inbox: [
     { key: 'caseStatus', label: 'Case Status', optionsField: 'caseStatuses' },
     { key: 'fromUser', label: 'From', optionsField: 'fromUsers' },
@@ -335,18 +310,20 @@ const MessagePanel = connect<MessagePanelOwnProps, typeof messagePanelDeps>(
           </div>
         )}
         <div className="grid-row grid-gap">
-          <div
-            className={
-              selectable
-                ? 'desktop:grid-col-8 tablet:grid-col-12 display-flex flex-align-center'
-                : undefined
-            }
-          >
-            <TableFilters
-              filters={filters}
-              onSelect={updateMessageFilterSequence}
-            ></TableFilters>
-          </div>
+          {filters.length > 0 && (
+            <div
+              className={
+                selectable
+                  ? 'desktop:grid-col-8 tablet:grid-col-12 display-flex flex-align-center'
+                  : undefined
+              }
+            >
+              <TableFilters
+                filters={filters}
+                onSelect={updateMessageFilterSequence}
+              ></TableFilters>
+            </div>
+          )}
           {selectable && (
             <div className="desktop:grid-col-4 tablet:grid-col-12 tablet:margin-top-2 text-right">
               <Button


### PR DESCRIPTION
https://github.com/ustaxcourt/ef-cms/issues/9507
This pull request refactors and enhances the Docket Clerk Report, focusing on improving test maintainability, updating table column logic, and simplifying the messages report UI. The most important changes are grouped below:

**Test Refactoring and Coverage Improvements:**

* Introduced a `runReportForFirstAvailableClerk` helper function to reduce code duplication and improve readability in the Docket Clerk Report Cypress tests. All relevant tests now use this helper for consistent setup. [[1]](diffhunk://#diff-af41670f0501a3169ed22a57578d1e9e25ecd4221a05615d67dff43898f0cd21R66-R86) [[2]](diffhunk://#diff-af41670f0501a3169ed22a57578d1e9e25ecd4221a05615d67dff43898f0cd21L123-R144) [[3]](diffhunk://#diff-af41670f0501a3169ed22a57578d1e9e25ecd4221a05615d67dff43898f0cd21L161-R162) [[4]](diffhunk://#diff-af41670f0501a3169ed22a57578d1e9e25ecd4221a05615d67dff43898f0cd21R173-R205) [[5]](diffhunk://#diff-af41670f0501a3169ed22a57578d1e9e25ecd4221a05615d67dff43898f0cd21L247-R247)
* Added assertions in the Cypress tests to verify the correct table headers for the "In Progress", "Processed", and "Messages Completed" tabs, ensuring the UI displays the expected columns. [[1]](diffhunk://#diff-af41670f0501a3169ed22a57578d1e9e25ecd4221a05615d67dff43898f0cd21R173-R205) [[2]](diffhunk://#diff-af41670f0501a3169ed22a57578d1e9e25ecd4221a05615d67dff43898f0cd21L247-R247)

**Docket Clerk Report Table and UI Updates:**

* Refactored the `DocketClerkReportWorkItemTable` component to make columns for "Case Status", "Processed Date", and "Received" configurable via props, and updated the table rendering logic accordingly. [[1]](diffhunk://#diff-99496ed0725ad0f3c3fadc267e65eb02aa250fb066c762ef51e8b9ce64c34bdaR24-R35) [[2]](diffhunk://#diff-99496ed0725ad0f3c3fadc267e65eb02aa250fb066c762ef51e8b9ce64c34bdaL48-R57) [[3]](diffhunk://#diff-99496ed0725ad0f3c3fadc267e65eb02aa250fb066c762ef51e8b9ce64c34bdaL60-R67) [[4]](diffhunk://#diff-99496ed0725ad0f3c3fadc267e65eb02aa250fb066c762ef51e8b9ce64c34bdaL106-R113) [[5]](diffhunk://#diff-99496ed0725ad0f3c3fadc267e65eb02aa250fb066c762ef51e8b9ce64c34bdaL124-R135) [[6]](diffhunk://#diff-99496ed0725ad0f3c3fadc267e65eb02aa250fb066c762ef51e8b9ce64c34bdaL166-R184) [[7]](diffhunk://#diff-99496ed0725ad0f3c3fadc267e65eb02aa250fb066c762ef51e8b9ce64c34bdaR233) [[8]](diffhunk://#diff-99496ed0725ad0f3c3fadc267e65eb02aa250fb066c762ef51e8b9ce64c34bdaR246-R247)
* Updated the "In Progress" and "Processed" tabs to show/hide columns as appropriate (e.g., "Processed Date" only appears in the "Processed" tab, "Case Status" hidden in "In Progress"). [[1]](diffhunk://#diff-99496ed0725ad0f3c3fadc267e65eb02aa250fb066c762ef51e8b9ce64c34bdaR233) [[2]](diffhunk://#diff-99496ed0725ad0f3c3fadc267e65eb02aa250fb066c762ef51e8b9ce64c34bdaR246-R247)

**Messages Report Simplification:**

* Removed unnecessary "Case Status", "Completed By", and "Section" columns and filters from the "Completed" messages tab, streamlining the UI and filter logic. [[1]](diffhunk://#diff-a6dc71fbaf078a22bf8887467af6ccbfc56d4efa35cb958da8ceca6bd286cb7aL131-L148) [[2]](diffhunk://#diff-a6dc71fbaf078a22bf8887467af6ccbfc56d4efa35cb958da8ceca6bd286cb7aL246-R228)
* Updated the logic so that the filters panel only renders if there are filters to display, preventing empty filter panels in the UI. [[1]](diffhunk://#diff-a6dc71fbaf078a22bf8887467af6ccbfc56d4efa35cb958da8ceca6bd286cb7aR313) [[2]](diffhunk://#diff-a6dc71fbaf078a22bf8887467af6ccbfc56d4efa35cb958da8ceca6bd286cb7aR326)
* Cleaned up unused properties and variables in the messages helper to reflect the simplified filter and column structure. [[1]](diffhunk://#diff-94fb28caf6a5eebb2acef08760d403effe3e59f4fe45d8c89603913a6dacbd10L13) [[2]](diffhunk://#diff-94fb28caf6a5eebb2acef08760d403effe3e59f4fe45d8c89603913a6dacbd10L67-R66) [[3]](diffhunk://#diff-94fb28caf6a5eebb2acef08760d403effe3e59f4fe45d8c89603913a6dacbd10L78)