### PR TITLE
10345 additional text to test 1787846439

### DIFF
--- a/shared/src/business/entities/EntityConstants.ts
+++ b/shared/src/business/entities/EntityConstants.ts
@@ -2267,7 +2267,7 @@ export const MOTION_ORDER_RESPONSE_OPTIONS = {
   orderType: 'motionOrderResponse',
 };
 
-export const MAX_ORDER_RESPONSE_TEXT_CHARACTERS = 240;
+export const MAX_ORDER_RESPONSE_TEXT_CHARACTERS = 256;
 
 export const GRANT_DENY_MOTION_OPTIONS = {
   issueOrderOptions: {

--- a/web-client/src/business/entities/MotionOrderResponseForm.test.ts
+++ b/web-client/src/business/entities/MotionOrderResponseForm.test.ts
@@ -227,7 +227,7 @@ describe('MotionOrderResponseForm', () => {
 
       const errors = form.getFormattedValidationErrors();
       expect(errors).toMatchObject({
-        'additionalOrderTextArray-0': 'Limit is 240 characters.',
+        'additionalOrderTextArray-0': 'Limit is 256 characters.',
       });
     });
 

--- a/web-client/src/business/entities/MotionOrderResponseForm.ts
+++ b/web-client/src/business/entities/MotionOrderResponseForm.ts
@@ -45,7 +45,7 @@ export class MotionOrderResponseForm extends JoiValidationEntity {
         JoiValidationConstants.STRING.max(MAX_ORDER_RESPONSE_TEXT_CHARACTERS)
           .allow('')
           .messages({
-            'string.max': 'Limit is 240 characters.',
+            'string.max': 'Limit is 256 characters.',
           }),
       )
       .min(1)


### PR DESCRIPTION
# 10345: Increase Order Response additional text character limit to 256

#10345

## Overview

The Order Response custom workflow's additional text field(s) were limited to 240 characters, while other custom workflows (e.g. Status Report Order, Grant/Deny Motion) allow 256 characters. This PR brings the Order Response workflow in line with the rest of DAWSON's custom workflows by raising its character limit to 256.

## Changes

- Updated `MAX_ORDER_RESPONSE_TEXT_CHARACTERS` in `shared/src/business/entities/EntityConstants.ts` from `240` to `256`.
- Updated the corresponding Joi validation error message in `MotionOrderResponseForm.ts` from "Limit is 240 characters." to "Limit is 256 characters."
- Updated the associated unit test assertion in `MotionOrderResponseForm.test.ts` to expect the new 256-character limit and error message.

## Verification

- Ran `MotionOrderResponseForm.test.ts` locally — all 14 tests pass, including the test verifying validation errors when the additional text exceeds the maximum length.
- Confirmed no other hardcoded references to the 240-character limit exist in the codebase (views, other tests, etc.) — the `OrderResponse` view already consumes the shared constant, so no additional changes were required there.
- Confirmed the new limit matches the 256-character limit already used by the Status Report Order and Grant/Deny Motion workflows.

## Pull Request Checklist

_PRs that do not meet these criteria may be closed without review._

### External Contributors

- [ ] I have read the [External Contributions](docs/external-contributions.md) documentation and assert that this pull request adheres to the guidelines outlined therein.
    - [ ] The issue I chose to work on is appropriate for an external contributor.
    - [ ] This PR is targeting the correct branch for the appropriate stage of the development cycle.
    - [ ] I have performed all [Pre-PR Validation](docs/external-contributions.md#pre-pr-validation) locally.

### Internal Contributors (DAWSON Team Members)

- [ ] I have conducted thorough manual testing:
   - [ ] Locally
   - [ ] Experimental Environment (if necessary)
- [ ] If this PR is for a user story, or tech debt (devex, opex, design debt, etc.) that is user-facing, I have created test case(s) in TestRail and executed them.
- [ ] I assert that all DoD criteria for this issue have been met.
- [ ] If this PR includes a data migration with timing-specific manual test steps, I will coordinate the deployment with a manual tester to verify the timing-specific manual tests in real time.
- [ ] All user-facing changes have been verified to be free of accessibility issues via manual testing and automated accessibility tests.
