### PR TITLE
10396: bump worker queue lambda runner up to 10G memory

### DIFF
--- a/web-api/terraform/modules/worker/worker.tf
+++ b/web-api/terraform/modules/worker/worker.tf
@@ -8,7 +8,7 @@ module "worker_lambda" {
   role           = var.lambda_role_arn
   environment    = var.lambda_environment
   timeout        = "900"
-  memory_size    = "3008"
+  memory_size    = "10240"
 }
 
 resource "aws_sqs_queue" "worker_queue" {


### PR DESCRIPTION
# 10396: Prevent worker Lambda out-of-memory failures

#10396

## Overview

Increase the worker queue Lambda memory allocation to prevent out-of-memory failures when processing large exhibits and generating coversheets.

## Changes

- Increased `worker_lambda` memory from 3,008 MB to 10,240 MB.
- No application code, database schema, or queue behavior changes.

## Verification

- Compared `10396-worker-ram` against `staging`; only `web-api/terraform/modules/worker/worker.tf` changed.

## Pull Request Checklist

- [x] I have conducted thorough manual testing:
   - [ ] Locally
   - [ ] Experimental Environment (if necessary)
   - [x] Prod
- [x] If this PR is for a user story, or tech debt (devex, opex, design debt, etc.) that is user-facing, I have created test case(s) in TestRail and executed them.
- [x] I assert that all DoD criteria for this issue have been met.
- [x] If this PR includes a data migration with timing-specific manual test steps, I will coordinate the deployment with a manual tester to verify the timing-specific manual tests in real time.
- [x] All user-facing changes have been verified to be free of accessibility issues via manual testing and automated accessibility tests.