### PR TITLE
10398 Keep the docket record filter out of the pending motions list

### DIFF
--- a/web-client/src/presenter/computeds/formattedDocketEntries.test.ts
+++ b/web-client/src/presenter/computeds/formattedDocketEntries.test.ts
@@ -808,6 +808,50 @@ describe('formattedDocketEntries', () => {
       ]);
     });
 
+    it.each([
+      ['exhibits', DOCKET_RECORD_FILTER_OPTIONS.exhibits],
+      ['orders', DOCKET_RECORD_FILTER_OPTIONS.orders],
+      ['motions', DOCKET_RECORD_FILTER_OPTIONS.motions],
+    ])(
+      'should keep the pending list intact when the docket record is filtered by %s',
+      (_label, docketRecordFilter) => {
+        const pendingMotion = {
+          ...mockDocketEntry,
+          docketEntryId: 'b8dd9fa0-46bd-4a2a-a1d1-7bcbc2c78d0d',
+          documentTitle: 'Motion for Continuance',
+          documentType: 'Motion for Continuance',
+          eventCode: 'M006',
+          index: 4,
+          isFileAttached: true,
+          isOnDocketRecord: true,
+          isStricken: false,
+          pending: true,
+          servedAt: '2020-09-18T17:38:32.418Z',
+          servedParties: [
+            { email: 'petitioner@example.com', name: 'Mona Schultz' },
+          ],
+        };
+        const caseDetail = {
+          ...MOCK_CASE,
+          docketEntries: [...mockDocketEntries, pendingMotion],
+        };
+
+        const result = runCompute(formattedDocketEntries, {
+          state: {
+            ...getBaseState(petitionsClerkUser),
+            caseDetail,
+            sessionMetadata: { docketRecordFilter },
+          },
+        });
+
+        expect(
+          result.formattedPendingDocketEntriesOnDocketRecord.map(
+            entry => entry.eventCode,
+          ),
+        ).toEqual(['M006']);
+      },
+    );
+
     it('should ONLY show exhibit docket entries when "Exhibits" has been selected as the filter', () => {
       const caseDetail = {
         ...MOCK_CASE,

--- a/web-client/src/presenter/computeds/formattedDocketEntries.ts
+++ b/web-client/src/presenter/computeds/formattedDocketEntries.ts
@@ -448,35 +448,36 @@ export const formattedDocketEntries = (
       docketRecordFilter,
     });
 
-  let docketEntriesFormatted = preformattedDocketEntries
-    .map(entry =>
-      getFormattedDocketEntry({
-        applicationContext,
-        docketNumber,
-        entry: { ...entry } as FormattedCaseDetailDocketEntry,
-        get,
-        permissions,
-        rawCase: caseDetail,
-        user,
-        visibilityPolicyDateFormatted,
-      }),
-    )
-    .map(docketEntry => {
-      return {
-        ...docketEntry,
-        isDocumentSelected: documentsSelectedForDownload.some(
-          docEntry => docEntry.docketEntryId === docketEntry.docketEntryId,
-        ),
-        isSelectableForDownload: !!isSelectableForDownload(docketEntry),
-        signatory: '',
-      };
-    });
+  const formatDocketEntries = (entries: RawDocketEntry[]) =>
+    sortDocketEntryTable(
+      entries
+        .map(entry =>
+          getFormattedDocketEntry({
+            applicationContext,
+            docketNumber,
+            entry: { ...entry } as FormattedCaseDetailDocketEntry,
+            get,
+            permissions,
+            rawCase: caseDetail,
+            user,
+            visibilityPolicyDateFormatted,
+          }),
+        )
+        .map(docketEntry => {
+          return {
+            ...docketEntry,
+            isDocumentSelected: documentsSelectedForDownload.some(
+              docEntry => docEntry.docketEntryId === docketEntry.docketEntryId,
+            ),
+            isSelectableForDownload: !!isSelectableForDownload(docketEntry),
+            signatory: '',
+          };
+        }),
+      docketRecordSortField,
+      docketRecordSortOrder,
+    );
 
-  docketEntriesFormatted = sortDocketEntryTable(
-    docketEntriesFormatted,
-    docketRecordSortField,
-    docketRecordSortOrder,
-  );
+  const docketEntriesFormatted = formatDocketEntries(preformattedDocketEntries);
 
   const selectableDocumentsCount = docketEntriesFormatted.filter(entry =>
     isSelectableForDownload(entry),
@@ -503,8 +504,20 @@ export const formattedDocketEntries = (
       docketEntryId: docEntry.docketEntryId,
     }));
 
-  const formattedPendingDocketEntriesOnDocketRecord =
-    formattedDocketEntriesOnDocketRecord.filter(docketEntry =>
+  // The pending motions tab under Tracked Items is a separate view of the case,
+  // so the docket record's filter must not reach it. Everything above is derived
+  // from the filtered entries, which left the tab empty whenever the docket
+  // record was filtered by orders or exhibits (#10398). getDocketEntriesByFilter
+  // returns the array it was given when no filter applies, so the reformat only
+  // happens when a filter is actually set.
+  const entriesForPendingList =
+    preformattedDocketEntries === formattedCase.formattedDocketEntries
+      ? docketEntriesFormatted
+      : formatDocketEntries(formattedCase.formattedDocketEntries);
+
+  const formattedPendingDocketEntriesOnDocketRecord = entriesForPendingList
+    .filter(d => d.isOnDocketRecord)
+    .filter(docketEntry =>
       applicationContext.getUtilities().isPending(docketEntry),
     );
 


### PR DESCRIPTION
The `formattedDocketEntries` computed applies `docketRecordFilter` once, at the top, to the entries it then formats. `formattedPendingDocketEntriesOnDocketRecord` is derived from that same filtered set, and `CaseDetailPendingReportList` renders it, so filtering the docket record by Orders or Exhibits empties the pending motions tab under Tracked Items. Filtering by Motions happens to leave it looking correct, which is probably why it went unnoticed for a while.

The per-entry formatting and sort move into a local `formatDocketEntries`, and the pending list is built from the unfiltered entries. `getDocketEntriesByFilter` returns the array it was handed when the filter is All documents or unset, so the identity check means nothing is formatted twice in the common case; the second pass only happens while a filter is actually selected.

Three parameterized cases in `formattedDocketEntries.test.ts` put a pending motion on a case alongside an exhibit, an order and a motion, and assert the pending list still holds exactly that motion under each filter. Against the current code two of the three fail, matching the report:

    ✕ should keep the pending list intact when the docket record is filtered by exhibits
    ✕ should keep the pending list intact when the docket record is filtered by orders
    ✓ should keep the pending list intact when the docket record is filtered by motions

    - Array [ ... ]
    + Array []

Run in a node:24 container, since the repo pins that and my host is on 26. `formattedDocketEntries.test.ts` is 43 passed, and the whole `web-client/src/presenter/computeds` tree is 182 suites and 2069 tests passed. Prettier and eslint are clean on both files through your lint-staged hook.

One unrelated thing I ran into: `.husky/pre-commit` ends with `[ "$HAS_CIRCLECI" -eq 1 ] && circleci config validate`. Without the circleci CLI installed that test is false, so the script's exit status is 1 and the commit is rejected even though gitleaks and lint-staged both passed. I committed past it here. Happy to send a one-line fix separately if that is worth having.

Fixes #10398