### PR TITLE
devex: linux/macOS cross-compatibility fixes

### DIFF
--- a/scripts/ecr/check-version.sh
+++ b/scripts/ecr/check-version.sh
@@ -6,8 +6,7 @@ if [[ -z "$AWS_SESSION_EXPIRATION" ]] || [[ -z "$ENV" ]]; then
 fi
 
 aws_expiration_iso="${AWS_SESSION_EXPIRATION%:*}${AWS_SESSION_EXPIRATION##*:}"
-# shellcheck disable=SC2327,SC2328
-if [[ -n "$(date --version >/dev/null 2>&1)" ]]; then
+if date --version >/dev/null 2>&1; then
   aws_expiration="$(date -d "$aws_expiration_iso" +%s)" # GNU date
 else
   aws_expiration="$(date -j -f '%Y-%m-%dT%H:%M:%S%z' "$aws_expiration_iso" +%s)" # BSD date

--- a/scripts/ecr/pull-and-tag.ts
+++ b/scripts/ecr/pull-and-tag.ts
@@ -7,7 +7,7 @@ import {
 import fs from 'fs';
 import path from 'path';
 import { runCommand } from '../helpers/runCommand';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 const scriptConfig: ScriptConfig = {
   description:
@@ -164,9 +164,10 @@ async function app() {
     \\"AWS_SECRET_ACCESS_KEY\\": \\"$AWS_SECRET_ACCESS_KEY\\",
     \\"AWS_SESSION_TOKEN\\": \\"$AWS_SESSION_TOKEN\\"
   }"`;
-  const sourceAwsAccessKeyIdString = execSync(
+  const sourceAwsAccessKeyIdString = execFileSync('zsh', [
+    '-c',
     `${envSwitcherCommand}; ${echoInfoCommand}`,
-  )
+  ])
     .toString()
     .trim();
 

--- a/scripts/env/env-for-circle.sh
+++ b/scripts/env/env-for-circle.sh
@@ -75,7 +75,7 @@ export ENV="$ENV"
 
 cp .env .env.sh
 sed -i.bak 's/^/export /g' .env.sh
-rm .env.sh.bak
+rm -f .env.sh.bak
 cat .env.sh >> "${BASH_ENV}"
 
 REGION=us-east-1

--- a/scripts/env/env-for-circle.sh
+++ b/scripts/env/env-for-circle.sh
@@ -74,7 +74,8 @@ export ENV="$ENV"
 ./scripts/load-environment-from-secrets.sh
 
 cp .env .env.sh
-sed -i 's/^/export /g' .env.sh
+sed -i.bak 's/^/export /g' .env.sh
+rm .env.sh.bak
 cat .env.sh >> "${BASH_ENV}"
 
 REGION=us-east-1

--- a/scripts/env/environments/example.env
+++ b/scripts/env/environments/example.env
@@ -26,7 +26,8 @@ IRS_SUPERUSER_EMAIL=""
 IRS_SUPERUSER_PASS=""
 if [[ -n "$IRS_SUPERUSER_EMAIL" ]]; then
   # overwrite the IRS_SUPERUSER_EMAIL we just retrieved from secrets with the value defined above
-  sed -i '' "/IRS_SUPERUSER_EMAIL/s/.*/IRS_SUPERUSER_EMAIL='$IRS_SUPERUSER_EMAIL'/" .env
+  sed -i.bak "/IRS_SUPERUSER_EMAIL/s/.*/IRS_SUPERUSER_EMAIL='$IRS_SUPERUSER_EMAIL'/" .env
+  rm .env.bak
 fi
 [[ -n "$IRS_SUPERUSER_PASS" ]] && echo "IRS_SUPERUSER_PASS='${IRS_SUPERUSER_PASS}'" >> .env
 

--- a/scripts/env/environments/example.env
+++ b/scripts/env/environments/example.env
@@ -27,7 +27,7 @@ IRS_SUPERUSER_PASS=""
 if [[ -n "$IRS_SUPERUSER_EMAIL" ]]; then
   # overwrite the IRS_SUPERUSER_EMAIL we just retrieved from secrets with the value defined above
   sed -i.bak "/IRS_SUPERUSER_EMAIL/s/.*/IRS_SUPERUSER_EMAIL='$IRS_SUPERUSER_EMAIL'/" .env
-  rm .env.bak
+  rm -f .env.bak
 fi
 [[ -n "$IRS_SUPERUSER_PASS" ]] && echo "IRS_SUPERUSER_PASS='${IRS_SUPERUSER_PASS}'" >> .env
 

--- a/scripts/git/pr-to.sh
+++ b/scripts/git/pr-to.sh
@@ -44,11 +44,14 @@ if [[ "$MY_ORG" != "$COURT_ORG" ]]; then
   INTERMEDIARY="${MY_ORG}:${INTERMEDIARY}"
   git branch -D "$TARGET_TS"
 fi
+
+set +e
+
 compare_url="https://github.com/${COURT_ORG}/ef-cms/compare/${TARGET}...${INTERMEDIARY}"
 if command -v open >/dev/null 2>&1; then
-  open "$compare_url"
+  open "$compare_url" || echo "Open this URL in a browser: ${compare_url}"
 elif command -v xdg-open >/dev/null 2>&1; then
-  xdg-open "$compare_url"
+  xdg-open "$compare_url" || echo "Open this URL in a browser: ${compare_url}"
 else
   echo "Open this URL in a browser: ${compare_url}"
 fi

--- a/scripts/git/pr-to.sh
+++ b/scripts/git/pr-to.sh
@@ -44,4 +44,11 @@ if [[ "$MY_ORG" != "$COURT_ORG" ]]; then
   INTERMEDIARY="${MY_ORG}:${INTERMEDIARY}"
   git branch -D "$TARGET_TS"
 fi
-open "https://github.com/${COURT_ORG}/ef-cms/compare/${TARGET}...${INTERMEDIARY}"
+compare_url="https://github.com/${COURT_ORG}/ef-cms/compare/${TARGET}...${INTERMEDIARY}"
+if command -v open >/dev/null 2>&1; then
+  open "$compare_url"
+elif command -v xdg-open >/dev/null 2>&1; then
+  xdg-open "$compare_url"
+else
+  echo "Open this URL in a browser: ${compare_url}"
+fi

--- a/scripts/postgres/connect.sh
+++ b/scripts/postgres/connect.sh
@@ -28,7 +28,7 @@ for param in "$@"; do
   { [[ "$param" =~ ^--file= ]] || [[ "$param" =~ ^-f= ]]; } && SQL_FILE="${param#*=}"
 done
 
-[[ -n "$SQL_FILE" ]] && [[ ! -e "$SQL_FILE" ]] && echo "Invalid file path: ${SQL_FILE}" && exit 1
+[[ -n "$SQL_FILE" ]] && [[ ! -f "$SQL_FILE" ]] && echo "Invalid file path: ${SQL_FILE}" && exit 1
 ./check-env-variables.sh "${CHECK_ENV_PARAMS[@]}"
 
 [[ -n "$DB_TOKEN" ]] && unset "DB_TOKEN"

--- a/scripts/postgres/connect.sh
+++ b/scripts/postgres/connect.sh
@@ -28,7 +28,7 @@ for param in "$@"; do
   { [[ "$param" =~ ^--file= ]] || [[ "$param" =~ ^-f= ]]; } && SQL_FILE="${param#*=}"
 done
 
-[[ -n "$SQL_FILE" ]] && [[ ! $(readlink -f "$SQL_FILE") ]] && echo "Invalid file path: ${SQL_FILE}" && exit 1
+[[ -n "$SQL_FILE" ]] && [[ ! -e "$SQL_FILE" ]] && echo "Invalid file path: ${SQL_FILE}" && exit 1
 ./check-env-variables.sh "${CHECK_ENV_PARAMS[@]}"
 
 [[ -n "$DB_TOKEN" ]] && unset "DB_TOKEN"


### PR DESCRIPTION
# DevEx: Linux/MacOS Cross-Compatibility Fixes

## Overview

Audited shell scripts in `scripts/` for syntax specific to `zsh` and `bash`, and for instances of Linux-specific or MacOS-specific dependencies, then fixed the shell scripts to work the same in either Linux or MacOS.

## Changes

- Fixed GNU `date` detection in `check-version.sh`.
- Replaced BSD-only `sed -i ''` usage with portable temp-file replacement in a few places.
- Replaced macOS-incompatible `readlink -f` validation in `connect.sh`.
- Added Linux `xdg-open` fallback when opening PR comparison URLs.

## Verification

- [x] Deployed a docker container on linux, proving the fixes for `pull-and-tag.ts` and `check-version.sh`.
   - [x] Deployed a docker container on MacOS, proving no regression.
- [x] Ran `pr-to.sh` on linux, proving the `xdg-open` fallback works.
   - [x] Ran `pr-to.sh` on MacOS, proving no regression.
- [x] Ran environment-switcher on Linux, proving fixes to the `sed` syntax in `.env` files
   - [x] Ran environment-switcher on MacOS, proving no regression.

## Pull Request Checklist

_PRs that do not meet these criteria may be closed without review._

- [x] I have conducted thorough manual testing:
   - [x] Locally
   - [ ] Experimental Environment (if necessary)
- [x] If this PR is for a user story, or tech debt (devex, opex, design debt, etc.) that is user-facing, I have created test case(s) in TestRail and executed them.
- [x] I assert that all DoD criteria for this issue have been met.
- [x] If this PR includes a data migration with timing-specific manual test steps, I will coordinate the deployment with a manual tester to verify the timing-specific manual tests in real time.
- [x] All user-facing changes have been verified to be free of accessibility issues via manual testing and automated accessibility tests.
