### PR TITLE
10377 bug documents unable to display on dawson to test 1789143565

### DIFF
--- a/cypress/local-only/tests/integration/fileUpload/upload-incremental-catalog-pdf.cy.ts
+++ b/cypress/local-only/tests/integration/fileUpload/upload-incremental-catalog-pdf.cy.ts
@@ -42,6 +42,13 @@ describe('uploading a PDF whose catalog is superseded by an incremental revision
       cy.get('[data-testid="file-upload-error-modal"]').contains(
         REJECTION_MESSAGE,
       );
+      cy.get('[data-testid="file-upload-error-modal"]')
+        .contains('a', 'Learn about troubleshooting files')
+        .should(
+          'have.attr',
+          'href',
+          'https://ustaxcourt.gov/dawson_faqs_case_management.html#FAQS6',
+        );
       checkA11y();
 
       cy.get('[data-testid="modal-button-confirm"]').click();

--- a/shared/src/business/entities/EntityConstants.ts
+++ b/shared/src/business/entities/EntityConstants.ts
@@ -2087,7 +2087,7 @@ export const MAX_STATUS_REPORT_ORDER_TEXT_CHARACTERS = 256;
 export const TROUBLESHOOTING_INFO = {
   APP_SUPPORT_EMAIL: 'dawson.support@ustaxcourt.gov',
   FILE_UPLOAD_TROUBLESHOOTING_LINK:
-    'https://ustaxcourt.gov/dawson_faqs_case_management.html#FileUpload',
+    'https://ustaxcourt.gov/dawson_faqs_case_management.html#FAQS6',
 };
 
 export const MINUTE_SHEET_FORM_SECTION_MAP = {


### PR DESCRIPTION
This pull request makes a small update to the `TROUBLESHOOTING_INFO` object in `EntityConstants.ts`. The change updates the file upload troubleshooting link to point to a new anchor in the FAQ page.