### PR TITLE
devex: improve manual steps collation in prod pr script

### DIFF
--- a/scripts/git/prod-release-pr-description.helpers.test.ts
+++ b/scripts/git/prod-release-pr-description.helpers.test.ts
@@ -577,7 +577,7 @@ describe('prod-release-pr-description', () => {
             manualSteps: [
               {
                 command: 'npm run ecr:check-version',
-                description: 'docker container `4.3.80`',
+                description: 'Manual step',
               },
             ],
             otherContributors: [],
@@ -587,6 +587,10 @@ describe('prod-release-pr-description', () => {
           },
           {
             manualSteps: [
+              {
+                command: 'npm run ecr:check-version',
+                description: 'docker container `4.3.80`',
+              },
               {
                 command: 'npm run ecr:check-version',
                 description: 'docker container `4.3.80`',
@@ -601,6 +605,35 @@ describe('prod-release-pr-description', () => {
       });
 
       expect(description.match(/npm run ecr:check-version/g)).toHaveLength(1);
+    });
+
+    it('keeps identical commands when they belong to different deployment sections', () => {
+      const description = renderPrDescription({
+        enrichedPullRequests: [
+          {
+            manualSteps: [
+              {
+                command: 'npm run verify',
+                description: 'Verify before deployment',
+                section: 'before',
+              },
+              {
+                command: 'npm run verify',
+                description: 'Verify after deployment',
+                section: 'after',
+              },
+            ],
+            otherContributors: [],
+            pullRequest: blankPullRequest,
+            ticketTask: '',
+            type: '',
+          },
+        ],
+      });
+
+      expect(description.match(/npm run verify/g)).toHaveLength(2);
+      expect(description).toContain('- [ ] Verify before deployment');
+      expect(description).toContain('- [ ] Verify after deployment');
     });
 
     it('does not collapse non-issue task types like devex or dependencies into one row', () => {
@@ -787,7 +820,18 @@ describe('prod-release-pr-description', () => {
       expect(enrichedPullRequest.manualSteps).toEqual([]);
     });
 
-    it('uses the checklist text before a bash block as the manual step description', () => {
+    it('ignores unclosed bash code blocks when enriching pull requests', () => {
+      const enrichedPullRequest = enrichPullRequest({
+        pullRequest: {
+          ...blankPullRequest,
+          body: ['Before', '', '```bash', 'npm run incomplete'].join('\n'),
+        },
+      });
+
+      expect(enrichedPullRequest.manualSteps).toEqual([]);
+    });
+
+    it('retains surrounding text and checklist text before a bash block', () => {
       const enrichedPullRequest = enrichPullRequest({
         pullRequest: {
           ...blankPullRequest,
@@ -806,9 +850,211 @@ describe('prod-release-pr-description', () => {
       expect(enrichedPullRequest.manualSteps).toEqual([
         {
           command: 'npm run deploy:account-specific',
-          description: 'Deploy account-specific terraform',
+          description:
+            'Manual release work is required.\n\nDeploy account-specific terraform:',
         },
       ]);
+    });
+
+    it('retains manual deployment sections and surrounding text for each bash command', () => {
+      const enrichedPullRequest = enrichPullRequest({
+        pullRequest: {
+          ...blankPullRequest,
+          body: [
+            '## Verification',
+            '',
+            '```bash',
+            'npm run verify',
+            '```',
+            '',
+            '## Manual Deployment Steps',
+            '',
+            '### Before Deployment',
+            '',
+            '#### Prepare the deployment',
+            '',
+            'Run this command before deploying:',
+            '',
+            '```bash',
+            'npm run deploy:prepare',
+            '```',
+            '',
+            '### After Deployment',
+            '',
+            'Confirm the deployment completed successfully:',
+            '',
+            '```bash',
+            'npm run deploy:verify',
+            '```',
+            '',
+            '## Notes',
+            '',
+            '```bash',
+            'npm run ignore',
+            '```',
+          ].join('\n'),
+        },
+      });
+
+      expect(enrichedPullRequest.manualSteps).toEqual([
+        {
+          command: 'npm run deploy:prepare',
+          description:
+            'Prepare the deployment\n\nRun this command before deploying:',
+          section: 'before',
+        },
+        {
+          command: 'npm run deploy:verify',
+          description: 'Confirm the deployment completed successfully:',
+          section: 'after',
+        },
+      ]);
+
+      const description = renderPrDescription({
+        enrichedPullRequests: [enrichedPullRequest],
+      });
+
+      expect(description.match(/#### Before Deployment/g)).toHaveLength(1);
+      expect(description.match(/#### After Deployment/g)).toHaveLength(1);
+      expect(description.indexOf('#### Before Deployment')).toBeLessThan(
+        description.indexOf('#### After Deployment'),
+      );
+      expect(description).toContain(
+        [
+          '- [ ] Prepare the deployment',
+          '   ',
+          '   Run this command before deploying:',
+          '   ```bash',
+          '   npm run deploy:prepare',
+          '   ```',
+        ].join('\n'),
+      );
+      expect(description).toContain(
+        [
+          '- [ ] Confirm the deployment completed successfully:',
+          '   ```bash',
+          '   npm run deploy:verify',
+          '   ```',
+        ].join('\n'),
+      );
+      expect(description).not.toContain('npm run verify');
+      expect(description).not.toContain('npm run ignore');
+    });
+
+    it('does not carry a deployment section through an unrelated heading', () => {
+      const enrichedPullRequest = enrichPullRequest({
+        pullRequest: {
+          ...blankPullRequest,
+          body: [
+            '## Manual Deployment Steps',
+            '',
+            '### Before Deployment',
+            '',
+            '### Verification',
+            '',
+            '```bash',
+            'npm run verify',
+            '```',
+            '',
+            '## Before Deployment',
+            '',
+            '```bash',
+            'npm run outside',
+            '```',
+          ].join('\n'),
+        },
+      });
+
+      expect(enrichedPullRequest.manualSteps).toEqual([
+        {
+          command: 'npm run verify',
+          description: 'Verification',
+        },
+      ]);
+    });
+
+    it('uses a generic checkbox description when no surrounding text exists', () => {
+      const enrichedPullRequest = enrichPullRequest({
+        pullRequest: {
+          ...blankPullRequest,
+          body: [
+            '### Before Deployment',
+            '',
+            '```bash',
+            'npm run verify',
+            '```',
+          ].join('\n'),
+        },
+      });
+
+      expect(enrichedPullRequest.manualSteps).toEqual([
+        {
+          command: 'npm run verify',
+          description: 'Manual step',
+          section: 'before',
+        },
+      ]);
+
+      const emptyDescriptionPullRequest = enrichPullRequest({
+        pullRequest: {
+          ...blankPullRequest,
+          body: ['- [ ]', '', '```bash', 'npm run verify', '```'].join('\n'),
+        },
+      });
+
+      expect(emptyDescriptionPullRequest.manualSteps).toEqual([
+        {
+          command: 'npm run verify',
+          description: 'Manual step',
+        },
+      ]);
+    });
+
+    it('groups before and after manual steps from multiple pull requests', () => {
+      const description = renderPrDescription({
+        enrichedPullRequests: [
+          {
+            manualSteps: [
+              {
+                command: 'before-one',
+                description: 'Before one',
+                section: 'before',
+              },
+              {
+                command: 'after-one',
+                description: 'After one',
+                section: 'after',
+              },
+            ],
+            otherContributors: [],
+            pullRequest: { ...blankPullRequest, number: 7005 },
+            ticketTask: '',
+            type: '',
+          },
+          {
+            manualSteps: [
+              {
+                command: 'before-two',
+                description: 'Before two',
+                section: 'before',
+              },
+            ],
+            otherContributors: [],
+            pullRequest: { ...blankPullRequest, number: 7006 },
+            ticketTask: '',
+            type: '',
+          },
+        ],
+      });
+
+      expect(description.match(/#### Before Deployment/g)).toHaveLength(1);
+      expect(description.match(/#### After Deployment/g)).toHaveLength(1);
+      expect(description.indexOf('before-one')).toBeLessThan(
+        description.indexOf('before-two'),
+      );
+      expect(description.indexOf('before-two')).toBeLessThan(
+        description.indexOf('after-one'),
+      );
     });
   });
   describe('cli integration', () => {

--- a/scripts/git/prod-release-pr-description.helpers.test.ts
+++ b/scripts/git/prod-release-pr-description.helpers.test.ts
@@ -809,6 +809,90 @@ describe('prod-release-pr-description', () => {
       expect(description).not.toContain('npm run ecr:check-version');
     });
 
+    it('does not duplicate a docker-image manual step already listed before deployment', () => {
+      const enrichedPullRequest = enrichPullRequest({
+        dockerImageTag: '4.3.80',
+        pullRequest: {
+          ...dockerDependencyPullRequest,
+          body: [
+            '## Manual Deployment Steps',
+            '',
+            '### Before Deployment',
+            '',
+            'Check the Docker image:',
+            '',
+            '```bash',
+            'npm run ecr:check-version',
+            '```',
+          ].join('\n'),
+        },
+      });
+
+      expect(enrichedPullRequest.manualSteps).toEqual([
+        {
+          command: 'npm run ecr:check-version',
+          description: 'Check the Docker image:',
+          section: 'before',
+        },
+      ]);
+    });
+
+    it('does not duplicate a docker-image manual step already listed without a section', () => {
+      const enrichedPullRequest = enrichPullRequest({
+        dockerImageTag: '4.3.80',
+        pullRequest: {
+          ...dockerDependencyPullRequest,
+          body: [
+            'Check the Docker image:',
+            '',
+            '```bash',
+            'npm run ecr:check-version',
+            '```',
+          ].join('\n'),
+        },
+      });
+
+      expect(enrichedPullRequest.manualSteps).toEqual([
+        {
+          command: 'npm run ecr:check-version',
+          description: 'Check the Docker image:',
+        },
+      ]);
+    });
+
+    it('keeps an explicit after-deployment docker-image step distinct', () => {
+      const enrichedPullRequest = enrichPullRequest({
+        dockerImageTag: '4.3.80',
+        pullRequest: {
+          ...dockerDependencyPullRequest,
+          body: [
+            '## Manual Deployment Steps',
+            '',
+            '### After Deployment',
+            '',
+            'Check the Docker image after deployment:',
+            '',
+            '```bash',
+            'npm run ecr:check-version',
+            '```',
+          ].join('\n'),
+        },
+      });
+
+      expect(enrichedPullRequest.manualSteps).toEqual([
+        {
+          command: 'npm run ecr:check-version',
+          description: 'Check the Docker image after deployment:',
+          section: 'after',
+        },
+        {
+          command: 'npm run ecr:check-version',
+          description: 'docker container `4.3.80`',
+          section: 'before',
+        },
+      ]);
+    });
+
     it('ignores empty bash code blocks when enriching pull requests', () => {
       const enrichedPullRequest = enrichPullRequest({
         pullRequest: {

--- a/scripts/git/prod-release-pr-description.helpers.ts
+++ b/scripts/git/prod-release-pr-description.helpers.ts
@@ -261,13 +261,21 @@ const resolveManualSteps = ({
     resolveTicketTask(pullRequest.title) === 'dependencies' &&
     hasDockerfileChange(pullRequest)
   ) {
-    manualSteps.push({
-      command: 'npm run ecr:check-version',
-      description: dockerImageTag
-        ? `docker container \`${dockerImageTag}\``
-        : 'docker container',
-      section: 'before',
-    });
+    const dockerCheckAlreadyIncluded = manualSteps.some(
+      manualStep =>
+        manualStep.command === 'npm run ecr:check-version' &&
+        (manualStep.section === undefined || manualStep.section === 'before'),
+    );
+
+    if (!dockerCheckAlreadyIncluded) {
+      manualSteps.push({
+        command: 'npm run ecr:check-version',
+        description: dockerImageTag
+          ? `docker container \`${dockerImageTag}\``
+          : 'docker container',
+        section: 'before',
+      });
+    }
   }
 
   return dedupeManualSteps(manualSteps);

--- a/scripts/git/prod-release-pr-description.helpers.ts
+++ b/scripts/git/prod-release-pr-description.helpers.ts
@@ -17,11 +17,17 @@ import {
   type GitHubUser,
 } from './github-client';
 import { haveValidationRulesChanged } from '../entity-validation/entityValidation';
+import {
+  dedupeManualSteps,
+  extractBashCodeBlocks,
+  extractManualSteps,
+  renderManualSteps,
+  type ManualStep,
+  type ManualStepSection,
+} from './prod-release-pr-description.manual-steps-helpers';
 
-export type ManualStep = {
-  command: string;
-  description: string;
-};
+export { extractBashCodeBlocks };
+export type { ManualStep, ManualStepSection };
 
 export type EnrichedPullRequest = {
   issue?: GitHubIssue;
@@ -47,8 +53,6 @@ const OPEX_PATTERN = /^opex\b/i;
 const BUG_DESCRIPTION_HEADING_PATTERN = /^[\s*_#>~-]*describe the bug\b/i;
 const BUG_LABEL = 'bug';
 const BUGFIX_LABEL = 'bugfix';
-const BASH_CODE_BLOCK_PATTERN = /```bash\s*\n([\s\S]*?)```/gi;
-const CHECKBOX_LIST_ITEM_PATTERN = /^\s*-\s*(?:\[[ xX]]\s*)?(.*?):?\s*$/;
 const COPILOT_PATTERN = /copilot/i;
 const CIRCLE_CONFIG_PATH = path.join(
   __dirname,
@@ -62,16 +66,8 @@ const DOCKER_IMAGE_TAG_PATTERN =
 const TABLE_HEADER = '| Ticket/Task | Type | Other Contributors | PR Made By |';
 const TABLE_DIVIDER = '| --- | --- | --- | --- |';
 
-const normalizeLineEndings = (value: string): string => {
-  return value.replace(/\r\n/g, '\n');
-};
-
 const normalizeLabelName = (label: GitHubLabel): string => {
   return label.name.trim().toLowerCase();
-};
-
-const normalizeWhitespace = (value: string): string => {
-  return normalizeLineEndings(value).trim();
 };
 
 export const extractIssueNumberFromTitle = (
@@ -144,21 +140,6 @@ export const resolveType = ({
   }
 
   return 'story';
-};
-
-export const extractBashCodeBlocks = (body: string): string[] => {
-  const normalizedBody = normalizeLineEndings(body);
-  const codeBlocks: string[] = [];
-
-  for (const match of normalizedBody.matchAll(BASH_CODE_BLOCK_PATTERN)) {
-    const codeBlock = normalizeWhitespace(match[1]);
-
-    if (codeBlock) {
-      codeBlocks.push(codeBlock);
-    }
-  }
-
-  return codeBlocks;
 };
 
 export const extractDockerImageTag = (
@@ -259,79 +240,12 @@ const renderGroupedTableRow = (
   return `| ${escapeTableCell(groupedReleaseEntry.ticketTask)} | ${escapeTableCell(groupedReleaseEntry.type)} | ${escapeTableCell(groupedReleaseEntry.otherContributors.join('<br />'))} | ${escapeTableCell(prMadeBy)} |`;
 };
 
-const extractManualSteps = (body: string): ManualStep[] => {
-  const lines = normalizeLineEndings(body).split('\n');
-  const manualSteps: ManualStep[] = [];
-
-  for (let index = 0; index < lines.length; index += 1) {
-    if (lines[index].trim() !== '```bash') {
-      continue;
-    }
-
-    const openingFenceIndex = index;
-    const commandLines: string[] = [];
-
-    for (
-      let commandIndex = index + 1;
-      commandIndex < lines.length;
-      commandIndex += 1
-    ) {
-      if (lines[commandIndex].trim() === '```') {
-        index = commandIndex;
-        break;
-      }
-
-      commandLines.push(lines[commandIndex]);
-    }
-
-    const command = normalizeWhitespace(commandLines.join('\n'));
-
-    if (!command) {
-      continue;
-    }
-
-    const previousNonEmptyLine = [...lines.slice(0, openingFenceIndex)]
-      .reverse()
-      .find(line => line.trim().length > 0);
-    const descriptionMatch = previousNonEmptyLine?.match(
-      CHECKBOX_LIST_ITEM_PATTERN,
-    );
-    const description = descriptionMatch?.[1]?.trim() || 'Manual step';
-
-    manualSteps.push({ command, description });
-  }
-
-  return manualSteps;
-};
-
 const hasDockerfileChange = (pullRequest: GitHubPullRequest): boolean => {
   return (
     pullRequest.files?.some(
       (file: GitHubPullRequestFile): boolean => file.path === 'Dockerfile',
     ) ?? false
   );
-};
-
-const dedupeManualSteps = (manualSteps: ManualStep[]): ManualStep[] => {
-  const uniqueSteps = new Map<string, ManualStep>();
-
-  for (const manualStep of manualSteps) {
-    const existingManualStep = uniqueSteps.get(manualStep.command);
-
-    if (!existingManualStep) {
-      uniqueSteps.set(manualStep.command, manualStep);
-      continue;
-    }
-
-    if (
-      existingManualStep.description === 'Manual step' &&
-      manualStep.description !== 'Manual step'
-    ) {
-      uniqueSteps.set(manualStep.command, manualStep);
-    }
-  }
-
-  return Array.from(uniqueSteps.values());
 };
 
 const resolveManualSteps = ({
@@ -352,6 +266,7 @@ const resolveManualSteps = ({
       description: dockerImageTag
         ? `docker container \`${dockerImageTag}\``
         : 'docker container',
+      section: 'before',
     });
   }
 
@@ -397,15 +312,6 @@ const groupEnrichedPullRequests = (
   }
 
   return Array.from(groupedEntries.values());
-};
-
-const renderManualStep = (manualStep: ManualStep): string[] => {
-  return [
-    `- [ ] ${manualStep.description}`,
-    '   ```bash',
-    `   ${manualStep.command.replace(/\n/g, '\n   ')}`,
-    '   ```',
-  ];
 };
 
 const hasDataMigrationChange = (pullRequest: GitHubPullRequest): boolean => {
@@ -497,14 +403,7 @@ export const renderPrDescription = ({
   if (manualSteps.length === 0) {
     lines.push('');
   } else {
-    lines.push('');
-    manualSteps.forEach((manualStep: ManualStep, index: number) => {
-      lines.push(...renderManualStep(manualStep));
-
-      if (index < manualSteps.length - 1) {
-        lines.push('');
-      }
-    });
+    lines.push('', ...renderManualSteps(manualSteps));
   }
 
   if (suggestedLabels.length > 0) {

--- a/scripts/git/prod-release-pr-description.manual-steps-helpers.test.ts
+++ b/scripts/git/prod-release-pr-description.manual-steps-helpers.test.ts
@@ -73,4 +73,125 @@ describe('prod-release-pr-description manual steps', () => {
       '   ```',
     ]);
   });
+
+  it('retains trailing annotations until the deployment section ends', () => {
+    const annotatedSteps = extractManualSteps(
+      [
+        '## Manual Deployment Steps',
+        '',
+        '### Before Deployment',
+        '',
+        '#### Deploy the change',
+        '',
+        'Run the deployment:',
+        '',
+        '```bash',
+        'npm run deploy',
+        '```',
+        '',
+        'Confirm the deployment completed successfully.',
+        '',
+        '### After Deployment',
+      ].join('\n'),
+    );
+
+    expect(annotatedSteps).toEqual([
+      {
+        command: 'npm run deploy',
+        description:
+          'Deploy the change\n\nRun the deployment:\n\nConfirm the deployment completed successfully.',
+        section: 'before',
+      },
+    ]);
+
+    const genericAnnotatedSteps = extractManualSteps(
+      [
+        '### Before Deployment',
+        '',
+        '```bash',
+        'npm run deploy',
+        '```',
+        '',
+        'Remember to confirm the deployment status.',
+        '',
+        '## Notes',
+        '',
+        'This note is not a deployment annotation.',
+      ].join('\n'),
+    );
+
+    expect(genericAnnotatedSteps).toEqual([
+      {
+        command: 'npm run deploy',
+        description: 'Remember to confirm the deployment status.',
+        section: 'before',
+      },
+    ]);
+
+    const unscopedSteps = extractManualSteps(
+      [
+        'Run this command:',
+        '',
+        '```bash',
+        'npm run deploy',
+        '```',
+        '',
+        'This is general PR text.',
+      ].join('\n'),
+    );
+
+    expect(unscopedSteps).toEqual([
+      {
+        command: 'npm run deploy',
+        description: 'Run this command:',
+      },
+    ]);
+  });
+
+  it('keeps annotations before a section boundary with the preceding step', () => {
+    const manualSteps = extractManualSteps(
+      [
+        '## Manual Deployment Steps',
+        '',
+        '### Before Deployment',
+        '',
+        '#### Prepare the deployment',
+        '',
+        '```bash',
+        'npm run deploy:prepare',
+        '```',
+        '',
+        'Confirm the preparation completed successfully.',
+        '',
+        '### After Deployment',
+        '',
+        '#### Verify the deployment',
+        '',
+        'Run the verification:',
+        '',
+        '```bash',
+        'npm run deploy:verify',
+        '```',
+        '',
+        'Confirm the verification completed successfully.',
+        '',
+        '## Notes',
+      ].join('\n'),
+    );
+
+    expect(manualSteps).toEqual([
+      {
+        command: 'npm run deploy:prepare',
+        description:
+          'Prepare the deployment\n\nConfirm the preparation completed successfully.',
+        section: 'before',
+      },
+      {
+        command: 'npm run deploy:verify',
+        description:
+          'Verify the deployment\n\nRun the verification:\n\nConfirm the verification completed successfully.',
+        section: 'after',
+      },
+    ]);
+  });
 });

--- a/scripts/git/prod-release-pr-description.manual-steps-helpers.test.ts
+++ b/scripts/git/prod-release-pr-description.manual-steps-helpers.test.ts
@@ -1,0 +1,76 @@
+import {
+  extractManualSteps,
+  renderManualSteps,
+} from './prod-release-pr-description.manual-steps-helpers';
+
+describe('prod-release-pr-description manual steps', () => {
+  it('extracts deployment sections and surrounding text', () => {
+    const manualSteps = extractManualSteps(
+      [
+        '## Manual Deployment Steps',
+        '',
+        '### Before Deployment',
+        '',
+        '#### Prepare the deployment',
+        '',
+        'Run this before deploying:',
+        '',
+        '```bash',
+        'npm run deploy:prepare',
+        '```',
+        '',
+        '### After Deployment',
+        '',
+        'Confirm the deployment:',
+        '',
+        '```bash',
+        'npm run deploy:verify',
+        '```',
+      ].join('\n'),
+    );
+
+    expect(manualSteps).toEqual([
+      {
+        command: 'npm run deploy:prepare',
+        description: 'Prepare the deployment\n\nRun this before deploying:',
+        section: 'before',
+      },
+      {
+        command: 'npm run deploy:verify',
+        description: 'Confirm the deployment:',
+        section: 'after',
+      },
+    ]);
+  });
+
+  it('renders every manual step as a checkbox and groups deployment sections', () => {
+    expect(
+      renderManualSteps([
+        {
+          command: 'npm run deploy:after',
+          description: 'After step',
+          section: 'after',
+        },
+        {
+          command: 'npm run deploy:before',
+          description: 'Before step',
+          section: 'before',
+        },
+      ]),
+    ).toEqual([
+      '#### Before Deployment',
+      '',
+      '- [ ] Before step',
+      '   ```bash',
+      '   npm run deploy:before',
+      '   ```',
+      '',
+      '#### After Deployment',
+      '',
+      '- [ ] After step',
+      '   ```bash',
+      '   npm run deploy:after',
+      '   ```',
+    ]);
+  });
+});

--- a/scripts/git/prod-release-pr-description.manual-steps-helpers.test.ts
+++ b/scripts/git/prod-release-pr-description.manual-steps-helpers.test.ts
@@ -194,4 +194,30 @@ describe('prod-release-pr-description manual steps', () => {
       },
     ]);
   });
+
+  it('does not treat heading descriptions as deployment section headings', () => {
+    const manualSteps = extractManualSteps(
+      [
+        '## Manual Deployment Steps',
+        '',
+        '### Before Deployment',
+        '',
+        '#### After Deployment: verify aliases',
+        '',
+        'Run this command:',
+        '',
+        '```bash',
+        'npm run deploy:verify',
+        '```',
+      ].join('\n'),
+    );
+
+    expect(manualSteps).toEqual([
+      {
+        command: 'npm run deploy:verify',
+        description: 'After Deployment: verify aliases\n\nRun this command:',
+        section: 'before',
+      },
+    ]);
+  });
 });

--- a/scripts/git/prod-release-pr-description.manual-steps-helpers.ts
+++ b/scripts/git/prod-release-pr-description.manual-steps-helpers.ts
@@ -47,6 +47,19 @@ type MarkdownHeading = {
   text: string;
 };
 
+type ManualStepContext = {
+  manualDeploymentHeadingLevel?: number;
+  manualStep: ManualStep;
+  sectionHeadingLevel?: number;
+  stepEndIndex: number;
+};
+
+const isScopedManualStepContext = (
+  context: ManualStepContext | undefined,
+): context is ManualStepContext =>
+  context?.manualDeploymentHeadingLevel !== undefined ||
+  context?.sectionHeadingLevel !== undefined;
+
 const parseHeading = (line: string): MarkdownHeading | undefined => {
   const match = line.match(HEADING_PATTERN);
 
@@ -176,6 +189,29 @@ const normalizeManualStepDescription = (lines: string[]): string => {
   return description || 'Manual step';
 };
 
+const appendTrailingDescription = (
+  manualStepContext: ManualStepContext,
+  lines: string[],
+  endIndex: number = lines.length,
+): void => {
+  if (!isScopedManualStepContext(manualStepContext)) {
+    return;
+  }
+
+  const trailingDescription = normalizeManualStepDescription(
+    lines.slice(manualStepContext.stepEndIndex + 1, endIndex),
+  );
+
+  if (trailingDescription === 'Manual step') {
+    return;
+  }
+
+  manualStepContext.manualStep.description =
+    manualStepContext.manualStep.description === 'Manual step'
+      ? trailingDescription
+      : `${manualStepContext.manualStep.description}\n\n${trailingDescription}`;
+};
+
 export const extractManualSteps = (body: string): ManualStep[] => {
   const normalizedBody = normalizeLineEndings(body);
   const lines = normalizedBody.split('\n');
@@ -191,11 +227,17 @@ export const extractManualSteps = (body: string): ManualStep[] => {
   let currentSection: ManualStepSection | undefined;
   let currentSectionHeadingLevel: number | undefined;
   let previousBlockEndIndex = 0;
+  let lastManualStepContext: ManualStepContext | undefined;
 
   for (let index = 0; index < lines.length; index += 1) {
     const heading = parseHeading(lines[index]);
 
     if (heading) {
+      if (isScopedManualStepContext(lastManualStepContext)) {
+        appendTrailingDescription(lastManualStepContext, lines, index);
+        lastManualStepContext = undefined;
+      }
+
       if (isManualDeploymentHeading(heading)) {
         currentManualDeploymentHeadingLevel = heading.level;
         currentSection = undefined;
@@ -213,6 +255,7 @@ export const extractManualSteps = (body: string): ManualStep[] => {
         ) {
           currentSection = section;
           currentSectionHeadingLevel = heading.level;
+          previousBlockEndIndex = index + 1;
         } else if (
           currentManualDeploymentHeadingLevel !== undefined &&
           heading.level <= currentManualDeploymentHeadingLevel
@@ -227,6 +270,7 @@ export const extractManualSteps = (body: string): ManualStep[] => {
         ) {
           currentSection = undefined;
           currentSectionHeadingLevel = undefined;
+          previousBlockEndIndex = index;
         }
       }
     }
@@ -259,6 +303,16 @@ export const extractManualSteps = (body: string): ManualStep[] => {
       description,
       ...(currentSection ? { section: currentSection } : {}),
     });
+    lastManualStepContext = {
+      manualDeploymentHeadingLevel: currentManualDeploymentHeadingLevel,
+      manualStep: manualSteps[manualSteps.length - 1],
+      sectionHeadingLevel: currentSectionHeadingLevel,
+      stepEndIndex: bashCodeBlock.closingFenceIndex,
+    };
+  }
+
+  if (lastManualStepContext) {
+    appendTrailingDescription(lastManualStepContext, lines);
   }
 
   return manualSteps;

--- a/scripts/git/prod-release-pr-description.manual-steps-helpers.ts
+++ b/scripts/git/prod-release-pr-description.manual-steps-helpers.ts
@@ -11,7 +11,7 @@ const BASH_CODE_BLOCK_OPENING_PATTERN = /^```bash\s*$/i;
 const LIST_ITEM_PREFIX_PATTERN = /^\s*-\s*(?:\[[ xX]\]\s*)?/;
 const HEADING_PATTERN = /^\s*(#{1,6})\s+(.+?)\s*#*\s*$/;
 const MANUAL_DEPLOYMENT_HEADING_PATTERN = /^manual deployment steps?:?$/i;
-const DEPLOYMENT_SECTION_HEADING_PATTERN = /^(before|after)\s+deployment\b/i;
+const DEPLOYMENT_SECTION_HEADING_PATTERN = /^(before|after)\s+deployment:?$/i;
 
 const normalizeLineEndings = (value: string): string => {
   return value.replace(/\r\n/g, '\n');

--- a/scripts/git/prod-release-pr-description.manual-steps-helpers.ts
+++ b/scripts/git/prod-release-pr-description.manual-steps-helpers.ts
@@ -1,0 +1,344 @@
+export type ManualStep = {
+  command: string;
+  description: string;
+  section?: ManualStepSection;
+};
+
+export type ManualStepSection = 'after' | 'before';
+
+const BASH_CODE_BLOCK_PATTERN = /```bash\s*\n([\s\S]*?)```/gi;
+const BASH_CODE_BLOCK_OPENING_PATTERN = /^```bash\s*$/i;
+const LIST_ITEM_PREFIX_PATTERN = /^\s*-\s*(?:\[[ xX]\]\s*)?/;
+const HEADING_PATTERN = /^\s*(#{1,6})\s+(.+?)\s*#*\s*$/;
+const MANUAL_DEPLOYMENT_HEADING_PATTERN = /^manual deployment steps?:?$/i;
+const DEPLOYMENT_SECTION_HEADING_PATTERN = /^(before|after)\s+deployment\b/i;
+
+const normalizeLineEndings = (value: string): string => {
+  return value.replace(/\r\n/g, '\n');
+};
+
+const normalizeWhitespace = (value: string): string => {
+  return normalizeLineEndings(value).trim();
+};
+
+export const extractBashCodeBlocks = (body: string): string[] => {
+  const normalizedBody = normalizeLineEndings(body);
+  const codeBlocks: string[] = [];
+
+  for (const match of normalizedBody.matchAll(BASH_CODE_BLOCK_PATTERN)) {
+    const codeBlock = normalizeWhitespace(match[1]);
+
+    if (codeBlock) {
+      codeBlocks.push(codeBlock);
+    }
+  }
+
+  return codeBlocks;
+};
+
+type BashCodeBlock = {
+  closingFenceIndex: number;
+  command: string;
+  openingFenceIndex: number;
+};
+
+type MarkdownHeading = {
+  level: number;
+  text: string;
+};
+
+const parseHeading = (line: string): MarkdownHeading | undefined => {
+  const match = line.match(HEADING_PATTERN);
+
+  if (!match) {
+    return undefined;
+  }
+
+  return { level: match[1].length, text: match[2].trim() };
+};
+
+const isManualDeploymentHeading = (heading: MarkdownHeading): boolean =>
+  MANUAL_DEPLOYMENT_HEADING_PATTERN.test(heading.text);
+
+const resolveManualStepSection = (
+  heading: MarkdownHeading,
+): ManualStepSection | undefined => {
+  const match = heading.text.match(DEPLOYMENT_SECTION_HEADING_PATTERN);
+
+  if (match?.[1].toLowerCase() === 'before') {
+    return 'before';
+  }
+
+  if (match?.[1].toLowerCase() === 'after') {
+    return 'after';
+  }
+
+  return undefined;
+};
+
+const extractBashCodeBlocksWithPositions = (body: string): BashCodeBlock[] => {
+  const lines = normalizeLineEndings(body).split('\n');
+  const codeBlocks: BashCodeBlock[] = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!BASH_CODE_BLOCK_OPENING_PATTERN.test(lines[index].trim())) {
+      continue;
+    }
+
+    const openingFenceIndex = index;
+    const commandLines: string[] = [];
+    let closingFenceIndex: number | undefined;
+
+    for (
+      let commandIndex = index + 1;
+      commandIndex < lines.length;
+      commandIndex += 1
+    ) {
+      if (lines[commandIndex].trim() === '```') {
+        closingFenceIndex = commandIndex;
+        break;
+      }
+
+      commandLines.push(lines[commandIndex]);
+    }
+
+    if (closingFenceIndex === undefined) {
+      break;
+    }
+
+    const command = normalizeWhitespace(commandLines.join('\n'));
+
+    codeBlocks.push({
+      closingFenceIndex,
+      command,
+      openingFenceIndex,
+    });
+
+    index = closingFenceIndex;
+  }
+
+  return codeBlocks;
+};
+
+const trimBlankLines = (lines: string[]): string[] => {
+  let firstNonBlankLine = 0;
+
+  while (
+    firstNonBlankLine < lines.length &&
+    lines[firstNonBlankLine].trim().length === 0
+  ) {
+    firstNonBlankLine += 1;
+  }
+
+  let lastNonBlankLine = lines.length;
+
+  while (
+    lastNonBlankLine > firstNonBlankLine &&
+    lines[lastNonBlankLine - 1].trim().length === 0
+  ) {
+    lastNonBlankLine -= 1;
+  }
+
+  return lines.slice(firstNonBlankLine, lastNonBlankLine);
+};
+
+const normalizeManualStepDescription = (lines: string[]): string => {
+  const descriptionLines = trimBlankLines(
+    lines.filter(line => {
+      const heading = parseHeading(line);
+
+      return (
+        !heading ||
+        (!isManualDeploymentHeading(heading) &&
+          resolveManualStepSection(heading) === undefined)
+      );
+    }),
+  );
+
+  if (descriptionLines.length === 0) {
+    return 'Manual step';
+  }
+
+  const normalizedDescriptionLines = descriptionLines.map((line, index) => {
+    const lineWithoutListPrefix = line.replace(LIST_ITEM_PREFIX_PATTERN, '');
+    const heading = parseHeading(lineWithoutListPrefix);
+
+    if (index === 0 && heading) {
+      return heading.text;
+    }
+
+    return lineWithoutListPrefix;
+  });
+  const description = normalizeWhitespace(
+    normalizedDescriptionLines.join('\n'),
+  );
+
+  return description || 'Manual step';
+};
+
+export const extractManualSteps = (body: string): ManualStep[] => {
+  const normalizedBody = normalizeLineEndings(body);
+  const lines = normalizedBody.split('\n');
+  const bashCodeBlocks = extractBashCodeBlocksWithPositions(normalizedBody);
+  const hasManualDeploymentSection = lines.some(line => {
+    const heading = parseHeading(line);
+
+    return heading ? isManualDeploymentHeading(heading) : false;
+  });
+  const manualSteps: ManualStep[] = [];
+  let bashCodeBlockIndex = 0;
+  let currentManualDeploymentHeadingLevel: number | undefined;
+  let currentSection: ManualStepSection | undefined;
+  let currentSectionHeadingLevel: number | undefined;
+  let previousBlockEndIndex = 0;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const heading = parseHeading(lines[index]);
+
+    if (heading) {
+      if (isManualDeploymentHeading(heading)) {
+        currentManualDeploymentHeadingLevel = heading.level;
+        currentSection = undefined;
+        currentSectionHeadingLevel = undefined;
+        previousBlockEndIndex = index + 1;
+      } else {
+        const section = resolveManualStepSection(heading);
+        const isWithinManualDeploymentSection =
+          currentManualDeploymentHeadingLevel !== undefined &&
+          heading.level > currentManualDeploymentHeadingLevel;
+
+        if (
+          section &&
+          (!hasManualDeploymentSection || isWithinManualDeploymentSection)
+        ) {
+          currentSection = section;
+          currentSectionHeadingLevel = heading.level;
+        } else if (
+          currentManualDeploymentHeadingLevel !== undefined &&
+          heading.level <= currentManualDeploymentHeadingLevel
+        ) {
+          currentManualDeploymentHeadingLevel = undefined;
+          currentSection = undefined;
+          currentSectionHeadingLevel = undefined;
+          previousBlockEndIndex = index + 1;
+        } else if (
+          currentSectionHeadingLevel !== undefined &&
+          heading.level <= currentSectionHeadingLevel
+        ) {
+          currentSection = undefined;
+          currentSectionHeadingLevel = undefined;
+        }
+      }
+    }
+
+    const bashCodeBlock = bashCodeBlocks[bashCodeBlockIndex];
+
+    if (!bashCodeBlock || bashCodeBlock.openingFenceIndex !== index) {
+      continue;
+    }
+
+    bashCodeBlockIndex += 1;
+    const descriptionStartIndex = previousBlockEndIndex;
+    index = bashCodeBlock.closingFenceIndex;
+    previousBlockEndIndex = index + 1;
+
+    if (
+      !bashCodeBlock.command ||
+      (hasManualDeploymentSection &&
+        currentManualDeploymentHeadingLevel === undefined)
+    ) {
+      continue;
+    }
+
+    const description = normalizeManualStepDescription(
+      lines.slice(descriptionStartIndex, bashCodeBlock.openingFenceIndex),
+    );
+
+    manualSteps.push({
+      command: bashCodeBlock.command,
+      description,
+      ...(currentSection ? { section: currentSection } : {}),
+    });
+  }
+
+  return manualSteps;
+};
+
+export const dedupeManualSteps = (manualSteps: ManualStep[]): ManualStep[] => {
+  const uniqueSteps = new Map<string, ManualStep>();
+
+  for (const manualStep of manualSteps) {
+    const uniqueStepKey = `${manualStep.section ?? 'unsectioned'}:${manualStep.command}`;
+    const existingManualStep = uniqueSteps.get(uniqueStepKey);
+
+    if (!existingManualStep) {
+      uniqueSteps.set(uniqueStepKey, manualStep);
+      continue;
+    }
+
+    if (
+      existingManualStep.description === 'Manual step' &&
+      manualStep.description !== 'Manual step'
+    ) {
+      uniqueSteps.set(uniqueStepKey, manualStep);
+    }
+  }
+
+  return Array.from(uniqueSteps.values());
+};
+
+const renderManualStep = (manualStep: ManualStep): string[] => {
+  const descriptionLines = manualStep.description.split('\n');
+
+  return [
+    `- [ ] ${descriptionLines[0]}`,
+    ...descriptionLines.slice(1).map(line => `   ${line}`),
+    '   ```bash',
+    `   ${manualStep.command.replace(/\n/g, '\n   ')}`,
+    '   ```',
+  ];
+};
+
+const appendManualSteps = (
+  lines: string[],
+  manualSteps: ManualStep[],
+): void => {
+  manualSteps.forEach((manualStep, index) => {
+    lines.push(...renderManualStep(manualStep));
+
+    if (index < manualSteps.length - 1) {
+      lines.push('');
+    }
+  });
+};
+
+export const renderManualSteps = (manualSteps: ManualStep[]): string[] => {
+  const lines: string[] = [];
+  const unsectionedManualSteps = manualSteps.filter(
+    manualStep => manualStep.section === undefined,
+  );
+
+  appendManualSteps(lines, unsectionedManualSteps);
+
+  for (const section of ['before', 'after'] as const) {
+    const sectionManualSteps = manualSteps.filter(
+      manualStep => manualStep.section === section,
+    );
+
+    if (sectionManualSteps.length === 0) {
+      continue;
+    }
+
+    if (lines.length > 0) {
+      lines.push('');
+    }
+
+    lines.push(
+      `#### ${section === 'before' ? 'Before Deployment' : 'After Deployment'}`,
+      '',
+    );
+    appendManualSteps(lines, sectionManualSteps);
+  }
+
+  return lines;
+};

--- a/scripts/git/prod-release-pr-description.ts
+++ b/scripts/git/prod-release-pr-description.ts
@@ -23,5 +23,4 @@ if (env !== 'prod') {
   process.exit(1);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-floating-promises
-prodReleasePrDescription();
+void prodReleasePrDescription();


### PR DESCRIPTION
# DevEx: Improve manual deployment steps output when generating production release PR descriptions

## Overview

Improve `prod-release-pr-description` script so generated production release PRs retain the context and organization of manual deployment instructions from their original PRs.

## Changes

- Extracted manual-step parsing and rendering into a dedicated helper.
- Preserved surrounding descriptions, headings, checklist text, and trailing annotations.
- Added support for `Before Deployment` and `After Deployment` subsections.
- Ignored unrelated Bash blocks outside the manual deployment section.
- Deduplicated commands within the same deployment section while retaining commands used in different sections.
- Added unit coverage for parsing, grouping, rendering, annotations, empty and unclosed code blocks, and deduplication.
- Updated the script entrypoint to explicitly discard the returned promise.

## Example

Here's how the `prod-release-pr-description` did with this week's OpenSearch update before and after this change.

### Before

```
- [ ] Manual step
   '''bash
   . scripts/env/set-env.zsh {YOUR_ENV}
   scripts/reports/indices.ts
   '''

- [ ] Manual step
   '''bash
   scripts/secrets/update-secret.ts --key "ES_ENGINE_VERSION" --value "OpenSearch_3.7"
   ''

- [ ] Manual step
   '''bash
   scripts/tests/run-cypress.ts --file cypress/deployed-and-local/integration/advancedSearch/search.cy.ts
   '''

- [ ] Manual step
   '''bash
   scripts/reports/indices.ts
   '''
```

### After

```
- [ ] OpenSearch 3.5 → 3.7 engine upgrade
   
   Run the OpenSearch indices report and note the indices and aliases in the target environment:
   '''bash
   . scripts/env/set-env.zsh {YOUR_ENV}
   scripts/reports/indices.ts
   '''

- [ ] Set the value of the `ES_ENGINE_VERSION` secret in the `[env]_deploy` secrets in Secrets Manager to `OpenSearch_3.7`:
   '''bash
   scripts/secrets/update-secret.ts --key "ES_ENGINE_VERSION" --value "OpenSearch_3.7"
   '''

- [ ] Deploy to the environment. While the OpenSearch upgrade is being performed (during the `allColors` terraform deployment), verify the cluster is still functional by running search smoketests against the current color:
   '''bash
   scripts/tests/run-cypress.ts --file cypress/deployed-and-local/integration/advancedSearch/search.cy.ts
   '''

- [ ] After the deployment's `cleanup` job is finished, rerun the OpenSearch indices report and ensure that all indices are present and populated, and that the aliases are configured as expected:
   '''bash
   scripts/reports/indices.ts
   '''
```

## Verification

- [x] Added and updated script unit tests covering the new manual-step behavior.
- [x] Ran against this week's release package and noted the improved output

## Limitations and Notes

- Manual deployment instructions must use `bash` fenced code blocks.
- Deployment section detection is based on Markdown headings named `Manual Deployment Steps`, `Before Deployment`, or `After Deployment`.

## Pull Request Checklist

_PRs that do not meet these criteria may be closed without review._

- [x] I have conducted thorough manual testing:
   - [x] Locally
   - [x] Experimental Environment (if necessary)
   - [x] Prod
- [x] If this PR is for a user story, or tech debt (devex, opex, design debt, etc.) that is user-facing, I have created test case(s) in TestRail and executed them.
- [x] I assert that all DoD criteria for this issue have been met.
- [x] If this PR includes a data migration with timing-specific manual test steps, I will coordinate the deployment with a manual tester to verify the timing-specific manual tests in real time.
- [x] All user-facing changes have been verified to be free of accessibility issues via manual testing and automated accessibility tests.